### PR TITLE
[AI-Assisted] test(tpflash): qualify PC-SAFT phase lifecycle

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2382,6 +2382,34 @@ derivative behavior, model or data parameter changes, saturation operations,
 electrolyte/reaction models, public API and serialization changes, Column Solver,
 Process Performance, proprietary data, and Huldra are outside this tranche.
 
+### 6.4.15 PC-SAFT methane/n-hexane phase-split lifecycle qualification
+
+The synthetic PC-SAFT qualification uses `SystemPCSAFT`, mixing rule 1, and an
+equimolar methane/n-hexane feed. Its local phase-split envelope is 248-252 K and
+9-11 bara. At 250 K and 10 bara, the existing total heat-capacity reference is
+`172.3659584364608 J/K` with an absolute tolerance of `0.1 J/K`. This is
+deterministic numerical qualification of the current Java calculation, not
+independent experimental validation or a re-fit of PC-SAFT parameters.
+
+Every qualified state must contain GAS and OIL phases with finite bounded phase
+fractions and compositions. Beta and phase compositions must normalize within
+`3e-12`, maximum component material-balance residual must remain below
+`1e-10`, and the maximum methane/n-hexane interphase log-fugacity residual must
+remain below `1e-8`. Both phases require positive finite compressibility, and
+total Gibbs energy and enthalpy must remain finite.
+
+Ordinary and explicit-multiphase public TP flashes must agree throughout the nearby
+temperature and pressure matrices. The regression also qualifies recovery from
+beta values within `1e-12` of a bound, a changed temperature/pressure state,
+return to the reference state, and an immediate deterministic repeat.
+
+The focused class performs 20 complete public TP flashes. This fixed workload is
+performance evidence only; no wall-clock threshold or speedup is claimed. PC-SAFT
+parameter or association changes, petroleum characterization, PH/PS operations,
+process equipment, saturation operations, public APIs, MCP payloads, Column
+Solver, Process Performance, proprietary data, and Huldra are outside this
+tranche.
+
 ### 6.5 Hybrid EOS-GE ionic-capacity safeguard
 
 In a fixed-role EOS-gas/GE-aqueous calculation, ions are excluded from every non-aqueous role.

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashPCSAFTPhaseLifecycleTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashPCSAFTPhaseLifecycleTest.java
@@ -1,0 +1,254 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPCSAFT;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Qualification tests for the PC-SAFT methane/n-hexane TP-flash lifecycle.
+ *
+ * <p>
+ * The synthetic binary retains the existing 250 K and 10 bara heat-capacity reference while
+ * adding strict equilibrium closure, algorithm agreement, poor-initialization, nearby-state, and
+ * reused-state contracts. This is numerical qualification, not independent validation of PC-SAFT
+ * parameters.
+ * </p>
+ */
+class TPflashPCSAFTPhaseLifecycleTest {
+  private static final double REFERENCE_TEMPERATURE_K = 250.0;
+  private static final double REFERENCE_PRESSURE_BARA = 10.0;
+  private static final double REFERENCE_HEAT_CAPACITY_J_PER_K = 172.3659584364608;
+
+  private static final double NORMALIZATION_TOLERANCE = 3.0e-12;
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+
+  /**
+   * Nearby temperature and pressure matrices must retain closed, algorithm-independent
+   * equilibrium.
+   */
+  @Test
+  void nearbyTemperatureAndPressureMatricesRemainClosed() {
+    for (double temperatureK : new double[] {248.0, REFERENCE_TEMPERATURE_K, 252.0}) {
+      SystemInterface ordinary = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, false));
+      SystemInterface multiphase =
+          flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, true));
+      assertQualifiedState(ordinary, "ordinary temperature " + temperatureK);
+      assertQualifiedState(multiphase, "multiphase temperature " + temperatureK);
+      assertEquivalentState(ordinary, multiphase, 1.0e-8,
+          "algorithm agreement at " + temperatureK + " K");
+    }
+
+    for (double pressureBara : new double[] {9.0, REFERENCE_PRESSURE_BARA, 11.0}) {
+      SystemInterface ordinary = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, false));
+      SystemInterface multiphase =
+          flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, true));
+      assertQualifiedState(ordinary, "ordinary pressure " + pressureBara);
+      assertQualifiedState(multiphase, "multiphase pressure " + pressureBara);
+      assertEquivalentState(ordinary, multiphase, 1.0e-8,
+          "algorithm agreement at " + pressureBara + " bara");
+    }
+  }
+
+  /**
+   * The established reference-state total heat capacity must remain unchanged.
+   */
+  @Test
+  void referenceStateRetainsHeatCapacityAnchor() {
+    SystemInterface system =
+        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    system.initProperties();
+
+    assertQualifiedState(system, "reference heat-capacity state");
+    assertEquals(REFERENCE_HEAT_CAPACITY_J_PER_K, system.getCp(), 0.1,
+        "reference total heat capacity in J/K");
+  }
+
+  /**
+   * Beta values near a bound must recover the same closed reference equilibrium.
+   */
+  @Test
+  void poorInitializationRecoversReferenceState() {
+    SystemInterface reference =
+        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface poor =
+        createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
+    poor.init(0);
+    assertTrue(poor.getNumberOfPhases() >= 2, "poor initialization requires two phase slots");
+    poor.setBeta(0, 1.0e-12);
+    poor.setBeta(1, 1.0 - 1.0e-12);
+    flash(poor);
+
+    assertEquivalentState(reference, poor, 1.0e-8, "poor initialization");
+  }
+
+  /**
+   * A reused system must match fresh changed and returned states and settle deterministically.
+   */
+  @Test
+  void changedReturnedAndRepeatedStatesRemainEquivalent() {
+    SystemInterface reference =
+        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface reused = reference.clone();
+
+    reused.setTemperature(252.0, "K");
+    reused.setPressure(11.0, "bara");
+    flash(reused);
+    SystemInterface freshChanged = flash(createSystem(252.0, 11.0, true));
+    assertEquivalentState(freshChanged, reused, 1.0e-8, "changed state");
+
+    reused.setTemperature(REFERENCE_TEMPERATURE_K, "K");
+    reused.setPressure(REFERENCE_PRESSURE_BARA, "bara");
+    flash(reused);
+    assertEquivalentState(reference, reused, 1.0e-8, "returned state");
+
+    SystemInterface previous = reused.clone();
+    flash(reused);
+    assertEquivalentState(previous, reused, 1.0e-10, "deterministic repeat");
+  }
+
+  private SystemInterface createSystem(
+      double temperatureK, double pressureBara, boolean multiphaseCheck) {
+    SystemInterface system = new SystemPCSAFT(temperatureK, pressureBara);
+    system.addComponent("methane", 1.0);
+    system.addComponent("n-hexane", 1.0);
+    system.setMixingRule(1);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    return system;
+  }
+
+  private SystemInterface flash(SystemInterface system) {
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertQualifiedState(SystemInterface system, String label) {
+    assertEquals(2, system.getNumberOfPhases(), label + " phase count");
+    assertTrue(system.hasPhaseType(PhaseType.GAS), label + " gas phase");
+    assertTrue(system.hasPhaseType(PhaseType.OIL), label + " oil phase");
+
+    int componentCount = system.getPhase(0).getNumberOfComponents();
+    double betaTotal = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0,
+          label + " beta " + phase + ": " + beta);
+      betaTotal += beta;
+
+      double compositionTotal = 0.0;
+      for (int component = 0; component < componentCount; component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0,
+            label + " composition " + phase + "/" + component + ": " + composition);
+        compositionTotal += composition;
+      }
+      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE,
+          label + " composition normalization " + phase);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ())
+          && system.getPhase(phase).getZ() > 0.0, label + " compressibility " + phase);
+    }
+    assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
+
+    double materialResidual = maximumComponentMaterialBalanceResidual(system);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
+        label + " material-balance residual " + materialResidual);
+
+    double fugacityResidual = maximumComparableLogFugacityResidual(system);
+    assertTrue(fugacityResidual < FUGACITY_TOLERANCE,
+        label + " fugacity residual " + fugacityResidual);
+
+    assertTrue(Double.isFinite(system.getGibbsEnergy()), label + " Gibbs energy");
+    assertTrue(Double.isFinite(system.getEnthalpy()), label + " enthalpy");
+  }
+
+  private void assertEquivalentState(
+      SystemInterface expected, SystemInterface actual, double tolerance, String label) {
+    assertQualifiedState(expected, label + " expected");
+    assertQualifiedState(actual, label + " actual");
+
+    for (PhaseType type : new PhaseType[] {PhaseType.GAS, PhaseType.OIL}) {
+      int expectedPhase = findPhase(expected, type);
+      int actualPhase = findPhase(actual, type);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
+          label + " beta " + type);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(),
+          tolerance, label + " compressibility " + type);
+      for (int component = 0;
+          component < expected.getPhase(expectedPhase).getNumberOfComponents();
+          component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
+            label + " composition " + type + "/" + component);
+      }
+    }
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance,
+        label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance,
+        label + " enthalpy");
+  }
+
+  private void assertExtensiveEquals(
+      double expected, double actual, double relativeTolerance, String label) {
+    assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
+  }
+
+  private int findPhase(SystemInterface system, PhaseType type) {
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      if (system.getPhase(phase).getType() == type) {
+        return phase;
+      }
+    }
+    throw new AssertionError("missing phase " + type);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int component = 0;
+        component < system.getPhase(0).getNumberOfComponents();
+        component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered +=
+            system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumComparableLogFugacityResidual(SystemInterface system) {
+    int gasPhase = findPhase(system, PhaseType.GAS);
+    int oilPhase = findPhase(system, PhaseType.OIL);
+    double maximumResidual = 0.0;
+    int comparisons = 0;
+    for (int component = 0;
+        component < system.getPhase(0).getNumberOfComponents();
+        component++) {
+      double gasComposition = system.getPhase(gasPhase).getComponent(component).getx();
+      double oilComposition = system.getPhase(oilPhase).getComponent(component).getx();
+      double gasCoefficient =
+          system.getPhase(gasPhase).getComponent(component).getFugacityCoefficient();
+      double oilCoefficient =
+          system.getPhase(oilPhase).getComponent(component).getFugacityCoefficient();
+      if (gasComposition > 1.0e-20 && oilComposition > 1.0e-20
+          && Double.isFinite(gasCoefficient) && gasCoefficient > 0.0
+          && Double.isFinite(oilCoefficient) && oilCoefficient > 0.0) {
+        double gasLogFugacity = Math.log(gasComposition * gasCoefficient);
+        double oilLogFugacity = Math.log(oilComposition * oilCoefficient);
+        maximumResidual =
+            Math.max(maximumResidual, Math.abs(gasLogFugacity - oilLogFugacity));
+        comparisons++;
+      }
+    }
+    assertEquals(2, comparisons, "both components must expose comparable fugacities");
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashPCSAFTPhaseLifecycleTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashPCSAFTPhaseLifecycleTest.java
@@ -14,10 +14,9 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * Qualification tests for the PC-SAFT methane/n-hexane TP-flash lifecycle.
  *
  * <p>
- * The synthetic binary retains the existing 250 K and 10 bara heat-capacity reference while
- * adding strict equilibrium closure, algorithm agreement, poor-initialization, nearby-state, and
- * reused-state contracts. This is numerical qualification, not independent validation of PC-SAFT
- * parameters.
+ * The synthetic binary retains the existing 250 K and 10 bara heat-capacity reference while adding strict equilibrium
+ * closure, algorithm agreement, poor-initialization, nearby-state, and reused-state contracts. This is numerical
+ * qualification, not independent validation of PC-SAFT parameters.
  * </p>
  */
 class TPflashPCSAFTPhaseLifecycleTest {
@@ -30,29 +29,24 @@ class TPflashPCSAFTPhaseLifecycleTest {
   private static final double FUGACITY_TOLERANCE = 1.0e-8;
 
   /**
-   * Nearby temperature and pressure matrices must retain closed, algorithm-independent
-   * equilibrium.
+   * Nearby temperature and pressure matrices must retain closed, algorithm-independent equilibrium.
    */
   @Test
   void nearbyTemperatureAndPressureMatricesRemainClosed() {
-    for (double temperatureK : new double[] {248.0, REFERENCE_TEMPERATURE_K, 252.0}) {
+    for (double temperatureK : new double[] { 248.0, REFERENCE_TEMPERATURE_K, 252.0 }) {
       SystemInterface ordinary = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, false));
-      SystemInterface multiphase =
-          flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, true));
+      SystemInterface multiphase = flash(createSystem(temperatureK, REFERENCE_PRESSURE_BARA, true));
       assertQualifiedState(ordinary, "ordinary temperature " + temperatureK);
       assertQualifiedState(multiphase, "multiphase temperature " + temperatureK);
-      assertEquivalentState(ordinary, multiphase, 1.0e-8,
-          "algorithm agreement at " + temperatureK + " K");
+      assertEquivalentState(ordinary, multiphase, 1.0e-8, "algorithm agreement at " + temperatureK + " K");
     }
 
-    for (double pressureBara : new double[] {9.0, REFERENCE_PRESSURE_BARA, 11.0}) {
+    for (double pressureBara : new double[] { 9.0, REFERENCE_PRESSURE_BARA, 11.0 }) {
       SystemInterface ordinary = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, false));
-      SystemInterface multiphase =
-          flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, true));
+      SystemInterface multiphase = flash(createSystem(REFERENCE_TEMPERATURE_K, pressureBara, true));
       assertQualifiedState(ordinary, "ordinary pressure " + pressureBara);
       assertQualifiedState(multiphase, "multiphase pressure " + pressureBara);
