### PR TITLE
[AI-Assisted] test(tpflash): qualify UMR-CPA dehydration lifecycle

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2352,6 +2352,36 @@ defaults, saturation operations, electrolyte-performance ownership, solids/wax,
 Column Solver, Process Performance, proprietary data, and Huldra are outside this
 tranche.
 
+### 6.4.14 UMR-CPA methane-water dehydration lifecycle qualification
+
+The synthetic dehydration qualification uses `SystemUMRCPAEoS` with the `HV` /
+`UNIFAC_UMRPRU` mixing rule and a normalized feed of 0.98 methane and 0.02 water.
+Its local envelope is 283.15-313.15 K and 30-120 bara. The 298.15 K / 70 bara
+reference retains the existing paper-facing gas-water mole-fraction envelope of
+`1e-5` to `5e-3`. This is deterministic numerical qualification of the public
+flash path, not independent experimental validation or a re-fit of UMR-CPA,
+association, alpha-function, or UNIFAC parameters.
+
+Every state must contain GAS and AQUEOUS phases with finite bounded phase fractions
+and compositions. Beta and phase compositions must normalize within `3e-12`,
+maximum component material-balance residual must remain below `1e-10`, and the
+maximum methane/water interphase log-fugacity residual must remain below `1e-8`.
+Both phases require positive finite compressibility, and total Gibbs energy and
+enthalpy must remain finite.
+
+The temperature matrix requires gas-phase water content to increase from 283.15 to
+313.15 K at 70 bara. The pressure matrix requires it to decrease from 30 to 120
+bara at 298.15 K. Ordinary and explicit-multiphase public TP flashes must agree
+throughout both matrices. The regression also qualifies recovery from beta values
+within `1e-12` of a bound, a changed temperature/pressure state, return to the
+reference state, and an immediate deterministic repeat.
+
+The focused class performs 21 complete public TP flashes. This fixed workload is
+performance evidence only; no wall-clock threshold or speedup is claimed. TEG
+derivative behavior, model or data parameter changes, saturation operations,
+electrolyte/reaction models, public API and serialization changes, Column Solver,
+Process Performance, proprietary data, and Huldra are outside this tranche.
+
 ### 6.5 Hybrid EOS-GE ionic-capacity safeguard
 
 In a fixed-role EOS-gas/GE-aqueous calculation, ions are excluded from every non-aqueous role.

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2376,7 +2376,7 @@ throughout both matrices. The regression also qualifies recovery from beta value
 within `1e-12` of a bound, a changed temperature/pressure state, return to the
 reference state, and an immediate deterministic repeat.
 
