### PR TITLE
[AI-Assisted] feat(dexpi): preserve material endpoint provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -180,11 +180,13 @@ functions.
 The same result also preserves every source `Connection` in document order, including parallel
 connections between the same endpoints. Each immutable `DexpiConnectionInfo` retains the owning
 piping-network segment identity and its explicit `ComponentClass`, `ComponentName`, and
-`TagName`, plus `FromID` and `ToID` direction, the resolved endpoint element names, and
-resolution status. Absent segment metadata remains empty without invented values. Missing source
-IDs receive deterministic evidence-only identities; missing, duplicate, self-referential, or
-unresolved source references remain explicit diagnostics. This inventory does not derive segment
-metadata, infer connectivity, or rewire the returned `ProcessSystem`.
+`TagName`, plus `FromID` and `ToID` direction, the resolved endpoint element names, resolution
+status, and each resolved endpoint object's own explicit `ComponentClass`, `ComponentName`, and
+`TagName`. Endpoint metadata is kept separate from segment and owner metadata; absent or unresolved
+values remain empty without fallback or invented values. Missing source IDs receive deterministic
+evidence-only identities; missing, duplicate, self-referential, or unresolved source references
+remain explicit diagnostics. This inventory does not derive segment metadata, infer connectivity, or
+rewire the returned `ProcessSystem`.
 
 For resolved nozzle endpoints, the same record exposes only explicit source ownership: the nearest
 ancestor `Equipment` or `PipingComponent` identity and XML element name. Direct equipment or
@@ -196,12 +198,14 @@ ownership or owner metadata from coordinates, endpoint tags, stream order, simul
 class heuristics.
 
 `ImportResult.getConnectionEndpoints()` provides a distinct endpoint inventory in first-reference
-order. Each immutable `DexpiConnectionEndpointInfo` records the resolved element, explicit owner
-identity and XML element name, and the owner's explicit `ComponentClass`, `ComponentName`, and
-`TagName`, plus the incoming and outgoing connection-evidence IDs in source order. Counts retain
-every occurrence, including parallel connections. Blank endpoint references remain findings and are
-omitted from this keyed inventory; unresolved non-empty IDs remain visible with empty owner
-provenance.
+order. Each immutable `DexpiConnectionEndpointInfo` separately records the resolved XML element
+name, the endpoint object's own explicit `ComponentClass`, `ComponentName`, and `TagName`, its
+explicit owner identity and XML element name, and the owner's explicit class, name, and tag. A direct
+equipment or piping-component endpoint may therefore carry the same source values in both roles, but
+the reader never copies or infers one role from the other. Incoming and outgoing connection-evidence
+IDs remain in source order, and counts retain every occurrence, including parallel connections. Blank
+endpoint references remain findings and are omitted from this keyed inventory; unresolved non-empty
+IDs remain visible with empty endpoint and owner provenance.
 
 `getIncidenceRole()` classifies only this directed source evidence: zero incoming and one outgoing
 is `SOURCE`; one incoming and zero outgoing is `SINK`; one of each is `PASS_THROUGH`; one

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
@@ -46,6 +46,9 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
 
   private final String endpointId;
   private final String elementName;
+  private final String componentClass;
+  private final String componentName;
+  private final String tagName;
   private final String ownerId;
   private final String ownerElementName;
   private final String ownerComponentClass;