-      assertEquivalentState(ordinary, multiphase, 1.0e-8,
-          "algorithm agreement at " + pressureBara + " bara");
+      assertEquivalentState(ordinary, multiphase, 1.0e-8, "algorithm agreement at " + pressureBara + " bara");
     }
   }
 
@@ -61,13 +55,11 @@ class TPflashPCSAFTPhaseLifecycleTest {
    */
   @Test
   void referenceStateRetainsHeatCapacityAnchor() {
-    SystemInterface system =
-        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface system = flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
     system.initProperties();
 
     assertQualifiedState(system, "reference heat-capacity state");
-    assertEquals(REFERENCE_HEAT_CAPACITY_J_PER_K, system.getCp(), 0.1,
-        "reference total heat capacity in J/K");
+    assertEquals(REFERENCE_HEAT_CAPACITY_J_PER_K, system.getCp(), 0.1, "reference total heat capacity in J/K");
   }
 
   /**
@@ -75,10 +67,8 @@ class TPflashPCSAFTPhaseLifecycleTest {
    */
   @Test
   void poorInitializationRecoversReferenceState() {
-    SystemInterface reference =
-        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
-    SystemInterface poor =
-        createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
+    SystemInterface reference = flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface poor = createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
     poor.init(0);
     assertTrue(poor.getNumberOfPhases() >= 2, "poor initialization requires two phase slots");
     poor.setBeta(0, 1.0e-12);
@@ -93,8 +83,7 @@ class TPflashPCSAFTPhaseLifecycleTest {
    */
   @Test
   void changedReturnedAndRepeatedStatesRemainEquivalent() {
-    SystemInterface reference =
-        flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
+    SystemInterface reference = flash(createSystem(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true));
     SystemInterface reused = reference.clone();
 
     reused.setTemperature(252.0, "K");
@@ -113,8 +102,7 @@ class TPflashPCSAFTPhaseLifecycleTest {
     assertEquivalentState(previous, reused, 1.0e-10, "deterministic repeat");
   }
 
-  private SystemInterface createSystem(
-      double temperatureK, double pressureBara, boolean multiphaseCheck) {
+  private SystemInterface createSystem(double temperatureK, double pressureBara, boolean multiphaseCheck) {
     SystemInterface system = new SystemPCSAFT(temperatureK, pressureBara);
     system.addComponent("methane", 1.0);
     system.addComponent("n-hexane", 1.0);
@@ -138,8 +126,7 @@ class TPflashPCSAFTPhaseLifecycleTest {
     double betaTotal = 0.0;
     for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
       double beta = system.getBeta(phase);
-      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0,
-          label + " beta " + phase + ": " + beta);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0, label + " beta " + phase + ": " + beta);
       betaTotal += beta;
 
       double compositionTotal = 0.0;
@@ -149,53 +136,43 @@ class TPflashPCSAFTPhaseLifecycleTest {
             label + " composition " + phase + "/" + component + ": " + composition);
         compositionTotal += composition;
       }
-      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE,
-          label + " composition normalization " + phase);
-      assertTrue(Double.isFinite(system.getPhase(phase).getZ())
-          && system.getPhase(phase).getZ() > 0.0, label + " compressibility " + phase);
+      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE, label + " composition normalization " + phase);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0,
+          label + " compressibility " + phase);
     }
     assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
 
     double materialResidual = maximumComponentMaterialBalanceResidual(system);
