### PR TITLE
[AI-Assisted] Fix downhill pipeline inlet-pressure solving

### DIFF
--- a/docs/process/tieback_early_phase_design.md
+++ b/docs/process/tieback_early_phase_design.md
@@ -131,6 +131,13 @@ A trial that throws — typically because the pressure ran negative part way alo
 from below. If the line cannot deliver the target at that rate at any inlet, the
 run fails with that stated explicitly.
 
+The inlet-pressure bracket also searches below the specified arrival pressure.
+A downhill liquid line can gain pressure from hydrostatic head, so its required
+inlet pressure can be lower than the host pressure. The solve must meet the
+configured arrival-pressure tolerance before publishing `getSolvedInletPressure()`.
+If the iteration budget is exhausted, it throws `IllegalStateException`, restores
+the original inlet pressure, and leaves the solved-pressure getter as `NaN`.
+
 ## 4. Wall thickness
 
 `DnvStF101PipelineDesignCalculator` returns every limit state with its

--- a/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
@@ -1575,14 +1575,15 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
    * Solves for the inlet pressure that delivers the specified outlet pressure at the current flow.
    *
    * <p>
-   * Bisects the inlet pressure between the target arrival pressure (no pressure drop) and an upper bound grown from the
-   * current inlet until the line delivers at or above the target. A trial that throws - typically because the pressure
-   * ran negative part way along - is treated as "inlet too low" and moves the lower bound up.
+   * Brackets the inlet pressure on both sides of the target arrival pressure, allowing a downhill line's hydrostatic
+   * head to require a lower inlet pressure. The upper bound grows until the line delivers at or above the target. A
+   * trial that throws - typically because the pressure ran negative part way along - is treated as "inlet too low".
    * </p>
    *
    * @param id calculation identifier
    */
   private void runWithSpecifiedArrivalPressure(UUID id) {
+    solvedInletPressure = Double.NaN;
     if (Double.isNaN(specifiedOutletPressure)) {
       throw new RuntimeException(new neqsim.util.exception.InvalidInputException("PipeBeggsAndBrills", "run",
           "specifiedOutletPressure", "must be set when using CALCULATE_INLET_PRESSURE mode"));
@@ -1593,14 +1594,28 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
       tempSystem.setPressure(specifiedOutletPressure, specifiedOutletPressureUnit);
       targetPressure = tempSystem.getPressure("bara");
     }
-    if (targetPressure <= 0.0) {
+    if (!Double.isFinite(targetPressure) || targetPressure <= 0.0) {
       throw new RuntimeException(new neqsim.util.exception.InvalidInputException("PipeBeggsAndBrills", "run",
-          "specifiedOutletPressure", "must be positive"));
+          "specifiedOutletPressure", "must be finite and positive"));
     }
 
     double originalInletPressure = inStream.getThermoSystem().getPressure("bara");
     double low = targetPressure;
     double high = Math.max(originalInletPressure, targetPressure * 1.5);
+
+    // Gravity can raise the outlet pressure above the inlet. In that case the
+    // arrival pressure is not a valid lower bracket for the required inlet.
+    double arrivalAtLow = tryArrivalPressure(low, id);
+    int lowerBoundIter = 0;
+    while (Double.isFinite(arrivalAtLow) && arrivalAtLow > targetPressure && lowerBoundIter < 30) {
+      low *= 0.5;
+      arrivalAtLow = tryArrivalPressure(low, id);
+      lowerBoundIter++;
+    }
+    if (Double.isFinite(arrivalAtLow) && arrivalAtLow > targetPressure) {
+      restoreInletPressure(originalInletPressure, id);
+      throw new IllegalStateException("Cannot bracket a positive inlet pressure for pipeline " + getName());
+    }
 
     double arrivalAtHigh = tryArrivalPressure(high, id);
     int boundIter = 0;
@@ -1630,9 +1645,9 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
         high = mid;
       }
     }
