### PR TITLE
[AI-Assisted] feat(dexpi): preserve connection segment provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -179,10 +179,12 @@ functions.
 
 The same result also preserves every source `Connection` in document order, including parallel
 connections between the same endpoints. Each immutable `DexpiConnectionInfo` retains the owning
-piping-network segment, `FromID` and `ToID` direction, the resolved endpoint element names, and
-resolution status. Missing source IDs receive deterministic evidence-only identities; missing,
-duplicate, self-referential, or unresolved source references remain explicit diagnostics. This
-inventory does not infer connectivity or rewire the returned `ProcessSystem`.
+piping-network segment identity and its explicit `ComponentClass`, `ComponentName`, and
+`TagName`, plus `FromID` and `ToID` direction, the resolved endpoint element names, and
+resolution status. Absent segment metadata remains empty without invented values. Missing source
+IDs receive deterministic evidence-only identities; missing, duplicate, self-referential, or
+unresolved source references remain explicit diagnostics. This inventory does not derive segment
+metadata, infer connectivity, or rewire the returned `ProcessSystem`.
 
 For resolved nozzle endpoints, the same record exposes only explicit source ownership: the nearest
 ancestor `Equipment` or `PipingComponent` identity and XML element name. Direct equipment or

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -20,6 +20,9 @@ public final class DexpiConnectionInfo implements Serializable {
   private final String id;
   private final String sourceId;
   private final String segmentId;
+  private final String segmentComponentClass;
+  private final String segmentComponentName;
+  private final String segmentTagName;
   private final String fromId;
   private final String toId;
   private final String fromElementName;
@@ -108,9 +111,49 @@ public final class DexpiConnectionInfo implements Serializable {
       String toOwnerElementName, String fromOwnerComponentClass, String fromOwnerComponentName, String fromOwnerTagName,
       String toOwnerComponentClass, String toOwnerComponentName, String toOwnerTagName, boolean fromResolved,
       boolean toResolved) {
+    this(id, sourceId, segmentId, "", "", "", fromId, toId, fromElementName, toElementName, fromOwnerId, toOwnerId,
+        fromOwnerElementName, toOwnerElementName, fromOwnerComponentClass, fromOwnerComponentName, fromOwnerTagName,
+        toOwnerComponentClass, toOwnerComponentName, toOwnerTagName, fromResolved, toResolved);
+  }
+
+  /**
+   * Creates immutable connection evidence with explicit segment and endpoint-owner provenance.
+   *
+   * @param id stable evidence identity
+   * @param sourceId source connection identity, or empty when absent
+   * @param segmentId owning piping-network segment identity, or empty when absent
+   * @param segmentComponentClass explicit segment ComponentClass, or empty when absent
+   * @param segmentComponentName explicit segment ComponentName, or empty when absent
+   * @param segmentTagName explicit segment TagName, or empty when absent
+   * @param fromId source endpoint identity
+   * @param toId target endpoint identity
+   * @param fromElementName resolved source XML element name
+   * @param toElementName resolved target XML element name
+   * @param fromOwnerId explicit source owner identity, or empty when absent
+   * @param toOwnerId explicit target owner identity, or empty when absent
+   * @param fromOwnerElementName source owner XML element name, or empty when absent
+   * @param toOwnerElementName target owner XML element name, or empty when absent
+   * @param fromOwnerComponentClass explicit source-owner ComponentClass, or empty when absent
+   * @param fromOwnerComponentName explicit source-owner ComponentName, or empty when absent
+   * @param fromOwnerTagName explicit source-owner TagName, or empty when absent
+   * @param toOwnerComponentClass explicit target-owner ComponentClass, or empty when absent
+   * @param toOwnerComponentName explicit target-owner ComponentName, or empty when absent
+   * @param toOwnerTagName explicit target-owner TagName, or empty when absent
+   * @param fromResolved whether the source endpoint resolves in the source document
+   * @param toResolved whether the target endpoint resolves in the source document
+   */
+  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String segmentComponentClass,
+      String segmentComponentName, String segmentTagName, String fromId, String toId, String fromElementName,
+      String toElementName, String fromOwnerId, String toOwnerId, String fromOwnerElementName,
+      String toOwnerElementName, String fromOwnerComponentClass, String fromOwnerComponentName, String fromOwnerTagName,
+      String toOwnerComponentClass, String toOwnerComponentName, String toOwnerTagName, boolean fromResolved,
+      boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);
+    this.segmentComponentClass = normalize(segmentComponentClass);
+    this.segmentComponentName = normalize(segmentComponentName);
+    this.segmentTagName = normalize(segmentTagName);
     this.fromId = normalize(fromId);
     this.toId = normalize(toId);
     this.fromElementName = normalize(fromElementName);
