### PR TITLE
[AI-Assisted] feat(refinery): integrate qualified D86 reference points

### DIFF
--- a/docs/standards/oil_quality_standards.md
+++ b/docs/standards/oil_quality_standards.md
@@ -734,11 +734,25 @@ Source: M. R. Riazi and T. E. Daubert, “Analytical correlations interconvert
 distillation-curve types,” *Oil & Gas Journal*, vol. 84, no. 34, pp. 50–54, 57,
 August 25, 1986 ([public bibliographic record](https://www.osti.gov/biblio/5212509)).
 
+After `Standard_ASTM_D86.calculate()` has generated the simulated TBP-like curve, a strict
+reference-point conversion is available directly from the standard:
+
+```java
+double qualifiedD86T50C = d86.getQualifiedD86Temperature(50.0);
+double qualifiedD86T90K = d86.getQualifiedD86Temperature(90.0, "K");
+```
+
+`getQualifiedD86Temperature` delegates to the qualified reference converter, accepts only the
+seven published recovery points, enforces the point-specific source domain, and applies the
+standard's configured barometric correction after conversion. An unsupported recovery such as
+5 vol% is rejected; the method does not interpolate coefficients.
+
 This empirical conversion does not implement the ASTM D86 laboratory procedure, establish
 standards conformance, or independently validate NeqSim's simulated full curve against
-laboratory measurements. The existing `Standard_ASTM_D86.TBP_CONVERTED` reporting basis also
-retains its legacy coefficient interpolation behavior and therefore has a broader, explicitly
-unqualified boundary than this discrete reference API.
+laboratory measurements. The existing `Standard_ASTM_D86.TBP_CONVERTED` basis and
+`getD86Curve()` retain their legacy full-curve coefficient interpolation for compatibility.
+They now reuse the qualified coefficient table as their single data source, but intermediate
+recovery points remain explicitly unqualified.
 
 ---
 

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -186,7 +186,7 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
         self.assertIn("getQualifiedD86Temperature(", d86_source)
         self.assertIn("reference-point conversion is available", self.guide)
         self.assertIn("legacy full-curve coefficient interpolation", self.guide)
-        self.assertIn("intermediate recovery points remain explicitly unqualified", self.guide)
+        self.assertIn("recovery points remain explicitly unqualified", self.guide)
 
     def test_standards_indexes_discover_the_guide(self):
         link = "[Oil-quality methods](oil_quality_standards)"

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -184,7 +184,7 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
             self.guide,
         )
         self.assertIn("getQualifiedD86Temperature(", d86_source)
-        self.assertIn("strict reference-point conversion", self.guide)
+        self.assertIn("reference-point conversion is available", self.guide)
         self.assertIn("legacy full-curve coefficient interpolation", self.guide)
         self.assertIn("intermediate recovery points remain explicitly unqualified", self.guide)
 

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -165,6 +165,7 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
 
     def test_result_and_specification_boundaries_are_explicit(self):
         d4052_source = self.sources["Standard_ASTM_D4052"]
+        d86_source = self.sources["Standard_ASTM_D86"]
         bsw_source = self.sources["Standard_BSW"]
         self.assertNotIn("setMinAPIGravity", d4052_source)
         self.assertNotIn("setMaxAPIGravity", d4052_source)
@@ -182,6 +183,10 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
             "are temperatures",
             self.guide,
         )
+        self.assertIn("getQualifiedD86Temperature(", d86_source)
+        self.assertIn("strict reference-point conversion", self.guide)
+        self.assertIn("legacy full-curve coefficient interpolation", self.guide)
+        self.assertIn("intermediate recovery points remain explicitly unqualified", self.guide)
 
     def test_standards_indexes_discover_the_guide(self):
         link = "[Oil-quality methods](oil_quality_standards)"

--- a/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D86.java
+++ b/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D86.java
@@ -104,11 +104,9 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
   private final Map<String, Double> specLimitsC = new LinkedHashMap<String, Double>();
 
   /**
-   * Qualified Riazi-Daubert reference rows: recovery vol%, a, b, D86 range, and worked-example
-   * temperatures.
+   * Qualified Riazi-Daubert reference rows: recovery vol%, a, b, D86 range, and worked-example temperatures.
    */