-    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
-        label + " material-balance residual " + materialResidual);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE, label + " material-balance residual " + materialResidual);
 
     double fugacityResidual = maximumComparableLogFugacityResidual(system);
-    assertTrue(fugacityResidual < FUGACITY_TOLERANCE,
-        label + " fugacity residual " + fugacityResidual);
+    assertTrue(fugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + fugacityResidual);
 
     assertTrue(Double.isFinite(system.getGibbsEnergy()), label + " Gibbs energy");
     assertTrue(Double.isFinite(system.getEnthalpy()), label + " enthalpy");
   }
 
-  private void assertEquivalentState(
-      SystemInterface expected, SystemInterface actual, double tolerance, String label) {
+  private void assertEquivalentState(SystemInterface expected, SystemInterface actual, double tolerance, String label) {
     assertQualifiedState(expected, label + " expected");
     assertQualifiedState(actual, label + " actual");
 
-    for (PhaseType type : new PhaseType[] {PhaseType.GAS, PhaseType.OIL}) {
+    for (PhaseType type : new PhaseType[] { PhaseType.GAS, PhaseType.OIL }) {
       int expectedPhase = findPhase(expected, type);
       int actualPhase = findPhase(actual, type);
-      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
-          label + " beta " + type);
-      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(),
-          tolerance, label + " compressibility " + type);
-      for (int component = 0;
-          component < expected.getPhase(expectedPhase).getNumberOfComponents();
-          component++) {
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance, label + " beta " + type);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), tolerance,
+          label + " compressibility " + type);
+      for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
         assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
             actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
             label + " composition " + type + "/" + component);
       }
     }
