### PR TITLE
[AI-Assisted] test(electrolyte): isolate CaCl2 pressure response

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -419,7 +419,14 @@ from the missing limiting-volume term. Al Ghafri et al. (2012),
 extracted to identical canonical row hashes, and the test fixture retains every row's 95% combined
 expanded density uncertainty. Against this hold-out, the current aqueous density path has MARE
 0.632%, RMSRE 0.845%, and maximum absolute relative error 2.661%; it is therefore explicitly
-unqualified for quantitative pressure-density use. The machine-readable record is available under
+unqualified for quantitative pressure-density use. This is not primarily an ambient-density offset:
+anchoring each of 25 molality-temperature isotherms to its lowest-pressure observation leaves 172
+pressure increments with MARE 0.596%, RMSRE 0.732%, maximum absolute relative error 2.129%, and a
+maximum increment residual 48.0 times the combined expanded source uncertainty. The anchored MARE
+also increases from 0.341% at 1 mol/kg to 0.670% at 3 mol/kg and 0.810% at 6 mol/kg. The existing
+path therefore fails the offset-free pressure-response test, and a replacement must represent the
+solution pressure response rather than merely retune an atmospheric density intercept. The
+machine-readable record is available under
 the [NIST data license](https://www.nist.gov/open/license). Its lowest concentration is 1 mol/kg, so
 it cannot determine the infinite-dilution CaCl2 volume needed to close the calcium-sulfate
 reaction-volume cycle. The candidate dilute lineage, Oakes et al. (1990),
@@ -427,7 +434,7 @@ reaction-volume cycle. The candidate dilute lineage, Oakes et al. (1990),
 row-level audit, propagated uncertainty, and redistribution-compatible provenance remain unresolved.
 Accordingly `hasIndependentAqueousPressureEvidence()` and
 `isAqueousPressureEvidenceRowAudited()` are true, while
-`isAqueousPressureDensityModelQualified()` and
+`isAqueousPressureDensityModelQualified()`, `isAqueousPressureResponseQualified()`, and
 `isAqueousLimitingVolumeEvidenceResolved()` remain false. These flags register evidence scope only;
 they do not change a COMPSALT coefficient or make high-pressure calcium-sulfate use qualified.
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -73,6 +73,18 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   public static final double AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_RELATIVE_UNCERTAINTY = 0.0003;
   /** Maximum publication-level relative density uncertainty reported in the article abstract. */
   public static final double AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_RELATIVE_UNCERTAINTY = 0.0005;
+  /** Number of molality-temperature isotherms used to isolate pressure response. */
+  public static final int AQUEOUS_PRESSURE_RESPONSE_GROUP_COUNT = 25;
+  /** Number of non-anchor pressure states in the pressure-response comparison. */
+  public static final int AQUEOUS_PRESSURE_RESPONSE_COMPARISON_COUNT = 172;
+  /** Mean absolute relative error after removing each isotherm's low-pressure density offset. */
+  public static final double AQUEOUS_PRESSURE_RESPONSE_MARE = 0.00596124964150643;
+  /** RMS relative error after removing each isotherm's low-pressure density offset. */
+  public static final double AQUEOUS_PRESSURE_RESPONSE_RMSRE = 0.0073152811349379634;
+  /** Maximum absolute relative error after removing each isotherm's low-pressure density offset. */
+  public static final double AQUEOUS_PRESSURE_RESPONSE_MAXARE = 0.021286678807350468;
+  /** Maximum pressure-increment residual divided by combined expanded source uncertainty. */
+  public static final double AQUEOUS_PRESSURE_RESPONSE_MAXIMUM_UNCERTAINTY_RATIO = 48.01423407881762;
   /** Temperature of the liquid-water density reference. */
   public static final double WATER_DENSITY_REFERENCE_TEMPERATURE_K = 298.15;
   /** Pressure of the liquid-water density reference. */
@@ -309,6 +321,15 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
    * @return {@code false}; the preregistered full-matrix residual test rejects quantitative use
    */
   public static boolean isAqueousPressureDensityModelQualified() {
+    return false;
+  }
+
+  /**
+   * Reports whether the current aqueous density model passes the offset-free pressure-response test.
+   *
+   * @return {@code false}; errors persist after anchoring every isotherm at its lowest pressure
+   */
+  public static boolean isAqueousPressureResponseQualified() {
     return false;
   }
 

--- a/src/test/java/neqsim/thermo/phase/CalciumChlorideDensityPressureValidationTest.java
+++ b/src/test/java/neqsim/thermo/phase/CalciumChlorideDensityPressureValidationTest.java
@@ -46,8 +46,16 @@ class CalciumChlorideDensityPressureValidationTest extends neqsim.NeqSimTest {
     double squaredRelativeResidualSum = 0.0;
     double maximumAbsoluteRelativeResidual = 0.0;
     double maximumExpandedUncertaintyRatio = 0.0;
+    double pressureAdjustedAbsoluteRelativeResidualSum = 0.0;
+    double pressureAdjustedSquaredRelativeResidualSum = 0.0;
+    double maximumPressureAdjustedAbsoluteRelativeResidual = 0.0;
+    double maximumPressureIncrementUncertaintyRatio = 0.0;
+    int pressureAdjustedCount = 0;
     Map<Double, Integer> countsByMolality = new HashMap<Double, Integer>();
+    Map<Double, Double> pressureAdjustedAbsoluteResidualByMolality = new HashMap<Double, Double>();
+    Map<Double, Integer> pressureAdjustedCountByMolality = new HashMap<Double, Integer>();
     Map<Double, SystemPitzer> systemsByMolality = new HashMap<Double, SystemPitzer>();
+    Map<String, double[]> pressureAnchors = new HashMap<String, double[]>();
     Set<String> coordinates = new HashSet<String>();
     MessageDigest rowDigest = MessageDigest.getInstance("SHA-256");
 
@@ -80,6 +88,29 @@ class CalciumChlorideDensityPressureValidationTest extends neqsim.NeqSimTest {
         maximumAbsoluteRelativeResidual = Math.max(maximumAbsoluteRelativeResidual, Math.abs(relativeResidual));
         maximumExpandedUncertaintyRatio = Math.max(maximumExpandedUncertaintyRatio,
             Math.abs(calculatedDensity - state.density) / state.expandedUncertainty);
+        String isothermKey = state.molality + ":" + state.temperatureKelvin;
+        double[] anchor = pressureAnchors.get(isothermKey);
+        if (anchor == null) {
+          pressureAnchors.put(isothermKey,
+              new double[] { state.pressureBara, state.density, calculatedDensity, state.expandedUncertainty });
+        } else {
+          assertTrue(state.pressureBara > anchor[0], "ThermoML isotherm is not ordered from its pressure anchor");
+          double pressureAdjustedRelativeResidual = (calculatedDensity - anchor[2] + anchor[1]) / state.density - 1.0;
+          pressureAdjustedAbsoluteRelativeResidualSum += Math.abs(pressureAdjustedRelativeResidual);
+          pressureAdjustedAbsoluteResidualByMolality.put(state.molality,
+              pressureAdjustedAbsoluteResidualByMolality.getOrDefault(state.molality, 0.0)
+                  + Math.abs(pressureAdjustedRelativeResidual));
+          pressureAdjustedCountByMolality.put(state.molality,
+              pressureAdjustedCountByMolality.getOrDefault(state.molality, 0) + 1);
+          pressureAdjustedSquaredRelativeResidualSum += pressureAdjustedRelativeResidual
+              * pressureAdjustedRelativeResidual;
+          maximumPressureAdjustedAbsoluteRelativeResidual = Math.max(maximumPressureAdjustedAbsoluteRelativeResidual,
+              Math.abs(pressureAdjustedRelativeResidual));
+          double pressureIncrementResidual = (calculatedDensity - anchor[2]) - (state.density - anchor[1]);
+          maximumPressureIncrementUncertaintyRatio = Math.max(maximumPressureIncrementUncertaintyRatio,
+              Math.abs(pressureIncrementResidual) / Math.hypot(state.expandedUncertainty, anchor[3]));
+          pressureAdjustedCount++;
+        }
         count++;
       }
     }
@@ -105,8 +136,27 @@ class CalciumChlorideDensityPressureValidationTest extends neqsim.NeqSimTest {
     assertEquals(0.008452033776539447, rootMeanSquaredRelativeError, 1.0e-12);
     assertEquals(0.026607051737136622, maximumAbsoluteRelativeResidual, 1.0e-12);
     assertEquals(107.15649486776948, maximumExpandedUncertaintyRatio, 1.0e-9);
+    assertEquals(CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_GROUP_COUNT,
+        pressureAnchors.size());
+    assertEquals(CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_COMPARISON_COUNT,
+        pressureAdjustedCount);
+    assertEquals(CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_MARE,
+        pressureAdjustedAbsoluteRelativeResidualSum / pressureAdjustedCount, 1.0e-12);
+    assertEquals(CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_RMSRE,
+        Math.sqrt(pressureAdjustedSquaredRelativeResidualSum / pressureAdjustedCount), 1.0e-12);
+    assertEquals(CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_MAXARE,
+        maximumPressureAdjustedAbsoluteRelativeResidual, 1.0e-12);
+    assertEquals(CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_MAXIMUM_UNCERTAINTY_RATIO,
+        maximumPressureIncrementUncertaintyRatio, 1.0e-9);
+    assertEquals(0.003412628603195073,
+        pressureAdjustedAbsoluteResidualByMolality.get(1.0) / pressureAdjustedCountByMolality.get(1.0), 1.0e-12);
+    assertEquals(0.006695893425517834,
+        pressureAdjustedAbsoluteResidualByMolality.get(3.0) / pressureAdjustedCountByMolality.get(3.0), 1.0e-12);
+    assertEquals(0.00809959684613692,
+        pressureAdjustedAbsoluteResidualByMolality.get(6.0) / pressureAdjustedCountByMolality.get(6.0), 1.0e-12);
     assertTrue(meanAbsoluteRelativeError > maximumRowRelativeUncertainty);
     assertFalse(CalciumSulfatePhaseBoundaryQualification.isAqueousPressureDensityModelQualified());
+    assertFalse(CalciumSulfatePhaseBoundaryQualification.isAqueousPressureResponseQualified());
   }
 
   private static double calculateDensity(ReferenceState state, Map<Double, SystemPitzer> systemsByMolality) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -47,6 +47,7 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     assertTrue(qualification.hasIndependentAqueousPressureEvidence());
     assertTrue(CalciumSulfatePhaseBoundaryQualification.isAqueousPressureEvidenceRowAudited());
     assertFalse(CalciumSulfatePhaseBoundaryQualification.isAqueousPressureDensityModelQualified());
+    assertFalse(CalciumSulfatePhaseBoundaryQualification.isAqueousPressureResponseQualified());
     assertFalse(qualification.isAqueousLimitingVolumeEvidenceResolved());
     assertEquals("10.1021/je2013704", qualification.getAqueousPressureEvidenceDoi());
     assertEquals("https://www.nist.gov/open/license", qualification.getAqueousPressureEvidenceLicenseUri());
@@ -70,6 +71,13 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
         CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MINIMUM_RELATIVE_UNCERTAINTY, 0.0);
     assertEquals(0.0005,
         CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_EVIDENCE_MAXIMUM_RELATIVE_UNCERTAINTY, 0.0);