@@ -147,6 +190,21 @@ public final class DexpiConnectionInfo implements Serializable {
   /** @return owning piping-network segment identity, or empty when absent */
   public String getSegmentId() {
     return segmentId;
+  }
+
+  /** @return explicit segment ComponentClass, or empty when absent */
+  public String getSegmentComponentClass() {
+    return segmentComponentClass;
+  }
+
+  /** @return explicit segment ComponentName, or empty when absent */
+  public String getSegmentComponentName() {
+    return segmentComponentName;
+  }
+
+  /** @return explicit segment TagName, or empty when absent */
+  public String getSegmentTagName() {
+    return segmentTagName;
   }
 
   /** @return source endpoint identity */
@@ -249,6 +307,9 @@ public final class DexpiConnectionInfo implements Serializable {
     result.put("id", id);
     result.put("sourceId", sourceId);
     result.put("segmentId", segmentId);
+    result.put("segmentComponentClass", segmentComponentClass);
+    result.put("segmentComponentName", segmentComponentName);
+    result.put("segmentTagName", segmentTagName);
     result.put("fromId", fromId);
     result.put("toId", toId);
     result.put("fromElementName", fromElementName);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1116,12 +1116,11 @@ public final class DexpiXmlReader {
           explicitAttribute(segment, "ComponentClass"), explicitAttribute(segment, "ComponentName"),
           explicitTagName(segment), fromId, toId, fromElement == null ? "" : fromElement.getTagName(),
           toElement == null ? "" : toElement.getTagName(), fromOwner == null ? "" : fromOwner.getAttribute("ID"),
-          toOwner == null ? "" : toOwner.getAttribute("ID"),
-          fromOwner == null ? "" : fromOwner.getTagName(), toOwner == null ? "" : toOwner.getTagName(),
-          explicitAttribute(fromOwner, "ComponentClass"), explicitAttribute(fromOwner, "ComponentName"),
-          explicitTagName(fromOwner), explicitAttribute(toOwner, "ComponentClass"),
-          explicitAttribute(toOwner, "ComponentName"), explicitTagName(toOwner), fromElement != null,
-          toElement != null));
+          toOwner == null ? "" : toOwner.getAttribute("ID"), fromOwner == null ? "" : fromOwner.getTagName(),
+          toOwner == null ? "" : toOwner.getTagName(), explicitAttribute(fromOwner, "ComponentClass"),
+          explicitAttribute(fromOwner, "ComponentName"), explicitTagName(fromOwner),
+          explicitAttribute(toOwner, "ComponentClass"), explicitAttribute(toOwner, "ComponentName"),
+          explicitTagName(toOwner), fromElement != null, toElement != null));
     }
     logger.info("Parsed {} material connections from DEXPI XML", connections.size());
     return connections;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1112,9 +1112,11 @@ public final class DexpiXmlReader {
       addConnectionOwnerDiagnostic(connection, fromElement, fromOwner, true, diagnostics);
       addConnectionOwnerDiagnostic(connection, toElement, toOwner, false, diagnostics);
 
-      connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId, fromId, toId,
-          fromElement == null ? "" : fromElement.getTagName(), toElement == null ? "" : toElement.getTagName(),
-          fromOwner == null ? "" : fromOwner.getAttribute("ID"), toOwner == null ? "" : toOwner.getAttribute("ID"),
+      connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId,
+          explicitAttribute(segment, "ComponentClass"), explicitAttribute(segment, "ComponentName"),
+          explicitTagName(segment), fromId, toId, fromElement == null ? "" : fromElement.getTagName(),
+          toElement == null ? "" : toElement.getTagName(), fromOwner == null ? "" : fromOwner.getAttribute("ID"),
+          toOwner == null ? "" : toOwner.getAttribute("ID"),
           fromOwner == null ? "" : fromOwner.getTagName(), toOwner == null ? "" : toOwner.getTagName(),
           explicitAttribute(fromOwner, "ComponentClass"), explicitAttribute(fromOwner, "ComponentName"),
           explicitTagName(fromOwner), explicitAttribute(toOwner, "ComponentClass"),

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -550,7 +550,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<Equipment ID=\"E-IN\" ComponentClass=\"Separator\" ComponentName=\"InletSeparator\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"V-101\"/></GenericAttributes>"
         + "<Nozzle ID=\"N-IN\"/></Equipment>"
-        + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\">"
+        + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\" ComponentName=\"MainSegment\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"L-100-1\"/></GenericAttributes>"
         + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-2\" ComponentClass=\"PipingNetworkSegment\">"
         + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>" + "</PlantModel>";
@@ -565,6 +566,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("S-1/connection-1", firstConnection.getId());
     assertFalse(firstConnection.hasSourceId());
     assertEquals("S-1", firstConnection.getSegmentId());
+    assertEquals("PipingNetworkSegment", firstConnection.getSegmentComponentClass());
+    assertEquals("MainSegment", firstConnection.getSegmentComponentName());
+    assertEquals("L-100-1", firstConnection.getSegmentTagName());
     assertEquals("N-OUT", firstConnection.getFromId());
     assertEquals("N-IN", firstConnection.getToId());
     assertEquals("Nozzle", firstConnection.getFromElementName());
@@ -584,6 +588,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("S-2/connection-1", first.getConnections().get(1).getId());
     assertEquals(2, countDiagnostics(first, "DEXPI_IMPORT_CONNECTION_ID_SYNTHESIZED"));
     assertTrue(first.toJson().contains("\"connectionCount\": 2"));
+    assertTrue(first.toJson().contains("\"segmentTagName\": \"L-100-1\""));
     assertEquals(first.toJson(), second.toJson());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnections().clear());
   }