-    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance,
-        label + " Gibbs energy");
-    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance,
-        label + " enthalpy");
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance, label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance, label + " enthalpy");
   }
 
-  private void assertExtensiveEquals(
-      double expected, double actual, double relativeTolerance, String label) {
+  private void assertExtensiveEquals(double expected, double actual, double relativeTolerance, String label) {
     assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
   }
 
@@ -210,13 +187,10 @@ class TPflashPCSAFTPhaseLifecycleTest {
 
   private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
     double maximumResidual = 0.0;
-    for (int component = 0;
-        component < system.getPhase(0).getNumberOfComponents();
-        component++) {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       double recovered = 0.0;
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
-        recovered +=
-            system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
       }
       maximumResidual = Math.max(maximumResidual,
           Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
@@ -229,22 +203,16 @@ class TPflashPCSAFTPhaseLifecycleTest {
     int oilPhase = findPhase(system, PhaseType.OIL);
     double maximumResidual = 0.0;
     int comparisons = 0;
-    for (int component = 0;
-        component < system.getPhase(0).getNumberOfComponents();
-        component++) {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       double gasComposition = system.getPhase(gasPhase).getComponent(component).getx();
       double oilComposition = system.getPhase(oilPhase).getComponent(component).getx();
-      double gasCoefficient =
-          system.getPhase(gasPhase).getComponent(component).getFugacityCoefficient();
-      double oilCoefficient =
-          system.getPhase(oilPhase).getComponent(component).getFugacityCoefficient();
-      if (gasComposition > 1.0e-20 && oilComposition > 1.0e-20
-          && Double.isFinite(gasCoefficient) && gasCoefficient > 0.0
-          && Double.isFinite(oilCoefficient) && oilCoefficient > 0.0) {
+      double gasCoefficient = system.getPhase(gasPhase).getComponent(component).getFugacityCoefficient();
+      double oilCoefficient = system.getPhase(oilPhase).getComponent(component).getFugacityCoefficient();
+      if (gasComposition > 1.0e-20 && oilComposition > 1.0e-20 && Double.isFinite(gasCoefficient)
+          && gasCoefficient > 0.0 && Double.isFinite(oilCoefficient) && oilCoefficient > 0.0) {
         double gasLogFugacity = Math.log(gasComposition * gasCoefficient);
         double oilLogFugacity = Math.log(oilComposition * oilCoefficient);
-        maximumResidual =
-            Math.max(maximumResidual, Math.abs(gasLogFugacity - oilLogFugacity));
+        maximumResidual = Math.max(maximumResidual, Math.abs(gasLogFugacity - oilLogFugacity));
         comparisons++;
       }
     }


### PR DESCRIPTION
## Summary

Advances #2937 with a bounded PC-SAFT methane/n-hexane phase-split lifecycle qualification.

- adds a 20-flash nearby-temperature/pressure, algorithm-agreement, poor-initialization, and changed/returned-state matrix
- retains the existing 250 K / 10 bara total heat-capacity reference
- requires strict material and fugacity closure, explicit phase-role resolution, bounded compositions, positive compressibility, and deterministic reuse
- documents composition, units, synthetic provenance, validity range, fixed workload, and explicit stop boundaries

Capability contract: https://github.com/equinor/neqsim/issues/2937#issuecomment-5560581813

## Exact-head contract

- Base/current master at publication: `263e7bac9bc3a38f0a9a82d690eed55d7dd79252`
- Current exact head: `c4106a6c964eceac05328e6479891764b0b442b3`
- Branch: `codex/2937-pcsaft-phase-lifecycle`
- Three ordered commits across two intended files

## Numerical acceptance

The synthetic calculation uses `SystemPCSAFT`, mixing rule 1, equimolar methane/n-hexane, 248–252 K, and 9–11 bara.

Every qualified endpoint requires:

- GAS+OIL topology
- beta and phase-composition normalization within `3e-12`
- component material-balance residual below `1e-10`
- maximum comparable methane/n-hexane interphase log-fugacity residual below `1e-8`
- finite bounded beta/compositions, positive compressibility, and finite Gibbs energy/enthalpy
- ordinary/multiphase agreement
- recovery from beta within `1e-12` of a bound
- retained `Cp = 172.3659584364608 ± 0.1 J/K` at 250 K / 10 bara
- changed/returned-state equivalence and deterministic repeat

The 20 complete flashes are a fixed-workload performance record only; no wall-clock threshold or speedup is claimed.

## Validation

**READY TO MERGE** at exact head `c4106a6c964eceac05328e6479891764b0b442b3`.

Java 8/21 on Ubuntu and Windows, all four slow shards, Javadocs, Spotless, pre-commit, documentation, CodeQL, and reference checks pass. The predecessor head’s sole branch-attributable failure was Spotless on the new PC-SAFT lifecycle test; the exact hosted formatter artifact was applied in the third commit without changing scientific assertions, tolerances, APIs, production code, or documentation semantics. The PR is open and mergeable with no reviews or unresolved threads.

## Documentation impact

`docs/thermodynamicoperations/TPflash_algorithm.md` records the feed, units, range, numerical gates, lifecycle matrix, heat-capacity evidence, workload, provenance limitation, and excluded scopes.

## Portfolio and boundaries

Current autonomous portfolio occupancy is **8/10**, below the absolute ceiling. This remains the sole active #2937 implementation PR.

This tranche does not modify production solvers, public APIs, PC-SAFT parameters or association terms, petroleum characterization, PH/PS operations, process equipment, saturation operations, MCP payloads, Column Solver, Process Performance, proprietary data, or Huldra.

Draft only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.