### PR TITLE
[AI-Assisted] feat(dexpi): expose complete component evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -218,8 +218,15 @@ branch or fitting, create live process connectivity, or establish process intent
 `ImportResult.getConnectionComponents()` groups non-empty endpoint identities by weak connectivity
 through explicit material-connection references. Components are ordered by their first endpoint;
 their endpoint IDs retain first-reference order and their connection-evidence IDs retain source
-order, including parallel occurrences. Each immutable `DexpiConnectionComponentInfo` also lists
-source, sink, potential multi-connection, and unresolved endpoints from the endpoint evidence.
+order, including parallel occurrences. `getEndpoints()` exposes the corresponding complete immutable
+`DexpiConnectionEndpointInfo` records in first-reference order, and `getConnections()` exposes
+the complete immutable `DexpiConnectionInfo` occurrences in source order. Reader-produced records
+therefore keep endpoint resolution, incidence, explicit endpoint and owner provenance, segment
+provenance, direction, one-sided references, and parallel occurrences available locally without a
+join against the global inventories. `hasCompleteEvidence()` distinguishes this projection from
+legacy values created with the older constructor; legacy object lists are empty while all existing
+identity and subset evidence remains unchanged. Each immutable `DexpiConnectionComponentInfo` also
+lists source, sink, potential multi-connection, and unresolved endpoints from the endpoint evidence.
 A connection with one non-empty endpoint remains visible as a singleton component. A connection
 with two blank endpoint references remains diagnostic evidence and is not assigned invented nodes.
 This grouping is a document-review aid, not proof that the grouped references form a hydraulically
@@ -274,8 +281,8 @@ continuity, identify a physical recycle, enumerate paths, or alter simulation to
 `connectionEndpointCount`, `connectionComponentCount`, `connectionCycleCount`,
 `connectionCycleTransitionCount`, and the ordered instrumentation-loop, actuating-function, information-flow, connection, endpoint,
 component, directed-cycle, and cycle-transition inventories, including reference resolution,