@@ -669,6 +674,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("", legacy.getToOwnerComponentClass());
     assertEquals("", legacy.getToOwnerComponentName());
     assertEquals("", legacy.getToOwnerTagName());
+    assertEquals("", legacy.getSegmentComponentClass());
+    assertEquals("", legacy.getSegmentComponentName());
+    assertEquals("", legacy.getSegmentTagName());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds immutable source provenance for each owning `PipingNetworkSegment` on Proteus-compatible DEXPI material-connection occurrences.

- preserves the segment's explicit `ComponentClass`, `ComponentName`, and `TagName`
- keeps absent segment metadata empty without invented values
- preserves parallel occurrences, direction, endpoint/owner evidence, deterministic JSON, legacy constructors and fields, Java 8 compatibility, O(V+E) parsing, topology, rendering, simulation, and exports
- documents the evidence boundary and non-inferences

## Capability contract

**Roadmaps:** #1332 and #2899  
**Exact base/publication-time master:** `c9881535945252ab2a58db74b52dc9513bfbf51f`  
**Current master:** `234214c8f76d84d4821b6028760f7033adb3372d` (one unrelated commit ahead; no rebase)  
**Exact publication head:** `ea85009b1be139fa142634932dfe742e59e78c14`  
**Complexity:** O(V+E) source parsing  
**Current autonomous portfolio:** **7/10**

## Validation

Status: **READY TO MERGE AT EXACT HEAD `ea85009b1be139fa142634932dfe742e59e78c14`**

- tests were added first for explicit segment class/name/tag evidence, deterministic JSON, and legacy-constructor empty defaults
- implementation is limited to the immutable connection record and the existing source-order parser
- documentation records the provenance-only boundary
- scope is five ordered commits across four intended files
- the initial hosted run identified only a Spotless wrap in `DexpiXmlReader.java`; the exact 610-byte formatter artifact was applied without semantic change
- all exact-head workflows pass: Spotless, pre-commit, documentation/search, notebook/focused handover, engineering-diagram performance, CodeQL, PaperLab, and reference checks
- Java 8/21 Ubuntu and Windows fast tests, all four Java 21 slow-test shards, and Javadocs pass
- GitHub reports the unchanged head open and mergeable as a draft, with no reviews or unresolved threads

No local Maven, Java, formatting, or documentation result is claimed; exact-head GitHub Actions are authoritative. Current portfolio occupancy is **7/10**, below the ten-capability ceiling.

## Engineering boundary

This change preserves explicit source evidence only. It does not derive segment metadata, infer hydraulic continuity, fitting or branch semantics, process or control intent, safeguard or SIS credit, modify live topology, certify a drawing, claim standards conformance, or provide engineering approval.

Whole-sheet visual gates are not applicable because geometry, layout, rendering, notebooks, writers, and exports are unchanged.

## Publication policy

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.