-The focused class performs 21 complete public TP flashes. This fixed workload is
+The focused class performs 20 complete public TP flashes. This fixed workload is
 performance evidence only; no wall-clock threshold or speedup is claimed. TEG
 derivative behavior, model or data parameter changes, saturation operations,
 electrolyte/reaction models, public API and serialization changes, Column Solver,

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashUMRCPADehydrationLifecycleTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashUMRCPADehydrationLifecycleTest.java
@@ -1,0 +1,271 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemUMRCPAEoS;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Qualification tests for the UMR-CPA methane-water dehydration flash lifecycle.
+ *
+ * <p>
+ * The synthetic binary uses the public UMR-CPA model and its HV/UNIFAC_UMRPRU mixing rule. It
+ * retains the existing paper-facing gas-water envelope while adding closure, algorithm agreement,
+ * poor-initialization, nearby-state, and reused-state contracts. This is numerical qualification,
+ * not an independent revalidation of UMR-CPA parameters.
+ * </p>
+ */
+class TPflashUMRCPADehydrationLifecycleTest {
+  private static final double METHANE_FEED = 0.98;
+  private static final double WATER_FEED = 0.02;
+  private static final double REFERENCE_TEMPERATURE_K = 298.15;
+  private static final double REFERENCE_PRESSURE_BARA = 70.0;
+
+  private static final double NORMALIZATION_TOLERANCE = 3.0e-12;
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+
+  /**
+   * Temperature and pressure matrices must retain closed gas-aqueous equilibrium and the expected
+   * dehydration trends.
+   */
+  @Test
+  void temperatureAndPressureMatricesRemainClosedAndMonotonic() {
+    double previousWaterInGas = -1.0;
+    for (double temperatureK : new double[] {283.15, REFERENCE_TEMPERATURE_K, 313.15}) {
+      SystemInterface ordinary = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, false));
+      SystemInterface multiphase = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, true));
+      assertQualifiedState(ordinary, "ordinary temperature " + temperatureK);
+      assertQualifiedState(multiphase, "multiphase temperature " + temperatureK);
+      assertEquivalentState(ordinary, multiphase, 1.0e-8,
+          "algorithm agreement at " + temperatureK + " K");
+
+      double waterInGas = gasWaterMoleFraction(ordinary);
+      assertTrue(waterInGas > previousWaterInGas,
+          "gas water content must increase with temperature: " + previousWaterInGas + " -> "
+              + waterInGas);
+      previousWaterInGas = waterInGas;
+    }
+
+    double previousWaterInGasAtPressure = Double.POSITIVE_INFINITY;
+    for (double pressureBara : new double[] {30.0, REFERENCE_PRESSURE_BARA, 120.0}) {
+      SystemInterface ordinary = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, false));
+      SystemInterface multiphase = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, true));
+      assertQualifiedState(ordinary, "ordinary pressure " + pressureBara);
+      assertQualifiedState(multiphase, "multiphase pressure " + pressureBara);
+      assertEquivalentState(ordinary, multiphase, 1.0e-8,
+          "algorithm agreement at " + pressureBara + " bara");
+
+      double waterInGas = gasWaterMoleFraction(ordinary);
+      assertTrue(waterInGas < previousWaterInGasAtPressure,
+          "gas water content must decrease with pressure: " + previousWaterInGasAtPressure + " -> "
+              + waterInGas);
+      previousWaterInGasAtPressure = waterInGas;
+    }
+  }
+
+  /**
+   * The established 298.15 K and 70 bara water-content envelope must remain visible.
+   */
+  @Test
+  void referenceStateRetainsPaperFacingWaterContentEnvelope() {
+    SystemInterface system =
+        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    assertQualifiedState(system, "reference state");
+
+    double waterInGas = gasWaterMoleFraction(system);
+    assertTrue(waterInGas > 1.0e-5 && waterInGas < 5.0e-3,
+        "gas-phase water mole fraction outside the established model envelope: " + waterInGas);
+  }
+
+  /**
+   * Beta values near a bound must recover the same closed reference equilibrium.
+   */
+  @Test
+  void poorInitializationRecoversReferenceState() {
+    SystemInterface reference =
+        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface poor =
+        createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
+    poor.init(0);
+    assertTrue(poor.getNumberOfPhases() >= 2, "poor initialization requires two phase slots");
+    poor.setBeta(0, 1.0e-12);
+    poor.setBeta(1, 1.0 - 1.0e-12);
+    flash(poor);
+
+    assertEquivalentState(reference, poor, 1.0e-8, "poor initialization");
+  }
+
+  /**
+   * A reused system must match fresh changed and returned states and settle deterministically.
+   */
+  @Test
+  void changedReturnedAndRepeatedStatesRemainEquivalent() {
+    SystemInterface reference =
+        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface reused = reference.clone();
+
+    reused.setTemperature(313.15, "K");
+    reused.setPressure(120.0, "bara");
+    flash(reused);
+    SystemInterface freshChanged = flash(createSystem(313.15, 120.0, true));
+    assertEquivalentState(freshChanged, reused, 1.0e-8, "changed state");
+
+    reused.setTemperature(REFERENCE_TEMPERATURE_K, "K");
+    reused.setPressure(REFERENCE_PRESSURE_BARA, "bara");
+    flash(reused);
+    assertEquivalentState(reference, reused, 1.0e-8, "returned state");
+
+    SystemInterface previous = reused.clone();
+    flash(reused);
+    assertEquivalentState(previous, reused, 1.0e-10, "deterministic repeat");
+  }
+
+  private SystemInterface createSystem(
+      double temperatureK, double pressureBara, boolean multiphaseCheck) {
+    SystemInterface system = new SystemUMRCPAEoS(temperatureK, pressureBara);
+    system.addComponent("methane", METHANE_FEED);
+    system.addComponent("water", WATER_FEED);
+    system.setMixingRule("HV", "UNIFAC_UMRPRU");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    return system;
+  }
+
+  private SystemInterface flash(SystemInterface system) {
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private double gasWaterMoleFraction(SystemInterface system) {
+    return system.getPhase(findPhase(system, PhaseType.GAS)).getComponent("water").getx();
+  }
+
+  private void assertQualifiedState(SystemInterface system, String label) {
+    assertEquals(2, system.getNumberOfPhases(), label + " phase count");
+    assertTrue(system.hasPhaseType(PhaseType.GAS), label + " gas phase");
+    assertTrue(system.hasPhaseType(PhaseType.AQUEOUS), label + " aqueous phase");
+
+    int componentCount = system.getPhase(0).getNumberOfComponents();
+    double betaTotal = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0,
+          label + " beta " + phase + ": " + beta);
+      betaTotal += beta;
+
+      double compositionTotal = 0.0;
+      for (int component = 0; component < componentCount; component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0,
+            label + " composition " + phase + "/" + component + ": " + composition);
+        compositionTotal += composition;
+      }
+      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE,
+          label + " composition normalization " + phase);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ())
+          && system.getPhase(phase).getZ() > 0.0, label + " compressibility " + phase);
+    }
+    assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
+
+    double materialResidual = maximumComponentMaterialBalanceResidual(system);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
+        label + " material-balance residual " + materialResidual);
+
+    double fugacityResidual = maximumComparableLogFugacityResidual(system);
+    assertTrue(fugacityResidual < FUGACITY_TOLERANCE,
+        label + " fugacity residual " + fugacityResidual);
+
+    assertTrue(Double.isFinite(system.getGibbsEnergy()), label + " Gibbs energy");
+    assertTrue(Double.isFinite(system.getEnthalpy()), label + " enthalpy");
+  }
+
+  private void assertEquivalentState(
+      SystemInterface expected, SystemInterface actual, double tolerance, String label) {
+    assertQualifiedState(expected, label + " expected");
+    assertQualifiedState(actual, label + " actual");
+
+    for (PhaseType type : new PhaseType[] {PhaseType.GAS, PhaseType.AQUEOUS}) {
+      int expectedPhase = findPhase(expected, type);
+      int actualPhase = findPhase(actual, type);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
+          label + " beta " + type);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(),
+          tolerance, label + " compressibility " + type);
+      for (int component = 0;
+          component < expected.getPhase(expectedPhase).getNumberOfComponents();
+          component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
+            label + " composition " + type + "/" + component);
+      }
+    }
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance,
+        label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance,
+        label + " enthalpy");
+  }
+
+  private void assertExtensiveEquals(
+      double expected, double actual, double relativeTolerance, String label) {
+    assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
+  }
+
+  private int findPhase(SystemInterface system, PhaseType type) {
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      if (system.getPhase(phase).getType() == type) {
+        return phase;
+      }
+    }
+    throw new AssertionError("missing phase " + type);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int component = 0;
+        component < system.getPhase(0).getNumberOfComponents();
+        component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered +=
+            system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumComparableLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    int comparisons = 0;
+    for (int component = 0;
+        component < system.getPhase(0).getNumberOfComponents();
+        component++) {
+      double gasComposition =
+          system.getPhase(findPhase(system, PhaseType.GAS)).getComponent(component).getx();
+      double aqueousComposition =
+          system.getPhase(findPhase(system, PhaseType.AQUEOUS)).getComponent(component).getx();
+      double gasCoefficient = system.getPhase(findPhase(system, PhaseType.GAS))
+          .getComponent(component).getFugacityCoefficient();
+      double aqueousCoefficient = system.getPhase(findPhase(system, PhaseType.AQUEOUS))
+          .getComponent(component).getFugacityCoefficient();
+      if (gasComposition > 1.0e-20 && aqueousComposition > 1.0e-20
+          && Double.isFinite(gasCoefficient) && gasCoefficient > 0.0
+          && Double.isFinite(aqueousCoefficient) && aqueousCoefficient > 0.0) {
+        double gasLogFugacity = Math.log(gasComposition * gasCoefficient);
+        double aqueousLogFugacity = Math.log(aqueousComposition * aqueousCoefficient);
+        maximumResidual =
+            Math.max(maximumResidual, Math.abs(gasLogFugacity - aqueousLogFugacity));
+        comparisons++;
+      }
+    }
+    assertEquals(2, comparisons, "both methane and water must expose comparable fugacities");
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashUMRCPADehydrationLifecycleTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashUMRCPADehydrationLifecycleTest.java
@@ -14,10 +14,9 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * Qualification tests for the UMR-CPA methane-water dehydration flash lifecycle.
  *
  * <p>
