### PR TITLE
[AI-Assisted] Fix pure EOS-CG phase roots and VU flashes

### DIFF
--- a/src/main/java/neqsim/thermo/phase/PhaseEOSCGEos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEOSCGEos.java
@@ -4,80 +4,129 @@ import org.netlib.util.doubleW;
 import neqsim.thermo.component.ComponentEOSCGEos;
 import neqsim.thermo.component.ComponentEosInterface;
 import neqsim.thermo.util.gerg.NeqSimEOSCG;
+import neqsim.util.exception.IsNaNException;
+import neqsim.util.exception.TooManyIterationsException;
 
 /** Phase implementation using the EOS-CG mixture model. */
 public class PhaseEOSCGEos extends PhaseGERG2008Eos {
   private static final long serialVersionUID = 1000;
+  private static final double PRESSURE_RELATIVE_TOLERANCE = 1.0e-6;
 
+  private transient boolean initializationInProgress;
+  private transient PhaseType resolvedRootType;
+  private transient PhaseType propertyRootType;
+
+  /** Create an EOS-CG phase. */
   public PhaseEOSCGEos() {
     thermoPropertyModelName = "EOS-CG";
   }
 
+  /** {@inheritDoc} */
   @Override
   public PhaseEOSCGEos clone() {
-    return (PhaseEOSCGEos) super.clone();
+    PhaseEOSCGEos clonedPhase = (PhaseEOSCGEos) super.clone();
+    if (clonedPhase != null) {
+      clonedPhase.invalidateCache();
+      clonedPhase.initializationInProgress = false;
+      clonedPhase.resolvedRootType = null;
+      clonedPhase.propertyRootType = null;
+    }
+    return clonedPhase;
   }
 
+  /** {@inheritDoc} */
   @Override
-  public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
-    super.addComponent(name, moles, molesInPhase, compNumber);
-    componentArray[compNumber] = new ComponentEOSCGEos(name, moles, molesInPhase, compNumber);
+  public void addComponent(String name, double moles, double molesInPhase, int componentNumber) {
+    super.addComponent(name, moles, molesInPhase, componentNumber);
+    componentArray[componentNumber] = new ComponentEOSCGEos(name, moles, molesInPhase, componentNumber);
   }
 
+  /** {@inheritDoc} */
   @Override
-  public void init(double totalNumberOfMoles, int numberOfComponents, int initType, PhaseType pt, double beta) {
-    IPHASE = pt == PhaseType.LIQUID ? -1 : -2;
-    super.init(totalNumberOfMoles, numberOfComponents, initType, pt, beta);
+  public void init(double totalNumberOfMoles, int numberOfComponents, int initType, PhaseType phaseType, double beta) {
+    resolvedRootType = referenceRootType(phaseType);
+    initializationInProgress = true;
+    try {
+      super.init(totalNumberOfMoles, numberOfComponents, initType, phaseType, beta);
+    } finally {
+      initializationInProgress = false;
+    }
 
-    if (!okVolume) {
-      IPHASE = pt == PhaseType.LIQUID ? -2 : -1;
-      super.init(totalNumberOfMoles, numberOfComponents, initType, pt, beta);
+    setType(resolvedRootType);
+    if (initType >= 1) {
+      refreshProperties(resolvedRootType);
     }
   }
 
+  /** {@inheritDoc} */
   @Override
-  public double[] getProperties_GERG2008() {
-    return getProperties_EOSCG();
-  }
-
-  @Override
-  public doubleW[] getAlpha0_GERG2008() {
-    return getAlpha0_EOSCG();
-  }
-
-  @Override
-  public doubleW[][] getAlphares_GERG2008() {
-    return getAlphares_EOSCG();
+  public double molarVolume(double pressure, double temperature, double attractionParameter, double covolumeParameter,
+      PhaseType phaseType) throws IsNaNException, TooManyIterationsException {
+    double molarDensityMolPerL = resolveMolarDensity(referenceRootType(phaseType));
+    double densityKgPerM3 = molarDensityMolPerL * getMolarMass() * 1000.0;
+    if (!Double.isFinite(densityKgPerM3) || densityKgPerM3 <= 0.0) {
+      throw new IsNaNException(this, "molarVolume", "EOS-CG density");
+    }
+    return getMolarMass() * 1.0e5 / densityKgPerM3;
   }
 
   /** {@inheritDoc} */
   @Override
   public double getDensity_GERG2008() {
-    NeqSimEOSCG eosCg = new NeqSimEOSCG(this);
-    return eosCg.getMolarDensity() * getMolarMass() * 1000.0;
+    double molarDensityMolPerL = resolveMolarDensity(activeRootType());
+    return molarDensityMolPerL * getMolarMass() * 1000.0;
   }
 
+  /** {@inheritDoc} */
   @Override
-  public double dFdN(int i) {
-    return ((ComponentEosInterface) getComponent(i)).dFdN(this, this.getNumberOfComponents(), temperature, pressure);
+  public double[] getProperties_GERG2008() {
+    NeqSimEOSCG eosCG = new NeqSimEOSCG(this);
+    return eosCG.propertiesEOSCG(resolveMolarDensity(eosCG, activeRootType()));
   }
 
+  /** {@inheritDoc} */
   @Override
-  public double dFdNdN(int i, int j) {
-    return ((ComponentEosInterface) getComponent(i)).dFdNdN(j, this, this.getNumberOfComponents(), temperature,
+  public doubleW[] getAlpha0_GERG2008() {
+    NeqSimEOSCG eosCG = new NeqSimEOSCG(this);
+    return eosCG.getAlpha0_EOSCG(resolveMolarDensity(eosCG, activeRootType()));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public doubleW[][] getAlphares_GERG2008() {
+    NeqSimEOSCG eosCG = new NeqSimEOSCG(this);
+    return eosCG.getAlphares_EOSCG(resolveMolarDensity(eosCG, activeRootType()));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double dFdN(int componentNumber) {
+    return ((ComponentEosInterface) getComponent(componentNumber)).dFdN(this, getNumberOfComponents(), temperature,
         pressure);
   }
 
+  /** {@inheritDoc} */
   @Override
-  public double dFdNdV(int i) {
-    return ((ComponentEosInterface) getComponent(i)).dFdNdV(this, this.getNumberOfComponents(), temperature, pressure);
+  public double dFdNdN(int componentNumber, int otherComponentNumber) {
+    return ((ComponentEosInterface) getComponent(componentNumber)).dFdNdN(otherComponentNumber, this,
+        getNumberOfComponents(), temperature, pressure);
   }
 
+  /** {@inheritDoc} */
   @Override
-  public double dFdNdT(int i) {
-    return ((ComponentEosInterface) getComponent(i)).dFdNdT(this, this.getNumberOfComponents(), temperature, pressure);
+  public double dFdNdV(int componentNumber) {
+    return ((ComponentEosInterface) getComponent(componentNumber)).dFdNdV(this, getNumberOfComponents(), temperature,
+        pressure);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public double dFdNdT(int componentNumber) {
+    return ((ComponentEosInterface) getComponent(componentNumber)).dFdNdT(this, getNumberOfComponents(), temperature,
+        pressure);
+  }
+
+  /** {@inheritDoc} */
   @Override
   public double getdPdTVn() {
     return (getNumberOfMolesInPhase() / getVolume()) * R * (1 + ar[0][1].val - ar[1][1].val);
@@ -87,10 +136,152 @@ public class PhaseEOSCGEos extends PhaseGERG2008Eos {
   @Override
   protected double residualHelmholtzEnergy(double molarDensity, double[] composition) {
     PhaseEOSCGEos evaluationPhase = clone();
-    for (int i = 0; i < composition.length; i++) {
-      evaluationPhase.getComponent(i).setx(composition[i]);
+    for (int componentNumber = 0; componentNumber < composition.length; componentNumber++) {
+      evaluationPhase.getComponent(componentNumber).setx(composition[componentNumber]);
     }
-    NeqSimEOSCG eosCg = new NeqSimEOSCG(evaluationPhase);
-    return eosCg.getResidualHelmholtzEnergy(temperature, molarDensity);
+    NeqSimEOSCG eosCG = new NeqSimEOSCG(evaluationPhase);
+    return eosCG.getResidualHelmholtzEnergy(temperature, molarDensity);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getMolarVolume() {
+    ensurePropertiesMatchPhaseType();
+    return super.getMolarVolume();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getZ() {
+    ensurePropertiesMatchPhaseType();
+    return super.getZ();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getGibbsEnergy() {
+    ensurePropertiesMatchPhaseType();
+    return super.getGibbsEnergy();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getEnthalpy() {
+    ensurePropertiesMatchPhaseType();
+    return super.getEnthalpy();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getEntropy() {
+    ensurePropertiesMatchPhaseType();
+    return super.getEntropy();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getInternalEnergy() {
+    ensurePropertiesMatchPhaseType();
+    return super.getInternalEnergy();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getCp() {
+    ensurePropertiesMatchPhaseType();
+    return super.getCp();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getCv() {
+    ensurePropertiesMatchPhaseType();
+    return super.getCv();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getJouleThomsonCoefficient() {
+    ensurePropertiesMatchPhaseType();
+    return super.getJouleThomsonCoefficient();
+  }
+
+  private void ensurePropertiesMatchPhaseType() {
+    if (!initializationInProgress && getNumberOfComponents() > 0 && propertyRootType != referenceRootType(getType())) {
+      refreshProperties(referenceRootType(getType()));
+    }
+  }
+
+  private void refreshProperties(PhaseType requestedRootType) {
+    NeqSimEOSCG eosCG = new NeqSimEOSCG(this);
+    double molarDensityMolPerL = resolveMolarDensity(eosCG, requestedRootType);
+    setType(resolvedRootType);
+    double densityKgPerM3 = molarDensityMolPerL * getMolarMass() * 1000.0;
+    double[] properties = eosCG.propertiesEOSCG(molarDensityMolPerL);
+    validatePropertyState(properties, densityKgPerM3, requestedRootType);
+
+    a0 = eosCG.getAlpha0_EOSCG(molarDensityMolPerL);
+    ar = eosCG.getAlphares_EOSCG(molarDensityMolPerL);
+    molarVolume = getMolarMass() * 1.0e5 / densityKgPerM3;
+    Z = properties[1];
+    internalEnery = properties[6];
+    enthalpy = properties[7];
+    entropy = properties[8];
+    CvGERG2008 = properties[9];
+    CpGERG2008 = properties[10];
+    W = properties[11];
+    gibbsEnergy = properties[12];
+    JTcoef = properties[13];
+    kappa = properties[14];
+    propertyRootType = resolvedRootType;
+  }
+
+  private void validatePropertyState(double[] properties, double densityKgPerM3, PhaseType requestedRootType) {
+    if (!Double.isFinite(densityKgPerM3) || densityKgPerM3 <= 0.0) {
+      throw new IllegalStateException("EOS-CG density is invalid for phase type " + requestedRootType);
+    }
+    double calculatedPressureBar = properties[0] / 100.0;
+    double pressureTolerance = PRESSURE_RELATIVE_TOLERANCE * Math.max(Math.abs(pressure), 1.0);
+    if (!Double.isFinite(calculatedPressureBar) || Math.abs(calculatedPressureBar - pressure) > pressureTolerance) {
+      throw new IllegalStateException("EOS-CG density root does not reproduce the specified pressure: specified="
+          + pressure + " bar, calculated=" + calculatedPressureBar + " bar, phase type=" + requestedRootType);
+    }
+  }
+
+  private double resolveMolarDensity(PhaseType requestedRootType) {
+    return resolveMolarDensity(new NeqSimEOSCG(this), requestedRootType);
+  }
+
+  private double resolveMolarDensity(NeqSimEOSCG eosCG, PhaseType requestedRootType) {
+    try {
+      double molarDensity = eosCG.getMolarDensity(requestedRootType);
+      resolvedRootType = requestedRootType;
+      return molarDensity;
+    } catch (IllegalStateException requestedRootFailure) {
+      PhaseType fallbackRootType = isLiquidRoot(requestedRootType) ? PhaseType.GAS : PhaseType.LIQUID;
+      try {
+        double molarDensity = eosCG.getMolarDensity(fallbackRootType);
+        resolvedRootType = fallbackRootType;
+        return molarDensity;
+      } catch (IllegalStateException fallbackRootFailure) {
+        requestedRootFailure.addSuppressed(fallbackRootFailure);
+        throw requestedRootFailure;
+      }
+    }
+  }
+
+  private PhaseType activeRootType() {
+    if (initializationInProgress && resolvedRootType != null) {
+      return resolvedRootType;
+    }
+    return referenceRootType(getType());
+  }
+
+  private static PhaseType referenceRootType(PhaseType phaseType) {
+    return isLiquidRoot(phaseType) ? PhaseType.LIQUID : PhaseType.GAS;
+  }
+
+  private static boolean isLiquidRoot(PhaseType phaseType) {
+    return phaseType == PhaseType.LIQUID || phaseType == PhaseType.OIL || phaseType == PhaseType.AQUEOUS;
   }
 }

--- a/src/main/java/neqsim/thermo/util/gerg/NeqSimEOSCG.java
+++ b/src/main/java/neqsim/thermo/util/gerg/NeqSimEOSCG.java
@@ -90,10 +90,23 @@ public class NeqSimEOSCG {
   }
 
   public double getPressure() {
-    double moldens = getMolarDensity();
+    return getPressure(getMolarDensity());
+  }
+
+  /**
+   * Calculate pressure at a specified molar density.
+   *
+   * @param molarDensityMolPerL molar density in mol/L
+   * @return pressure in kPa
+   * @throws IllegalArgumentException if the density is not finite and positive
+   */
+  public double getPressure(double molarDensityMolPerL) {
+    if (!Double.isFinite(molarDensityMolPerL) || molarDensityMolPerL <= 0.0) {
+      throw new IllegalArgumentException("Molar density must be finite and positive");
+    }
     doubleW P = new doubleW(0.0);
     doubleW Z = new doubleW(0.0);
-    eosCG.pressure(phase.getTemperature(), moldens, normalizedComposition, P, Z);
+    eosCG.pressure(phase.getTemperature(), molarDensityMolPerL, normalizedComposition, P, Z);
     return P.val;
   }
 
@@ -104,18 +117,24 @@ public class NeqSimEOSCG {
   }
 
   public double getMolarDensity() {
-    int flag = 0;
-    if (phase != null) {
-      PhaseType type = phase.getType();
-      if (type == PhaseType.LIQUID || type == PhaseType.OIL || type == PhaseType.AQUEOUS) {
-        flag = 2; // search for high density root
-      }
-    }
+    return getMolarDensity(phase.getType());
+  }
+
+  /**
+   * Get the molar-density root associated with a requested phase type.
+   *
+   * @param phaseType phase type selecting the vapor or liquid density root
+   * @return molar density in mol/L
+   * @throws IllegalStateException if the requested density root cannot be found
+   */
+  public double getMolarDensity(PhaseType phaseType) {
+    boolean liquidRoot = phaseType == PhaseType.LIQUID || phaseType == PhaseType.OIL || phaseType == PhaseType.AQUEOUS;
+    int flag = liquidRoot ? 2 : 0;
     intW ierr = new intW(0);
     StringW herr = new StringW("");
     doubleW D = new doubleW(0.0);
     double pressure = phase.getPressure() * 1.0e2;
-    if (flag == 2) {
+    if (liquidRoot) {
       double liquidDensity = ReferenceEosLiquidDensitySolver.solve(pressure, density -> {
         doubleW calculatedPressure = new doubleW(0.0);
         doubleW compressibility = new doubleW(0.0);
@@ -127,9 +146,9 @@ public class NeqSimEOSCG {
       }
     }
     eosCG.density(flag, phase.getTemperature(), pressure, normalizedComposition, D, ierr, herr);
-    if (ierr.val != 0) {
-      // System.out.println("NeqSimEOSCG: Density solver failed. ierr=" + ierr.val + ", herr=" +
-      // herr.val);
+    if (ierr.val != 0 || !Double.isFinite(D.val) || D.val <= 0.0) {
+      throw new IllegalStateException("EOS-CG density calculation failed for phase type " + phaseType + " at "
+          + phase.getTemperature() + " K and " + phase.getPressure() + " bar: " + herr.val);
     }
     return D.val;
   }
@@ -160,6 +179,20 @@ public class NeqSimEOSCG {
   }
 
   public double[] propertiesEOSCG() {
+    return propertiesEOSCG(getMolarDensity());
+  }
+
+  /**
+   * Calculate EOS-CG properties at a specified molar density without solving a pressure-density root.
+   *
+   * @param molarDensityMolPerL molar density in mol/L
+   * @return property vector in the native EOS-CG units
+   * @throws IllegalArgumentException if the density is not finite and positive
+   */
+  public double[] propertiesEOSCG(double molarDensityMolPerL) {
+    if (!Double.isFinite(molarDensityMolPerL) || molarDensityMolPerL <= 0.0) {
+      throw new IllegalArgumentException("Molar density must be finite and positive");
+    }
     doubleW p = new doubleW(0.0);
     doubleW z = new doubleW(0.0);
     doubleW dpdd = new doubleW(0.0);
@@ -176,9 +209,8 @@ public class NeqSimEOSCG {
     doubleW jt = new doubleW(0.0);
     doubleW kappa = new doubleW(0.0);
     doubleW A = new doubleW(0.0);
-    double dens = getMolarDensity();
-    eosCG.properties(phase.getTemperature(), dens, normalizedComposition, p, z, dpdd, d2pdd2, d2pdtd, dpdt, u, h, s, cv,
-        cp, w, g, jt, kappa, A);
+    eosCG.properties(phase.getTemperature(), molarDensityMolPerL, normalizedComposition, p, z, dpdd, d2pdd2, d2pdtd,
+        dpdt, u, h, s, cv, cp, w, g, jt, kappa, A);
     return new double[] { p.val, z.val, dpdd.val, d2pdd2.val, d2pdtd.val, dpdt.val, u.val, h.val, s.val, cv.val, cp.val,
         w.val, g.val, jt.val, kappa.val };
   }
@@ -311,26 +343,48 @@ public class NeqSimEOSCG {
     for (double value : notNormalizedComposition) {
       result += value;
     }
+    if (result < 1.0e-30) {
+      Arrays.fill(normalizedComposition, 0.0);
+      return;
+    }
     for (int k = 0; k < normalizedComposition.length; k++) {
       normalizedComposition[k] = notNormalizedComposition[k] / result;
     }
   }
 
   public doubleW[] getAlpha0_EOSCG() {
+    return getAlpha0_EOSCG(getMolarDensity());
+  }
+
+  /**
+   * Calculate ideal Helmholtz-energy derivatives at a specified molar density.
+   *
+   * @param molarDensityMolPerL molar density in mol/L
+   * @return ideal Helmholtz-energy derivative vector
+   */
+  public doubleW[] getAlpha0_EOSCG(double molarDensityMolPerL) {
     double temperature = phase.getTemperature();
-    double molarDensity = getMolarDensity(phase);
     int rows = 4;
     doubleW[] a0 = new doubleW[rows];
     for (int i = 0; i < rows; i++) {
       a0[i] = new doubleW(0.0);
     }
-    eosCG.alpha0(temperature, molarDensity, normalizedComposition, a0);
+    eosCG.alpha0(temperature, molarDensityMolPerL, normalizedComposition, a0);
     return a0;
   }
 
   public doubleW[][] getAlphares_EOSCG() {
+    return getAlphares_EOSCG(getMolarDensity());
+  }
+
+  /**
+   * Calculate residual Helmholtz-energy derivatives at a specified molar density.
+   *
+   * @param molarDensityMolPerL molar density in mol/L
+   * @return residual Helmholtz-energy derivative matrix
+   */
+  public doubleW[][] getAlphares_EOSCG(double molarDensityMolPerL) {
     double temperature = phase.getTemperature();
-    double molarDensity = getMolarDensity(phase);
 
     int rows = 4;
     int cols = 4;
@@ -341,7 +395,7 @@ public class NeqSimEOSCG {
       }
     }
 
-    eosCG.alphar(2, 3, temperature, molarDensity, normalizedComposition, ar);
+    eosCG.alphar(2, 3, temperature, molarDensityMolPerL, normalizedComposition, ar);
     return ar;
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -37,6 +37,7 @@ import neqsim.thermodynamicoperations.flashops.TSFlash;
 import neqsim.thermodynamicoperations.flashops.TUflash;
 import neqsim.thermodynamicoperations.flashops.TVflash;
 import neqsim.thermodynamicoperations.flashops.VHflashQfunc;
+import neqsim.thermodynamicoperations.flashops.VUflashPureEOSCG;
 import neqsim.thermodynamicoperations.flashops.VUflashSingleComp;
 import neqsim.thermodynamicoperations.flashops.dTPflash;
 import neqsim.thermodynamicoperations.flashops.saturationops.AddIonToScaleSaturation;
@@ -1122,12 +1123,18 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @param warmStartInitialization whether the initialization TP flash may reuse current K-values
    */
   public void VUflash(double Vspec, double Uspec, boolean warmStartInitialization) {
-    if (isPureComponentWithinInternalEnergyRange(Uspec)) {
+    if (isPureEOSCGSystem()) {
+      operation = new VUflashPureEOSCG(system, Vspec, Uspec);
+    } else if (isPureComponentWithinInternalEnergyRange(Uspec)) {
       operation = new VUflashSingleComp(system, Vspec, Uspec);
     } else {
       operation = new OptimizedVUflash(system, Vspec, Uspec, warmStartInitialization);
     }
     getOperation().run();
+  }
+
+  private boolean isPureEOSCGSystem() {
+    return system.getPhase(0).getNumberOfComponents() == 1 && "EOS-CG".equals(system.getModelName());
   }
 
   private boolean isPureComponentWithinInternalEnergyRange(double Uspec) {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/EOSCGSaturationVUFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/EOSCGSaturationVUFlash.java
@@ -1,0 +1,324 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Solves a pure EOS-CG two-phase VU state along its saturation line. */
+final class EOSCGSaturationVUFlash {
+  private static final Logger logger = LogManager.getLogger(EOSCGSaturationVUFlash.class);
+  private static final int SATURATION_SCAN_INTERVALS = 32;
+  private static final int LOCAL_SCAN_INTERVALS = 24;
+  private static final int MAXIMUM_ROOT_ITERATIONS = 80;
+
+  private final SystemInterface system;
+  private final double targetVolume;
+  private final double targetInternalEnergy;
+
+  /**
+   * Create the saturation-line solver.
+   *
+   * @param system pure-component EOS-CG system
+   * @param targetVolume specified volume in NeqSim internal volume units
+   * @param targetInternalEnergy specified total internal energy in J
+   */
+  EOSCGSaturationVUFlash(SystemInterface system, double targetVolume, double targetInternalEnergy) {
+    this.system = system;
+    this.targetVolume = targetVolume;
+    this.targetInternalEnergy = targetInternalEnergy;
+  }
+
+  /**
+   * Solve and apply a two-phase state satisfying the volume and energy specifications.
+   *
+   * @return {@code true} when a physical saturation-line solution is found
+   */
+  boolean solve() {
+    if (system.getPhase(0).getNumberOfComponents() != 1) {
+      return false;
+    }
+    double totalMoles = system.getTotalNumberOfMoles();
+    if (!Double.isFinite(totalMoles) || totalMoles <= 0.0) {
+      return false;
+    }
+
+    double targetMolarVolume = targetVolume / totalMoles;
+    double targetMolarEnergy = targetInternalEnergy / totalMoles;
+    double triplePressureBar = system.getPhase(0).getComponent(0).getTriplePointPressure();
+    double criticalPressureBar = system.getPhase(0).getComponent(0).getPC();
+    double lowerPressureBar = Math.max(0.01, triplePressureBar + 1.0e-6);
+    double upperPressureBar = criticalPressureBar - Math.max(1.0e-6, criticalPressureBar * 1.0e-8);
+    if (!(lowerPressureBar < upperPressureBar)) {
+      return false;
+    }
+
+    Candidate[] bracket = findBracket(lowerPressureBar, upperPressureBar, targetMolarVolume, targetMolarEnergy);
+    if (bracket == null) {
+      return false;
+    }
+    Candidate solution = refineBracket(bracket[0], bracket[1], targetMolarVolume, targetMolarEnergy);
+    if (solution == null || !solution.physical) {
+      return false;
+    }
+
+    apply(solution);
+    validateSpecifications();
+    return true;
+  }
+
+  private Candidate[] findBracket(double lowerPressureBar, double upperPressureBar, double targetMolarVolume,
+      double targetMolarEnergy) {
+    Candidate previousCandidate = null;
+    double coarsePressureStep = (upperPressureBar - lowerPressureBar) / SATURATION_SCAN_INTERVALS;
+    for (int interval = 0; interval <= SATURATION_SCAN_INTERVALS; interval++) {
+      double fraction = interval / (double) SATURATION_SCAN_INTERVALS;
+      double pressureBar = lowerPressureBar + fraction * (upperPressureBar - lowerPressureBar);
+      Candidate candidate = evaluate(pressureBar, targetMolarVolume, targetMolarEnergy);
+      if (candidate == null) {
+        if (previousCandidate != null) {
+          double localUpperPressureBar = Math.min(upperPressureBar, pressureBar + coarsePressureStep);
+          Candidate[] localBracket = findLocalBracket(previousCandidate, localUpperPressureBar, targetMolarVolume,
+              targetMolarEnergy);
+          if (localBracket != null) {
+            return localBracket;
+          }
+          previousCandidate = null;
+        }
+        continue;
+      }
+      if (withinVolumeTolerance(candidate, targetMolarVolume)) {
+        return new Candidate[] { candidate, candidate };
+      }
+      if (!candidate.physical) {
+        if (previousCandidate != null && residualSignChanged(previousCandidate, candidate)) {
+          return new Candidate[] { previousCandidate, candidate };
+        }
+        previousCandidate = null;
+        continue;
+      }
+      if (previousCandidate != null && residualSignChanged(previousCandidate, candidate)) {
+        return new Candidate[] { previousCandidate, candidate };
+      }
+      previousCandidate = candidate;
+    }
+    return null;
+  }
+
+  private Candidate[] findLocalBracket(Candidate lowerCandidate, double upperPressureBar, double targetMolarVolume,
+      double targetMolarEnergy) {
+    Candidate previousPhysicalCandidate = lowerCandidate;
+    double pressureRange = upperPressureBar - lowerCandidate.pressureBar;
+    for (int interval = 1; interval <= LOCAL_SCAN_INTERVALS; interval++) {
+      double pressureBar = lowerCandidate.pressureBar + interval / (double) LOCAL_SCAN_INTERVALS * pressureRange;
+      Candidate candidate = evaluate(pressureBar, targetMolarVolume, targetMolarEnergy);
+      if (candidate == null) {
+        continue;
+      }
+      if (withinVolumeTolerance(candidate, targetMolarVolume)) {
+        return new Candidate[] { candidate, candidate };
+      }
+      if (residualSignChanged(previousPhysicalCandidate, candidate)) {
+        return new Candidate[] { previousPhysicalCandidate, candidate };
+      }
+      if (candidate.physical) {
+        previousPhysicalCandidate = candidate;
+      }
+    }
+    return null;
+  }
+
+  private Candidate refineBracket(Candidate lowerCandidate, Candidate upperCandidate, double targetMolarVolume,
+      double targetMolarEnergy) {
+    if (lowerCandidate == upperCandidate) {
+      return lowerCandidate;
+    }
+
+    Candidate bestPhysicalCandidate = closerPhysicalCandidate(lowerCandidate, upperCandidate);
+    for (int iteration = 0; iteration < MAXIMUM_ROOT_ITERATIONS; iteration++) {
+      double pressureBar = 0.5 * (lowerCandidate.pressureBar + upperCandidate.pressureBar);
+      Candidate candidate = evaluate(pressureBar, targetMolarVolume, targetMolarEnergy);
+      if (candidate == null) {
+        Candidate lowerBoundary = refineCandidateBoundary(lowerCandidate, pressureBar, targetMolarVolume,
+            targetMolarEnergy);
+        if (lowerBoundary != lowerCandidate && lowerBoundary.physical
+            && residualSignChanged(lowerCandidate, lowerBoundary)) {
+          upperCandidate = lowerBoundary;
+          bestPhysicalCandidate = lowerBoundary;
+          continue;
+        }
+        Candidate upperBoundary = refineCandidateBoundary(upperCandidate, pressureBar, targetMolarVolume,
+            targetMolarEnergy);
+        if (upperBoundary != upperCandidate && (upperBoundary.physical || upperCandidate.physical)
+            && residualSignChanged(upperBoundary, upperCandidate)) {
+          lowerCandidate = upperBoundary;
+          if (upperBoundary.physical) {
+            bestPhysicalCandidate = upperBoundary;
+          }
+          continue;
+        }
+        return null;
+      }
+      if (candidate.physical) {
+        bestPhysicalCandidate = candidate;
+      }
+      if (candidate.physical && withinVolumeTolerance(candidate, targetMolarVolume)) {
+        return candidate;
+      }
+      if (sameResidualSign(lowerCandidate, candidate)) {
+        lowerCandidate = candidate;
+      } else {
+        upperCandidate = candidate;
+      }
+    }
+    return bestPhysicalCandidate != null && withinVolumeTolerance(bestPhysicalCandidate, targetMolarVolume)
+        ? bestPhysicalCandidate
+        : null;
+  }
+
+  private Candidate refineCandidateBoundary(Candidate validCandidate, double invalidPressureBar,
+      double targetMolarVolume, double targetMolarEnergy) {
+    Candidate boundaryCandidate = validCandidate;
+    double invalidBoundary = invalidPressureBar;
+    for (int iteration = 0; iteration < MAXIMUM_ROOT_ITERATIONS; iteration++) {
+      double pressureBar = 0.5 * (boundaryCandidate.pressureBar + invalidBoundary);
+      if (pressureBar == boundaryCandidate.pressureBar || pressureBar == invalidBoundary) {
+        break;
+      }
+      Candidate candidate = evaluate(pressureBar, targetMolarVolume, targetMolarEnergy);
+      if (candidate == null) {
+        invalidBoundary = pressureBar;
+      } else {
+        boundaryCandidate = candidate;
+      }
+    }
+    return boundaryCandidate;
+  }
+
+  private Candidate evaluate(double pressureBar, double targetMolarVolume, double targetMolarEnergy) {
+    try {
+      SystemInterface trialSystem = system.clone();
+      saturateAtPressure(trialSystem, pressureBar);
+      if (trialSystem.getNumberOfPhases() != 2) {
+        return null;
+      }
+      int gasPhaseIndex = phaseIndex(trialSystem, PhaseType.GAS);
+      int liquidPhaseIndex = otherPhaseIndex(trialSystem, gasPhaseIndex);
+      PhaseInterface gasPhase = trialSystem.getPhase(gasPhaseIndex);
+      PhaseInterface liquidPhase = trialSystem.getPhase(liquidPhaseIndex);
+      double gasEnergy = gasPhase.getInternalEnergy("J/mol");
+      double liquidEnergy = liquidPhase.getInternalEnergy("J/mol");
+      double energyDifference = gasEnergy - liquidEnergy;
+      double energyScale = Math.max(Math.max(Math.abs(gasEnergy), Math.abs(liquidEnergy)), 1.0);
+      if (!Double.isFinite(energyDifference) || Math.abs(energyDifference) < 1.0e-8 * energyScale) {
+        return null;
+      }
+      double vaporFraction = (targetMolarEnergy - liquidEnergy) / energyDifference;
+      if (!Double.isFinite(vaporFraction)) {
+        return null;
+      }
+      boolean physical = vaporFraction >= 0.0 && vaporFraction <= 1.0;
+      double molarVolume = vaporFraction * gasPhase.getMolarVolume()
+          + (1.0 - vaporFraction) * liquidPhase.getMolarVolume();
+      if (!Double.isFinite(molarVolume) || molarVolume <= 0.0) {
+        return null;
+      }
+      return new Candidate(pressureBar, vaporFraction, molarVolume - targetMolarVolume, physical);
+    } catch (Exception exception) {
+      logger.debug("Pure-component saturation candidate failed at {} bar", pressureBar, exception);
+      return null;
+    }
+  }
+
+  private void apply(Candidate candidate) {
+    try {
+      saturateAtPressure(system, candidate.pressureBar);
+    } catch (Exception exception) {
+      throw new IllegalStateException("Pure-component saturation flash failed at " + candidate.pressureBar + " bar",
+          exception);
+    }
+    int gasPhaseIndex = phaseIndex(system, PhaseType.GAS);
+    int liquidPhaseIndex = otherPhaseIndex(system, gasPhaseIndex);
+    system.setBeta(gasPhaseIndex, candidate.vaporFraction);
+    system.setBeta(liquidPhaseIndex, 1.0 - candidate.vaporFraction);
+    system.init(3);
+  }
+
+  private void validateSpecifications() {
+    double volumeResidual = Math.abs(system.getVolume() - targetVolume) / Math.max(Math.abs(targetVolume), 1.0e-30);
+    double energyResidual = Math.abs(system.getInternalEnergy() - targetInternalEnergy)
+        / Math.max(Math.abs(targetInternalEnergy), 1.0);
+    if (!Double.isFinite(volumeResidual) || !Double.isFinite(energyResidual)
+        || volumeResidual > VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE
+        || energyResidual > VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE) {
+      throw new IllegalStateException("Pure-component saturation VU flash residual exceeds tolerance: volume="
+          + volumeResidual + ", internalEnergy=" + energyResidual + ", targetVolume=" + targetVolume + ", actualVolume="
+          + system.getVolume() + ", targetInternalEnergy=" + targetInternalEnergy + ", actualInternalEnergy="
+          + system.getInternalEnergy());
+    }
+  }
+
+  private static void saturateAtPressure(SystemInterface targetSystem, double pressureBar) throws Exception {
+    targetSystem.setPressure(pressureBar);
+    new ThermodynamicOperations(targetSystem).bubblePointTemperatureFlash();
+    targetSystem.init(3);
+  }
+
+  private static int phaseIndex(SystemInterface targetSystem, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < targetSystem.getNumberOfPhases(); phaseIndex++) {
+      if (targetSystem.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
+    }
+    throw new IllegalStateException("Saturation flash is missing phase type " + phaseType);
+  }
+
+  private static int otherPhaseIndex(SystemInterface targetSystem, int phaseIndex) {
+    for (int candidate = 0; candidate < targetSystem.getNumberOfPhases(); candidate++) {
+      if (candidate != phaseIndex) {
+        return candidate;
+      }
+    }
+    throw new IllegalStateException("Saturation flash is missing a second phase");
+  }
+
+  private static boolean withinVolumeTolerance(Candidate candidate, double targetMolarVolume) {
+    return candidate.physical
+        && Math.abs(candidate.volumeResidual) <= VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE * targetMolarVolume;
+  }
+
+  private static boolean residualSignChanged(Candidate first, Candidate second) {
+    return !sameResidualSign(first, second);
+  }
+
+  private static boolean sameResidualSign(Candidate first, Candidate second) {
+    return Math.signum(first.volumeResidual) == Math.signum(second.volumeResidual);
+  }
+
+  private static Candidate closerPhysicalCandidate(Candidate first, Candidate second) {
+    Candidate best = null;
+    if (first.physical) {
+      best = first;
+    }
+    if (second.physical && (best == null || Math.abs(second.volumeResidual) < Math.abs(best.volumeResidual))) {
+      best = second;
+    }
+    return best;
+  }
+
+  private static final class Candidate {
+    private final double pressureBar;
+    private final double vaporFraction;
+    private final double volumeResidual;
+    private final boolean physical;
+
+    private Candidate(double pressureBar, double vaporFraction, double volumeResidual, boolean physical) {
+      this.pressureBar = pressureBar;
+      this.vaporFraction = vaporFraction;
+      this.volumeResidual = volumeResidual;
+      this.physical = physical;
+    }
+  }
+}

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/EOSCGSinglePhaseVUFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/EOSCGSinglePhaseVUFlash.java
@@ -1,0 +1,293 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.util.gerg.NeqSimEOSCG;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Solves a pure EOS-CG single-phase VU state at the density imposed by its volume. */
+final class EOSCGSinglePhaseVUFlash {
+  private static final Logger logger = LogManager.getLogger(EOSCGSinglePhaseVUFlash.class);
+  private static final int MAXIMUM_ROOT_ITERATIONS = 80;
+  private static final int BRACKET_SEARCH_ITERATIONS = 24;
+  private static final double MINIMUM_TEMPERATURE = 50.0;
+  private static final double MAXIMUM_TEMPERATURE = 5000.0;
+
+  private final SystemInterface system;
+  private final double targetVolume;
+  private final double targetInternalEnergy;
+
+  /**
+   * Create the fixed-density single-phase solver.
+   *
+   * @param system pure-component EOS-CG system
+   * @param targetVolume specified volume in NeqSim internal volume units
+   * @param targetInternalEnergy specified total internal energy in J
+   */
+  EOSCGSinglePhaseVUFlash(SystemInterface system, double targetVolume, double targetInternalEnergy) {
+    this.system = system;
+    this.targetVolume = targetVolume;
+    this.targetInternalEnergy = targetInternalEnergy;
+  }
+
+  /**
+   * Solve and apply a stable homogeneous state.
+   *
+   * @return {@code true} when a stable single-phase state satisfies both specifications
+   */
+  boolean solve() {
+    double initialTemperature = clampTemperature(system.getTemperature());
+    Candidate initialCandidate = evaluate(initialTemperature);
+    if (initialCandidate == null) {
+      return false;
+    }
+    if (meetsEnergySpecification(initialCandidate)) {
+      return applyIfStable(initialCandidate);
+    }
+
+    int preferredDirection = initialCandidate.energyResidual > 0.0 ? -1 : 1;
+    Bracket bracket = findBracket(initialCandidate, preferredDirection);
+    if (bracket == null) {
+      bracket = findBracket(initialCandidate, -preferredDirection);
+    }
+    if (bracket == null) {
+      return false;
+    }
+
+    Candidate bestCandidate = Math.abs(bracket.lower.energyResidual) <= Math.abs(bracket.upper.energyResidual)
+        ? bracket.lower
+        : bracket.upper;
+    for (int iteration = 0; iteration < MAXIMUM_ROOT_ITERATIONS; iteration++) {
+      Candidate candidate = evaluate(interpolateTemperature(bracket));
+      if (candidate == null) {
+        return false;
+      }
+      if (Math.abs(candidate.energyResidual) < Math.abs(bestCandidate.energyResidual)) {
+        bestCandidate = candidate;
+      }
+      if (meetsEnergySpecification(candidate)) {
+        return applyIfStable(candidate);
+      }
+      if (sameResidualSign(bracket.lower, candidate)) {
+        bracket = new Bracket(candidate, bracket.upper);
+      } else {
+        bracket = new Bracket(bracket.lower, candidate);
+      }
+    }
+
+    return meetsEnergySpecification(bestCandidate) && applyIfStable(bestCandidate);
+  }
+
+  private Bracket findBracket(Candidate initialCandidate, int direction) {
+    Candidate previousCandidate = initialCandidate;
+    double step = Math.max(1.0, 0.02 * initialCandidate.temperature);
+    for (int iteration = 0; iteration < BRACKET_SEARCH_ITERATIONS; iteration++) {
+      double temperature = clampTemperature(initialCandidate.temperature + direction * step);
+      if (temperature == previousCandidate.temperature) {
+        break;
+      }
+      Candidate candidate = evaluate(temperature);
+      if (candidate == null) {
+        candidate = refineBranchBoundary(previousCandidate, temperature);
+        if (candidate != null && !sameResidualSign(initialCandidate, candidate)) {
+          return orderedBracket(initialCandidate, candidate);
+        }
+        break;
+      }
+      if (!sameResidualSign(initialCandidate, candidate)) {
+        return orderedBracket(initialCandidate, candidate);
+      }
+      previousCandidate = candidate;
+      step *= 1.8;
+    }
+    return null;
+  }
+
+  private Candidate refineBranchBoundary(Candidate validCandidate, double invalidTemperature) {
+    Candidate boundaryCandidate = validCandidate;
+    double invalidBoundary = invalidTemperature;
+    for (int iteration = 0; iteration < MAXIMUM_ROOT_ITERATIONS; iteration++) {
+      double temperature = 0.5 * (boundaryCandidate.temperature + invalidBoundary);
+      if (temperature == boundaryCandidate.temperature || temperature == invalidBoundary) {
+        break;
+      }
+      Candidate candidate = evaluate(temperature);
+      if (candidate == null) {
+        invalidBoundary = temperature;
+      } else {
+        boundaryCandidate = candidate;
+      }
+    }
+    return boundaryCandidate;
+  }
+
+  private Candidate evaluate(double temperature) {
+    try {
+      SystemInterface trialSystem = system.clone();
+      trialSystem.setTemperature(temperature);
+      double totalMoles = trialSystem.getTotalNumberOfMoles();
+      double molarDensityMolPerL = 100.0 * totalMoles / targetVolume;
+      double[] properties = new NeqSimEOSCG(trialSystem.getPhase(0)).propertiesEOSCG(molarDensityMolPerL);
+      double pressureBar = properties[0] / 100.0;
+      double internalEnergy = properties[6] * totalMoles;
+      if (!Double.isFinite(internalEnergy) || !Double.isFinite(pressureBar) || pressureBar <= 0.0) {
+        return null;
+      }
+      return new Candidate(temperature, pressureBar, internalEnergy - targetInternalEnergy);
+    } catch (RuntimeException exception) {
+      logger.debug("Fixed-volume EOS-CG candidate failed at {} K", temperature, exception);
+      return null;
+    }
+  }
+
+  private boolean applyIfStable(Candidate candidate) {
+    if (!isStable(candidate)) {
+      return false;
+    }
+    try {
+      system.setTemperature(candidate.temperature);
+      system.setPressure(candidate.pressureBar);
+      new TPflash(system).run();
+      system.init(3);
+      return specificationsAreSatisfied(system);
+    } catch (RuntimeException exception) {
+      logger.debug("Converged EOS-CG candidate could not be applied", exception);
+      return false;
+    }
+  }
+
+  private boolean isStable(Candidate candidate) {
+    if (!outsideSaturationVolumeEnvelope(candidate)) {
+      return false;
+    }
+    try {
+      SystemInterface trialSystem = system.clone();
+      trialSystem.setTemperature(candidate.temperature);
+      trialSystem.setPressure(candidate.pressureBar);
+      new TPflash(trialSystem).run();
+      trialSystem.init(3);
+      return trialSystem.getNumberOfPhases() == 1 && specificationsAreSatisfied(trialSystem);
+    } catch (RuntimeException exception) {
+      logger.debug("EOS-CG single-phase stability check failed", exception);
+      return false;
+    }
+  }
+
+  private boolean outsideSaturationVolumeEnvelope(Candidate candidate) {
+    double triplePressureBar = system.getPhase(0).getComponent(0).getTriplePointPressure();
+    double criticalPressureBar = system.getPhase(0).getComponent(0).getPC();
+    if (candidate.pressureBar <= triplePressureBar || candidate.pressureBar >= criticalPressureBar) {
+      return true;
+    }
+    try {
+      SystemInterface saturationSystem = system.clone();
+      saturateAtPressure(saturationSystem, candidate.pressureBar);
+      int gasPhaseIndex = phaseIndex(saturationSystem, PhaseType.GAS);
+      int liquidPhaseIndex = otherPhaseIndex(saturationSystem, gasPhaseIndex);
+      double gasMolarVolume = saturationSystem.getPhase(gasPhaseIndex).getMolarVolume();
+      double liquidMolarVolume = saturationSystem.getPhase(liquidPhaseIndex).getMolarVolume();
+      double lowerMolarVolume = Math.min(gasMolarVolume, liquidMolarVolume);
+      double upperMolarVolume = Math.max(gasMolarVolume, liquidMolarVolume);
+      double rootSeparationTolerance = VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE
+          * Math.max(upperMolarVolume, 1.0e-30);
+      if (upperMolarVolume - lowerMolarVolume <= rootSeparationTolerance) {
+        return false;
+      }
+      double targetMolarVolume = targetVolume / system.getTotalNumberOfMoles();
+      double tolerance = VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE
+          * Math.max(Math.max(Math.abs(targetMolarVolume), upperMolarVolume), 1.0e-30);
+      return targetMolarVolume < lowerMolarVolume - tolerance || targetMolarVolume > upperMolarVolume + tolerance;
+    } catch (Exception exception) {
+      logger.debug("Saturation-volume check failed at {} bar", candidate.pressureBar, exception);
+      return false;
+    }
+  }
+
+  private boolean meetsEnergySpecification(Candidate candidate) {
+    double tolerance = VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE
+        * Math.max(Math.abs(targetInternalEnergy), 1.0);
+    return Math.abs(candidate.energyResidual) <= tolerance;
+  }
+
+  private boolean specificationsAreSatisfied(SystemInterface targetSystem) {
+    double volumeResidual = Math.abs(targetSystem.getVolume() - targetVolume)
+        / Math.max(Math.abs(targetVolume), 1.0e-30);
+    double energyResidual = Math.abs(targetSystem.getInternalEnergy() - targetInternalEnergy)
+        / Math.max(Math.abs(targetInternalEnergy), 1.0);
+    return Double.isFinite(volumeResidual) && Double.isFinite(energyResidual)
+        && volumeResidual <= VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE
+        && energyResidual <= VUflashPureEOSCG.SPECIFICATION_RELATIVE_TOLERANCE;
+  }
+
+  private static double interpolateTemperature(Bracket bracket) {
+    double temperatureRange = bracket.upper.temperature - bracket.lower.temperature;
+    double residualRange = bracket.upper.energyResidual - bracket.lower.energyResidual;
+    double temperature = bracket.lower.temperature - bracket.lower.energyResidual * temperatureRange / residualRange;
+    double margin = 1.0e-12 * Math.max(Math.abs(temperatureRange), 1.0);
+    if (!Double.isFinite(temperature) || temperature <= bracket.lower.temperature + margin
+        || temperature >= bracket.upper.temperature - margin) {
+      return 0.5 * (bracket.lower.temperature + bracket.upper.temperature);
+    }
+    return temperature;
+  }
+
+  private static void saturateAtPressure(SystemInterface targetSystem, double pressureBar) throws Exception {
+    targetSystem.setPressure(pressureBar);
+    new ThermodynamicOperations(targetSystem).bubblePointTemperatureFlash();
+    targetSystem.init(3);
+  }
+
+  private static int phaseIndex(SystemInterface targetSystem, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < targetSystem.getNumberOfPhases(); phaseIndex++) {
+      if (targetSystem.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
+    }
+    throw new IllegalStateException("Saturation flash is missing phase type " + phaseType);
+  }
+
+  private static int otherPhaseIndex(SystemInterface targetSystem, int phaseIndex) {
+    for (int candidate = 0; candidate < targetSystem.getNumberOfPhases(); candidate++) {
+      if (candidate != phaseIndex) {
+        return candidate;
+      }
+    }
+    throw new IllegalStateException("Saturation flash is missing a second phase");
+  }
+
+  private static Bracket orderedBracket(Candidate first, Candidate second) {
+    return first.temperature <= second.temperature ? new Bracket(first, second) : new Bracket(second, first);
+  }
+
+  private static boolean sameResidualSign(Candidate first, Candidate second) {
+    return Math.signum(first.energyResidual) == Math.signum(second.energyResidual);
+  }
+
+  private static double clampTemperature(double temperature) {
+    return Math.max(MINIMUM_TEMPERATURE, Math.min(MAXIMUM_TEMPERATURE, temperature));
+  }
+
+  private static final class Candidate {
+    private final double temperature;
+    private final double pressureBar;
+    private final double energyResidual;
+
+    private Candidate(double temperature, double pressureBar, double energyResidual) {
+      this.temperature = temperature;
+      this.pressureBar = pressureBar;
+      this.energyResidual = energyResidual;
+    }
+  }
+
+  private static final class Bracket {
+    private final Candidate lower;
+    private final Candidate upper;
+
+    private Bracket(Candidate lower, Candidate upper) {
+      this.lower = lower;
+      this.upper = upper;
+    }
+  }
+}

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/VUflashPureEOSCG.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/VUflashPureEOSCG.java
@@ -1,0 +1,62 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import neqsim.thermo.system.SystemInterface;
+
+/** Volume-energy flash specialized for pure-component EOS-CG systems. */
+public class VUflashPureEOSCG extends Flash {
+  private static final long serialVersionUID = 1000;
+  static final double SPECIFICATION_RELATIVE_TOLERANCE = 1.0e-8;
+
+  private final double targetVolume;
+  private final double targetInternalEnergy;
+
+  /**
+   * Create a pure-component EOS-CG volume-energy flash.
+   *
+   * @param system thermodynamic system containing one component and using EOS-CG
+   * @param targetVolume specified total volume in NeqSim internal volume units
+   * @param targetInternalEnergy specified total internal energy in J
+   */
+  public VUflashPureEOSCG(SystemInterface system, double targetVolume, double targetInternalEnergy) {
+    this.system = system;
+    this.targetVolume = targetVolume;
+    this.targetInternalEnergy = targetInternalEnergy;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run() {
+    validateInput();
+
+    EOSCGSinglePhaseVUFlash singlePhaseFlash = new EOSCGSinglePhaseVUFlash(system, targetVolume, targetInternalEnergy);
+    if (singlePhaseFlash.solve()) {
+      return;
+    }
+
+    EOSCGSaturationVUFlash twoPhaseFlash = new EOSCGSaturationVUFlash(system, targetVolume, targetInternalEnergy);
+    if (twoPhaseFlash.solve()) {
+      return;
+    }
+
+    throw new IllegalStateException(
+        "Pure EOS-CG VU flash could not find a stable single-phase or saturation-line solution");
+  }
+
+  private void validateInput() {
+    if (!Double.isFinite(targetVolume) || targetVolume <= 0.0) {
+      throw new IllegalArgumentException("Specified volume must be finite and positive");
+    }
+    if (!Double.isFinite(targetInternalEnergy)) {
+      throw new IllegalArgumentException("Specified internal energy must be finite");
+    }
+    if (system.getPhase(0).getNumberOfComponents() != 1 || !"EOS-CG".equals(system.getModelName())) {
+      throw new IllegalArgumentException("VUflashPureEOSCG requires a pure-component EOS-CG system");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public org.jfree.chart.JFreeChart getJFreeChart(String name) {
+    return null;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/VUFlashEOSCGTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/VUFlashEOSCGTest.java
@@ -1,0 +1,205 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemEOSCGEos;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.util.gerg.NeqSimEOSCG;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression tests for pure-carbon-dioxide EOS-CG volume-energy flashes. */
+class VUFlashEOSCGTest {
+  private static final double RELATIVE_TOLERANCE = 2.0e-8;
+
+  @Test
+  void directEOSCGEvaluationIsFiniteAtInitialDenseState() {
+    SystemInterface system = new SystemEOSCGEos(294.25, 125.4);
+    system.addComponent("CO2", 1.0);
+    system.init(0);
+
+    NeqSimEOSCG eosCG = new NeqSimEOSCG(system.getPhase(0));
+    double molarDensityMolPerL = eosCG.getMolarDensity();
+    double[] properties = eosCG.propertiesEOSCG();
+
+    assertTrue(Double.isFinite(molarDensityMolPerL));
+    assertTrue(molarDensityMolPerL > 0.0);
+    assertTrue(Double.isFinite(properties[0]));
+    assertTrue(properties[1] > 0.0);
+    assertEquals(12540.0, eosCG.getPressure(molarDensityMolPerL), RELATIVE_TOLERANCE * 12540.0);
+    assertEquals(12540.0, eosCG.propertiesEOSCG(molarDensityMolPerL)[0], RELATIVE_TOLERANCE * 12540.0);
+    assertEquals(system.getPhase(0).getDensity_EOSCG(), system.getPhase(0).getDensity("kg/m3"),
+        RELATIVE_TOLERANCE * system.getPhase(0).getDensity("kg/m3"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "10.0, 0.50", "30.0, 0.05", "52.0, 0.25" })
+  void twoPhaseRoundTripPreservesVolumeEnergyAndPhaseCount(double pressureBar, double vaporFraction) throws Exception {
+    SystemInterface reference = createSaturationReference(pressureBar, vaporFraction);
+    double targetVolumeM3 = reference.getVolume("m3");
+    double targetInternalEnergyJ = reference.getInternalEnergy("J");
+    SystemInterface system = createPureCarbonDioxideSystem(294.25, 125.4);
+
+    new ThermodynamicOperations(system).VUflash(targetVolumeM3, targetInternalEnergyJ, "m3", "J");
+    system.init(3);
+
+    assertEquals(2, system.getNumberOfPhases(),
+        "reference pressure=" + pressureBar + " bar, vapor fraction=" + vaporFraction + ", result temperature="
+            + system.getTemperature() + " K, result pressure=" + system.getPressure() + " bar");
+    assertSpecifications(system, targetVolumeM3, targetInternalEnergyJ);
+  }
+
+  @Test
+  void singlePhaseRoundTripPreservesVolumeAndEnergy() {
+    SystemInterface system = createPureCarbonDioxideSystem(294.25, 125.4);
+    double targetVolumeM3 = system.getVolume("m3");
+    double targetInternalEnergyJ = system.getInternalEnergy("J");
+
+    new ThermodynamicOperations(system).VUflash(targetVolumeM3, targetInternalEnergyJ, "m3", "J");
+    system.init(3);
+
+    assertEquals(1, system.getNumberOfPhases());
+    assertSpecifications(system, targetVolumeM3, targetInternalEnergyJ);
+  }
+
+  @Test
+  void infeasibleSpecificationFailsExplicitly() {
+    SystemInterface system = createPureCarbonDioxideSystem(294.25, 125.4);
+    double targetVolumeM3 = system.getVolume("m3");
+    double infeasibleInternalEnergyJ = system.getInternalEnergy("J") + 1.0e12;
+
+    assertThrows(IllegalStateException.class,
+        () -> new ThermodynamicOperations(system).VUflash(targetVolumeM3, infeasibleInternalEnergyJ, "m3", "J"));
+  }
+
+  @Test
+  void nearCriticalDegenerateSaturationIsNotAcceptedAsSinglePhase() throws Exception {
+    SystemInterface reference = createSaturationReference(70.0, 0.5);
+    double targetVolumeM3 = reference.getVolume("m3");
+    double targetInternalEnergyJ = reference.getInternalEnergy("J");
+    SystemInterface system = createPureCarbonDioxideSystem(294.25, 125.4);
+
+    try {
+      new ThermodynamicOperations(system).VUflash(targetVolumeM3, targetInternalEnergyJ, "m3", "J");
+      system.init(3);
+      assertEquals(2, system.getNumberOfPhases());
+      PhaseInterface gasPhase = phaseOfType(system, PhaseType.GAS);
+      PhaseInterface liquidPhase = otherPhase(system, gasPhase);
+      assertNotEquals(gasPhase.getDensity("kg/m3"), liquidPhase.getDensity("kg/m3"), 1.0);
+    } catch (IllegalStateException expectedFailure) {
+      assertTrue(expectedFailure.getMessage().contains("could not find a stable"));
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "0.001", "0.999" })
+  void nearSaturationLimitStateRemainsTwoPhase(double vaporFraction) throws Exception {
+    SystemInterface reference = createSaturationReference(52.0, vaporFraction);
+    double targetVolumeM3 = reference.getVolume("m3");
+    double targetInternalEnergyJ = reference.getInternalEnergy("J");
+    SystemInterface system = createPureCarbonDioxideSystem(294.25, 125.4);
+
+    new ThermodynamicOperations(system).VUflash(targetVolumeM3, targetInternalEnergyJ, "m3", "J");
+    system.init(3);
+
+    assertEquals(2, system.getNumberOfPhases());
+    assertSpecifications(system, targetVolumeM3, targetInternalEnergyJ);
+  }
+
+  @Test
+  void compressedLiquidTPFlashSelectsDenseRoot() {
+    SystemInterface system = new SystemEOSCGEos(286.570871248841, 53.400617864310);
+    system.addComponent("CO2", 1.0);
+    system.setMultiPhaseCheck(true);
+
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+
+    assertEquals(1, system.getNumberOfPhases());
+    assertEquals(5.221579133419594, system.getVolume(), RELATIVE_TOLERANCE * 5.221579133419594);
+    assertTrue(system.getDensity("kg/m3") > 800.0);
+  }
+
+  @Test
+  void saturatedPhasesUseDistinctEOSCGDensityRoots() throws Exception {
+    SystemInterface system = createPureCarbonDioxideSystem(285.0, 52.0);
+
+    new ThermodynamicOperations(system).bubblePointTemperatureFlash();
+    system.init(3);
+
+    assertEquals(2, system.getNumberOfPhases());
+    PhaseInterface gasPhase = phaseOfType(system, PhaseType.GAS);
+    PhaseInterface liquidPhase = otherPhase(system, gasPhase);
+    assertNotEquals(gasPhase.getDensity("kg/m3"), liquidPhase.getDensity("kg/m3"), 1.0);
+    assertPhasePropertiesMatchDirectEOSCG(gasPhase);
+    assertPhasePropertiesMatchDirectEOSCG(liquidPhase);
+  }
+
+  private static void assertSpecifications(SystemInterface system, double targetVolumeM3,
+      double targetInternalEnergyJ) {
+    assertEquals(targetVolumeM3, system.getVolume("m3"), RELATIVE_TOLERANCE * targetVolumeM3);
+    assertEquals(targetInternalEnergyJ, system.getInternalEnergy("J"),
+        RELATIVE_TOLERANCE * Math.abs(targetInternalEnergyJ));
+  }
+
+  private static SystemInterface createSaturationReference(double pressureBar, double vaporFraction) throws Exception {
+    SystemInterface system = createPureCarbonDioxideSystem(285.0, pressureBar);
+    new ThermodynamicOperations(system).bubblePointTemperatureFlash();
+    int gasPhaseIndex = phaseIndex(system, PhaseType.GAS);
+    int liquidPhaseIndex = otherPhaseIndex(system, gasPhaseIndex);
+    system.setBeta(gasPhaseIndex, vaporFraction);
+    system.setBeta(liquidPhaseIndex, 1.0 - vaporFraction);
+    system.init(3);
+    return system;
+  }
+
+  private static SystemInterface createPureCarbonDioxideSystem(double temperatureK, double pressureBar) {
+    SystemInterface system = new SystemEOSCGEos(temperatureK, pressureBar);
+    system.addComponent("CO2", 1.0);
+    system.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private static PhaseInterface phaseOfType(SystemInterface system, PhaseType phaseType) {
+    return system.getPhase(phaseIndex(system, phaseType));
+  }
+
+  private static int phaseIndex(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
+    }
+    throw new AssertionError("Missing phase type " + phaseType);
+  }
+
+  private static PhaseInterface otherPhase(SystemInterface system, PhaseInterface phase) {
+    return system.getPhase(otherPhaseIndex(system, phaseIndex(system, phase.getType())));
+  }
+
+  private static int otherPhaseIndex(SystemInterface system, int phaseIndex) {
+    for (int candidate = 0; candidate < system.getNumberOfPhases(); candidate++) {
+      if (candidate != phaseIndex) {
+        return candidate;
+      }
+    }
+    throw new AssertionError("Missing second fluid phase");
+  }
+
+  private static void assertPhasePropertiesMatchDirectEOSCG(PhaseInterface phase) {
+    double[] directProperties = phase.getProperties_EOSCG();
+    assertEquals(directProperties[6], phase.getInternalEnergy("J/mol"),
+        RELATIVE_TOLERANCE * Math.max(Math.abs(directProperties[6]), 1.0));
+    assertEquals(directProperties[8], phase.getEntropy("J/molK"),
+        RELATIVE_TOLERANCE * Math.max(Math.abs(directProperties[8]), 1.0));
+  }
+
+}


### PR DESCRIPTION
## Summary

- Preserve the requested vapor or liquid density root during EOS-CG phase initialization.
- Keep cached EOS-CG properties synchronized when the phase root changes.
- Add direct fixed-density EOS-CG pressure, property, and Helmholtz derivative evaluations.
- Add dedicated single-phase and saturation-line VU solvers for pure EOS-CG systems.
- Reject unresolved or degenerate states instead of silently accepting a numerically matched but physically inconsistent result.

Closes #3497

## Motivation

Pure-component EOS-CG flashes could lose the requested density root during phase initialization. This could leave the phase label, molar volume, and cached thermodynamic properties inconsistent, leading to invalid fugacity inputs or failed VU flashes for dense carbon-dioxide states.

## Validation

The following affected tests pass on the final implementation:

- EOS-CG density and sound-speed tests
- EOS-CG thermodynamic-consistency tests
- VU, TV, and Q-function flash tests
- Pure CO2 EOS-CG single-phase and two-phase VU round trips
- Saturation pressures of 10, 30, and 52 bar
- Vapor fractions of 0.001 and 0.999
- Dense-liquid root selection
- Explicit failure for infeasible or degenerate specifications

Result: 52 tests passed, 0 failures, 0 errors.

Additional checks:

- `spotless:check`: passed
- `checkstyle:check`: 0 violations
- `javadoc:javadoc`: completed successfully

The complete `./mvnw test` suite was not run locally; validation was limited to the affected test suite listed above.

## Scope and known limitation

The dedicated VU path is limited to pure-component EOS-CG systems. A separate near-critical EOS-CG initialization and bubble-point issue was observed around 70 bar. This change rejects degenerate saturation roots instead of silently accepting them, but does not claim to resolve that separate near-critical issue.

## Checklist

- [ ] Full `./mvnw test` suite completed locally (affected suite completed instead)
- [x] Code formatting and Checkstyle verified
- [x] Relevant documentation reviewed; no user-facing documentation change is required
- [x] Associated issue linked
- [ ] CODEOWNERS and independent domain review requested after opening the PR
- [x] NRC and migration note are not applicable because this does not change a major public contract

This contribution was AI-assisted. I reviewed the physical and numerical changes and verified them locally.