@@ -89,8 +92,35 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
   public DexpiConnectionEndpointInfo(String endpointId, String elementName, String ownerId, String ownerElementName,
       String ownerComponentClass, String ownerComponentName, String ownerTagName, boolean resolved,
       List<String> incomingConnectionIds, List<String> outgoingConnectionIds) {
+    this(endpointId, elementName, "", "", "", ownerId, ownerElementName, ownerComponentClass, ownerComponentName,
+        ownerTagName, resolved, incomingConnectionIds, outgoingConnectionIds);
+  }
+
+  /**
+   * Creates immutable endpoint-incidence evidence with explicit endpoint and owner provenance.
+   *
+   * @param endpointId explicit source endpoint identity
+   * @param elementName resolved endpoint XML element name, or empty when unresolved
+   * @param componentClass explicit endpoint ComponentClass, or empty when absent
+   * @param componentName explicit endpoint ComponentName, or empty when absent
+   * @param tagName explicit endpoint TagName, or empty when absent
+   * @param ownerId explicit endpoint owner identity, or empty when absent
+   * @param ownerElementName endpoint owner XML element name, or empty when absent
+   * @param ownerComponentClass explicit owner ComponentClass, or empty when absent
+   * @param ownerComponentName explicit owner ComponentName, or empty when absent
+   * @param ownerTagName explicit owner TagName, or empty when absent
+   * @param resolved whether the endpoint resolves in the source document
+   * @param incomingConnectionIds incoming connection-evidence IDs in source order
+   * @param outgoingConnectionIds outgoing connection-evidence IDs in source order
+   */
+  public DexpiConnectionEndpointInfo(String endpointId, String elementName, String componentClass, String componentName,
+      String tagName, String ownerId, String ownerElementName, String ownerComponentClass, String ownerComponentName,
+      String ownerTagName, boolean resolved, List<String> incomingConnectionIds, List<String> outgoingConnectionIds) {
     this.endpointId = normalize(endpointId);
     this.elementName = normalize(elementName);
+    this.componentClass = normalize(componentClass);
+    this.componentName = normalize(componentName);
+    this.tagName = normalize(tagName);
     this.ownerId = normalize(ownerId);
     this.ownerElementName = normalize(ownerElementName);
     this.ownerComponentClass = normalize(ownerComponentClass);
@@ -109,6 +139,21 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
   /** @return resolved endpoint XML element name, or empty when unresolved */
   public String getElementName() {
     return elementName;
+  }
+
+  /** @return explicit endpoint ComponentClass, or empty when absent */
+  public String getComponentClass() {
+    return componentClass;
+  }
+
+  /** @return explicit endpoint ComponentName, or empty when absent */
+  public String getComponentName() {
+    return componentName;
+  }
+
+  /** @return explicit endpoint TagName, or empty when absent */
+  public String getTagName() {
+    return tagName;
   }
 
   /** @return explicit endpoint owner identity, or empty when absent */
@@ -214,6 +259,9 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("endpointId", endpointId);
     result.put("elementName", elementName);
+    result.put("componentClass", componentClass);
+    result.put("componentName", componentName);
+    result.put("tagName", tagName);
     result.put("ownerId", ownerId);
     result.put("ownerElementName", ownerElementName);
     result.put("ownerComponentClass", ownerComponentClass);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -197,8 +197,8 @@ public final class DexpiConnectionInfo implements Serializable {
       String toElementName, String fromComponentClass, String fromComponentName, String fromTagName,
       String toComponentClass, String toComponentName, String toTagName, String fromOwnerId, String toOwnerId,
       String fromOwnerElementName, String toOwnerElementName, String fromOwnerComponentClass,
-      String fromOwnerComponentName, String fromOwnerTagName, String toOwnerComponentClass,
-      String toOwnerComponentName, String toOwnerTagName, boolean fromResolved, boolean toResolved) {
+      String fromOwnerComponentName, String fromOwnerTagName, String toOwnerComponentClass, String toOwnerComponentName,
+      String toOwnerTagName, boolean fromResolved, boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -27,6 +27,12 @@ public final class DexpiConnectionInfo implements Serializable {
   private final String toId;
   private final String fromElementName;
   private final String toElementName;
+  private final String fromComponentClass;
+  private final String fromComponentName;
+  private final String fromTagName;
+  private final String toComponentClass;
+  private final String toComponentName;
+  private final String toTagName;
   private final String fromOwnerId;
   private final String toOwnerId;
   private final String fromOwnerElementName;
@@ -148,6 +154,51 @@ public final class DexpiConnectionInfo implements Serializable {
       String toOwnerElementName, String fromOwnerComponentClass, String fromOwnerComponentName, String fromOwnerTagName,
       String toOwnerComponentClass, String toOwnerComponentName, String toOwnerTagName, boolean fromResolved,
       boolean toResolved) {
+    this(id, sourceId, segmentId, segmentComponentClass, segmentComponentName, segmentTagName, fromId, toId,
+        fromElementName, toElementName, "", "", "", "", "", "", fromOwnerId, toOwnerId, fromOwnerElementName,
+        toOwnerElementName, fromOwnerComponentClass, fromOwnerComponentName, fromOwnerTagName, toOwnerComponentClass,
+        toOwnerComponentName, toOwnerTagName, fromResolved, toResolved);
+  }
+
+  /**
+   * Creates immutable connection evidence with explicit segment, endpoint, and owner provenance.
+   *
+   * @param id stable evidence identity
+   * @param sourceId source connection identity, or empty when absent
+   * @param segmentId owning piping-network segment identity, or empty when absent
+   * @param segmentComponentClass explicit segment ComponentClass, or empty when absent
+   * @param segmentComponentName explicit segment ComponentName, or empty when absent
+   * @param segmentTagName explicit segment TagName, or empty when absent
+   * @param fromId source endpoint identity
+   * @param toId target endpoint identity
+   * @param fromElementName resolved source XML element name
+   * @param toElementName resolved target XML element name
+   * @param fromComponentClass explicit source-endpoint ComponentClass, or empty when absent
+   * @param fromComponentName explicit source-endpoint ComponentName, or empty when absent
+   * @param fromTagName explicit source-endpoint TagName, or empty when absent
+   * @param toComponentClass explicit target-endpoint ComponentClass, or empty when absent
+   * @param toComponentName explicit target-endpoint ComponentName, or empty when absent
+   * @param toTagName explicit target-endpoint TagName, or empty when absent
+   * @param fromOwnerId explicit source owner identity, or empty when absent
+   * @param toOwnerId explicit target owner identity, or empty when absent
+   * @param fromOwnerElementName source owner XML element name, or empty when absent
+   * @param toOwnerElementName target owner XML element name, or empty when absent
+   * @param fromOwnerComponentClass explicit source-owner ComponentClass, or empty when absent
+   * @param fromOwnerComponentName explicit source-owner ComponentName, or empty when absent
+   * @param fromOwnerTagName explicit source-owner TagName, or empty when absent
+   * @param toOwnerComponentClass explicit target-owner ComponentClass, or empty when absent
+   * @param toOwnerComponentName explicit target-owner ComponentName, or empty when absent
+   * @param toOwnerTagName explicit target-owner TagName, or empty when absent
+   * @param fromResolved whether the source endpoint resolves in the source document
+   * @param toResolved whether the target endpoint resolves in the source document
+   */
+  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String segmentComponentClass,
+      String segmentComponentName, String segmentTagName, String fromId, String toId, String fromElementName,
+      String toElementName, String fromComponentClass, String fromComponentName, String fromTagName,
+      String toComponentClass, String toComponentName, String toTagName, String fromOwnerId, String toOwnerId,
+      String fromOwnerElementName, String toOwnerElementName, String fromOwnerComponentClass,
+      String fromOwnerComponentName, String fromOwnerTagName, String toOwnerComponentClass,
+      String toOwnerComponentName, String toOwnerTagName, boolean fromResolved, boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);
@@ -158,6 +209,12 @@ public final class DexpiConnectionInfo implements Serializable {
     this.toId = normalize(toId);
     this.fromElementName = normalize(fromElementName);
     this.toElementName = normalize(toElementName);
+    this.fromComponentClass = normalize(fromComponentClass);
+    this.fromComponentName = normalize(fromComponentName);
+    this.fromTagName = normalize(fromTagName);
+    this.toComponentClass = normalize(toComponentClass);
+    this.toComponentName = normalize(toComponentName);
+    this.toTagName = normalize(toTagName);
     this.fromOwnerId = normalize(fromOwnerId);
     this.toOwnerId = normalize(toOwnerId);
     this.fromOwnerElementName = normalize(fromOwnerElementName);
@@ -225,6 +282,36 @@ public final class DexpiConnectionInfo implements Serializable {
   /** @return resolved target endpoint XML element name, or empty when unresolved */
   public String getToElementName() {
     return toElementName;
+  }
+
+  /** @return explicit source-endpoint ComponentClass, or empty when absent */
+  public String getFromComponentClass() {
+    return fromComponentClass;
+  }
+
+  /** @return explicit source-endpoint ComponentName, or empty when absent */
+  public String getFromComponentName() {
+    return fromComponentName;
+  }
+
+  /** @return explicit source-endpoint TagName, or empty when absent */
+  public String getFromTagName() {
+    return fromTagName;
+  }
+
+  /** @return explicit target-endpoint ComponentClass, or empty when absent */
+  public String getToComponentClass() {
+    return toComponentClass;
+  }
+
+  /** @return explicit target-endpoint ComponentName, or empty when absent */
+  public String getToComponentName() {
+    return toComponentName;
+  }
+
+  /** @return explicit target-endpoint TagName, or empty when absent */
+  public String getToTagName() {
+    return toTagName;
   }
 
   /** @return explicit source endpoint owner identity, or empty when absent */
@@ -314,6 +401,12 @@ public final class DexpiConnectionInfo implements Serializable {
     result.put("toId", toId);
     result.put("fromElementName", fromElementName);
     result.put("toElementName", toElementName);
+    result.put("fromComponentClass", fromComponentClass);
+    result.put("fromComponentName", fromComponentName);
+    result.put("fromTagName", fromTagName);
+    result.put("toComponentClass", toComponentClass);
+    result.put("toComponentName", toComponentName);
+    result.put("toTagName", toTagName);
     result.put("fromOwnerId", fromOwnerId);
     result.put("toOwnerId", toOwnerId);
     result.put("fromOwnerElementName", fromOwnerElementName);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1115,7 +1115,10 @@ public final class DexpiXmlReader {
       connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId,
           explicitAttribute(segment, "ComponentClass"), explicitAttribute(segment, "ComponentName"),
           explicitTagName(segment), fromId, toId, fromElement == null ? "" : fromElement.getTagName(),
-          toElement == null ? "" : toElement.getTagName(), fromOwner == null ? "" : fromOwner.getAttribute("ID"),
+          toElement == null ? "" : toElement.getTagName(), explicitAttribute(fromElement, "ComponentClass"),
+          explicitAttribute(fromElement, "ComponentName"), explicitTagName(fromElement),
+          explicitAttribute(toElement, "ComponentClass"), explicitAttribute(toElement, "ComponentName"),
+          explicitTagName(toElement), fromOwner == null ? "" : fromOwner.getAttribute("ID"),
           toOwner == null ? "" : toOwner.getAttribute("ID"), fromOwner == null ? "" : fromOwner.getTagName(),
           toOwner == null ? "" : toOwner.getTagName(), explicitAttribute(fromOwner, "ComponentClass"),
           explicitAttribute(fromOwner, "ComponentName"), explicitTagName(fromOwner),
@@ -1494,6 +1497,9 @@ public final class DexpiXmlReader {
     if (endpoint == null) {
       endpoint = new ConnectionEndpointAccumulator(endpointId,
           source ? connection.getFromElementName() : connection.getToElementName(),
+          source ? connection.getFromComponentClass() : connection.getToComponentClass(),
+          source ? connection.getFromComponentName() : connection.getToComponentName(),
+          source ? connection.getFromTagName() : connection.getToTagName(),
           source ? connection.getFromOwnerId() : connection.getToOwnerId(),
           source ? connection.getFromOwnerElementName() : connection.getToOwnerElementName(),
           source ? connection.getFromOwnerComponentClass() : connection.getToOwnerComponentClass(),
@@ -1508,6 +1514,9 @@ public final class DexpiXmlReader {
   private static final class ConnectionEndpointAccumulator {
     private final String endpointId;
     private final String elementName;
+    private final String componentClass;
+    private final String componentName;
+    private final String tagName;
     private final String ownerId;
     private final String ownerElementName;
     private final String ownerComponentClass;
@@ -1517,11 +1526,14 @@ public final class DexpiXmlReader {
     private final List<String> incomingConnectionIds = new ArrayList<String>();
     private final List<String> outgoingConnectionIds = new ArrayList<String>();
 
-    private ConnectionEndpointAccumulator(String endpointId, String elementName, String ownerId,
-        String ownerElementName, String ownerComponentClass, String ownerComponentName, String ownerTagName,
-        boolean resolved) {
+    private ConnectionEndpointAccumulator(String endpointId, String elementName, String componentClass,
+        String componentName, String tagName, String ownerId, String ownerElementName, String ownerComponentClass,
+        String ownerComponentName, String ownerTagName, boolean resolved) {
       this.endpointId = endpointId;
       this.elementName = elementName;
+      this.componentClass = componentClass;
+      this.componentName = componentName;
+      this.tagName = tagName;
       this.ownerId = ownerId;
       this.ownerElementName = ownerElementName;
       this.ownerComponentClass = ownerComponentClass;
@@ -1539,8 +1551,9 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionEndpointInfo toInfo() {
-      return new DexpiConnectionEndpointInfo(endpointId, elementName, ownerId, ownerElementName, ownerComponentClass,
-          ownerComponentName, ownerTagName, resolved, incomingConnectionIds, outgoingConnectionIds);
+      return new DexpiConnectionEndpointInfo(endpointId, elementName, componentClass, componentName, tagName, ownerId,
+          ownerElementName, ownerComponentClass, ownerComponentName, ownerTagName, resolved, incomingConnectionIds,
+          outgoingConnectionIds);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -546,10 +546,14 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
         + "<Equipment ID=\"E-OUT\" ComponentClass=\"CentrifugalPump\" ComponentName=\"ExportPump\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"P-101\"/></GenericAttributes>"
-        + "<Nozzle ID=\"N-OUT\"/></Equipment>"
+        + "<Nozzle ID=\"N-OUT\" ComponentClass=\"ProcessConnection\" ComponentName=\"PumpDischargeNozzle\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"NZ-OUT\"/></GenericAttributes>"
+        + "</Nozzle></Equipment>"
         + "<Equipment ID=\"E-IN\" ComponentClass=\"Separator\" ComponentName=\"InletSeparator\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"V-101\"/></GenericAttributes>"
-        + "<Nozzle ID=\"N-IN\"/></Equipment>"
+        + "<Nozzle ID=\"N-IN\" ComponentClass=\"ProcessConnection\" ComponentName=\"SeparatorInletNozzle\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"NZ-IN\"/>"
+        + "</GenericAttributes></Nozzle></Equipment>"
         + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\" ComponentName=\"MainSegment\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"L-100-1\"/></GenericAttributes>"
         + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
@@ -573,6 +577,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("N-IN", firstConnection.getToId());
     assertEquals("Nozzle", firstConnection.getFromElementName());
     assertEquals("Nozzle", firstConnection.getToElementName());
+    assertEquals("ProcessConnection", firstConnection.getFromComponentClass());
+    assertEquals("PumpDischargeNozzle", firstConnection.getFromComponentName());
+    assertEquals("NZ-OUT", firstConnection.getFromTagName());
+    assertEquals("ProcessConnection", firstConnection.getToComponentClass());
+    assertEquals("SeparatorInletNozzle", firstConnection.getToComponentName());
+    assertEquals("NZ-IN", firstConnection.getToTagName());
     assertEquals("E-OUT", firstConnection.getFromOwnerId());
     assertEquals("E-IN", firstConnection.getToOwnerId());
     assertEquals("Equipment", firstConnection.getFromOwnerElementName());
@@ -585,10 +595,22 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("V-101", firstConnection.getToOwnerTagName());
     assertTrue(firstConnection.isResolved());
     assertTrue(firstConnection.isOwnershipResolved());
+    DexpiConnectionEndpointInfo sourceEndpoint = first.getConnectionEndpoints().get(0);
+    assertEquals("ProcessConnection", sourceEndpoint.getComponentClass());
+    assertEquals("PumpDischargeNozzle", sourceEndpoint.getComponentName());
+    assertEquals("NZ-OUT", sourceEndpoint.getTagName());
+    assertEquals("CentrifugalPump", sourceEndpoint.getOwnerComponentClass());
+    DexpiConnectionEndpointInfo targetEndpoint = first.getConnectionEndpoints().get(1);
+    assertEquals("ProcessConnection", targetEndpoint.getComponentClass());
+    assertEquals("SeparatorInletNozzle", targetEndpoint.getComponentName());
+    assertEquals("NZ-IN", targetEndpoint.getTagName());
+    assertEquals("Separator", targetEndpoint.getOwnerComponentClass());
     assertEquals("S-2/connection-1", first.getConnections().get(1).getId());
     assertEquals(2, countDiagnostics(first, "DEXPI_IMPORT_CONNECTION_ID_SYNTHESIZED"));
     assertTrue(first.toJson().contains("\"connectionCount\": 2"));
     assertTrue(first.toJson().contains("\"segmentTagName\": \"L-100-1\""));
+    assertTrue(first.toJson().contains("\"fromTagName\": \"NZ-OUT\""));
+    assertTrue(first.toJson().contains("\"componentName\": \"PumpDischargeNozzle\""));
     assertEquals(first.toJson(), second.toJson());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnections().clear());
   }
@@ -609,11 +631,17 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionInfo connection = result.getConnections().get(0);
 
     assertEquals("PipingComponent", connection.getFromElementName());
+    assertEquals("GlobeValve", connection.getFromComponentClass());
+    assertEquals("ValveShape", connection.getFromComponentName());
+    assertEquals("XV-101", connection.getFromTagName());
     assertEquals("PC-DIRECT", connection.getFromOwnerId());
     assertEquals("GlobeValve", connection.getFromOwnerComponentClass());
     assertEquals("ValveShape", connection.getFromOwnerComponentName());
     assertEquals("XV-101", connection.getFromOwnerTagName());
     assertEquals("Equipment", connection.getToElementName());
+    assertEquals("Tank", connection.getToComponentClass());
+    assertEquals("TankShape", connection.getToComponentName());
+    assertEquals("TK-101", connection.getToTagName());
     assertEquals("E-DIRECT", connection.getToOwnerId());
     assertEquals("Tank", connection.getToOwnerComponentClass());
     assertEquals("TankShape", connection.getToOwnerComponentName());
@@ -634,6 +662,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(2, result.getConnections().size());
     assertEquals("C-1", result.getConnections().get(0).getId());
     assertFalse(result.getConnections().get(0).isResolved());
+    assertEquals("", result.getConnections().get(0).getFromComponentClass());
+    assertEquals("", result.getConnections().get(0).getFromComponentName());
+    assertEquals("", result.getConnections().get(0).getFromTagName());
+    assertEquals("", result.getConnections().get(0).getToComponentClass());
+    assertEquals("", result.getConnections().get(0).getToComponentName());
+    assertEquals("", result.getConnections().get(0).getToTagName());
     assertEquals("C-1#2", result.getConnections().get(1).getId());
     assertTrue(result.getConnections().get(1).isSelfReference());
     assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SOURCE_MISSING");


### PR DESCRIPTION
## Summary

Advances the #1332 / #2899 shared P&ID–DEXPI roadmap with a bounded source-provenance increment.

- preserves each resolved material-connection endpoint object's own explicit `ComponentClass`, `ComponentName`, and `TagName`
- keeps endpoint-object provenance separate from piping-segment provenance and endpoint-owner provenance
- exposes the same immutable fields in the distinct endpoint inventory and deterministic JSON
- preserves source order, parallel occurrences, diagnostics, existing constructors, and existing JSON fields
- keeps absent and unresolved metadata empty without owner fallback or invented values

Capability contracts:
- https://github.com/equinor/neqsim/issues/1332#issuecomment-5558511410
- https://github.com/equinor/neqsim/issues/2899#issuecomment-5558511624

## Exact-head contract

- Exact base / publication-time master: `bfb337d5780860c9eb1c3bf54ccb5a92b5bee6cd`
- Current master: `a7fb137897cec05988ea7874b930af9cce38ee40` (four unrelated commits ahead; no rebase)
- Exact publication head: `b9caf4e7e2bd155bc98bd57786f9152d3df0749c`
- Branch: `ai/dexpi-connection-endpoint-provenance`
- Six ordered commits across five intended files
- Zero commits behind publication-time master

Changed files:

1. `src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java`
2. `src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java`
3. `src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java`
4. `src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java`
5. `docs/integration/dexpi-reader.md`

## Acceptance evidence

Tests were authored first and require:

- distinct source- and target-endpoint class, name, and tag values for resolved nozzle endpoints
- preservation of owner provenance without conflating it with endpoint provenance
- direct equipment and piping-component endpoints to retain their own explicit metadata
- unresolved or absent endpoint metadata to remain empty
- deterministic JSON to expose the new evidence
- existing source ordering and parallel-connection behavior to remain unchanged

Connector-side inspection confirms the intended five-file diff, six commits, exact base, and zero-behind publication state. No local Maven, Java, Spotless, Javadocs, pre-commit, or documentation result is claimed.

## Semantic boundary

This is immutable source evidence only. It does not infer ownership, topology, hydraulic continuity, fittings, control intent, safeguard or SIS function, standards conformance, certification, or engineering approval. It does not modify simulation, process wiring, rendering, or exports.

Whole-sheet visual gate: not applicable; no diagram geometry or rendering output changes.

## Validation

**VALIDATION PENDING EXACT-HEAD CI — JAVA 8 ACTIVE**

The predecessor head failed pre-commit only on one Spotless line wrap in `DexpiConnectionInfo`. Exact head `b9caf4e7e2bd155bc98bd57786f9152d3df0749c` applies the hosted formatter artifact without any semantic, API, test, or documentation change. Seven of eight workflows pass. Java 21 Ubuntu/Windows fast tests, all four Java 21 slow shards, Javadocs, formatting, pre-commit, documentation/search, notebook, engineering-diagram performance, CodeQL, PaperLab, change detection, and agent-skill references pass. Only Java 8 Ubuntu and Windows remain active, with zero reported failures. The single-repair allowance is exhausted.

## Portfolio and publication policy

Current autonomous implementation-portfolio occupancy is **5/10**, below the ten-capability target and absolute ceiling. This is the sole active shared PFD/P&ID/DEXPI campaign PR, and its five files do not overlap the other positively identified autonomous drafts.

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.