- * The synthetic binary uses the public UMR-CPA model and its HV/UNIFAC_UMRPRU mixing rule. It
- * retains the existing paper-facing gas-water envelope while adding closure, algorithm agreement,
- * poor-initialization, nearby-state, and reused-state contracts. This is numerical qualification,
- * not an independent revalidation of UMR-CPA parameters.
+ * The synthetic binary uses the public UMR-CPA model and its HV/UNIFAC_UMRPRU mixing rule. It retains the existing
+ * paper-facing gas-water envelope while adding closure, algorithm agreement, poor-initialization, nearby-state, and
+ * reused-state contracts. This is numerical qualification, not an independent revalidation of UMR-CPA parameters.
  * </p>
  */
 class TPflashUMRCPADehydrationLifecycleTest {
@@ -31,40 +30,35 @@ class TPflashUMRCPADehydrationLifecycleTest {
   private static final double FUGACITY_TOLERANCE = 1.0e-8;
 
   /**
-   * Temperature and pressure matrices must retain closed gas-aqueous equilibrium and the expected
-   * dehydration trends.
+   * Temperature and pressure matrices must retain closed gas-aqueous equilibrium and the expected dehydration trends.
    */
   @Test
   void temperatureAndPressureMatricesRemainClosedAndMonotonic() {
     double previousWaterInGas = -1.0;
-    for (double temperatureK : new double[] {283.15, REFERENCE_TEMPERATURE_K, 313.15}) {
+    for (double temperatureK : new double[] { 283.15, REFERENCE_TEMPERATURE_K, 313.15 }) {
       SystemInterface ordinary = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, false));
       SystemInterface multiphase = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, true));
       assertQualifiedState(ordinary, "ordinary temperature " + temperatureK);
       assertQualifiedState(multiphase, "multiphase temperature " + temperatureK);
-      assertEquivalentState(ordinary, multiphase, 1.0e-8,
-          "algorithm agreement at " + temperatureK + " K");
+      assertEquivalentState(ordinary, multiphase, 1.0e-8, "algorithm agreement at " + temperatureK + " K");
 
       double waterInGas = gasWaterMoleFraction(ordinary);
       assertTrue(waterInGas > previousWaterInGas,
-          "gas water content must increase with temperature: " + previousWaterInGas + " -> "
-              + waterInGas);
+          "gas water content must increase with temperature: " + previousWaterInGas + " -> " + waterInGas);
       previousWaterInGas = waterInGas;
     }
 
     double previousWaterInGasAtPressure = Double.POSITIVE_INFINITY;
