### PR TITLE
[AI-Assisted] feat(refinery): qualify D86 TBP reference conversion

### DIFF
--- a/docs/standards/oil_quality_standards.md
+++ b/docs/standards/oil_quality_standards.md
@@ -700,6 +700,48 @@ print(f"Classification: {d4052.getOilClassification()}")
 
 ---
 
+
+## Riazi-Daubert D86/TBP reference conversion
+
+`RiaziDaubertDistillationConversion` exposes the seven discrete recovery points from the
+Riazi-Daubert atmospheric distillation interconversion as a Java/JPype-friendly, fail-closed API.
+The source relation is
+
+$T_{\mathrm{TBP}} = a\,T_{\mathrm{D86}}^b$
+
+where both temperatures are evaluated in kelvin at the same liquid-volume percentage recovered.
+The public methods accept and return degrees Celsius and perform the kelvin conversion internally.
+
+```java
+double tbpT50C =
+    RiaziDaubertDistillationConversion.convertD86ToTbpC(101.5, 50.0);
+double recoveredD86T50C =
+    RiaziDaubertDistillationConversion.convertTbpToD86C(tbpT50C, 50.0);
+```
+
+Only 0, 10, 30, 50, 70, 90, and 95 vol% are qualified. Intermediate percentages are rejected
+because coefficient interpolation is not part of this reference-point contract. Each point also
+has a source-defined D86 temperature range; input or inverse results outside that range are
+rejected. `getReferenceData()` returns a defensive copy with columns
+
+`[recovery vol%, a, b, minimum D86 C, maximum D86 C, example D86 C, example TBP C]`.
+
+The public worked example converts D86
+`[36.5, 54.1, 76.9, 101.5, 131.0, 171.0, 186.5] °C` to TBP
+`[14.1, 33.4, 68.9, 101.6, 135.1, 180.5, 194.1] °C`, subject to published rounding.
+
+Source: M. R. Riazi and T. E. Daubert, “Analytical correlations interconvert
+distillation-curve types,” *Oil & Gas Journal*, vol. 84, no. 34, pp. 50–54, 57,
+August 25, 1986 ([public bibliographic record](https://www.osti.gov/biblio/5212509)).
+
+This empirical conversion does not implement the ASTM D86 laboratory procedure, establish
+standards conformance, or independently validate NeqSim's simulated full curve against
+laboratory measurements. The existing `Standard_ASTM_D86.TBP_CONVERTED` reporting basis also
+retains its legacy coefficient interpolation behavior and therefore has a broader, explicitly
+unqualified boundary than this discrete reference API.
+
+---
+
 ## Related Documentation
 
 - [ASTM D6377 - simulated vapour pressure](astm_d6377_rvp.md)

--- a/src/main/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversion.java
+++ b/src/main/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversion.java
@@ -1,40 +1,42 @@
 package neqsim.standards.oilquality;
 
 /**
- * Literature-qualified reference-point conversion between ASTM D86 and atmospheric true boiling
- * point (TBP) temperatures.
+ * Literature-qualified reference-point conversion between ASTM D86 and atmospheric true boiling point (TBP)
+ * temperatures.
  *
- * <p>The correlation is {@code T_TBP = a * T_D86^b}, with both temperatures in kelvin. Coefficients
- * and applicability ranges are defined at seven discrete liquid-volume recovery points. This class
- * intentionally rejects intermediate recovery percentages rather than inventing an interpolation
- * rule that is not part of the qualified reference-point contract.</p>
+ * <p>
+ * The correlation is {@code T_TBP = a * T_D86^b}, with both temperatures in kelvin. Coefficients and applicability
+ * ranges are defined at seven discrete liquid-volume recovery points. This class intentionally rejects intermediate
+ * recovery percentages rather than inventing an interpolation rule that is not part of the qualified reference-point
+ * contract.
+ * </p>
  *
- * <p>Source: M. R. Riazi and T. E. Daubert, "Analytical correlations interconvert
- * distillation-curve types," Oil &amp; Gas Journal, vol. 84, no. 34, pp. 50-54, 57, August 25,
- * 1986. Public bibliographic record: https://www.osti.gov/biblio/5212509.</p>
+ * <p>
+ * Source: M. R. Riazi and T. E. Daubert, "Analytical correlations interconvert distillation-curve types," Oil &amp; Gas
+ * Journal, vol. 84, no. 34, pp. 50-54, 57, August 25, 1986. Public bibliographic record:
+ * https://www.osti.gov/biblio/5212509.
+ * </p>
  *
- * <p>This empirical conversion is not an implementation of the ASTM D86 test procedure and does
- * not establish standards compliance.</p>
+ * <p>
+ * This empirical conversion is not an implementation of the ASTM D86 test procedure and does not establish standards
+ * compliance.
+ * </p>
  */
 public final class RiaziDaubertDistillationConversion {
   private static final double CELSIUS_TO_KELVIN = 273.15;
   private static final double POINT_TOLERANCE = 1.0e-9;
 
   /**
-   * Rows are recovery vol%, a, b, minimum D86 temperature in C, maximum D86 temperature in C,
-   * worked-example D86 temperature in C, and worked-example TBP temperature in C.
+   * Rows are recovery vol%, a, b, minimum D86 temperature in C, maximum D86 temperature in C, worked-example D86
+   * temperature in C, and worked-example TBP temperature in C.
    */
-  private static final double[][] REFERENCE_DATA = {
-    {0.0, 0.9177, 1.0019, 20.0, 320.0, 36.5, 14.1},
-    {10.0, 0.5564, 1.0900, 35.0, 305.0, 54.1, 33.4},
-    {30.0, 0.7617, 1.0425, 50.0, 315.0, 76.9, 68.9},
-    {50.0, 0.9013, 1.0176, 55.0, 320.0, 101.5, 101.6},
-    {70.0, 0.8821, 1.0226, 65.0, 330.0, 131.0, 135.1},
-    {90.0, 0.9552, 1.0110, 75.0, 345.0, 171.0, 180.5},
-    {95.0, 0.8177, 1.0355, 75.0, 400.0, 186.5, 194.1}
-  };
+  private static final double[][] REFERENCE_DATA = { { 0.0, 0.9177, 1.0019, 20.0, 320.0, 36.5, 14.1 },
+      { 10.0, 0.5564, 1.0900, 35.0, 305.0, 54.1, 33.4 }, { 30.0, 0.7617, 1.0425, 50.0, 315.0, 76.9, 68.9 },
+      { 50.0, 0.9013, 1.0176, 55.0, 320.0, 101.5, 101.6 }, { 70.0, 0.8821, 1.0226, 65.0, 330.0, 131.0, 135.1 },
+      { 90.0, 0.9552, 1.0110, 75.0, 345.0, 171.0, 180.5 }, { 95.0, 0.8177, 1.0355, 75.0, 400.0, 186.5, 194.1 } };
 
-  private RiaziDaubertDistillationConversion() {}
+  private RiaziDaubertDistillationConversion() {
+  }
 
   /**
    * Converts a D86 temperature to TBP at a published recovery point.
@@ -42,8 +44,7 @@ public final class RiaziDaubertDistillationConversion {
    * @param d86TemperatureC D86 temperature in degrees Celsius
    * @param recoveryVolumePercent liquid-volume percent recovered
    * @return TBP temperature in degrees Celsius
-   * @throws IllegalArgumentException if the recovery point or temperature is outside the published
-   *         reference domain
+   * @throws IllegalArgumentException if the recovery point or temperature is outside the published reference domain
    */
   public static double convertD86ToTbpC(double d86TemperatureC, double recoveryVolumePercent) {
     int index = requireReferencePoint(recoveryVolumePercent);
@@ -54,8 +55,7 @@ public final class RiaziDaubertDistillationConversion {
     if (d86TemperatureK <= 0.0) {
       throw new IllegalArgumentException("D86 temperature must be above absolute zero");
     }
-    double tbpTemperatureK =
-        REFERENCE_DATA[index][1] * Math.pow(d86TemperatureK, REFERENCE_DATA[index][2]);
+    double tbpTemperatureK = REFERENCE_DATA[index][1] * Math.pow(d86TemperatureK, REFERENCE_DATA[index][2]);
     if (!isFinite(tbpTemperatureK) || tbpTemperatureK <= 0.0) {
       throw new IllegalArgumentException("D86 to TBP conversion produced an invalid temperature");
     }
@@ -68,8 +68,8 @@ public final class RiaziDaubertDistillationConversion {
    * @param tbpTemperatureC TBP temperature in degrees Celsius
    * @param recoveryVolumePercent liquid-volume percent recovered
    * @return D86 temperature in degrees Celsius
-   * @throws IllegalArgumentException if the recovery point is unsupported or the inverse result is
-   *         outside the published D86-temperature domain
+   * @throws IllegalArgumentException if the recovery point is unsupported or the inverse result is outside the
+   * published D86-temperature domain
    */
   public static double convertTbpToD86C(double tbpTemperatureC, double recoveryVolumePercent) {
     int index = requireReferencePoint(recoveryVolumePercent);
@@ -79,8 +79,7 @@ public final class RiaziDaubertDistillationConversion {
     if (tbpTemperatureK <= 0.0) {
       throw new IllegalArgumentException("TBP temperature must be above absolute zero");
     }
-    double d86TemperatureK =
-        Math.pow(tbpTemperatureK / REFERENCE_DATA[index][1], 1.0 / REFERENCE_DATA[index][2]);
+    double d86TemperatureK = Math.pow(tbpTemperatureK / REFERENCE_DATA[index][1], 1.0 / REFERENCE_DATA[index][2]);
     if (!isFinite(d86TemperatureK) || d86TemperatureK <= 0.0) {
       throw new IllegalArgumentException("TBP to D86 conversion produced an invalid temperature");
     }
@@ -110,8 +109,7 @@ public final class RiaziDaubertDistillationConversion {
   /**
    * Returns a defensive copy of the qualified reference data.
    *
-   * @return rows containing recovery vol%, a, b, minimum D86 C, maximum D86 C, example D86 C, and
-   *         example TBP C
+   * @return rows containing recovery vol%, a, b, minimum D86 C, maximum D86 C, example D86 C, and example TBP C
    */
   public static double[][] getReferenceData() {
     double[][] copy = new double[REFERENCE_DATA.length][];
@@ -139,16 +137,14 @@ public final class RiaziDaubertDistillationConversion {
         return i;
       }
     }
-    throw new IllegalArgumentException(
-        "Unsupported recovery volume percent; use 0, 10, 30, 50, 70, 90, or 95");
+    throw new IllegalArgumentException("Unsupported recovery volume percent; use 0, 10, 30, 50, 70, 90, or 95");
   }
 
   private static void requireD86TemperatureInRange(double d86TemperatureC, int index) {
     double minimumC = REFERENCE_DATA[index][3];
     double maximumC = REFERENCE_DATA[index][4];
     if (d86TemperatureC < minimumC || d86TemperatureC > maximumC) {
-      throw new IllegalArgumentException(
-          "D86 temperature is outside the published range at this recovery point");
+      throw new IllegalArgumentException("D86 temperature is outside the published range at this recovery point");
     }
   }
 
@@ -162,3 +158,4 @@ public final class RiaziDaubertDistillationConversion {
     return !Double.isNaN(value) && !Double.isInfinite(value);
   }
 }
+

--- a/src/main/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversion.java
+++ b/src/main/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversion.java
@@ -158,4 +158,3 @@ public final class RiaziDaubertDistillationConversion {
     return !Double.isNaN(value) && !Double.isInfinite(value);
   }
 }
-

--- a/src/main/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversion.java
+++ b/src/main/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversion.java
@@ -1,0 +1,164 @@
+package neqsim.standards.oilquality;
+
+/**
+ * Literature-qualified reference-point conversion between ASTM D86 and atmospheric true boiling
+ * point (TBP) temperatures.
+ *
+ * <p>The correlation is {@code T_TBP = a * T_D86^b}, with both temperatures in kelvin. Coefficients
+ * and applicability ranges are defined at seven discrete liquid-volume recovery points. This class
+ * intentionally rejects intermediate recovery percentages rather than inventing an interpolation
+ * rule that is not part of the qualified reference-point contract.</p>
+ *
+ * <p>Source: M. R. Riazi and T. E. Daubert, "Analytical correlations interconvert
+ * distillation-curve types," Oil &amp; Gas Journal, vol. 84, no. 34, pp. 50-54, 57, August 25,
+ * 1986. Public bibliographic record: https://www.osti.gov/biblio/5212509.</p>
+ *
+ * <p>This empirical conversion is not an implementation of the ASTM D86 test procedure and does
+ * not establish standards compliance.</p>
+ */
+public final class RiaziDaubertDistillationConversion {
+  private static final double CELSIUS_TO_KELVIN = 273.15;
+  private static final double POINT_TOLERANCE = 1.0e-9;
+
+  /**
+   * Rows are recovery vol%, a, b, minimum D86 temperature in C, maximum D86 temperature in C,
+   * worked-example D86 temperature in C, and worked-example TBP temperature in C.
+   */
+  private static final double[][] REFERENCE_DATA = {
+    {0.0, 0.9177, 1.0019, 20.0, 320.0, 36.5, 14.1},
+    {10.0, 0.5564, 1.0900, 35.0, 305.0, 54.1, 33.4},
+    {30.0, 0.7617, 1.0425, 50.0, 315.0, 76.9, 68.9},
+    {50.0, 0.9013, 1.0176, 55.0, 320.0, 101.5, 101.6},
+    {70.0, 0.8821, 1.0226, 65.0, 330.0, 131.0, 135.1},
+    {90.0, 0.9552, 1.0110, 75.0, 345.0, 171.0, 180.5},
+    {95.0, 0.8177, 1.0355, 75.0, 400.0, 186.5, 194.1}
+  };
+
+  private RiaziDaubertDistillationConversion() {}
+
+  /**
+   * Converts a D86 temperature to TBP at a published recovery point.
+   *
+   * @param d86TemperatureC D86 temperature in degrees Celsius
+   * @param recoveryVolumePercent liquid-volume percent recovered
+   * @return TBP temperature in degrees Celsius
+   * @throws IllegalArgumentException if the recovery point or temperature is outside the published
+   *         reference domain
+   */
+  public static double convertD86ToTbpC(double d86TemperatureC, double recoveryVolumePercent) {
+    int index = requireReferencePoint(recoveryVolumePercent);
+    requireFinite(d86TemperatureC, "D86 temperature");
+    requireD86TemperatureInRange(d86TemperatureC, index);
+
+    double d86TemperatureK = d86TemperatureC + CELSIUS_TO_KELVIN;
+    if (d86TemperatureK <= 0.0) {
+      throw new IllegalArgumentException("D86 temperature must be above absolute zero");
+    }
+    double tbpTemperatureK =
+        REFERENCE_DATA[index][1] * Math.pow(d86TemperatureK, REFERENCE_DATA[index][2]);
+    if (!isFinite(tbpTemperatureK) || tbpTemperatureK <= 0.0) {
+      throw new IllegalArgumentException("D86 to TBP conversion produced an invalid temperature");
+    }
+    return tbpTemperatureK - CELSIUS_TO_KELVIN;
+  }
+
+  /**
+   * Converts a TBP temperature to D86 at a published recovery point.
+   *
+   * @param tbpTemperatureC TBP temperature in degrees Celsius
+   * @param recoveryVolumePercent liquid-volume percent recovered
+   * @return D86 temperature in degrees Celsius
+   * @throws IllegalArgumentException if the recovery point is unsupported or the inverse result is
+   *         outside the published D86-temperature domain
+   */
+  public static double convertTbpToD86C(double tbpTemperatureC, double recoveryVolumePercent) {
+    int index = requireReferencePoint(recoveryVolumePercent);
+    requireFinite(tbpTemperatureC, "TBP temperature");
+
+    double tbpTemperatureK = tbpTemperatureC + CELSIUS_TO_KELVIN;
+    if (tbpTemperatureK <= 0.0) {
+      throw new IllegalArgumentException("TBP temperature must be above absolute zero");
+    }
+    double d86TemperatureK =
+        Math.pow(tbpTemperatureK / REFERENCE_DATA[index][1], 1.0 / REFERENCE_DATA[index][2]);
+    if (!isFinite(d86TemperatureK) || d86TemperatureK <= 0.0) {
+      throw new IllegalArgumentException("TBP to D86 conversion produced an invalid temperature");
+    }
+    double d86TemperatureC = d86TemperatureK - CELSIUS_TO_KELVIN;
+    requireD86TemperatureInRange(d86TemperatureC, index);
+    return d86TemperatureC;
+  }
+
+  /**
+   * Returns whether a recovery percentage is one of the seven published reference points.
+   *
+   * @param recoveryVolumePercent liquid-volume percent recovered
+   * @return true for 0, 10, 30, 50, 70, 90, or 95 vol%
+   */
+  public static boolean isSupportedRecoveryPoint(double recoveryVolumePercent) {
+    if (!isFinite(recoveryVolumePercent)) {
+      return false;
+    }
+    for (int i = 0; i < REFERENCE_DATA.length; i++) {
+      if (Math.abs(recoveryVolumePercent - REFERENCE_DATA[i][0]) <= POINT_TOLERANCE) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns a defensive copy of the qualified reference data.
+   *
+   * @return rows containing recovery vol%, a, b, minimum D86 C, maximum D86 C, example D86 C, and
+   *         example TBP C
+   */
+  public static double[][] getReferenceData() {
+    double[][] copy = new double[REFERENCE_DATA.length][];
+    for (int i = 0; i < REFERENCE_DATA.length; i++) {
+      copy[i] = REFERENCE_DATA[i].clone();
+    }
+    return copy;
+  }
+
+  /**
+   * Returns the public bibliographic record for the source correlation.
+   *
+   * @return source URI
+   */
+  public static String getSourceUri() {
+    return "https://www.osti.gov/biblio/5212509";
+  }
+
+  private static int requireReferencePoint(double recoveryVolumePercent) {
+    if (!isFinite(recoveryVolumePercent)) {
+      throw new IllegalArgumentException("Recovery volume percent must be finite");
+    }
+    for (int i = 0; i < REFERENCE_DATA.length; i++) {
+      if (Math.abs(recoveryVolumePercent - REFERENCE_DATA[i][0]) <= POINT_TOLERANCE) {
+        return i;
+      }
+    }
+    throw new IllegalArgumentException(
+        "Unsupported recovery volume percent; use 0, 10, 30, 50, 70, 90, or 95");
+  }
+
+  private static void requireD86TemperatureInRange(double d86TemperatureC, int index) {
+    double minimumC = REFERENCE_DATA[index][3];
+    double maximumC = REFERENCE_DATA[index][4];
+    if (d86TemperatureC < minimumC || d86TemperatureC > maximumC) {
+      throw new IllegalArgumentException(
+          "D86 temperature is outside the published range at this recovery point");
+    }
+  }
+
+  private static void requireFinite(double value, String name) {
+    if (!isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+}

--- a/src/test/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversionTest.java
+++ b/src/test/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversionTest.java
@@ -73,4 +73,3 @@ class RiaziDaubertDistillationConversionTest {
         () -> RiaziDaubertDistillationConversion.convertTbpToD86C(1000.0, 50.0));
   }
 }
-

--- a/src/test/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversionTest.java
+++ b/src/test/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversionTest.java
@@ -1,0 +1,88 @@
+package neqsim.standards.oilquality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests the literature-qualified Riazi-Daubert D86/TBP reference conversion. */
+class RiaziDaubertDistillationConversionTest {
+  private static final double[] RECOVERY_PERCENT = {0.0, 10.0, 30.0, 50.0, 70.0, 90.0, 95.0};
+  private static final double[] D86_C = {36.5, 54.1, 76.9, 101.5, 131.0, 171.0, 186.5};
+  private static final double[] TBP_C = {14.1, 33.4, 68.9, 101.6, 135.1, 180.5, 194.1};
+
+  @Test
+  void reproducesPublishedWorkedExample() {
+    double previousTbpC = Double.NEGATIVE_INFINITY;
+    for (int i = 0; i < RECOVERY_PERCENT.length; i++) {
+      double convertedTbpC =
+          RiaziDaubertDistillationConversion.convertD86ToTbpC(
+              D86_C[i], RECOVERY_PERCENT[i]);
+      assertEquals(TBP_C[i], convertedTbpC, 0.08, "published rounded TBP value");
+      assertTrue(convertedTbpC > previousTbpC, "converted reference curve must be ordered");
+      previousTbpC = convertedTbpC;
+    }
+  }
+
+  @Test
+  void inverseConversionClosesAtEveryReferencePoint() {
+    for (int i = 0; i < RECOVERY_PERCENT.length; i++) {
+      double tbpC =
+          RiaziDaubertDistillationConversion.convertD86ToTbpC(
+              D86_C[i], RECOVERY_PERCENT[i]);
+      double recoveredD86C =
+          RiaziDaubertDistillationConversion.convertTbpToD86C(
+              tbpC, RECOVERY_PERCENT[i]);
+      assertEquals(D86_C[i], recoveredD86C, 1.0e-10, "D86 inverse round trip");
+
+      double d86C =
+          RiaziDaubertDistillationConversion.convertTbpToD86C(
+              tbpC, RECOVERY_PERCENT[i]);
+      double recoveredTbpC =
+          RiaziDaubertDistillationConversion.convertD86ToTbpC(
+              d86C, RECOVERY_PERCENT[i]);
+      assertEquals(tbpC, recoveredTbpC, 1.0e-10, "TBP inverse round trip");
+    }
+  }
+
+  @Test
+  void referenceDataIsCompleteAndDefensivelyCopied() {
+    double[][] first = RiaziDaubertDistillationConversion.getReferenceData();
+    double[][] second = RiaziDaubertDistillationConversion.getReferenceData();
+
+    assertEquals(7, first.length);
+    assertEquals(7, first[0].length);
+    assertEquals(0.9177, first[0][1], 0.0);
+    assertEquals(1.0355, first[6][2], 0.0);
+    assertEquals(20.0, first[0][3], 0.0);
+    assertEquals(400.0, first[6][4], 0.0);
+    assertEquals("https://www.osti.gov/biblio/5212509",
+        RiaziDaubertDistillationConversion.getSourceUri());
+
+    first[0][1] = -1.0;
+    assertEquals(0.9177, second[0][1], 0.0);
+    assertEquals(0.9177, RiaziDaubertDistillationConversion.getReferenceData()[0][1], 0.0);
+  }
+
+  @Test
+  void rejectsUnsupportedOrOutOfDomainInputs() {
+    assertTrue(RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(0.0));
+    assertTrue(RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(95.0));
+    assertTrue(!RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(5.0));
+    assertTrue(!RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(Double.NaN));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(100.0, 5.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(Double.NaN, 50.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(34.9, 10.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(400.1, 95.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RiaziDaubertDistillationConversion.convertTbpToD86C(-273.15, 50.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RiaziDaubertDistillationConversion.convertTbpToD86C(1000.0, 50.0));
+  }
+}

--- a/src/test/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversionTest.java
+++ b/src/test/java/neqsim/standards/oilquality/RiaziDaubertDistillationConversionTest.java
@@ -8,17 +8,15 @@ import org.junit.jupiter.api.Test;
 
 /** Tests the literature-qualified Riazi-Daubert D86/TBP reference conversion. */
 class RiaziDaubertDistillationConversionTest {
-  private static final double[] RECOVERY_PERCENT = {0.0, 10.0, 30.0, 50.0, 70.0, 90.0, 95.0};
-  private static final double[] D86_C = {36.5, 54.1, 76.9, 101.5, 131.0, 171.0, 186.5};
-  private static final double[] TBP_C = {14.1, 33.4, 68.9, 101.6, 135.1, 180.5, 194.1};
+  private static final double[] RECOVERY_PERCENT = { 0.0, 10.0, 30.0, 50.0, 70.0, 90.0, 95.0 };
+  private static final double[] D86_C = { 36.5, 54.1, 76.9, 101.5, 131.0, 171.0, 186.5 };
+  private static final double[] TBP_C = { 14.1, 33.4, 68.9, 101.6, 135.1, 180.5, 194.1 };
 
   @Test
   void reproducesPublishedWorkedExample() {
     double previousTbpC = Double.NEGATIVE_INFINITY;
     for (int i = 0; i < RECOVERY_PERCENT.length; i++) {
-      double convertedTbpC =
-          RiaziDaubertDistillationConversion.convertD86ToTbpC(
-              D86_C[i], RECOVERY_PERCENT[i]);
+      double convertedTbpC = RiaziDaubertDistillationConversion.convertD86ToTbpC(D86_C[i], RECOVERY_PERCENT[i]);
       assertEquals(TBP_C[i], convertedTbpC, 0.08, "published rounded TBP value");
       assertTrue(convertedTbpC > previousTbpC, "converted reference curve must be ordered");
       previousTbpC = convertedTbpC;
@@ -28,20 +26,12 @@ class RiaziDaubertDistillationConversionTest {
   @Test
   void inverseConversionClosesAtEveryReferencePoint() {
     for (int i = 0; i < RECOVERY_PERCENT.length; i++) {
-      double tbpC =
-          RiaziDaubertDistillationConversion.convertD86ToTbpC(
-              D86_C[i], RECOVERY_PERCENT[i]);
-      double recoveredD86C =
-          RiaziDaubertDistillationConversion.convertTbpToD86C(
-              tbpC, RECOVERY_PERCENT[i]);
+      double tbpC = RiaziDaubertDistillationConversion.convertD86ToTbpC(D86_C[i], RECOVERY_PERCENT[i]);
+      double recoveredD86C = RiaziDaubertDistillationConversion.convertTbpToD86C(tbpC, RECOVERY_PERCENT[i]);
       assertEquals(D86_C[i], recoveredD86C, 1.0e-10, "D86 inverse round trip");
 
-      double d86C =
-          RiaziDaubertDistillationConversion.convertTbpToD86C(
-              tbpC, RECOVERY_PERCENT[i]);
-      double recoveredTbpC =
-          RiaziDaubertDistillationConversion.convertD86ToTbpC(
-              d86C, RECOVERY_PERCENT[i]);
+      double d86C = RiaziDaubertDistillationConversion.convertTbpToD86C(tbpC, RECOVERY_PERCENT[i]);
+      double recoveredTbpC = RiaziDaubertDistillationConversion.convertD86ToTbpC(d86C, RECOVERY_PERCENT[i]);
       assertEquals(tbpC, recoveredTbpC, 1.0e-10, "TBP inverse round trip");
     }
   }
@@ -57,8 +47,7 @@ class RiaziDaubertDistillationConversionTest {
     assertEquals(1.0355, first[6][2], 0.0);
     assertEquals(20.0, first[0][3], 0.0);
     assertEquals(400.0, first[6][4], 0.0);
-    assertEquals("https://www.osti.gov/biblio/5212509",
-        RiaziDaubertDistillationConversion.getSourceUri());
+    assertEquals("https://www.osti.gov/biblio/5212509", RiaziDaubertDistillationConversion.getSourceUri());
 
     first[0][1] = -1.0;
     assertEquals(0.9177, second[0][1], 0.0);
@@ -72,12 +61,10 @@ class RiaziDaubertDistillationConversionTest {
     assertTrue(!RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(5.0));
     assertTrue(!RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(Double.NaN));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(100.0, 5.0));
+    assertThrows(IllegalArgumentException.class, () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(100.0, 5.0));
     assertThrows(IllegalArgumentException.class,
         () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(Double.NaN, 50.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(34.9, 10.0));
+    assertThrows(IllegalArgumentException.class, () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(34.9, 10.0));
     assertThrows(IllegalArgumentException.class,
         () -> RiaziDaubertDistillationConversion.convertD86ToTbpC(400.1, 95.0));
     assertThrows(IllegalArgumentException.class,
@@ -86,3 +73,4 @@ class RiaziDaubertDistillationConversionTest {
         () -> RiaziDaubertDistillationConversion.convertTbpToD86C(1000.0, 50.0));
   }
 }
+


### PR DESCRIPTION
## Summary

Advances #3305 with a literature-qualified, Java/JPype-friendly reference-point conversion between ASTM D86 and atmospheric true boiling point (TBP) temperatures.

- preserves the seven published liquid-volume recovery points and coefficients;
- uses the published Kelvin power law `T_TBP = a × T_D86^b` and its analytical inverse;
- enforces each point's published D86 temperature applicability range;
- rejects unsupported recovery percentages, non-finite inputs, nonphysical temperatures, and inverse results outside the source domain;
- returns defensive reference-data copies and a public source URI;
- reproduces the public worked example, verifies inverse closure and ordering, and documents the scientific boundary.

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5557130085

## Exact-head contract

- Exact base: `c9881535945252ab2a58db74b52dc9513bfbf51f`
- Exact current head: `9b8ef27ddc99399c9139a4a01c0c40ccdb254e07`
- Branch: `codex/3305-riazi-daubert-reference-conversion`
- Eight ordered commits across three intended files; the final two remove only hosted-Spotless trailing blank lines
- Zero commits behind the recorded base at publication

## Scientific acceptance

The public worked example converts D86
`[36.5, 54.1, 76.9, 101.5, 131.0, 171.0, 186.5] °C` at
`[0, 10, 30, 50, 70, 90, 95] vol%` to TBP
`[14.1, 33.4, 68.9, 101.6, 135.1, 180.5, 194.1] °C`, within source rounding.

Focused tests require:

- all seven published coefficient and applicability records;
- worked-example agreement within `0.08 °C`;
- strict monotonic ordering of the converted reference curve;
- D86→TBP→D86 and TBP→D86→TBP closure within `1e-10 °C`;
- defensive-copy behavior;
- fail-closed unsupported percentages, NaN, absolute-zero, and out-of-domain temperatures.

## Provenance

M. R. Riazi and T. E. Daubert, “Analytical correlations interconvert distillation-curve types,” *Oil & Gas Journal*, vol. 84, no. 34, pp. 50–54, 57, August 25, 1986.

Public bibliographic record and abstract: https://www.osti.gov/biblio/5212509

Only numerical facts and equations are represented with attribution. No ASTM procedure text is copied.

## Validation

**READY TO MERGE** on exact head `9b8ef27ddc99399c9139a4a01c0c40ccdb254e07`.

All exact-head GitHub Actions pass: Java 8/21 on Ubuntu and Windows, all four slow-test shards, full tests and Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, and agent-skill checks. The final two commits remove only the hosted Spotless trailing blank line from each new Java file; no semantic, scientific, test, API, provenance, acceptance-limit, or documentation content changed.

## Documentation impact

`docs/standards/oil_quality_standards.md` now documents the API, units, equation, supported recovery points, applicability boundary, example, source, and exclusions.

## Portfolio and overlap

This is the sole active #3305 implementation PR. Five other autonomous implementation drafts are positively identified (#3493, #3494, #3498, #3500, #3501), giving current occupancy **6/10**. No changed file overlaps those active drafts.

## Stop boundary

This increment qualifies only the seven discrete literature reference points. It does not change PVF flashes, fraction interpolation, default `MOLAR` behavior, liquid-volume recovery, barometric correction, specification logic, pseudo-component characterization, or Sarir data. It does not implement the ASTM D86 laboratory procedure, establish standards conformance, or independently validate NeqSim's simulated full curve against laboratory measurements. The legacy `Standard_ASTM_D86.TBP_CONVERTED` interpolation remains explicitly outside this qualification.

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.

Generated with AI assistance.