### PR TITLE
[AI-Assisted] feat(dexpi): expose cycle component evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -243,9 +243,15 @@ and JPype reviewers inspect complete cycle-local endpoint evidence without joini
 endpoint inventory. `getConnections()` exposes the corresponding immutable
 `DexpiConnectionInfo` records in the same order, including source connection and owning
 `PipingNetworkSegment` identities, endpoint resolution, resolved element names, and explicit
-Equipment/PipingComponent ownership. Each immutable `DexpiConnectionCycleInfo` links to its owning
-weak connection component, keeps unresolved endpoint IDs visible, and separately lists source-ordered
-connection occurrences entering and leaving the cyclic group. Boundary lists preserve parallel
+Equipment/PipingComponent ownership. Each immutable `DexpiConnectionCycleInfo` retains its owning
+weak connection-component ID and, for reader-produced values, exposes the exact complete immutable
+`DexpiConnectionComponentInfo` from the global component inventory through
+`getConnectionComponent()`. This keeps the component's endpoint, connection, incidence, resolution,
+and provenance evidence local to the cycle without copying or re-resolving it.
+`hasConnectionComponentEvidence()` distinguishes that projection from legacy values constructed
+through the older overloads; their getter returns `null` while the component ID and all existing
+cycle evidence remain unchanged. The cycle also keeps unresolved endpoint IDs visible and separately
+lists source-ordered connection occurrences entering and leaving the cyclic group. Boundary lists preserve parallel
 references and exclude connections whose source or target identity is blank.
 `getBoundaryConnections()` additionally preserves the overall source order
 across incoming and outgoing occurrences. Each immutable `DexpiConnectionCycleBoundaryInfo` records

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -23,6 +23,7 @@ public final class DexpiConnectionCycleInfo implements Serializable {
 
   private final String id;
   private final String connectionComponentId;
+  private final DexpiConnectionComponentInfo connectionComponent;
   private final List<String> endpointIds;
   private final List<DexpiConnectionEndpointInfo> endpoints;
   private final List<String> connectionIds;
@@ -119,8 +120,36 @@ public final class DexpiConnectionCycleInfo implements Serializable {
       List<String> incomingBoundaryConnectionIds, List<String> outgoingBoundaryConnectionIds,
       List<DexpiConnectionCycleBoundaryInfo> boundaryConnections, List<String> unresolvedEndpointIds,
       boolean selfReference) {
+    this(id, connectionComponentId, null, endpointIds, endpoints, connectionIds, connections,
+        incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
+        selfReference);
+  }
+
+  /**
+   * Creates immutable directed-cycle evidence with its complete owning weak connection component.
+   *
+   * @param id deterministic cycle-group evidence identity
+   * @param connectionComponentId owning weak connection-component evidence identity
+   * @param connectionComponent complete owning weak connection-component evidence
+   * @param endpointIds endpoint identities in first-reference order
+   * @param endpoints endpoint evidence records in first-reference order
+   * @param connectionIds internal connection-evidence identities in source order
+   * @param connections internal connection occurrences in source order
+   * @param incomingBoundaryConnectionIds connection-evidence identities entering the cyclic group in source order
+   * @param outgoingBoundaryConnectionIds connection-evidence identities leaving the cyclic group in source order
+   * @param boundaryConnections boundary occurrences in overall source-document order
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   * @param selfReference whether the group contains an explicit self-reference connection
+   */
+  public DexpiConnectionCycleInfo(String id, String connectionComponentId,
+      DexpiConnectionComponentInfo connectionComponent, List<String> endpointIds,
+      List<DexpiConnectionEndpointInfo> endpoints, List<String> connectionIds, List<DexpiConnectionInfo> connections,
+      List<String> incomingBoundaryConnectionIds, List<String> outgoingBoundaryConnectionIds,
+      List<DexpiConnectionCycleBoundaryInfo> boundaryConnections, List<String> unresolvedEndpointIds,
+      boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
+    this.connectionComponent = connectionComponent;
     this.endpointIds = immutableCopy(endpointIds);
     this.endpoints = Collections.unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(endpoints));
     this.connectionIds = immutableCopy(connectionIds);
@@ -141,6 +170,16 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   /** @return owning weak connection-component evidence identity */
   public String getConnectionComponentId() {
     return connectionComponentId;
+  }
+
+  /** @return complete owning weak connection-component evidence, or {@code null} for legacy values */
+  public DexpiConnectionComponentInfo getConnectionComponent() {
+    return connectionComponent;
+  }
+
+  /** @return whether complete owning weak connection-component evidence is available */
+  public boolean hasConnectionComponentEvidence() {
+    return connectionComponent != null;
   }
 
   /** @return immutable endpoint identities in first-reference order */
@@ -222,6 +261,8 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("id", id);
     result.put("connectionComponentId", connectionComponentId);
+    result.put("hasConnectionComponentEvidence", Boolean.valueOf(hasConnectionComponentEvidence()));
+    result.put("connectionComponent", connectionComponent == null ? null : connectionComponent.toMap());
     result.put("endpointCount", Integer.valueOf(getEndpointCount()));
     result.put("connectionCount", Integer.valueOf(getConnectionCount()));
     result.put("incomingBoundaryConnectionCount", Integer.valueOf(getIncomingBoundaryConnectionCount()));

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1295,8 +1295,7 @@ public final class DexpiXmlReader {
       }
     }
 