-    for (double pressureBara : new double[] {30.0, REFERENCE_PRESSURE_BARA, 120.0}) {
+    for (double pressureBara : new double[] { 30.0, REFERENCE_PRESSURE_BARA, 120.0 }) {
       SystemInterface ordinary = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, false));
       SystemInterface multiphase = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, true));
       assertQualifiedState(ordinary, "ordinary pressure " + pressureBara);
       assertQualifiedState(multiphase, "multiphase pressure " + pressureBara);
-      assertEquivalentState(ordinary, multiphase, 1.0e-8,
-          "algorithm agreement at " + pressureBara + " bara");
+      assertEquivalentState(ordinary, multiphase, 1.0e-8, "algorithm agreement at " + pressureBara + " bara");
 
       double waterInGas = gasWaterMoleFraction(ordinary);
       assertTrue(waterInGas < previousWaterInGasAtPressure,
-          "gas water content must decrease with pressure: " + previousWaterInGasAtPressure + " -> "
-              + waterInGas);
+          "gas water content must decrease with pressure: " + previousWaterInGasAtPressure + " -> " + waterInGas);
       previousWaterInGasAtPressure = waterInGas;
     }
   }
@@ -74,8 +68,7 @@ class TPflashUMRCPADehydrationLifecycleTest {
    */
   @Test
   void referenceStateRetainsPaperFacingWaterContentEnvelope() {
-    SystemInterface system =
-        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface system = flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
     assertQualifiedState(system, "reference state");
 
     double waterInGas = gasWaterMoleFraction(system);
@@ -88,10 +81,8 @@ class TPflashUMRCPADehydrationLifecycleTest {
    */
   @Test
   void poorInitializationRecoversReferenceState() {
-    SystemInterface reference =
-        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
-    SystemInterface poor =
-        createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
+    SystemInterface reference = flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface poor = createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
     poor.init(0);
     assertTrue(poor.getNumberOfPhases() >= 2, "poor initialization requires two phase slots");
     poor.setBeta(0, 1.0e-12);
@@ -106,8 +97,7 @@ class TPflashUMRCPADehydrationLifecycleTest {
    */
   @Test
   void changedReturnedAndRepeatedStatesRemainEquivalent() {
-    SystemInterface reference =
-        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface reference = flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
     SystemInterface reused = reference.clone();
 
     reused.setTemperature(313.15, "K");
@@ -126,8 +116,7 @@ class TPflashUMRCPADehydrationLifecycleTest {
     assertEquivalentState(previous, reused, 1.0e-10, "deterministic repeat");
   }
 
-  private SystemInterface createSystem(
-      double temperatureK, double pressureBara, boolean multiphaseCheck) {
+  private SystemInterface createSystem(double temperatureK, double pressureBara, boolean multiphaseCheck) {
     SystemInterface system = new SystemUMRCPAEoS(temperatureK, pressureBara);
     system.addComponent("methane", METHANE_FEED);
     system.addComponent("water", WATER_FEED);
@@ -155,8 +144,7 @@ class TPflashUMRCPADehydrationLifecycleTest {
     double betaTotal = 0.0;
     for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
       double beta = system.getBeta(phase);
-      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0,
-          label + " beta " + phase + ": " + beta);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0, label + " beta " + phase + ": " + beta);
       betaTotal += beta;
 
       double compositionTotal = 0.0;
@@ -166,53 +154,43 @@ class TPflashUMRCPADehydrationLifecycleTest {
             label + " composition " + phase + "/" + component + ": " + composition);
         compositionTotal += composition;
       }
-      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE,
-          label + " composition normalization " + phase);
-      assertTrue(Double.isFinite(system.getPhase(phase).getZ())
-          && system.getPhase(phase).getZ() > 0.0, label + " compressibility " + phase);
+      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE, label + " composition normalization " + phase);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0,
+          label + " compressibility " + phase);
     }
     assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
 
     double materialResidual = maximumComponentMaterialBalanceResidual(system);
-    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
-        label + " material-balance residual " + materialResidual);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE, label + " material-balance residual " + materialResidual);
 
     double fugacityResidual = maximumComparableLogFugacityResidual(system);