-    solvedInletPressure = mid;
-    logger.warn("PipeBeggsAndBrills '{}': inlet-pressure solve hit the iteration limit at {} bara", getName(),
-        solvedInletPressure);
+    restoreInletPressure(originalInletPressure, id);
+    throw new IllegalStateException("Inlet-pressure solve did not converge for pipeline " + getName() + " after "
+        + maxFlowIterations + " iterations");
   }
 
   /**
@@ -1647,7 +1662,8 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
       inStream.getThermoSystem().setPressure(inletPressureBara, "bara");
       inStream.run(id);
       runWithSpecifiedFlowRate(id);
-      return outStream.getPressure("bara");
+      double arrivalPressure = outStream.getPressure("bara");
+      return Double.isFinite(arrivalPressure) && arrivalPressure > 0.0 ? arrivalPressure : Double.NaN;
     } catch (RuntimeException ex) {
       logger.debug("Inlet-pressure trial at {} bara failed: {}", inletPressureBara, ex.getMessage());
       return Double.NaN;
@@ -1833,8 +1849,8 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
   /**
    * Returns the inlet pressure found by the inlet-pressure solver.
    *
-   * @return solved inlet pressure in bara, or NaN when {@link CalculationMode#CALCULATE_INLET_PRESSURE} has not been
-   * run
+   * @return solved inlet pressure in bara, or NaN when {@link CalculationMode#CALCULATE_INLET_PRESSURE} has not
+   * completed successfully on the latest attempt
    */
   public double getSolvedInletPressure() {
     return solvedInletPressure;

--- a/src/test/java/neqsim/process/equipment/pipeline/PipeInletPressureRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipeInletPressureRegressionTest.java
@@ -1,0 +1,49 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Forward/inverse consistency for downhill, flat, and uphill liquid pipelines. */
+class PipeInletPressureRegressionTest extends neqsim.NeqSimTest {
+  @ParameterizedTest
+  @ValueSource(doubles = { -5.0, 0.0, 5.0 })
+  void inverseRecoversForwardPressureAndRejectsUnconvergedTrials(double angle) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 30.0);
+    fluid.addComponent("water", 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("water feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.run();
+    PipeBeggsAndBrills pipe = new PipeBeggsAndBrills("downhill line", feed);
+    pipe.setLength(1000.0);
+    pipe.setDiameter(0.2);
+    pipe.setAngle(angle);
+    pipe.setNumberOfIncrements(10);
+    pipe.run();
+    double arrivalPressure = pipe.getOutletStream().getPressure("bara");
+    if (angle < 0.0) {
+      assertTrue(arrivalPressure > 35.0, "The downhill liquid head must exceed friction losses");
+    }
+
+    feed.setPressure(45.0, "bara");
+    pipe.setOutletPressure(arrivalPressure, "bara");
+    pipe.setCalculationMode(PipeBeggsAndBrills.CalculationMode.CALCULATE_INLET_PRESSURE);
+    pipe.run();
+
+    assertEquals(30.0, pipe.getSolvedInletPressure(), 0.01,
+        "The inverse must recover the known forward inlet, even below the arrival pressure");
+    assertEquals(arrivalPressure, pipe.getOutletStream().getPressure("bara"), 0.01);
+
+    feed.setPressure(45.0, "bara");
+    pipe.setMaxFlowIterations(1);
+    assertThrows(IllegalStateException.class, () -> pipe.run(),
+        "An exhausted iteration budget must not publish the last trial as a solved pressure");
+    assertTrue(Double.isNaN(pipe.getSolvedInletPressure()));
+    assertEquals(45.0, feed.getPressure("bara"), 1.0e-12);
+  }
+}


### PR DESCRIPTION
## Problem

The two-week regression review found that the inlet-pressure solver introduced by #3463 assumed the required inlet pressure could never be below the requested arrival pressure. That excludes a downhill liquid line whose hydrostatic head exceeds friction.

A 1 km water line, 0.2 m diameter, -5° inclination, and 10,000 kg/h was run forward from **30 bara**. Inverting its resulting arrival pressure returned **38.564087 bara** instead of 30 bara. The solver then exhausted its iteration budget and published the last trial as a solved inlet.

The forward/inverse regression failed on master `263e7bac9bc3a38f0a9a82d690eed55d7dd79252`.

## Changes

- Expand the lower bracket below arrival pressure when gravity creates a pressure gain.
- Require finite, positive target and trial arrival pressures.
- Publish the solved inlet only after satisfying the requested arrival-pressure tolerance.
- On iteration exhaustion, restore the original inlet pressure and throw an explicit exception; clear the solved-pressure getter at the start of each attempt to prevent stale successful results.
- Exercise downhill, flat, and uphill water lines against their own forward solution, plus iteration-limit failure after a successful solve.

The corrected downhill inverse recovers **30 bara within 0.01 bar**.

## Validation

NeqSim 3.19.0 source, OpenJDK 17.0.20, base above; Maven bootstrapped with the work-with-neqsim helper.

- Original downhill regression: **1 test, 1 failure**.
- Corrected pipeline and route tests pass; the final selected review suite passes **179 tests in 20 classes, 0 failures/errors/skips**.
- `./mvnw -o -q -DskipTests compile`: **exit 0**.
- Direct `devtools/run_spotless.py apply`: **exit 0**, repeated; final repeat changed no Java files.
- Direct `devtools/run_spotless.py check`: **exit 0**.
- Direct `devtools/check_documentation_search.py`: **exit 0**.
- `git diff --check`: **exit 0**.
- The environment-provided Python interpreter ran the scripts. `pre-commit` executable/module is unavailable; its configured gates were run directly.

The broader local validation workspace also contained the separate valve/cooler fixes from this review. No full repository suite or actual Java 8 JVM run is claimed. **VALIDATION PENDING EXACT-HEAD CI**.

## Documentation impact

Updated the tie-back design guide and solved-pressure Javadoc to explain downhill pressure gain, convergence acceptance, failure behavior, and NaN results after failed attempts.

## Scope

This is a forward/inverse consistency repair of the existing Beggs–Brill inlet-pressure mode. It does not alter the forward correlation, two-fluid equations, or hydraulic-model selection. Draft only; existing campaign branches are preserved.

Generated with AI assistance.