-    Map<String, DexpiConnectionComponentInfo> connectionComponentByEndpointId =
-        new HashMap<String, DexpiConnectionComponentInfo>();
+    Map<String, DexpiConnectionComponentInfo> connectionComponentByEndpointId = new HashMap<String, DexpiConnectionComponentInfo>();
     for (DexpiConnectionComponentInfo component : connectionComponents) {
       for (String endpointId : component.getEndpointIds()) {
         connectionComponentByEndpointId.put(endpointId, component);
@@ -1442,8 +1441,8 @@ public final class DexpiXmlReader {
 
     private DexpiConnectionCycleInfo toInfo() {
       return new DexpiConnectionCycleInfo(id, connectionComponentId, connectionComponent, endpointIds, endpoints,
-          connectionIds, connections, incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
-          boundaryConnections, unresolvedEndpointIds, selfReference);
+          connectionIds, connections, incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections,
+          unresolvedEndpointIds, selfReference);
     }
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1295,10 +1295,11 @@ public final class DexpiXmlReader {
       }
     }
 
-    Map<String, String> connectionComponentByEndpointId = new HashMap<String, String>();
+    Map<String, DexpiConnectionComponentInfo> connectionComponentByEndpointId =
+        new HashMap<String, DexpiConnectionComponentInfo>();
     for (DexpiConnectionComponentInfo component : connectionComponents) {
       for (String endpointId : component.getEndpointIds()) {
-        connectionComponentByEndpointId.put(endpointId, component.getId());
+        connectionComponentByEndpointId.put(endpointId, component);
       }
     }
 
@@ -1385,6 +1386,7 @@ public final class DexpiXmlReader {
   private static final class ConnectionCycleAccumulator {
     private final String id;
     private final String connectionComponentId;
+    private final DexpiConnectionComponentInfo connectionComponent;
     private final List<String> endpointIds = new ArrayList<String>();
     private final List<DexpiConnectionEndpointInfo> endpoints = new ArrayList<DexpiConnectionEndpointInfo>();
     private final List<String> connectionIds = new ArrayList<String>();
@@ -1395,9 +1397,10 @@ public final class DexpiXmlReader {
     private final List<String> unresolvedEndpointIds = new ArrayList<String>();
     private boolean selfReference;
 
-    private ConnectionCycleAccumulator(String id, String connectionComponentId) {
+    private ConnectionCycleAccumulator(String id, DexpiConnectionComponentInfo connectionComponent) {
       this.id = id;
-      this.connectionComponentId = connectionComponentId;
+      this.connectionComponent = connectionComponent;
+      this.connectionComponentId = connectionComponent == null ? "" : connectionComponent.getId();
     }
 
     private void addEndpoint(DexpiConnectionEndpointInfo endpoint) {
@@ -1438,9 +1441,9 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionCycleInfo toInfo() {
-      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, endpoints, connectionIds, connections,
-          incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
-          selfReference);
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, connectionComponent, endpointIds, endpoints,
+          connectionIds, connections, incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
+          boundaryConnections, unresolvedEndpointIds, selfReference);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -3,6 +3,7 @@ package neqsim.process.processmodel.dexpi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -965,6 +966,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionCycleInfo threeEndpointCycle = first.getConnectionCycles().get(0);
     assertEquals("cycle-1", threeEndpointCycle.getId());
     assertEquals("component-2", threeEndpointCycle.getConnectionComponentId());
+    assertTrue(threeEndpointCycle.hasConnectionComponentEvidence());
+    assertSame(first.getConnectionComponents().get(1), threeEndpointCycle.getConnectionComponent());
+    assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"),
+        threeEndpointCycle.getConnectionComponent().getEndpointIds());
     assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getEndpointIds());
     List<DexpiConnectionEndpointInfo> cycleEndpoints = threeEndpointCycle.getEndpoints();
     assertEquals(3, cycleEndpoints.size());
@@ -998,6 +1003,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionCycleInfo selfReference = first.getConnectionCycles().get(1);
     assertEquals("cycle-2", selfReference.getId());
     assertEquals("component-4", selfReference.getConnectionComponentId());
+    assertTrue(selfReference.hasConnectionComponentEvidence());
+    assertSame(first.getConnectionComponents().get(3), selfReference.getConnectionComponent());
     assertEquals(Collections.singletonList("N-S"), selfReference.getEndpointIds());
     assertEquals(Collections.singletonList("C-8"), selfReference.getConnectionIds());
     assertEquals("C-8", selfReference.getConnections().get(0).getSourceId());
@@ -1008,6 +1015,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionCycleInfo unresolved = first.getConnectionCycles().get(2);
     assertEquals("cycle-3", unresolved.getId());
     assertEquals("component-5", unresolved.getConnectionComponentId());
+    assertTrue(unresolved.hasConnectionComponentEvidence());
+    assertSame(first.getConnectionComponents().get(4), unresolved.getConnectionComponent());
     assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getEndpointIds());
     assertEquals(Arrays.asList("C-9", "C-10"), unresolved.getConnectionIds());
     assertEquals(2, unresolved.getConnections().size());
@@ -1029,11 +1038,20 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getEndpoints().clear());
     assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getConnections().clear());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionCycles().clear());