-    assertTrue(fugacityResidual < FUGACITY_TOLERANCE,
-        label + " fugacity residual " + fugacityResidual);
+    assertTrue(fugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + fugacityResidual);
 
     assertTrue(Double.isFinite(system.getGibbsEnergy()), label + " Gibbs energy");
     assertTrue(Double.isFinite(system.getEnthalpy()), label + " enthalpy");
   }
 
-  private void assertEquivalentState(
-      SystemInterface expected, SystemInterface actual, double tolerance, String label) {
+  private void assertEquivalentState(SystemInterface expected, SystemInterface actual, double tolerance, String label) {
     assertQualifiedState(expected, label + " expected");
     assertQualifiedState(actual, label + " actual");
 
-    for (PhaseType type : new PhaseType[] {PhaseType.GAS, PhaseType.AQUEOUS}) {
+    for (PhaseType type : new PhaseType[] { PhaseType.GAS, PhaseType.AQUEOUS }) {
       int expectedPhase = findPhase(expected, type);
       int actualPhase = findPhase(actual, type);
-      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
-          label + " beta " + type);
-      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(),
-          tolerance, label + " compressibility " + type);
-      for (int component = 0;
-          component < expected.getPhase(expectedPhase).getNumberOfComponents();
-          component++) {
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance, label + " beta " + type);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), tolerance,
+          label + " compressibility " + type);
+      for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
         assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
             actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
             label + " composition " + type + "/" + component);
       }
     }