+    assertEquals(25, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_GROUP_COUNT);
+    assertEquals(172, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_COMPARISON_COUNT);
+    assertEquals(0.00596124964150643, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_MARE, 0.0);
+    assertEquals(0.0073152811349379634, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_RMSRE, 0.0);
+    assertEquals(0.021286678807350468, CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_MAXARE, 0.0);
+    assertEquals(48.01423407881762,
+        CalciumSulfatePhaseBoundaryQualification.AQUEOUS_PRESSURE_RESPONSE_MAXIMUM_UNCERTAINTY_RATIO, 0.0);
     assertFalse(qualification.isHighPressureQualified());
     assertEquals("10.2475/ajs.261.1.61", qualification.getHighPressureLineageDoi());
     assertEquals(1.01325, CalciumSulfatePhaseBoundaryQualification.COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA, 0.0);


### PR DESCRIPTION
## Summary

Advances #3144 by isolating the pressure-response component of the merged 197-row NIST ThermoML CaCl2 density rejection.

- anchors each of 25 molality-temperature isotherms to its lowest-pressure observation;
- compares 172 remaining measured and calculated density increments;
- removes the absolute-density intercept independently for every isotherm;
- records overall and concentration-resolved pressure-response residuals;
- keeps the current density path and quantitative high-pressure calcium-sulfate use fail-closed.

Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5560811250