+
+    DexpiConnectionCycleInfo legacy = new DexpiConnectionCycleInfo("legacy-cycle", "legacy-component",
+        Collections.singletonList("N-LEGACY"), Collections.singletonList("C-LEGACY"),
+        Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(), false);
+    assertFalse(legacy.hasConnectionComponentEvidence());
+    assertNull(legacy.getConnectionComponent());
+
     assertTrue(first.toJson().contains("\"connectionCycleCount\": 3"));
     assertTrue(first.toJson().contains("\"endpoints\": ["));
     assertTrue(first.toJson().contains("\"connections\": ["));
     assertTrue(first.toJson().contains("\"segmentId\": \"S-3\""));
     assertTrue(first.toJson().contains("\"connectionComponentId\": \"component-4\""));
+    assertTrue(first.toJson().contains("\"hasConnectionComponentEvidence\": true"));
+    assertTrue(first.toJson().contains("\"connectionComponent\": {"));
     assertTrue(first.toJson().contains("\"selfReference\": true"));
     assertEquals(first.toJson(), second.toJson());
   }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -968,8 +968,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("component-2", threeEndpointCycle.getConnectionComponentId());
     assertTrue(threeEndpointCycle.hasConnectionComponentEvidence());
     assertSame(first.getConnectionComponents().get(1), threeEndpointCycle.getConnectionComponent());
