### PR TITLE
[AI-Assisted] feat(electrolyte): register CaCl2 pressure evidence

### DIFF
--- a/.github/skills/neqsim-electrolyte-systems/SKILL.md
+++ b/.github/skills/neqsim-electrolyte-systems/SKILL.md
@@ -141,6 +141,9 @@ separates this mineral-standard-state evidence from the Pitzer or electrolyte-CP
 currently fail-closed against the CC BY 4.0 Voigt–Freyer pure-water and NaCl crossing envelopes and does not qualify
 high-pressure use; do not fit or reinterpret Pitzer interactions to hide a mineral-correlation mismatch. See
 `docs/pvtsimulation/scale_prediction_api.md` for the source matrix, numerical residuals, and limits.
+The object registers the NIST ThermoML CaCl2 pressure series as independent finite-concentration
+evidence, but explicitly leaves the dilute limiting-volume term unresolved; do not treat the presence
+of pressure evidence as high-pressure calcium-sulfate qualification.
 
 ### CaCO3 (Calcite) Scaling
 

--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -355,6 +355,10 @@ double ambientReactionVolume =
     evidence.getCrystallographicTransitionReactionVolumeCm3PerMol();
 double compsaltReactionVolume =
     evidence.getCompsaltTransitionReactionVolumeCm3PerMol();