-  private static final double[][] CONVERSION_REFERENCE_DATA =
-      RiaziDaubertDistillationConversion.getReferenceData();
+  private static final double[][] CONVERSION_REFERENCE_DATA = RiaziDaubertDistillationConversion.getReferenceData();
 
   /**
    * Reporting basis for the recovered (distilled) fraction of an ASTM D86 curve.
@@ -694,20 +692,19 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
   }
 
   /**
-   * Returns a source-qualified ASTM D86 temperature converted from the simulated TBP-like
-   * temperature at one published recovery point.
+   * Returns a source-qualified ASTM D86 temperature converted from the simulated TBP-like temperature at one published
+   * recovery point.
    *
    * <p>
-   * Only 0, 10, 30, 50, 70, 90, and 95 liquid-volume percent are accepted. Unlike the legacy
-   * full-curve conversion, this method does not interpolate correlation coefficients.
+   * Only 0, 10, 30, 50, 70, 90, and 95 liquid-volume percent are accepted. Unlike the legacy full-curve conversion,
+   * this method does not interpolate correlation coefficients.
    * </p>
    *
    * @param recoveryVolumePercent one of the seven published liquid-volume recovery percentages
    * @return converted ASTM D86 temperature in degrees Celsius
-   * @throws IllegalArgumentException if the recovery point or converted temperature is outside
-   *         the published reference domain
-   * @throws IllegalStateException if {@link #calculate()} did not produce the required TBP-like
-   *         temperature
+   * @throws IllegalArgumentException if the recovery point or converted temperature is outside the published reference
+   * domain
+   * @throws IllegalStateException if {@link #calculate()} did not produce the required TBP-like temperature
    */
   public double getQualifiedD86Temperature(double recoveryVolumePercent) {
     return getQualifiedD86Temperature(recoveryVolumePercent, "C");
@@ -719,27 +716,23 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
    * @param recoveryVolumePercent one of the seven published liquid-volume recovery percentages
    * @param tempUnit temperature unit ("C", "K", "F", or "R")
    * @return converted ASTM D86 temperature in the requested unit
-   * @throws IllegalArgumentException if the recovery point or converted temperature is outside
-   *         the published reference domain
-   * @throws IllegalStateException if {@link #calculate()} did not produce the required TBP-like
-   *         temperature
+   * @throws IllegalArgumentException if the recovery point or converted temperature is outside the published reference
+   * domain
+   * @throws IllegalStateException if {@link #calculate()} did not produce the required TBP-like temperature
    */
   public double getQualifiedD86Temperature(double recoveryVolumePercent, String tempUnit) {
     if (!RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(recoveryVolumePercent)) {
-      throw new IllegalArgumentException(
-          "Qualified D86 conversion supports only 0, 10, 30, 50, 70, 90, or 95 vol%");
+      throw new IllegalArgumentException("Qualified D86 conversion supports only 0, 10, 30, 50, 70, 90, or 95 vol%");
     }
 
     double fraction = recoveryVolumePercent / 100.0;
-    double tbpK = Math.abs(recoveryVolumePercent) < 1.0e-9 ? IBP
-        : getTemperatureAtFraction(fraction);
+    double tbpK = Math.abs(recoveryVolumePercent) < 1.0e-9 ? IBP : getTemperatureAtFraction(fraction);
     if (Double.isNaN(tbpK) || Double.isInfinite(tbpK)) {
       throw new IllegalStateException(
           "No simulated TBP-like temperature is available; call calculate() successfully first");
     }
 
-    double d86C = RiaziDaubertDistillationConversion.convertTbpToD86C(tbpK - 273.15,
-        recoveryVolumePercent);
+    double d86C = RiaziDaubertDistillationConversion.convertTbpToD86C(tbpK - 273.15, recoveryVolumePercent);
     double correctedC = applyBarometricCorrectionK(d86C + 273.15) - 273.15;
     return convertTempFromC(correctedC, tempUnit);
   }

--- a/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D86.java
+++ b/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D86.java
@@ -103,14 +103,12 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
   /** Optional product specification limits (point key -&gt; max temperature in Celsius). */
   private final Map<String, Double> specLimitsC = new LinkedHashMap<String, Double>();
 
-  /** Volume-percent breakpoints for the Riazi-Daubert ASTM D86 &harr; TBP interconversion. */
-  private static final double[] CONV_PCT = { 0.0, 10.0, 30.0, 50.0, 70.0, 90.0, 95.0 };
-
-  /** Coefficient a for T_TBP = a (T_D86)^b at each breakpoint (Kelvin). */
-  private static final double[] CONV_A = { 0.9177, 0.5564, 0.7617, 0.9013, 0.8821, 0.9552, 0.8177 };
-
-  /** Exponent b for T_TBP = a (T_D86)^b at each breakpoint (Kelvin). */
-  private static final double[] CONV_B = { 1.0019, 1.0900, 1.0425, 1.0176, 1.0226, 1.0110, 1.0355 };
+  /**
+   * Qualified Riazi-Daubert reference rows: recovery vol%, a, b, D86 range, and worked-example
+   * temperatures.
+   */
+  private static final double[][] CONVERSION_REFERENCE_DATA =
+      RiaziDaubertDistillationConversion.getReferenceData();
 
   /**
    * Reporting basis for the recovered (distilled) fraction of an ASTM D86 curve.
@@ -457,22 +455,25 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
    * @return a two-element array {a, b}
    */
   private double[] conversionCoefficients(double percent) {
-    int last = CONV_PCT.length - 1;
-    if (percent <= CONV_PCT[0]) {
-      return new double[] { CONV_A[0], CONV_B[0] };
+    int last = CONVERSION_REFERENCE_DATA.length - 1;
+    if (percent <= CONVERSION_REFERENCE_DATA[0][0]) {
+      return new double[] { CONVERSION_REFERENCE_DATA[0][1], CONVERSION_REFERENCE_DATA[0][2] };
     }
-    if (percent >= CONV_PCT[last]) {
-      return new double[] { CONV_A[last], CONV_B[last] };
+    if (percent >= CONVERSION_REFERENCE_DATA[last][0]) {
+      return new double[] { CONVERSION_REFERENCE_DATA[last][1], CONVERSION_REFERENCE_DATA[last][2] };
     }
-    for (int i = 1; i < CONV_PCT.length; i++) {
-      if (percent <= CONV_PCT[i]) {
-        double t = (percent - CONV_PCT[i - 1]) / (CONV_PCT[i] - CONV_PCT[i - 1]);
-        double a = CONV_A[i - 1] + t * (CONV_A[i] - CONV_A[i - 1]);
-        double b = CONV_B[i - 1] + t * (CONV_B[i] - CONV_B[i - 1]);
+    for (int i = 1; i < CONVERSION_REFERENCE_DATA.length; i++) {
+      if (percent <= CONVERSION_REFERENCE_DATA[i][0]) {
+        double t = (percent - CONVERSION_REFERENCE_DATA[i - 1][0])
+            / (CONVERSION_REFERENCE_DATA[i][0] - CONVERSION_REFERENCE_DATA[i - 1][0]);
+        double a = CONVERSION_REFERENCE_DATA[i - 1][1]
+            + t * (CONVERSION_REFERENCE_DATA[i][1] - CONVERSION_REFERENCE_DATA[i - 1][1]);
+        double b = CONVERSION_REFERENCE_DATA[i - 1][2]
+            + t * (CONVERSION_REFERENCE_DATA[i][2] - CONVERSION_REFERENCE_DATA[i - 1][2]);
         return new double[] { a, b };
       }
     }
-    return new double[] { CONV_A[last], CONV_B[last] };
+    return new double[] { CONVERSION_REFERENCE_DATA[last][1], CONVERSION_REFERENCE_DATA[last][2] };
   }
 
   /**
@@ -690,6 +691,57 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
       curve[i][1] = Double.isNaN(temperatures[i]) ? Double.NaN : temperatures[i] - 273.15;
     }
     return curve;
+  }
+
+  /**
+   * Returns a source-qualified ASTM D86 temperature converted from the simulated TBP-like
+   * temperature at one published recovery point.
+   *
+   * <p>
+   * Only 0, 10, 30, 50, 70, 90, and 95 liquid-volume percent are accepted. Unlike the legacy
+   * full-curve conversion, this method does not interpolate correlation coefficients.
+   * </p>
+   *
+   * @param recoveryVolumePercent one of the seven published liquid-volume recovery percentages
+   * @return converted ASTM D86 temperature in degrees Celsius
+   * @throws IllegalArgumentException if the recovery point or converted temperature is outside
+   *         the published reference domain
+   * @throws IllegalStateException if {@link #calculate()} did not produce the required TBP-like
+   *         temperature
+   */
+  public double getQualifiedD86Temperature(double recoveryVolumePercent) {
+    return getQualifiedD86Temperature(recoveryVolumePercent, "C");
+  }
+
+  /**
+   * Returns a source-qualified ASTM D86 temperature in the requested unit.
+   *
+   * @param recoveryVolumePercent one of the seven published liquid-volume recovery percentages
+   * @param tempUnit temperature unit ("C", "K", "F", or "R")
+   * @return converted ASTM D86 temperature in the requested unit
+   * @throws IllegalArgumentException if the recovery point or converted temperature is outside
+   *         the published reference domain
+   * @throws IllegalStateException if {@link #calculate()} did not produce the required TBP-like
+   *         temperature
+   */
+  public double getQualifiedD86Temperature(double recoveryVolumePercent, String tempUnit) {
+    if (!RiaziDaubertDistillationConversion.isSupportedRecoveryPoint(recoveryVolumePercent)) {
+      throw new IllegalArgumentException(
+          "Qualified D86 conversion supports only 0, 10, 30, 50, 70, 90, or 95 vol%");
+    }
+
+    double fraction = recoveryVolumePercent / 100.0;
+    double tbpK = Math.abs(recoveryVolumePercent) < 1.0e-9 ? IBP
+        : getTemperatureAtFraction(fraction);
+    if (Double.isNaN(tbpK) || Double.isInfinite(tbpK)) {
+      throw new IllegalStateException(
+          "No simulated TBP-like temperature is available; call calculate() successfully first");
+    }
+
+    double d86C = RiaziDaubertDistillationConversion.convertTbpToD86C(tbpK - 273.15,
+        recoveryVolumePercent);
+    double correctedC = applyBarometricCorrectionK(d86C + 273.15) - 273.15;
+    return convertTempFromC(correctedC, tempUnit);
   }
 
   /**

--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
@@ -285,8 +285,8 @@ public class OilQualityStandardsTest {
   }
 
   /**
-   * Verifies the strict Standard_ASTM_D86 integration delegates published recovery points to the
-   * qualified converter while preserving the legacy curve at those breakpoints.
+   * Verifies the strict Standard_ASTM_D86 integration delegates published recovery points to the qualified converter
+   * while preserving the legacy curve at those breakpoints.
    */
   @Test
   void testASTM_D86_qualifiedReferencePointIntegration() {
@@ -306,15 +306,12 @@ public class OilQualityStandardsTest {
     }
 
     assertTrue(!Double.isNaN(tbpT50C), "Simulated TBP-like T50 should be available");
-    double expectedD86T50C =
-        RiaziDaubertDistillationConversion.convertTbpToD86C(tbpT50C, 50.0);
+    double expectedD86T50C = RiaziDaubertDistillationConversion.convertTbpToD86C(tbpT50C, 50.0);
     assertEquals(expectedD86T50C, standard.getQualifiedD86Temperature(50.0), 1.0e-10);
-    assertEquals(expectedD86T50C + 273.15,
-        standard.getQualifiedD86Temperature(50.0, "K"), 1.0e-10);
+    assertEquals(expectedD86T50C + 273.15, standard.getQualifiedD86Temperature(50.0, "K"), 1.0e-10);
     assertEquals(expectedD86T50C, legacyD86T50C, 1.0e-10,
         "Legacy interpolation must be unchanged at a published breakpoint");
-    assertThrows(IllegalArgumentException.class,
-        () -> standard.getQualifiedD86Temperature(5.0));
+    assertThrows(IllegalArgumentException.class, () -> standard.getQualifiedD86Temperature(5.0));
   }
 
   /**

--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
@@ -2,6 +2,7 @@ package neqsim.standards.oilquality;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.phase.PhaseType;
@@ -281,6 +282,39 @@ public class OilQualityStandardsTest {
     double convertedT50 = standard.getValue("T50");
     assertTrue(Math.abs(convertedT50 - molarT50) > 0.1, "TBP_CONVERTED basis should change the reported T50");
     standard.setBasis(Standard_ASTM_D86.D86Basis.MOLAR);
+  }
+
+  /**
+   * Verifies the strict Standard_ASTM_D86 integration delegates published recovery points to the
+   * qualified converter while preserving the legacy curve at those breakpoints.
+   */
+  @Test
+  void testASTM_D86_qualifiedReferencePointIntegration() {
+    Standard_ASTM_D86 standard = new Standard_ASTM_D86(createLightOil());
+    standard.calculate();
+
+    double tbpT50C = Double.NaN;
+    double legacyD86T50C = Double.NaN;
+    double[][] tbpCurve = standard.getTBPCurve();
+    double[][] legacyD86Curve = standard.getD86Curve();
+    for (int i = 0; i < tbpCurve.length; i++) {
+      if (Math.abs(tbpCurve[i][0] - 50.0) < 1.0e-9) {
+        tbpT50C = tbpCurve[i][1];
+        legacyD86T50C = legacyD86Curve[i][1];
+        break;
+      }
+    }
+
+    assertTrue(!Double.isNaN(tbpT50C), "Simulated TBP-like T50 should be available");
+    double expectedD86T50C =
+        RiaziDaubertDistillationConversion.convertTbpToD86C(tbpT50C, 50.0);
+    assertEquals(expectedD86T50C, standard.getQualifiedD86Temperature(50.0), 1.0e-10);
+    assertEquals(expectedD86T50C + 273.15,
+        standard.getQualifiedD86Temperature(50.0, "K"), 1.0e-10);
+    assertEquals(expectedD86T50C, legacyD86T50C, 1.0e-10,
+        "Legacy interpolation must be unchanged at a published breakpoint");
+    assertThrows(IllegalArgumentException.class,
+        () -> standard.getQualifiedD86Temperature(5.0));
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements the next dependency-ready increment for refinery campaign #3305 under the preimplementation contract recorded in [the campaign ledger](https://github.com/equinor/neqsim/issues/3305#issuecomment-5559783197).

- adds Java/JPype-friendly strict Riazi–Daubert D86 accessors on `Standard_ASTM_D86`
- accepts only the seven published recovery points and delegates the calculation to `RiaziDaubertDistillationConversion`
- rejects unsupported recoveries, unavailable simulated temperatures, unsupported units, and out-of-domain inverse results
- reuses the qualified reference table as the single coefficient source for the existing legacy interpolation
- preserves the existing `TBP_CONVERTED` and `getD86Curve()` full-curve behavior

## Scientific and engineering boundary

The strict path is qualified only at the seven published recovery points and within the converter's documented temperature domains. It applies the configured barometric correction after the D86/TBP conversion. Intermediate recovery interpolation remains legacy behavior and is not upgraded to qualified evidence.

The implementation does not change PVF calculation, D86 bases, barometric correction order, product specifications, recovery logic, pseudo-components, fractionation, Sarir data, defaults, or other oil-quality standards.

Provenance is the public bibliographic record for Riazi and Daubert (1986): https://www.osti.gov/biblio/5212509. No ASTM procedure text is reproduced and no ASTM compliance claim is made.

## Validation and acceptance

Added focused tests for:

- strict standard-to-converter delegation
- Celsius and Kelvin unit handling
- fail-closed unsupported recovery behavior
- unchanged legacy interpolation at a published breakpoint

Documentation and its executable contract distinguish the strict seven-point path from the legacy full-curve path.

Connector-side structural audits pass: balanced braces, no tabs or trailing whitespace, Java line length at most 120 characters, and all expected contract markers present. The previous exact head passed Spotless, pre-commit, PaperLab, CodeQL, and the full build/test/Javadocs workflow. This repair changes only the remaining documentation assertion to match the contiguous boundary phrase already present in the guide; engineering behavior, APIs, provenance, and acceptance limits are unchanged. Fresh exact-head CI is running, so status is **VALIDATION PENDING EXACT-HEAD CI**.

## Exact-head record

- recorded base: `a3e3798477f9282e5f0ce7f0fa739c5bc11a8ed6`
- exact head: `f97886b205f3b35d2c103400ad2a5dd5d54f805b`
- ordered commits: 6
- changed files: 4
- comparison against recorded base: 6 commits ahead, 0 behind
- portfolio occupancy: **6/10**
- ownership check: no overlap with open autonomous PRs #3493, #3503, #3506, #3507, or #3508

## Publication boundary

Draft only. Do not merge, rebase, synchronize, replace, close, or mark ready for review through the autonomous campaign. Any branch-attributable validation repair must preserve this capability contract and scientific acceptance boundary.