-incidence roles, review subsets, complete cycle-local endpoint and internal connection occurrences,
-explicit cycle-boundary occurrences, and exact-once transitions with nested connection and endpoint
+incidence roles, review subsets, complete component- and cycle-local endpoint and connection
+occurrences, explicit cycle-boundary occurrences, and exact-once transitions with nested connection and endpoint
 evidence, alongside the process-unit count and findings. Python callers through JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getInstrumentationLoops()`,
 `ImportResult.getActuatingFunctions()`, `ImportResult.getInformationFlows()`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
@@ -23,14 +23,22 @@ public final class DexpiConnectionComponentInfo implements Serializable {
 
   private final String id;
   private final List<String> endpointIds;
+  private final List<DexpiConnectionEndpointInfo> endpoints;
   private final List<String> connectionIds;
+  private final List<DexpiConnectionInfo> connections;
   private final List<String> sourceEndpointIds;
   private final List<String> sinkEndpointIds;
   private final List<String> potentialMultiConnectionEndpointIds;
   private final List<String> unresolvedEndpointIds;
+  private final boolean completeEvidence;
 
   /**
    * Creates immutable source-reference component evidence.
+   *
+   * <p>
+   * This legacy constructor preserves scalar and identity evidence only. {@link #hasCompleteEvidence()} returns
+   * {@code false}; use the complete-evidence constructor when endpoint and connection records are available.
+   * </p>
    *
    * @param id deterministic component evidence identity
    * @param endpointIds explicit endpoint identities in first-reference order
@@ -43,13 +51,46 @@ public final class DexpiConnectionComponentInfo implements Serializable {
   public DexpiConnectionComponentInfo(String id, List<String> endpointIds, List<String> connectionIds,
       List<String> sourceEndpointIds, List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
       List<String> unresolvedEndpointIds) {
+    this(id, endpointIds, Collections.<DexpiConnectionEndpointInfo>emptyList(), connectionIds,
+        Collections.<DexpiConnectionInfo>emptyList(), sourceEndpointIds, sinkEndpointIds,
+        potentialMultiConnectionEndpointIds, unresolvedEndpointIds, false);
+  }
+
+  /**
+   * Creates immutable source-reference component evidence with complete endpoint and connection occurrences.
+   *
+   * @param id deterministic component evidence identity
+   * @param endpointIds explicit endpoint identities in first-reference order
+   * @param endpoints endpoint evidence records in first-reference order
+   * @param connectionIds connection-evidence identities in source order
+   * @param connections connection occurrences in source order
+   * @param sourceEndpointIds endpoints classified as source evidence
+   * @param sinkEndpointIds endpoints classified as sink evidence
+   * @param potentialMultiConnectionEndpointIds endpoints with multiple incoming or outgoing occurrences
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   */
+  public DexpiConnectionComponentInfo(String id, List<String> endpointIds,
+      List<DexpiConnectionEndpointInfo> endpoints, List<String> connectionIds, List<DexpiConnectionInfo> connections,
+      List<String> sourceEndpointIds, List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
+      List<String> unresolvedEndpointIds) {
+    this(id, endpointIds, endpoints, connectionIds, connections, sourceEndpointIds, sinkEndpointIds,
+        potentialMultiConnectionEndpointIds, unresolvedEndpointIds, true);
+  }
+
+  private DexpiConnectionComponentInfo(String id, List<String> endpointIds,
+      List<DexpiConnectionEndpointInfo> endpoints, List<String> connectionIds, List<DexpiConnectionInfo> connections,
+      List<String> sourceEndpointIds, List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
+      List<String> unresolvedEndpointIds, boolean completeEvidence) {
     this.id = normalize(id);
     this.endpointIds = immutableCopy(endpointIds);
+    this.endpoints = Collections.unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(endpoints));
     this.connectionIds = immutableCopy(connectionIds);
+    this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
     this.sourceEndpointIds = immutableCopy(sourceEndpointIds);
     this.sinkEndpointIds = immutableCopy(sinkEndpointIds);
     this.potentialMultiConnectionEndpointIds = immutableCopy(potentialMultiConnectionEndpointIds);
     this.unresolvedEndpointIds = immutableCopy(unresolvedEndpointIds);
+    this.completeEvidence = completeEvidence;
   }
 
   /** @return deterministic component evidence identity */
@@ -62,9 +103,19 @@ public final class DexpiConnectionComponentInfo implements Serializable {
     return endpointIds;
   }
 
+  /** @return immutable endpoint evidence records in first-reference order */
+  public List<DexpiConnectionEndpointInfo> getEndpoints() {
+    return endpoints;
+  }
+
   /** @return immutable connection-evidence identities in source order */
   public List<String> getConnectionIds() {
     return connectionIds;
+  }
+
+  /** @return immutable connection occurrences in source order */
+  public List<DexpiConnectionInfo> getConnections() {
+    return connections;
   }
 
   /** @return immutable endpoint identities classified as source evidence */
@@ -101,6 +152,11 @@ public final class DexpiConnectionComponentInfo implements Serializable {
     return connectionIds.size();
   }
 
+  /** @return whether complete endpoint and connection records were supplied */
+  public boolean hasCompleteEvidence() {
+    return completeEvidence;
+  }
+
   /** @return whether any endpoint reference in this component is unresolved */
   public boolean hasUnresolvedEndpoints() {
     return !unresolvedEndpointIds.isEmpty();
@@ -116,10 +172,21 @@ public final class DexpiConnectionComponentInfo implements Serializable {
     result.put("id", id);
     result.put("endpointCount", Integer.valueOf(getEndpointCount()));
     result.put("connectionCount", Integer.valueOf(getConnectionCount()));
+    result.put("completeEvidence", Boolean.valueOf(hasCompleteEvidence()));
     result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
     result.put("hasPotentialMultiConnectionNodes", Boolean.valueOf(hasPotentialMultiConnectionNodes()));
     result.put("endpointIds", endpointIds);
+    List<Map<String, Object>> endpointMaps = new ArrayList<Map<String, Object>>();
+    for (DexpiConnectionEndpointInfo endpoint : endpoints) {
+      endpointMaps.add(endpoint.toMap());
+    }
+    result.put("endpoints", endpointMaps);
     result.put("connectionIds", connectionIds);
+    List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
+    for (DexpiConnectionInfo connection : connections) {
+      connectionMaps.add(connection.toMap());
+    }
+    result.put("connections", connectionMaps);
     result.put("sourceEndpointIds", sourceEndpointIds);
     result.put("sinkEndpointIds", sinkEndpointIds);
     result.put("potentialMultiConnectionEndpointIds", potentialMultiConnectionEndpointIds);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
@@ -69,17 +69,17 @@ public final class DexpiConnectionComponentInfo implements Serializable {
    * @param potentialMultiConnectionEndpointIds endpoints with multiple incoming or outgoing occurrences
    * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
    */
-  public DexpiConnectionComponentInfo(String id, List<String> endpointIds,
-      List<DexpiConnectionEndpointInfo> endpoints, List<String> connectionIds, List<DexpiConnectionInfo> connections,
-      List<String> sourceEndpointIds, List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
+  public DexpiConnectionComponentInfo(String id, List<String> endpointIds, List<DexpiConnectionEndpointInfo> endpoints,
+      List<String> connectionIds, List<DexpiConnectionInfo> connections, List<String> sourceEndpointIds,
+      List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
       List<String> unresolvedEndpointIds) {
     this(id, endpointIds, endpoints, connectionIds, connections, sourceEndpointIds, sinkEndpointIds,
         potentialMultiConnectionEndpointIds, unresolvedEndpointIds, true);
   }
 
-  private DexpiConnectionComponentInfo(String id, List<String> endpointIds,
-      List<DexpiConnectionEndpointInfo> endpoints, List<String> connectionIds, List<DexpiConnectionInfo> connections,
-      List<String> sourceEndpointIds, List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
+  private DexpiConnectionComponentInfo(String id, List<String> endpointIds, List<DexpiConnectionEndpointInfo> endpoints,
+      List<String> connectionIds, List<DexpiConnectionInfo> connections, List<String> sourceEndpointIds,
+      List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
       List<String> unresolvedEndpointIds, boolean completeEvidence) {
     this.id = normalize(id);
     this.endpointIds = immutableCopy(endpointIds);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1190,7 +1190,7 @@ public final class DexpiXmlReader {
         componentIndex = componentByEndpointId.get(connection.getToId());
       }
       if (componentIndex != null) {
-        components.get(componentIndex.intValue()).addConnection(connection.getId());
+        components.get(componentIndex.intValue()).addConnection(connection);
       }
     }
 
@@ -1387,7 +1387,7 @@ public final class DexpiXmlReader {
     private final String connectionComponentId;
     private final List<String> endpointIds = new ArrayList<String>();
     private final List<DexpiConnectionEndpointInfo> endpoints = new ArrayList<DexpiConnectionEndpointInfo>();
-    private final List<String> connectionIds = new ArrayList<String>();
+    private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     private final List<String> incomingBoundaryConnectionIds = new ArrayList<String>();
     private final List<String> outgoingBoundaryConnectionIds = new ArrayList<String>();
@@ -1457,12 +1457,16 @@ public final class DexpiXmlReader {
       endpoints.add(endpoint);
     }
 
-    private void addConnection(String connectionId) {
-      connectionIds.add(connectionId);
+    private void addConnection(DexpiConnectionInfo connection) {
+      connections.add(connection);
     }
 
     private DexpiConnectionComponentInfo toInfo() {
       List<String> endpointIds = new ArrayList<String>();
+      List<String> connectionIds = new ArrayList<String>();
+      for (DexpiConnectionInfo connection : connections) {
+        connectionIds.add(connection.getId());
+      }
       List<String> sourceEndpointIds = new ArrayList<String>();
       List<String> sinkEndpointIds = new ArrayList<String>();
       List<String> potentialMultiConnectionEndpointIds = new ArrayList<String>();
@@ -1482,8 +1486,8 @@ public final class DexpiXmlReader {
           unresolvedEndpointIds.add(endpoint.getEndpointId());
         }
       }
-      return new DexpiConnectionComponentInfo(id, endpointIds, connectionIds, sourceEndpointIds, sinkEndpointIds,
-          potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
+      return new DexpiConnectionComponentInfo(id, endpointIds, endpoints, connectionIds, connections,
+          sourceEndpointIds, sinkEndpointIds, potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
     }
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1387,7 +1387,7 @@ public final class DexpiXmlReader {
     private final String connectionComponentId;
     private final List<String> endpointIds = new ArrayList<String>();
     private final List<DexpiConnectionEndpointInfo> endpoints = new ArrayList<DexpiConnectionEndpointInfo>();
-    private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
+    private final List<String> connectionIds = new ArrayList<String>();
     private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     private final List<String> incomingBoundaryConnectionIds = new ArrayList<String>();
     private final List<String> outgoingBoundaryConnectionIds = new ArrayList<String>();
@@ -1447,7 +1447,7 @@ public final class DexpiXmlReader {
   private static final class ConnectionComponentAccumulator {
     private final String id;
     private final List<DexpiConnectionEndpointInfo> endpoints = new ArrayList<DexpiConnectionEndpointInfo>();
-    private final List<String> connectionIds = new ArrayList<String>();
+    private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
 
     private ConnectionComponentAccumulator(String id) {
       this.id = id;
@@ -1486,8 +1486,8 @@ public final class DexpiXmlReader {
           unresolvedEndpointIds.add(endpoint.getEndpointId());
         }
       }
-      return new DexpiConnectionComponentInfo(id, endpointIds, endpoints, connectionIds, connections,
-          sourceEndpointIds, sinkEndpointIds, potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
+      return new DexpiConnectionComponentInfo(id, endpointIds, endpoints, connectionIds, connections, sourceEndpointIds,
+          sinkEndpointIds, potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -912,8 +912,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"connectionComponentCount\": 3"));
     assertTrue(first.toJson().contains("\"hasUnresolvedEndpoints\": true"));
     assertTrue(first.toJson().contains("\"completeEvidence\": true"));
-    assertTrue(first.toJson().contains("\"connections\": [{"));
-    assertTrue(first.toJson().contains("\"endpoints\": [{"));
+    assertTrue(first.toJson().contains("\"connections\": ["));
+    assertTrue(first.toJson().contains("\"endpoints\": ["));
     assertEquals(first.toJson(), second.toJson());
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -865,9 +865,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(chain.hasUnresolvedEndpoints());
     assertFalse(chain.hasPotentialMultiConnectionNodes());
     assertTrue(chain.hasCompleteEvidence());
-    assertEquals(Arrays.asList("N-A", "N-J", "N-C"),
-        Arrays.asList(chain.getEndpoints().get(0).getEndpointId(), chain.getEndpoints().get(1).getEndpointId(),
-            chain.getEndpoints().get(2).getEndpointId()));
+    assertEquals(Arrays.asList("N-A", "N-J", "N-C"), Arrays.asList(chain.getEndpoints().get(0).getEndpointId(),
+        chain.getEndpoints().get(1).getEndpointId(), chain.getEndpoints().get(2).getEndpointId()));
     assertEquals("E-A", chain.getEndpoints().get(0).getOwnerId());
     assertSame(first.getConnectionEndpoints().get(0), chain.getEndpoints().get(0));
     assertEquals(Arrays.asList("C-1", "C-2"),

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -3,6 +3,7 @@ package neqsim.process.processmodel.dexpi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -864,6 +864,16 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(2, chain.getConnectionCount());
     assertFalse(chain.hasUnresolvedEndpoints());
     assertFalse(chain.hasPotentialMultiConnectionNodes());
+    assertTrue(chain.hasCompleteEvidence());
+    assertEquals(Arrays.asList("N-A", "N-J", "N-C"),
+        Arrays.asList(chain.getEndpoints().get(0).getEndpointId(), chain.getEndpoints().get(1).getEndpointId(),
+            chain.getEndpoints().get(2).getEndpointId()));
+    assertEquals("E-A", chain.getEndpoints().get(0).getOwnerId());
+    assertSame(first.getConnectionEndpoints().get(0), chain.getEndpoints().get(0));
+    assertEquals(Arrays.asList("C-1", "C-2"),
+        Arrays.asList(chain.getConnections().get(0).getId(), chain.getConnections().get(1).getId()));
+    assertEquals("S-1", chain.getConnections().get(0).getSegmentId());
+    assertSame(first.getConnections().get(0), chain.getConnections().get(0));
 
     DexpiConnectionComponentInfo parallel = first.getConnectionComponents().get(1);
     assertEquals("component-2", parallel.getId());
@@ -871,6 +881,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(Arrays.asList("C-3", "C-4"), parallel.getConnectionIds());
     assertEquals(Arrays.asList("N-X", "N-Y"), parallel.getPotentialMultiConnectionEndpointIds());
     assertTrue(parallel.hasPotentialMultiConnectionNodes());
+    assertEquals(Arrays.asList("C-3", "C-4"),
+        Arrays.asList(parallel.getConnections().get(0).getId(), parallel.getConnections().get(1).getId()));
+    assertSame(first.getConnections().get(2), parallel.getConnections().get(0));
+    assertSame(first.getConnections().get(3), parallel.getConnections().get(1));
 
     DexpiConnectionComponentInfo unresolved = first.getConnectionComponents().get(2);
     assertEquals("component-3", unresolved.getId());
@@ -879,11 +893,27 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(Collections.singletonList("UNKNOWN"), unresolved.getSourceEndpointIds());
     assertEquals(Collections.singletonList("UNKNOWN"), unresolved.getUnresolvedEndpointIds());
     assertTrue(unresolved.hasUnresolvedEndpoints());
+    assertFalse(unresolved.getEndpoints().get(0).isResolved());
+    assertEquals("C-5", unresolved.getConnections().get(0).getId());
 
     assertThrows(UnsupportedOperationException.class, () -> chain.getEndpointIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> chain.getEndpoints().clear());
+    assertThrows(UnsupportedOperationException.class, () -> chain.getConnections().clear());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionComponents().clear());
+
+    DexpiConnectionComponentInfo legacy = new DexpiConnectionComponentInfo("legacy",
+        Collections.singletonList("N-LEGACY"), Collections.singletonList("C-LEGACY"),
+        Collections.singletonList("N-LEGACY"), Collections.<String>emptyList(), Collections.<String>emptyList(),
+        Collections.<String>emptyList());
+    assertFalse(legacy.hasCompleteEvidence());
+    assertTrue(legacy.getEndpoints().isEmpty());
+    assertTrue(legacy.getConnections().isEmpty());
+
     assertTrue(first.toJson().contains("\"connectionComponentCount\": 3"));
     assertTrue(first.toJson().contains("\"hasUnresolvedEndpoints\": true"));
+    assertTrue(first.toJson().contains("\"completeEvidence\": true"));
+    assertTrue(first.toJson().contains("\"connections\": [{"));
+    assertTrue(first.toJson().contains("\"endpoints\": [{"));
     assertEquals(first.toJson(), second.toJson());
   }
 


### PR DESCRIPTION
## Summary

Advances the #1332 / #2899 shared P&ID–DEXPI roadmap with complete component-local source evidence.

- exposes complete immutable endpoint records for every weak material-reference component in first-reference order
- exposes complete immutable connection occurrences in source order, including parallel and one-sided references
- reuses the reader's existing parsed evidence so resolution, incidence, endpoint/owner provenance, segment provenance, and direction are available locally
- preserves all legacy constructors, ID getters, subsets, component identities, counts, ordering, diagnostics, and existing JSON fields
- adds a completeness discriminator for legacy scalar-only values

Capability contracts:
- https://github.com/equinor/neqsim/issues/1332#issuecomment-5559742533
- https://github.com/equinor/neqsim/issues/2899#issuecomment-5559743898

## Exact-head contract

- Exact base / publication-time master: `a3e3798477f9282e5f0ce7f0fa739c5bc11a8ed6`
- Exact repaired head: `16a98ec8ee9ceba874bae7f4c40f0bac5b54a2bb`
- Branch: `ai/dexpi-connection-component-evidence`
- Nine ordered commits across four intended files
- Zero commits behind publication-time master

Changed files:

1. `src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java`
2. `src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java`
3. `src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java`
4. `docs/integration/dexpi-reader.md`

## Acceptance evidence

Tests were authored first and require:

- component-local endpoint and connection records in deterministic order
- object identity with the existing global inventories
- parallel occurrences to remain distinct
- unresolved non-empty endpoints and one-sided connections to remain visible
- immutable object lists
- legacy constructors to retain existing scalar evidence while reporting incomplete object projection
- deterministic nested JSON

Connector-side inspection confirms the intended four-file diff, nine commits, exact base, and zero-behind publication state. No local Maven, Java, Spotless, Javadocs, pre-commit, or documentation result is claimed.

## Engineering boundary

This is immutable source-document evidence only. Weak grouping semantics are unchanged. It does not establish hydraulic continuity, line or fitting identity, process intent, flow feasibility, or executable topology. It does not repair or rewire topology and does not change simulation, rendering, geometry, layout, writer, or export behavior.

Whole-sheet visual gate: N/A because no diagram geometry or rendering path changes.

No DEXPI/ISO/ISA conformance claim, certification, safety credit, or engineering approval.

## Validation

**DRAFT — VALIDATION PENDING CI: JAVA 8 LANES ACTIVE**

Exact-head hosted results on `16a98ec8ee9ceba874bae7f4c40f0bac5b54a2bb`:

- Java 21 fast tests on Ubuntu and Windows: passed.
- All four Java 21 slow-test shards and Javadocs: passed.
- Spotless, pre-commit, PaperLab, CodeQL, documentation search, engineering-diagram performance, and the process-to-engineering notebook: passed.
- Java 8 fast tests on Ubuntu and Windows: active without a reported failure.

The predecessor head `e5ccc08d4d5ee7aa4537182a8532fb6e4372c78d` cleared compilation and passed the complete slow/non-Java matrix, then Java 21 Windows exposed one branch-attributable fast-test failure at `DexpiXmlReaderTest:915`: the test expected Gson's pretty-printed object array to contain the whitespace-sensitive literal `[{`, although Gson emits a newline between `[` and `{`.

The exact-head repair removes only that pretty-print whitespace coupling from two component JSON field-presence assertions. The typed component contents, object identity, deterministic ordering, immutable-list rejection, non-empty endpoint/connection evidence, and deterministic full JSON equality gates remain unchanged.

The two automated representation-exposure threads are resolved with evidence: both getters return constructor-owned `Collections.unmodifiableList` values whose entries are immutable. The suggested `List.copyOf` is unavailable under the Java 8 compatibility contract and copying entries would violate the intentional identity gate.

Production behavior, evidence semantics, compatibility, changed-file scope, DEXPI/ISO/ISA boundaries, whole-sheet visual applicability, and Huldra scope are unchanged. Exact-head GitHub Actions remain authoritative.

## Portfolio and publication policy

Current autonomous implementation-portfolio occupancy is **5/10**, below the ten-capability target and absolute ceiling. This is the sole active shared PFD/P&ID/DEXPI campaign PR, and its four files do not overlap the other positively identified autonomous drafts.

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.

Generated with AI assistance.