+boolean independentAqueousPressureEvidence =
+    evidence.hasIndependentAqueousPressureEvidence();
+boolean aqueousLimitingVolumeResolved =
+    evidence.isAqueousLimitingVolumeEvidenceResolved();
 double requiredWaterActivity25C = evidence.getRequiredWaterActivityAt25Celsius();
 boolean publicationReady = evidence.isPublicationReady();
 ```
@@ -402,6 +406,21 @@ pressure response is not a pure-mineral-volume mapping. It is a diagnostic, not 
 `Vdelta`: published cell standard errors do not bound thermal expansion, compressibility, sample
 and other systematic effects, or aqueous partial molar volumes. Consequently
 `highPressureQualified` and `aqueousSpeciesVolumeResolved` remain false.
+
+The result also registers the independent finite-concentration aqueous pressure evidence separately
+from the missing limiting-volume term. Al Ghafri et al. (2012),
+[DOI 10.1021/je2013704](https://doi.org/10.1021/je2013704), provide 197 CaCl2 density points in
+[NIST ThermoML](https://trc.nist.gov/ThermoML/10.1021/je2013704.html): 1–6 mol/kg, 283–472 K, and
+pressures through 68.5 MPa, with reported relative density uncertainties of 0.03–0.05%. The
+machine-readable record is available under the [NIST data license](https://www.nist.gov/open/license)
+and is suitable as an independent pressure-response hold-out. Its lowest concentration is 1 mol/kg,
+so it cannot determine the infinite-dilution CaCl2 volume needed to close the calcium-sulfate
+reaction-volume cycle. The candidate dilute lineage, Oakes et al. (1990),
+[DOI 10.1021/je00061a022](https://doi.org/10.1021/je00061a022), predates the ThermoML archive;
+row-level audit, propagated uncertainty, and redistribution-compatible provenance remain unresolved.
+Accordingly `hasIndependentAqueousPressureEvidence()` is true while
+`isAqueousLimitingVolumeEvidenceResolved()` remains false. These flags register evidence scope only;
+they do not change a COMPSALT coefficient or make high-pressure calcium-sulfate use qualified.
 
 The process-system test carries the solid ledger beside the residual fluid through a
 `Stream -> Heater -> ProcessSystem` calculation, then re-equilibrates it at the outlet. Its

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -41,6 +41,30 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   public static final String GYPSUM_CRYSTALLOGRAPHY_DOI = "10.1154/1.1725254";
   /** Liquid-water density reference-correlation DOI. */
   public static final String WATER_DENSITY_REFERENCE_DOI = "10.1063/1.3043575";
+  /** Independent machine-readable aqueous CaCl2 pressure-evidence DOI. */
+  public static final String AQUEOUS_PRESSURE_EVIDENCE_DOI = "10.1021/je2013704";
+  /** NIST license applying to the machine-readable ThermoML pressure evidence. */
+  public static final String AQUEOUS_PRESSURE_EVIDENCE_LICENSE = "NIST Open Access to Data";
+  /** NIST license URI for the machine-readable ThermoML pressure evidence. */
+  public static final String AQUEOUS_PRESSURE_EVIDENCE_LICENSE_URI = "https://www.nist.gov/open/license";
+  /** Candidate dilute CaCl2 lineage DOI whose row-level reuse remains unresolved. */
+  public static final String AQUEOUS_LIMITING_VOLUME_LINEAGE_DOI = "10.1021/je00061a022";
+  /** Number of CaCl2 density points in the independent ThermoML pressure evidence. */
+  public static final int AQUEOUS_PRESSURE_EVIDENCE_POINT_COUNT = 197;
+  /** Minimum CaCl2 molality in the independent ThermoML pressure evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_MOLALITY = 1.0;
+  /** Maximum CaCl2 molality in the independent ThermoML pressure evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_MOLALITY = 6.0;
+  /** Minimum temperature in the independent ThermoML pressure evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_TEMPERATURE_K = 283.0;
+  /** Maximum temperature in the independent ThermoML pressure evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_TEMPERATURE_K = 472.0;
+  /** Maximum pressure in the independent ThermoML pressure evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_PRESSURE_BARA = 685.0;
+  /** Minimum reported relative density uncertainty in the ThermoML evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_RELATIVE_UNCERTAINTY = 0.0003;
+  /** Maximum reported relative density uncertainty in the ThermoML evidence. */
+  public static final double AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_RELATIVE_UNCERTAINTY = 0.0005;
   /** Temperature of the liquid-water density reference. */
   public static final double WATER_DENSITY_REFERENCE_TEMPERATURE_K = 298.15;
   /** Pressure of the liquid-water density reference. */
@@ -252,6 +276,40 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
     return false;
   }
 
+  /**
+   * Reports whether an independent, machine-readable aqueous CaCl2 pressure series is registered.
+   *
+   * <p>
+   * This evidence can test pressure response at finite concentration. Its one mol/kg lower limit cannot determine the
+   * infinite-dilution CaCl2 partial molar volume needed to close the calcium-sulfate reaction-volume cycle.
+   * </p>
+   *
+   * @return {@code true}; the NIST ThermoML pressure series is registered
+   */
+  public boolean hasIndependentAqueousPressureEvidence() {
+    return true;
+  }
+
+  /** @return {@code false}; the dilute CaCl2 limiting-volume rows and uncertainty remain unresolved */
+  public boolean isAqueousLimitingVolumeEvidenceResolved() {
+    return false;
+  }
+
+  /** @return DOI of the independent machine-readable aqueous CaCl2 pressure evidence */
+  public String getAqueousPressureEvidenceDoi() {
+    return AQUEOUS_PRESSURE_EVIDENCE_DOI;
+  }
+
+  /** @return NIST license URI for the machine-readable aqueous CaCl2 pressure evidence */
+  public String getAqueousPressureEvidenceLicenseUri() {
+    return AQUEOUS_PRESSURE_EVIDENCE_LICENSE_URI;
+  }
+
+  /** @return candidate dilute CaCl2 lineage DOI whose row-level reuse remains unresolved */
+  public String getAqueousLimitingVolumeLineageDoi() {
+    return AQUEOUS_LIMITING_VOLUME_LINEAGE_DOI;
+  }
+
   /** @return {@code false}; the high-pressure reaction-volume convention remains unqualified */
   public boolean isHighPressureQualified() {
     return false;
@@ -362,6 +420,10 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
             + "bound thermal expansion, compressibility, sample, or other systematic effects",
         "High-pressure use requires a verified reaction-volume convention that separately resolves aqueous partial "
             + "or apparent molar volumes",
+        "The independent NIST ThermoML CaCl2 pressure series starts at 1 mol/kg and therefore cannot determine the "
+            + "infinite-dilution aqueous volume needed by the calcium-sulfate reaction-volume cycle",
+        "The candidate 1990 dilute CaCl2 lineage is outside the NIST ThermoML archive; row-level audit, uncertainty, "
+            + "and redistribution-compatible provenance remain unresolved",
         "The registered evidence covers pure-water and NaCl phase crossings, not general "
             + "mixed-brine mineral equilibrium"));
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -44,6 +44,23 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     assertEquals(0.0, qualification.getAnhydriteLogKspPressureCorrection(), 0.0);
     assertEquals(0.0, qualification.getGypsumLogKspPressureCorrection(), 0.0);
     assertFalse(qualification.isAqueousSpeciesVolumeResolved());
+    assertTrue(qualification.hasIndependentAqueousPressureEvidence());
+    assertFalse(qualification.isAqueousLimitingVolumeEvidenceResolved());
+    assertEquals("10.1021/je2013704", qualification.getAqueousPressureEvidenceDoi());
+    assertEquals("https://www.nist.gov/open/license", qualification.getAqueousPressureEvidenceLicenseUri());
+    assertEquals("10.1021/je00061a022", qualification.getAqueousLimitingVolumeLineageDoi());
+    assertEquals("NIST Open Access to Data",
+        CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_LICENSE);
+    assertEquals(197, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_POINT_COUNT);
+    assertEquals(1.0, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_MOLALITY, 0.0);
+    assertEquals(6.0, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_MOLALITY, 0.0);
+    assertEquals(283.0, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_TEMPERATURE_K, 0.0);
+    assertEquals(472.0, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_TEMPERATURE_K, 0.0);
+    assertEquals(685.0, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_PRESSURE_BARA, 0.0);
+    assertEquals(0.0003,
+        CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_RELATIVE_UNCERTAINTY, 0.0);
+    assertEquals(0.0005,
+        CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_RELATIVE_UNCERTAINTY, 0.0);
     assertFalse(qualification.isHighPressureQualified());
     assertEquals("10.2475/ajs.261.1.61", qualification.getHighPressureLineageDoi());
     assertEquals(1.01325, CalciumSulfatePhaseBoundaryQualification.COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA, 0.0);
@@ -97,6 +114,8 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     CalciumSulfatePhaseBoundaryQualification highPressure = new ThermodynamicOperations(new SystemSrkEos(313.15, 500.0))
         .qualifyCalciumSulfatePhaseBoundary();
     assertFalse(highPressure.isReferencePressureEnvelopePass());
+    assertTrue(highPressure.hasIndependentAqueousPressureEvidence());
+    assertFalse(highPressure.isAqueousLimitingVolumeEvidenceResolved());
     assertFalse(highPressure.isPublicationReady());
     assertEquals(75.92, highPressure.getPredictedPureWaterTransitionAtEvaluatedPressureCelsius(), 0.01);
     assertEquals(52.4 * (500.0 - 1.01325) / (83.1446 * 313.15), highPressure.getAnhydriteLogKspPressureCorrection(),


### PR DESCRIPTION
## Summary

Advances #3144 with a bounded, fail-closed registry for independent aqueous CaCl2 pressure evidence.

**Exact base:** `4e3ea7808470066d1406ef62660713086a813624`  
**Exact publication head:** `cbc33c20af900fdd9e9acf42da7b999edb49ef87`

## Capability

- registers the 197-point Al Ghafri et al. CaCl2 density series from NIST ThermoML;
- exposes its 1–6 mol/kg, 283–472 K, and up-to-68.5 MPa envelope;
- exposes the reported 0.03–0.05% relative density uncertainty;
- records the DOI and NIST data-license URI;
- distinguishes this independent finite-concentration pressure hold-out from the unresolved infinite-dilution CaCl2 volume;
- records the 1990 Oakes dilute lineage without redistributing its copyrighted rows or adopting its fitted value;
- keeps the evidence object immutable, deterministic, Java/JPype-accessible, and serializable.

## Scientific and model-semantics boundary

The ThermoML series is valid independent pressure-response evidence, but its minimum concentration is 1 mol/kg. It cannot determine the infinite-dilution CaCl2 volume needed to close the calcium-sulfate reaction-volume cycle. The Oakes et al. (1990) lineage predates the ThermoML archive, and its row-level audit, propagated uncertainty, and redistribution-compatible provenance remain unresolved.

Accordingly:

- `hasIndependentAqueousPressureEvidence()` returns true;
- `isAqueousLimitingVolumeEvidenceResolved()` returns false;
- `isAqueousSpeciesVolumeResolved()` remains false;
- `isHighPressureQualified()` remains false.

No COMPSALT `Vdelta`, Ksp coefficient, reaction, Pitzer parameter, solver path, phase behavior, tolerance, or MCP structured payload changes.

## Provenance

- Al Ghafri et al. (2012), DOI [10.1021/je2013704](https://doi.org/10.1021/je2013704)
- [NIST ThermoML machine-readable record](https://trc.nist.gov/ThermoML/10.1021/je2013704.html)
- [NIST data license](https://www.nist.gov/open/license)
- Limiting-volume lineage only: Oakes et al. (1990), DOI [10.1021/je00061a022](https://doi.org/10.1021/je00061a022)

No external table rows are copied into the repository.

## Validation

**READY TO MERGE — EXACT-HEAD VALIDATION COMPLETE**

Passed locally from the exact base plus these four files:

- `python3 devtools/run_spotless.py apply`
- `python3 devtools/run_spotless.py check`
- `python3 devtools/check_documentation_search.py`
- `./mvnw -q -Dtest=CalciumSulfatePhaseBoundaryQualificationTest test` (2 tests)

The constructor and thermodynamic calculation path are unchanged. Added operations are constant getters/flags only, so no flash, thermodynamic initialization, iteration, or fallback is added. All exact-head hosted gates pass: Java 8/21 on Ubuntu and Windows, all four slow shards, Javadocs, Spotless, pre-commit, documentation/search, CodeQL, PaperLab, and skills/agents lint. GitHub reports the unchanged head mergeable with no reviews or unresolved threads. Current master has advanced independently; no rebase or synchronization was performed.

## Documentation impact

The scale-prediction guide and electrolyte skill now separate finite-concentration pressure evidence from the missing limiting-volume term and explicitly prohibit treating the evidence registry as high-pressure calcium-sulfate qualification.

## Portfolio and overlap

At publication, seven other autonomous implementation drafts were positively identified (#3477, #3478, #3483, #3485, #3486, #3487, and #3488), giving occupancy **8/10**. Subsequent merges reduced current occupancy to **4/10** (#3487, #3489, #3490, and #3491). No other active #3144 PR exists, and no changed file overlaps the declared scope of the current drafts.

## Stop boundary

This increment registers provenance and evidence scope only. Do not expand it into parameter adoption, copyrighted-row redistribution, density fitting, single-ion conventions, high-pressure qualification, or MCP payload growth.

Draft-only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.

Generated with AI assistance.