-    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance,
-        label + " Gibbs energy");
-    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance,
-        label + " enthalpy");
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance, label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance, label + " enthalpy");
   }
 
-  private void assertExtensiveEquals(
-      double expected, double actual, double relativeTolerance, String label) {
+  private void assertExtensiveEquals(double expected, double actual, double relativeTolerance, String label) {
     assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
   }
 
@@ -227,13 +205,10 @@ class TPflashUMRCPADehydrationLifecycleTest {
 
   private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
     double maximumResidual = 0.0;
-    for (int component = 0;
-        component < system.getPhase(0).getNumberOfComponents();
-        component++) {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       double recovered = 0.0;
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
-        recovered +=
-            system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
       }
       maximumResidual = Math.max(maximumResidual,
           Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
@@ -244,24 +219,18 @@ class TPflashUMRCPADehydrationLifecycleTest {
   private double maximumComparableLogFugacityResidual(SystemInterface system) {
     double maximumResidual = 0.0;
     int comparisons = 0;
-    for (int component = 0;
-        component < system.getPhase(0).getNumberOfComponents();
-        component++) {
-      double gasComposition =
-          system.getPhase(findPhase(system, PhaseType.GAS)).getComponent(component).getx();
-      double aqueousComposition =
-          system.getPhase(findPhase(system, PhaseType.AQUEOUS)).getComponent(component).getx();
-      double gasCoefficient = system.getPhase(findPhase(system, PhaseType.GAS))
-          .getComponent(component).getFugacityCoefficient();
-      double aqueousCoefficient = system.getPhase(findPhase(system, PhaseType.AQUEOUS))
-          .getComponent(component).getFugacityCoefficient();
-      if (gasComposition > 1.0e-20 && aqueousComposition > 1.0e-20
-          && Double.isFinite(gasCoefficient) && gasCoefficient > 0.0
-          && Double.isFinite(aqueousCoefficient) && aqueousCoefficient > 0.0) {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      double gasComposition = system.getPhase(findPhase(system, PhaseType.GAS)).getComponent(component).getx();
+      double aqueousComposition = system.getPhase(findPhase(system, PhaseType.AQUEOUS)).getComponent(component).getx();
+      double gasCoefficient = system.getPhase(findPhase(system, PhaseType.GAS)).getComponent(component)
+          .getFugacityCoefficient();
+      double aqueousCoefficient = system.getPhase(findPhase(system, PhaseType.AQUEOUS)).getComponent(component)
+          .getFugacityCoefficient();
+      if (gasComposition > 1.0e-20 && aqueousComposition > 1.0e-20 && Double.isFinite(gasCoefficient)
+          && gasCoefficient > 0.0 && Double.isFinite(aqueousCoefficient) && aqueousCoefficient > 0.0) {
         double gasLogFugacity = Math.log(gasComposition * gasCoefficient);
         double aqueousLogFugacity = Math.log(aqueousComposition * aqueousCoefficient);
-        maximumResidual =
-            Math.max(maximumResidual, Math.abs(gasLogFugacity - aqueousLogFugacity));
+        maximumResidual = Math.max(maximumResidual, Math.abs(gasLogFugacity - aqueousLogFugacity));
         comparisons++;
       }
     }


### PR DESCRIPTION
## Summary

Advances #2937 with a bounded UMR-CPA methane-water dehydration lifecycle qualification.

- adds a 20-flash temperature/pressure, algorithm-agreement, poor-initialization, and changed/returned-state matrix
- retains the established 298.15 K / 70 bara paper-facing gas-water model envelope
- requires strict material and fugacity closure, phase-role resolution, bounded compositions, positive compressibility, and deterministic reuse
- documents composition, units, provenance, validity range, fixed workload, and explicit stop boundaries

Capability contract: https://github.com/equinor/neqsim/issues/2937#issuecomment-5556892913

## Exact-head contract

- Base: `c9881535945252ab2a58db74b52dc9513bfbf51f`
- Publication head: `6e9db32a187daaa41d599084212277b0d6fd3edd`
- Branch: `codex/2937-umr-cpa-dehydration-lifecycle`
- Four ordered commits across two intended files

## Numerical acceptance

The synthetic `SystemUMRCPAEoS` calculation uses normalized methane/water `0.98/0.02`, `HV` / `UNIFAC_UMRPRU`, 283.15–313.15 K, and 30–120 bara.

Every qualified endpoint requires:

- GAS+AQUEOUS topology
- beta and phase-composition normalization within `3e-12`
- component material-balance residual below `1e-10`
- maximum comparable methane/water interphase log-fugacity residual below `1e-8`
- finite bounded beta/compositions, positive compressibility, and finite Gibbs energy/enthalpy
- ordinary/multiphase agreement
- recovery from beta within `1e-12` of a bound
- temperature and pressure water-content trends
- changed/returned-state equivalence and deterministic repeat

The 20 complete flashes are a fixed-workload performance record only; no wall-clock threshold or speedup is claimed.

## Validation

**VALIDATION PENDING CI — JAVA 8 UBUNTU ACTIVE**

On exact head `6e9db32a187daaa41d599084212277b0d6fd3edd`, Spotless, pre-commit, documentation/search, CodeQL, agent-skill checks, Javadocs, Java 21 Ubuntu/Windows, and all four slow shards pass. Java 8 Windows passes; Java 8 Ubuntu is the sole active lane without a reported failure.

The predecessor's only failure was Spotless line layout in the new Java test; this head applies the exact hosted formatter artifact without changing any scientific or numerical assertion. No local Maven, Java, Spotless, pre-commit, or documentation result is claimed.

## Documentation impact

`docs/thermodynamicoperations/TPflash_algorithm.md` now records the feed, units, range, numerical gates, lifecycle matrix, workload, provenance limitation, and excluded scopes.

## Portfolio and boundaries

Current autonomous implementation-portfolio occupancy is **5/10** (#3491–#3494 and #3498), below the ten-capability ceiling. This is the sole active #2937 implementation PR.

This tranche does not modify production solvers, public APIs, EOS/association/UNIFAC parameters, TEG derivatives, saturation operations, electrolyte/reaction models, Column Solver, Process Performance, proprietary data, or Huldra.

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.