## Exact-head contract

- Exact base / publication-time master: d9a61e682adffdb639e73423d5ffe4ca078e188a
- Exact publication head: 87e0bd3a7edc57bf136997c8253f346c47f1f40f
- Branch: ai/electrolyte-cacl2-pressure-response-diagnostic
- Four ordered commits across four intended files
- Zero commits behind publication-time master
- Every published blob is byte-identical to the locally qualified corpus

## Scientific method and result

Source evidence remains Al Ghafri et al. (2012), [DOI 10.1021/je2013704](https://doi.org/10.1021/je2013704), from the licensed [NIST ThermoML record](https://trc.nist.gov/ThermoML/10.1021/je2013704.html).

For each exact molality-temperature group, the lowest-pressure row is the anchor. At every higher-pressure state, the test subtracts the calculated and measured anchor densities before comparing the resulting increments. This diagnostic removes all group-specific atmospheric/low-pressure offsets without fitting.

Exact no-fit result:

- 25 isotherm groups and 172 non-anchor comparisons;
- pressure-response MARE: **0.005961249642**;
- RMSRE: **0.007315281135**;
- MAXARE: **0.021286678807**;
- maximum pressure-increment residual / combined expanded source uncertainty: **48.0142**;
- MARE by CaCl2 molality: **0.003412628603** at 1 mol/kg, **0.006695893426** at 3 mol/kg, and **0.008099596846** at 6 mol/kg.

The full absolute-density MARE was 0.006323634129. Retaining 0.005961249642 after all isotherm offsets are removed shows that the failure is predominantly in solution pressure response, not merely the ambient density intercept. Its concentration dependence also rules out treating the discrepancy as pure-water compressibility alone.

## Model-semantics boundary

No Ksp, COMPSALT Vdelta, Pitzer coefficient, reaction, solver, tolerance, phase behavior, or MCP payload changes. No coefficient is fitted from the hold-out.

isAqueousPressureResponseQualified() remains false alongside isAqueousPressureDensityModelQualified(), isAqueousLimitingVolumeEvidenceResolved(), isAqueousSpeciesVolumeResolved(), and isHighPressureQualified().

## Local validation

- Spotless apply/check: passed.
- Focused Java: 3 tests passed.
- Complete offset-free diagnostic: approximately 1.1 s.
- Relevant documentation contract: 7 tests passed.
- Checkstyle: zero violations.
- PMD completed with no findings on changed classes.
- Diff whitespace check: passed.

Hosted exact-head CI is authoritative for Java 8/21, Windows/Ubuntu, slow shards, Javadocs, formatting, documentation, security, PaperLab, and skills/agent checks.

## Portfolio and publication policy

Six other autonomous implementation drafts are positively identified: #3493, #3503, #3505, #3506, #3507, and #3508. Including this draft, occupancy is **7/10**. No changed path overlaps those drafts, and this is the sole active #3144 PR.

**DRAFT — VALIDATION PENDING EXACT-HEAD CI.**

Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.