-    assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"),
-        threeEndpointCycle.getConnectionComponent().getEndpointIds());
+    assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getConnectionComponent().getEndpointIds());
     assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getEndpointIds());
     List<DexpiConnectionEndpointInfo> cycleEndpoints = threeEndpointCycle.getEndpoints();
     assertEquals(3, cycleEndpoints.size());
@@ -1040,8 +1039,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionCycles().clear());
 
     DexpiConnectionCycleInfo legacy = new DexpiConnectionCycleInfo("legacy-cycle", "legacy-component",
-        Collections.singletonList("N-LEGACY"), Collections.singletonList("C-LEGACY"),
-        Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(), false);
+        Collections.singletonList("N-LEGACY"), Collections.singletonList("C-LEGACY"), Collections.<String>emptyList(),
+        Collections.<String>emptyList(), Collections.<String>emptyList(), false);
     assertFalse(legacy.hasConnectionComponentEvidence());
     assertNull(legacy.getConnectionComponent());
 


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 with complete, immutable ownership evidence for directed DEXPI material-reference cycles.

- each reader-produced `DexpiConnectionCycleInfo` exposes the exact `DexpiConnectionComponentInfo` already present in the global component inventory;
- preserves the existing component ID and all endpoint, connection, boundary, parallel, unresolved, and source-order evidence;
- legacy constructors remain compatible and return `null` with an explicit false evidence marker;
- deterministic JSON adds the nested component record without removing or renaming existing fields;
- construction remains O(V+E) and reuses the already-resolved immutable object.

Capability contracts: [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5561133834) and [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5561135180).

## Exact-head contract

- Exact base: `c867c3e6e3d050f9f574de7ceabcf0649d700c1a`
- Exact publication head: `928af7f32064e58b6ed265ef489338095fa35a9f`
- Branch: `ai/dexpi-cycle-component-evidence`
- Five ordered commits across four intended files
- Tests were authored first
- Zero commits behind the recorded base

## Acceptance and validation

The focused regression requires:

- object identity between cycle-local and global weak-component evidence;
- complete resolved, self-reference, and unresolved-component coverage;
- legacy-constructor absence semantics;
- deterministic nested JSON;
- unchanged immutable cycle collections.

Connector-side exact-head audits confirm the frozen four-file scope, balanced production-source braces, no tabs or trailing whitespace, and all required API, identity, legacy, and JSON markers. The only branch-attributable initial failure was Spotless; the fifth commit applies exactly the two-file patch emitted by the hosted formatter, without semantic expansion.

No local checkout was available, so no local Maven, Java, Spotless, pre-commit, or documentation result is claimed. Hosted exact-head CI is authoritative for Java 8/21, Ubuntu/Windows, slow shards, Javadocs, formatting, documentation, performance, CodeQL, PaperLab, and reference checks.

Status: **VALIDATION PENDING EXACT-HEAD CI**.

## Scope and evidence boundary

Changed files:

- `src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java`
- `src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java`
- `src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java`
- `docs/integration/dexpi-reader.md`

This is source-document evidence only. It does not infer hydraulic recycle, repair or rewire topology, change simulation, rendering, layout, or export, award safety credit, claim ISO/ISA/DEXPI conformance, certify a drawing, or provide accountable engineering approval. The whole-sheet visual gate is not applicable because diagram output is unchanged.

Eight other autonomous implementation drafts were positively identified at publication. No changed path overlaps them; occupancy with this draft is **9/10**, below the absolute ceiling. The shared PFD/P&ID/DEXPI lane has no other active implementation PR.

## Draft-only workflow

Keep this PR open and draft. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it through the autonomous campaign.