### PR TITLE
[AI-Assisted] Fix valve sizing and dynamic cooler regressions

### DIFF
--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -631,6 +631,22 @@ The transient network modes make ownership of flow and pressure explicit:
 | `Cooler` | dynamic temperature control disabled (default) | Historical specified-temperature behavior is retained. |
 | `Cooler` | configured dynamic temperature control | A bounded utility-valve/NTU model applies actuator and process thermal lags. |
 
+The dynamic cooler advances its actuator and thermal state once per physical
+timestep. Repeated evaluations with the same non-null calculation UUID reuse
+the timestep's initial valve position and outlet temperature while recalculating
+the heat-transfer target from the current inlet conditions. This supports the
+second pass of semi-implicit integration without applying the lag twice. Use a
+new UUID for each physical timestep. If the inlet is at or below the cooling
+medium temperature, this cooling-only model passes through the inlet temperature
+and adds no heat.
+
+Valve `autoSize(safetyFactor, designOpeningPercent)` evaluates the sizing
+correlation at the requested design opening, including when it differs from the
+current valve position. With a safety factor of 1 and no minimum-Cv floor
+limitation, that opening reproduces the design flow after transient handoff.
+The safety factor must be finite and positive, and the design opening must be
+finite and in (0, 100] percent; configured valve travel limits still apply.
+
 Example handoff after the steady-state recycle has converged:
 
 ```java

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Cooler.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Cooler.java
@@ -43,6 +43,15 @@ public class Cooler extends Heater {
   /** First-order process-side thermal time constant, in seconds. */
   private double dynamicThermalTimeConstant = 20.0;
 
+  /** Identifier of the physical timestep whose initial dynamic state is cached. */
+  private UUID dynamicStepIdentifier;
+
+  /** Utility-valve opening at the beginning of the current physical timestep, in percent. */
+  private double dynamicStepInitialValveOpening;
+
+  /** Outlet temperature at the beginning of the current physical timestep, in Kelvin. */
+  private double dynamicStepInitialOutletTemperature;
+
   /**
    * Constructor for Cooler.
    *
@@ -92,6 +101,7 @@ public class Cooler extends Heater {
     dynamicCoolingMediumTemperature = mediumKelvin;
     dynamicDesignNtu = -Math.log((outletKelvin - mediumKelvin) / (inletKelvin - mediumKelvin));
     coolingValveOpening = dynamicDesignValveOpening;
+    dynamicStepIdentifier = null;
     dynamicTemperatureControlEnabled = true;
     setOutletTemperature(outletKelvin, "K");
   }
@@ -157,19 +167,25 @@ public class Cooler extends Heater {
   @Override
   public void runTransient(double dt, UUID id) {
     if (!dynamicTemperatureControlEnabled || getCalculateSteadyState()) {
+      dynamicStepIdentifier = null;
       super.runTransient(dt, id);
       return;
     }
 
-    boolean alreadyEvaluatedForStep = id != null && id.equals(getCalculationIdentifier());
-    double requestedOpening = coolingValveOpening;
+    boolean alreadyEvaluatedForStep = id != null && id.equals(dynamicStepIdentifier);
+    if (!alreadyEvaluatedForStep) {
+      dynamicStepInitialValveOpening = coolingValveOpening;
+      dynamicStepInitialOutletTemperature = getOutletStream().getTemperature("K");
+    }
+    double requestedOpening = dynamicStepInitialValveOpening;
     if (hasController && getController().isActive()) {
-      getController().runTransient(coolingValveOpening, dt, id);
+      getController().runTransient(dynamicStepInitialValveOpening, dt, id);
       requestedOpening = getController().getResponse();
     }
     requestedOpening = Math.max(0.0, Math.min(100.0, requestedOpening));
     double actuatorFraction = dynamicActuatorTimeConstant > 0.0 ? dt / (dynamicActuatorTimeConstant + dt) : 1.0;
-    coolingValveOpening += actuatorFraction * (requestedOpening - coolingValveOpening);
+    coolingValveOpening = dynamicStepInitialValveOpening
+        + actuatorFraction * (requestedOpening - dynamicStepInitialValveOpening);
 
     double currentMassFlow = Math.max(getInletStream().getFlowRate("kg/hr"), 1.0e-12);
     double inletTemperature = getInletStream().getTemperature("K");
@@ -182,16 +198,18 @@ public class Cooler extends Heater {
           + (inletTemperature - dynamicCoolingMediumTemperature) * Math.exp(-currentNtu);
     }
 
-    double previousOutletTemperature = getOutletStream().getTemperature("K");
+    double previousOutletTemperature = dynamicStepInitialOutletTemperature;
     if (!Double.isFinite(previousOutletTemperature)) {
       previousOutletTemperature = equilibriumOutletTemperature;
     }
     double thermalFraction = dynamicThermalTimeConstant > 0.0 ? dt / (dynamicThermalTimeConstant + dt) : 1.0;
     double outletTemperature = previousOutletTemperature
         + thermalFraction * (equilibriumOutletTemperature - previousOutletTemperature);
-    outletTemperature = Math.max(dynamicCoolingMediumTemperature, Math.min(inletTemperature, outletTemperature));
+    double minimumOutletTemperature = Math.min(dynamicCoolingMediumTemperature, inletTemperature);
+    outletTemperature = Math.max(minimumOutletTemperature, Math.min(inletTemperature, outletTemperature));
     setOutletTemperature(outletTemperature, "K");
     run(id);
+    dynamicStepIdentifier = id;
     if (!alreadyEvaluatedForStep) {
       increaseTime(dt);
     }

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -1585,8 +1585,15 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
    *
    * @param safetyFactor safety factor to apply (e.g., 1.2 for 20% margin)
    * @param designOpeningPercent the target valve opening percentage at design flow (typically 50%)
+   * @throws IllegalArgumentException if the safety factor is not finite and positive or the design opening is not in
+   * (0, 100]
    */
   public void autoSize(double safetyFactor, double designOpeningPercent) {
+    if (!Double.isFinite(safetyFactor) || safetyFactor <= 0.0 || !Double.isFinite(designOpeningPercent)
+        || designOpeningPercent <= 0.0 || designOpeningPercent > 100.0) {
+      throw new IllegalArgumentException(
+          "Valve sizing requires a positive safety factor and design opening in (0, 100]");
+    }
     if (getInletStream() == null) {
       throw new IllegalStateException("Cannot auto-size valve without inlet stream");
     }
@@ -1610,7 +1617,10 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     double designCv;
 
     if (hasFlow) {
-      // Calculate Cv at 100% opening for current flow
+      // calcDesign converts effective Cv to full-open Cv using the current opening.
+      // Select the requested design opening before sizing, including when re-sizing
+      // a valve that is currently operating at a different position.
+      setPercentValveOpening(designOpeningPercent);
       getMechanicalDesign().calcDesign();
       double calculatedCv = getMechanicalDesign().getValveCvMax();
 

--- a/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTransientBoundsRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTransientBoundsRegressionTest.java
@@ -1,0 +1,90 @@
+package neqsim.process.equipment.heatexchanger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.controllerdevice.ControllerDeviceInterface.ControllerMode;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.measurementdevice.TemperatureTransmitter;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for the physical bounds and timestep semantics of the dynamic cooler. */
+class CoolerTransientBoundsRegressionTest extends neqsim.NeqSimTest {
+  private Cooler createCooler() {
+    SystemSrkEos fluid = new SystemSrkEos(353.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.run();
+    Cooler cooler = new Cooler("dynamic cooler", feed);
+    cooler.configureDynamicTemperatureControl(10000.0, 80.0, 35.0, 20.0, "C");
+    cooler.setDynamicTimeConstants(5.0, 10.0);
+    cooler.run();
+    cooler.setCalculateSteadyState(false);
+    return cooler;
+  }
+
+  @Test
+  void repeatedEvaluationDoesNotAdvanceThermalStateTwice() {
+    Cooler cooler = createCooler();
+    cooler.getInletStream().setTemperature(100.0, "C");
+    cooler.getInletStream().run();
+    UUID step = UUID.randomUUID();
+    cooler.runTransient(2.0, step);
+    double temperature = cooler.getOutletStream().getTemperature("K");
+    double opening = cooler.getCoolingValveOpening();
+
+    cooler.runTransient(2.0, step);
+
+    assertEquals(temperature, cooler.getOutletStream().getTemperature("K"), 1.0e-10,
+        "Repeated evaluation of one physical timestep must reuse its initial thermal state");
+    assertEquals(opening, cooler.getCoolingValveOpening(), 1.0e-12);
+    assertEquals(2.0, cooler.getTime(), 0.0);
+    cooler.runTransient(2.0, UUID.randomUUID());
+    assertTrue(cooler.getOutletStream().getTemperature("K") > temperature);
+    assertEquals(4.0, cooler.getTime(), 0.0);
+  }
+
+  @Test
+  void repeatedEvaluationReusesActuatorStateAndRefreshesChangedInlet() {
+    Cooler cooler = createCooler();
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("utility controller");
+    controller.setTransmitter(new TemperatureTransmitter("outlet temperature", cooler.getOutletStream()));
+    controller.setMode(ControllerMode.MANUAL);
+    controller.setManualOutput(100.0);
+    cooler.setController(controller);
+    UUID step = UUID.randomUUID();
+    cooler.runTransient(2.0, step);
+    double opening = 50.0 + 2.0 / 7.0 * 50.0;
+    assertEquals(opening, cooler.getCoolingValveOpening(), 1.0e-12);
+
+    cooler.getInletStream().setTemperature(100.0, "C");
+    cooler.getInletStream().run();
+    cooler.runTransient(2.0, step);
+
+    double ntu = -Math.log(15.0 / 60.0) * opening / 50.0;
+    double equilibriumTemperatureC = 20.0 + 80.0 * Math.exp(-ntu);
+    double expectedTemperatureC = 35.0 + 2.0 / 12.0 * (equilibriumTemperatureC - 35.0);
+    assertEquals(expectedTemperatureC, cooler.getOutletStream().getTemperature("C"), 1.0e-9,
+        "The second pass must refresh inlet conditions using the same initial thermal state");
+    assertEquals(opening, cooler.getCoolingValveOpening(), 1.0e-12);
+    assertEquals(2.0, cooler.getTime(), 0.0);
+  }
+
+  @Test
+  void colderThanUtilityFeedDoesNotReceiveArtificialHeating() {
+    Cooler cooler = createCooler();
+    cooler.setDynamicTimeConstants(0.0, 0.0);
+    cooler.getInletStream().setTemperature(10.0, "C");
+    cooler.getInletStream().run();
+
+    cooler.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(10.0, cooler.getOutletStream().getTemperature("C"), 1.0e-9,
+        "A cooling-only model must bypass cooling below the utility temperature");
+    assertEquals(0.0, cooler.getDuty(), 1.0e-5);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/valve/ValveAutoSizeOpeningRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ValveAutoSizeOpeningRegressionTest.java
@@ -1,0 +1,44 @@
+package neqsim.process.equipment.valve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.UUID;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for sizing a valve at an opening different from its current position. */
+class ValveAutoSizeOpeningRegressionTest extends neqsim.NeqSimTest {
+  @ParameterizedTest
+  @CsvSource({ "100.0, 50.0, methane, linear", "30.0, 70.0, methane, linear", "70.0, 30.0, methane, linear",
+      "100.0, 50.0, methane, equal percentage", "100.0, 50.0, water, linear", "30.0, 70.0, water, equal percentage" })
+  void requestedDesignOpeningPreservesDesignFlow(double initialOpening, double designOpening, String component,
+      String characteristic) {
+    SystemSrkEos fluid = new SystemSrkEos(303.15, 50.0);
+    fluid.addComponent(component, 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.run();
+    ThrottlingValve valve = new ThrottlingValve("sized valve", feed);
+    valve.setOutletPressure(40.0);
+    valve.setPercentValveOpening(initialOpening);
+    valve.getMechanicalDesign().setValveCharacterization(characteristic);
+
+    valve.autoSize(1.0, designOpening);
+    assertEquals(designOpening, valve.getPercentValveOpening(), 1.0e-12);
+    valve.setCalculateSteadyState(false);
+    valve.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(10000.0, valve.getOutletStream().getFlowRate("kg/hr"), 1.0,
+        "The requested opening must carry the design flow after sizing");
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "NaN, 50.0", "0.0, 50.0", "1.0, NaN", "1.0, 0.0", "1.0, 101.0" })
+  void invalidDesignIsRejectedBeforeChangingTheValve(double safetyFactor, double opening) {
+    ThrottlingValve valve = new ThrottlingValve("unconnected valve");
+    assertThrows(IllegalArgumentException.class, () -> valve.autoSize(safetyFactor, opening));
+  }
+}


### PR DESCRIPTION
## Problem

The 23 August–6 September regression review reproduced three defects introduced by #3419 on master `263e7bac9bc3a38f0a9a82d690eed55d7dd79252`:

- Valve auto-sizing calculated full-open Cv at the old valve position before setting the requested design position. For 10,000 kg/h design flow, the 100% → 50% case delivered 5,000 kg/h; 30% → 70% delivered 23,333.33 kg/h.
- Repeated dynamic cooler evaluations with one physical-timestep UUID integrated the thermal state again even though the clock advanced once: 308.983333 K became 309.677778 K without another timestep.
- The cooling-only outlet clamp heated a 10°C inlet to the 20°C utility temperature.

The original targeted regression run produced **5 failures out of 5 cases**.

## Changes

- Select the requested design opening before the valve sizing correlation converts effective Cv to full-open Cv; reject non-finite/non-positive design inputs.
- Retain the cooler's initial valve position and outlet temperature for each non-null physical-timestep UUID. Repeated evaluations refresh the inlet-dependent target while integrating from the same initial state.
- Pass through an inlet at or below utility temperature without artificial heating.
- Cover gas and liquid feeds, linear and equal-percentage characteristics, different initial/design openings, invalid sizing inputs, thermal and actuator repeat evaluation, changed inlet conditions, and advancement with a new UUID.

## Validation

NeqSim 3.19.0 source, OpenJDK 17.0.20, master base above; Maven bootstrapped with the work-with-neqsim helper and resolved from the existing cache.

- `./mvnw -o -q -DskipTests compile`: **exit 0**.
- Selected regression review suite: **179 tests in 20 classes; 0 failures, 0 errors, 0 skipped**. It includes the changed equipment tests, valve mechanical design, ProcessSystem transients, ProcessModel auto tuning, constraint registry/snapshots, component aliases, TBP acentric factors, GE Henry derivatives, EOS-CG VU flashes, entrainment SPI, saturation P/T, and MCP response guards.
- Direct `devtools/run_spotless.py apply`: **exit 0**, repeated; final repeat changed no Java files.
- Direct `devtools/run_spotless.py check`: **exit 0**.
- Direct `devtools/check_documentation_search.py`: **exit 0**.
- `git diff --check`: **exit 0**.
- The environment-provided Python interpreter ran these scripts. The `pre-commit` executable/module is unavailable; the configured formatting and documentation gates were run directly.

The 179-test validation workspace also contained the separately published pipeline inlet-pressure fix from the same review. No full repository suite or actual Java 8 JVM run is claimed. **VALIDATION PENDING EXACT-HEAD CI**.

## Documentation impact

Updated the dynamic simulation guide with timestep identity, cooling-only bounds, design-opening sizing, and input constraints; added the valve argument exception contract in Javadoc.

## Review scope and publication

The review inventoried 327 PRs updated in the window (315 merged during it), including file manifests for all merged/open entries. Investigation prioritized behavior changes and targeted execution; this is not exhaustive certification of every PR. This draft contains only the #3419 equipment corrections. Existing campaign branches were preserved. No merge or release is requested.

Generated with AI assistance.