### PR TITLE
[AI-Assisted] docs(examples): make comparison quickstart executable

### DIFF
--- a/docs/examples/comparesimulations_quickstart.md
+++ b/docs/examples/comparesimulations_quickstart.md
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.util.report.Report;
@@ -56,7 +57,7 @@ public final class ProcessComparisonQuickStart {
     inletSection.add(firstStageSeparator);
 
     // 3) Create the compressor section from the separator gas outlet.
-    Stream compressorFeed = firstStageSeparator.getGasOutStream();
+    StreamInterface compressorFeed = firstStageSeparator.getGasOutStream();
     Compressor compressor1 = new Compressor("Compressor1", compressorFeed);
     compressor1.setPolytropicEfficiency(0.56);
     compressor1.setUsePolytropicCalc(true);

--- a/docs/examples/comparesimulations_quickstart.md
+++ b/docs/examples/comparesimulations_quickstart.md
@@ -19,6 +19,8 @@ other tools.
 ## Step-by-step Java example
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.stream.Stream;
@@ -28,51 +30,62 @@ import neqsim.process.util.report.Report;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-// 1) Build the feed to mirror the notebook composition
-SystemInterface wellFluid = new SystemSrkEos(310.0, 50.0); // T=310 K, p=50 bara
-wellFluid.addComponent("methane", 0.8);
-wellFluid.addComponent("ethane", 0.1);
-wellFluid.addComponent("propane", 0.05);
-wellFluid.addComponent("n-butane", 0.05);
-wellFluid.initProperties();
+public final class ProcessComparisonQuickStart {
+  private static final Logger logger =
+      LogManager.getLogger(ProcessComparisonQuickStart.class);
 
-// 2) Create the inlet process section (stream + three-phase separator)
-Stream wellStreamHP = new Stream("HP well stream", wellFluid);
-wellStreamHP.setFlowRate(10.0, "MSm3/day");
-ThreePhaseSeparator firstStageSeparator =
-    new ThreePhaseSeparator("1st stage separator", wellStreamHP);
+  private ProcessComparisonQuickStart() {}
 
-ProcessSystem inletSection = new ProcessSystem();
-inletSection.add(wellStreamHP);
-inletSection.add(firstStageSeparator);
+  public static void main(String[] args) {
+    // 1) Build the synthetic feed used by this comparison pattern.
+    SystemInterface wellFluid = new SystemSrkEos(310.0, 50.0);
+    wellFluid.addComponent("methane", 0.8);
+    wellFluid.addComponent("ethane", 0.1);
+    wellFluid.addComponent("propane", 0.05);
+    wellFluid.addComponent("n-butane", 0.05);
+    wellFluid.initProperties();
 
-// 3) Create the compressor section using the separator gas outlet
-Stream compressorFeed = firstStageSeparator.getGasOutStream();
-Compressor compressor1 = new Compressor("Compressor1", compressorFeed);
-compressor1.setPolytropicEfficiency(0.56);
-compressor1.setUsePolytropicCalc(true);
-compressor1.setOutletPressure(100.0, "bara");
+    // 2) Create the inlet process section.
+    Stream wellStreamHP = new Stream("HP well stream", wellFluid);
+    wellStreamHP.setFlowRate(10.0, "MSm3/day");
+    ThreePhaseSeparator firstStageSeparator =
+        new ThreePhaseSeparator("1st stage separator", wellStreamHP);
 
-ProcessSystem compressorSection = new ProcessSystem();
-compressorSection.add(compressorFeed);
-compressorSection.add(compressor1);
+    ProcessSystem inletSection = new ProcessSystem();
+    inletSection.add(wellStreamHP);
+    inletSection.add(firstStageSeparator);
 
-// 4) Combine the sections in a ProcessModel and run them sequentially
-ProcessModel combinedProcess = new ProcessModel();
-combinedProcess.add("feed process", inletSection);
-combinedProcess.add("compressor process", compressorSection);
-combinedProcess.setRunStep(true); // ensures each section runs in the order added
-combinedProcess.run();
+    // 3) Create the compressor section from the separator gas outlet.
+    Stream compressorFeed = firstStageSeparator.getGasOutStream();
+    Compressor compressor1 = new Compressor("Compressor1", compressorFeed);
+    compressor1.setPolytropicEfficiency(0.56);
+    compressor1.setUsePolytropicCalc(true);
+    compressor1.setOutletPressure(100.0, "bara");
 
-// 5) Read results or export the JSON report used for cross-tool comparison
-System.out.printf("Gas flow after separator: %.3f MSm3/day%n",
-    firstStageSeparator.getGasOutStream().getFlowRate("MSm3/day"));
-System.out.printf("Compressor outlet temperature: %.2f C%n",
-    compressor1.getOutletStream().getTemperature("C"));
+    ProcessSystem compressorSection = new ProcessSystem();
+    compressorSection.add(compressorFeed);
+    compressorSection.add(compressor1);
 
-Report reporter = new Report(combinedProcess);
-String jsonReport = reporter.generateJsonReport();
-System.out.println(jsonReport);
+    // 4) Combine the sections and run them sequentially.
+    ProcessModel combinedProcess = new ProcessModel();
+    combinedProcess.add("feed process", inletSection);
+    combinedProcess.add("compressor process", compressorSection);
+    combinedProcess.setRunStep(true);
+    combinedProcess.run();
+
+    // 5) Read bounded diagnostics and export the comparison report.
+    double gasFlow =
+        firstStageSeparator.getGasOutStream().getFlowRate("MSm3/day");
+    double outletTemperature =
+        compressor1.getOutletStream().getTemperature("C");
+    logger.info("Gas flow after separator: {} MSm3/day", gasFlow);
+    logger.info("Compressor outlet temperature: {} C", outletTemperature);
+
+    Report reporter = new Report(combinedProcess);
+    String jsonReport = reporter.generateJsonReport();
+    logger.info("{}", jsonReport);
+  }
+}
 ```
 
 Tips when translating the notebook to Java:

--- a/docs/test_tutorial_cookbook_examples_documentation.py
+++ b/docs/test_tutorial_cookbook_examples_documentation.py
@@ -66,6 +66,12 @@ INDEX_PAGES = (
     DOCS / "tutorials/index.md",
 )
 
+PROCESS_COMPARISON_PAGE = DOCS / "examples/comparesimulations_quickstart.md"
+COMBINED_MODELS_TEST = (
+    DOCS.parent
+    / "src/test/java/neqsim/process/processmodel/CombinedModelsTest.java"
+)
+
 
 def metadata_value(metadata, name):
     """Return a plain scalar, including folded YAML front-matter values."""
@@ -140,8 +146,60 @@ def link_candidates(page, raw_target):
     )
 
 
+def section_after_heading(source, heading):
+    """Return the Markdown section that starts at an exact level-two heading."""
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        source,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Missing section: {heading}")
+    return match.group("section")
+
+
 class TutorialCookbookExamplesDocumentationContractTest(unittest.TestCase):
     """Protect the frozen rotation-scope-6 documentation surface."""
+
+    def test_process_comparison_quickstart_matches_executable_regression(self):
+        page = PROCESS_COMPARISON_PAGE.read_text(encoding="utf-8")
+        java_test = COMBINED_MODELS_TEST.read_text(encoding="utf-8")
+        section = section_after_heading(page, "## Step-by-step Java example")
+
+        self.assertNotIn("System.out", section)
+        self.assertIn("ProcessComparisonQuickStart", section)
+        self.assertIn("LogManager.getLogger(ProcessComparisonQuickStart.class)", section)
+        self.assertIn("logger.info(", section)
+        self.assertIn("testProcessComparisonQuickStart", java_test)
+
+        workflow_markers = (
+            "new SystemSrkEos(310.0, 50.0)",
+            'setFlowRate(10.0, "MSm3/day")',
+            'new ThreePhaseSeparator("1st stage separator", wellStreamHP)',
+            "firstStageSeparator.getGasOutStream()",
+            'setOutletPressure(100.0, "bara")',
+            "combinedProcess.setRunStep(true)",
+            "combinedProcess.run()",
+            "reporter.generateJsonReport()",
+        )
+        for marker in workflow_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, section)
+                self.assertIn(marker, java_test)
+
+        regression_markers = (
+            "Double.isFinite(gasFlow)",
+            "gasFlow > 0.0",
+            "gasFlow <= 10.0",
+            "Double.isFinite(outletTemperature)",
+            "outletTemperature > 36.85",
+            "outletTemperature < 300.0",
+            "Assertions.assertFalse(jsonReport.isEmpty())",
+            "Assertions.assertEquals(combinedProcess.getReport_json(), jsonReport)",
+        )
+        for marker in regression_markers:
+            with self.subTest(regression_marker=marker):
+                self.assertIn(marker, java_test)
 
     def test_frozen_scope_exists(self):
         self.assertEqual(48, len(SCOPE_PAGES))

--- a/src/test/java/neqsim/process/processmodel/CombinedModelsTest.java
+++ b/src/test/java/neqsim/process/processmodel/CombinedModelsTest.java
@@ -11,6 +11,7 @@ import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.report.Report;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
 /**
  * CombinedModelsTest is a test class for validating the combined process model which includes an inlet model and a
@@ -129,4 +130,57 @@ public class CombinedModelsTest {
     Report reporter = new Report(fullProcess);
     Assertions.assertTrue(fullProcess.getReport_json().equals(reporter.generateJsonReport()));
   }
+
+  /** Verifies the complete synthetic process-comparison documentation quickstart. */
+  @Test
+  public void testProcessComparisonQuickStart() {
+    SystemInterface wellFluid = new SystemSrkEos(310.0, 50.0);
+    wellFluid.addComponent("methane", 0.8);
+    wellFluid.addComponent("ethane", 0.1);
+    wellFluid.addComponent("propane", 0.05);
+    wellFluid.addComponent("n-butane", 0.05);
+    wellFluid.initProperties();
+
+    Stream wellStreamHP = new Stream("HP well stream", wellFluid);
+    wellStreamHP.setFlowRate(10.0, "MSm3/day");
+    ThreePhaseSeparator firstStageSeparator =
+        new ThreePhaseSeparator("1st stage separator", wellStreamHP);
+
+    ProcessSystem inletSection = new ProcessSystem();
+    inletSection.add(wellStreamHP);
+    inletSection.add(firstStageSeparator);
+
+    Stream compressorFeed = firstStageSeparator.getGasOutStream();
+    Compressor compressor1 = new Compressor("Compressor1", compressorFeed);
+    compressor1.setPolytropicEfficiency(0.56);
+    compressor1.setUsePolytropicCalc(true);
+    compressor1.setOutletPressure(100.0, "bara");
+
+    ProcessSystem compressorSection = new ProcessSystem();
+    compressorSection.add(compressorFeed);
+    compressorSection.add(compressor1);
+
+    ProcessModel combinedProcess = new ProcessModel();
+    combinedProcess.add("feed process", inletSection);
+    combinedProcess.add("compressor process", compressorSection);
+    combinedProcess.setRunStep(true);
+    combinedProcess.run();
+
+    double gasFlow =
+        firstStageSeparator.getGasOutStream().getFlowRate("MSm3/day");
+    double outletTemperature =
+        compressor1.getOutletStream().getTemperature("C");
+    Assertions.assertTrue(Double.isFinite(gasFlow));
+    Assertions.assertTrue(gasFlow > 0.0);
+    Assertions.assertTrue(gasFlow <= 10.0);
+    Assertions.assertTrue(Double.isFinite(outletTemperature));
+    Assertions.assertTrue(outletTemperature > 36.85);
+    Assertions.assertTrue(outletTemperature < 300.0);
+
+    Report reporter = new Report(combinedProcess);
+    String jsonReport = reporter.generateJsonReport();
+    Assertions.assertFalse(jsonReport.isEmpty());
+    Assertions.assertEquals(combinedProcess.getReport_json(), jsonReport);
+  }
+
 }

--- a/src/test/java/neqsim/process/processmodel/CombinedModelsTest.java
+++ b/src/test/java/neqsim/process/processmodel/CombinedModelsTest.java
@@ -143,8 +143,7 @@ public class CombinedModelsTest {
 
     Stream wellStreamHP = new Stream("HP well stream", wellFluid);
     wellStreamHP.setFlowRate(10.0, "MSm3/day");
-    ThreePhaseSeparator firstStageSeparator =
-        new ThreePhaseSeparator("1st stage separator", wellStreamHP);
+    ThreePhaseSeparator firstStageSeparator = new ThreePhaseSeparator("1st stage separator", wellStreamHP);
 
     ProcessSystem inletSection = new ProcessSystem();
     inletSection.add(wellStreamHP);
@@ -166,10 +165,8 @@ public class CombinedModelsTest {
     combinedProcess.setRunStep(true);
     combinedProcess.run();
 
-    double gasFlow =
-        firstStageSeparator.getGasOutStream().getFlowRate("MSm3/day");
-    double outletTemperature =
-        compressor1.getOutletStream().getTemperature("C");
+    double gasFlow = firstStageSeparator.getGasOutStream().getFlowRate("MSm3/day");
+    double outletTemperature = compressor1.getOutletStream().getTemperature("C");
     Assertions.assertTrue(Double.isFinite(gasFlow));
     Assertions.assertTrue(gasFlow > 0.0);
     Assertions.assertTrue(gasFlow <= 10.0);

--- a/src/test/java/neqsim/process/processmodel/CombinedModelsTest.java
+++ b/src/test/java/neqsim/process/processmodel/CombinedModelsTest.java
@@ -149,7 +149,7 @@ public class CombinedModelsTest {
     inletSection.add(wellStreamHP);
     inletSection.add(firstStageSeparator);
 
-    Stream compressorFeed = firstStageSeparator.getGasOutStream();
+    StreamInterface compressorFeed = firstStageSeparator.getGasOutStream();
     Compressor compressor1 = new Compressor("Compressor1", compressorFeed);
     compressor1.setPolytropicEfficiency(0.56);
     compressor1.setUsePolytropicCalc(true);


### PR DESCRIPTION
## Summary

Advances #2499 as D127 by making the process-comparison Java quickstart complete, runnable, and source-linked to an exact executable regression.

- replaces the top-level fragment with a complete Java 8 `ProcessComparisonQuickStart` class
- uses parameterized Log4j2 diagnostics instead of `System.out`
- preserves the documented synthetic four-component fluid and sequential `ProcessModel` workflow
- adds bounded separator-flow and compressor-temperature assertions plus deterministic JSON-report coverage
- strengthens the 48-page tutorials/cookbook/troubleshooting/examples documentation contract

Campaign ledger: https://github.com/equinor/neqsim/issues/2499#issuecomment-5432666687

## Capability contract

**Capability:** process-comparison Java quickstart integrity  
**Exact base / publication-time master:** `234214c8f76d84d4821b6028760f7033adb3372d`  
**Exact repaired head:** `60f024bcb31f917631f974d060d24da011d5e807`  
**Branch:** `codex/d127-process-comparison-quickstart`  
**Scope:** six ordered commits across exactly three frozen files  
**Autonomous portfolio after reservation:** **5/10**

Frozen batch:

1. `docs/examples/comparesimulations_quickstart.md`
2. `docs/test_tutorial_cookbook_examples_documentation.py`
3. `src/test/java/neqsim/process/processmodel/CombinedModelsTest.java`

No changed file overlaps active autonomous drafts #3487, #3490, #3491, or #3492.

## Executable acceptance

The documentation and regression use the same synthetic workflow:

- SRK fluid at 310 K and 50 bar with methane/ethane/propane/n-butane `0.80/0.10/0.05/0.05`
- 10 MSm³/day feed through a `ThreePhaseSeparator`
- polytropic compressor at 0.56 efficiency and 100 bara outlet pressure
- sequential `ProcessModel` execution through `setRunStep(true)`

The focused Java test requires:

- finite gas flow greater than zero and no greater than the 10 MSm³/day feed
- finite compressor outlet temperature between 36.85 °C and 300 °C
- nonempty JSON output identical to `combinedProcess.getReport_json()`

The Python documentation contract binds the page to the executable test, requires the complete Java class and logger markers, and rejects `System.out`.

## Validation

**VALIDATION PENDING FRESH EXACT-HEAD CI**

Connector-side proposed-corpus checks at the exact publication head confirm:

- exactly three intended files and six ordered commits
- Python syntax parses
- Markdown fences balance
- Java braces balance
- the page contains a complete class and `main`
- the page contains no `System.out`
- the executable regression and bounded assertions are present

The predecessor head failed pre-commit only on three Spotless wraps, then repaired head `66b84d95a178601d51e4eb76ef3f29955102d2b3` failed test compilation because `getGasOutStream()` returns `StreamInterface`, not `Stream`. The current run applied the recorded bounded repair to both the documentation quickstart and executable regression: both now declare `StreamInterface compressorFeed`, and the page imports that interface. No calculation, assertion, workflow, evidence boundary, or frozen scope changed. The branch is six commits ahead and seven commits behind current `master` `a7fb137897cec05988ea7874b930af9cce38ee40`; it was intentionally not rebased or synchronized. Fresh GitHub Actions on exact head `60f024bcb31f917631f974d060d24da011d5e807` are authoritative. No local Maven or Java result is claimed.

## Evidence boundary

This change validates a synthetic NeqSim translation pattern and bounded internal consistency only. It does not establish HYSYS or DWSIM equivalence, field calibration, equipment design suitability, performance guarantees, standards conformance, or engineering approval.

No production API, notebook source/output, DEXPI/PFD, release, or Huldra scope is changed.

## Publication policy

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.