### PR TITLE
[AI-Assisted] Fix EOS envelope caching and run-status regressions

### DIFF
--- a/docs/process/equipment/streams.md
+++ b/docs/process/equipment/streams.md
@@ -409,6 +409,14 @@ double ccbPres = stream.CCB("bara");   // Pressure
 stream.phaseEnvelope();  // Opens plot window
 ```
 
+`CCT` and `CCB` share a cached envelope. Changes to temperature, pressure, composition,
+component critical properties, attractive-term selection or indexed coefficients, the
+covolume mixing rule, or binary interaction parameters trigger a new trace. EOS tuning
+inputs are checked in each allocated phase, including a liquid phase that is not currently
+active. Replacing an attractive-term object also invalidates the result. Custom attractive
+terms with more than three indexed coefficients should override `getNumberOfParameters()`
+so all coefficients participate in this check.
+
 ### Vapor Pressure
 
 ```java

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -25,6 +25,7 @@ import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.standards.gasquality.Standard_ISO6976;
 import neqsim.standards.oilquality.Standard_ASTM_D6377;
 import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.component.attractiveeosterm.AttractiveTermInterface;
 import neqsim.thermo.mixingrule.EosMixingRulesInterface;
 import neqsim.thermo.phase.PhaseEosInterface;
 import neqsim.thermo.system.SystemInterface;
@@ -49,7 +50,7 @@ public class Stream extends ProcessEquipmentBaseClass
    * temperature and in bara to the pressure.
    */
   private static final double CRICONDEN_ECHO_TOLERANCE = 1.0e-6;
-  /** Initial value for the deterministic criconden-envelope input fingerprint. */
+  /** Initial value for the criconden-envelope input fingerprint. */
   private static final long CRICONDEN_SIGNATURE_SEED = 1125899906842597L;
 
   /** Stable transaction identity retained by Java serialization. */
@@ -748,11 +749,12 @@ public class Stream extends ProcessEquipmentBaseClass
    * </p>
    *
    * <p>
-   * A single envelope contains both cricondenpoints. The result is therefore cached against a deterministic fingerprint
-   * of the complete EOS input used by the trace, so repeated {@link #CCT(String)} and {@link #CCB(String)} calls do not
-   * repeat the expensive envelope calculation. Temperature and pressure are part of the fingerprint because they seed
-   * the numerical trace. Composition, pseudo-component properties and EOS binary-interaction parameters are included to
-   * prevent stale reuse after direct mutation of the stream fluid.
+   * A single envelope contains both cricondenpoints. The result is therefore cached against a fingerprint of the EOS
+   * inputs inspected below, so repeated {@link #CCT(String)} and {@link #CCB(String)} calls do not repeat the expensive
+   * envelope calculation. Temperature and pressure are part of the fingerprint because they seed the numerical trace.
+   * Composition, pseudo-component properties, attractive-term types and coefficients, covolume mixing rules and EOS
+   * binary-interaction parameters in every allocated phase are included to prevent stale reuse after direct tuning of
+   * those inputs.
    * </p>
    *
    * <p>
@@ -841,10 +843,10 @@ public class Stream extends ProcessEquipmentBaseClass
   }
 
   /**
-   * Calculate a deterministic fingerprint of every EOS input that can affect the traced envelope.
+   * Calculate a fingerprint of the stream state and phase-local EOS tuning inputs.
    *
    * @param system stream fluid to fingerprint
-   * @return exact criconden-envelope input fingerprint
+   * @return criconden-envelope input fingerprint
    */
   private long calculateCricondenInputSignature(SystemInterface system) {
     long signature = CRICONDEN_SIGNATURE_SEED;
@@ -856,27 +858,50 @@ public class Stream extends ProcessEquipmentBaseClass
 
     int componentCount = system.getNumberOfComponents();
     signature = updateCricondenInputSignature(signature, componentCount);
-    for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
-      ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
-      signature = updateCricondenInputSignature(signature, component.getComponentName());
-      signature = updateCricondenInputSignature(signature, component.getz());
-      signature = updateCricondenInputSignature(signature, component.getMolarMass());
-      signature = updateCricondenInputSignature(signature, component.getNormalLiquidDensity());
-      signature = updateCricondenInputSignature(signature, component.getTC());
-      signature = updateCricondenInputSignature(signature, component.getPC());
-      signature = updateCricondenInputSignature(signature, component.getAcentricFactor());
-    }
+    signature = updateCricondenInputSignature(signature, system.getMaxNumberOfPhases());
+    for (int phaseIndex = 0; phaseIndex < system.getMaxNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex) == null) {
+        signature = updateCricondenInputSignature(signature, -1L);
+        continue;
+      }
+      signature = updateCricondenInputSignature(signature, system.getPhase(phaseIndex).getClass().getName());
+      for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+        ComponentInterface component = system.getPhase(phaseIndex).getComponent(componentIndex);
+        signature = updateCricondenInputSignature(signature, component.getComponentName());
+        signature = updateCricondenInputSignature(signature, component.getz());
+        signature = updateCricondenInputSignature(signature, component.getMolarMass());
+        signature = updateCricondenInputSignature(signature, component.getNormalLiquidDensity());
+        signature = updateCricondenInputSignature(signature, component.getTC());
+        signature = updateCricondenInputSignature(signature, component.getPC());
+        signature = updateCricondenInputSignature(signature, component.getAcentricFactor());
+        signature = updateCricondenInputSignature(signature, component.getAttractiveTermNumber());
+        AttractiveTermInterface attractiveTerm = component.getAttractiveTerm();
+        if (attractiveTerm != null) {
+          // Replacing a term may also replace coefficients not exposed by the indexed parameter API.
+          signature = updateCricondenInputSignature(signature, System.identityHashCode(attractiveTerm));
+          signature = updateCricondenInputSignature(signature, attractiveTerm.getClass().getName());
+          signature = updateCricondenInputSignature(signature, attractiveTerm.getm());
+          int parameterCount = attractiveTerm.getNumberOfParameters();
+          signature = updateCricondenInputSignature(signature, parameterCount);
+          for (int parameterIndex = 0; parameterIndex < parameterCount; parameterIndex++) {
+            signature = updateCricondenInputSignature(signature, attractiveTerm.getParameters(parameterIndex));
+          }
+        }
+      }
 
-    if (system.getPhase(0) instanceof PhaseEosInterface) {
-      EosMixingRulesInterface mixingRule = ((PhaseEosInterface) system.getPhase(0)).getEosMixingRule();
-      if (mixingRule != null) {
-        signature = updateCricondenInputSignature(signature, ((long) componentCount) * componentCount);
-        for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
-          for (int otherComponentIndex = 0; otherComponentIndex < componentCount; otherComponentIndex++) {
-            signature = updateCricondenInputSignature(signature,
-                mixingRule.getBinaryInteractionParameter(componentIndex, otherComponentIndex));
-            signature = updateCricondenInputSignature(signature,
-                mixingRule.getBinaryInteractionParameterT1(componentIndex, otherComponentIndex));
+      if (system.getPhase(phaseIndex) instanceof PhaseEosInterface) {
+        EosMixingRulesInterface mixingRule = ((PhaseEosInterface) system.getPhase(phaseIndex)).getEosMixingRule();
+        if (mixingRule != null) {
+          signature = updateCricondenInputSignature(signature, mixingRule.getClass().getName());
+          signature = updateCricondenInputSignature(signature, mixingRule.getBmixType());
+          signature = updateCricondenInputSignature(signature, ((long) componentCount) * componentCount);
+          for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+            for (int otherComponentIndex = 0; otherComponentIndex < componentCount; otherComponentIndex++) {
+              signature = updateCricondenInputSignature(signature,
+                  mixingRule.getBinaryInteractionParameter(componentIndex, otherComponentIndex));
+              signature = updateCricondenInputSignature(signature,
+                  mixingRule.getBinaryInteractionParameterT1(componentIndex, otherComponentIndex));
+            }
           }
         }
       }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -2906,9 +2906,20 @@ public class ProcessSystem extends SimulationBaseClass {
       return;
     }
     if (!runThrew) {
+      java.util.Set<String> failedNames = null;
+      for (UnitRunStatus status : lastRunStatus.getUnits()) {
+        if (!status.isSuccess()) {
+          if (failedNames == null) {
+            failedNames = new java.util.HashSet<String>();
+          }
+          failedNames.add(status.getUnitName());
+        }
+      }
       List<UnitRunStatus> successfulStatuses = getSuccessfulRunStatuses();
       for (UnitRunStatus status : successfulStatuses) {
-        lastRunStatus.recordSuccess(status);
+        if (failedNames == null || !failedNames.contains(status.getUnitName())) {
+          lastRunStatus.recordSuccess(status);
+        }
       }
     }
     lastRunStatus.markComplete(!runThrew);

--- a/src/main/java/neqsim/thermo/component/attractiveeosterm/AttractiveTermBaseClass.java
+++ b/src/main/java/neqsim/thermo/component/attractiveeosterm/AttractiveTermBaseClass.java
@@ -114,6 +114,12 @@ public abstract class AttractiveTermBaseClass implements AttractiveTermInterface
     return parameters[i];
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int getNumberOfParameters() {
+    return parameters.length;
+  }
+
   /**
    * Get component.
    *

--- a/src/main/java/neqsim/thermo/component/attractiveeosterm/AttractiveTermInterface.java
+++ b/src/main/java/neqsim/thermo/component/attractiveeosterm/AttractiveTermInterface.java
@@ -75,6 +75,20 @@ public interface AttractiveTermInterface extends Cloneable, java.io.Serializable
   public double getParameters(int i);
 
   /**
+   * Returns the number of coefficients exposed by {@link #getParameters(int)}.
+   *
+   * <p>
+   * The default preserves the three-coefficient contract of existing implementations. Terms with a different
+   * coefficient count must override this method so callers can inspect every tunable coefficient.
+   * </p>
+   *
+   * @return number of indexed attractive-term coefficients
+   */
+  public default int getNumberOfParameters() {
+    return 3;
+  }
+
+  /**
    * setm.
    *
    * @param val a double

--- a/src/test/java/neqsim/process/equipment/stream/StreamCricondenMutationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamCricondenMutationTest.java
@@ -1,0 +1,93 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseEosInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for direct EOS tuning after a stream envelope has been cached. */
+class StreamCricondenMutationTest extends neqsim.NeqSimTest {
+  /** Builds a synthetic hydrocarbon gas with a resolved two-phase envelope. */
+  private SystemInterface createFluid() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("ethane", 0.1);
+    fluid.addComponent("propane", 0.1);
+    fluid.setMixingRule("classic");
+    fluid.init(0);
+    return fluid;
+  }
+
+  /** Compares a warmed accessor with a new stream tracing the identical mutated EOS. */
+  private void assertMutationRecalculates(SystemInterface fluid, Consumer<SystemInterface> mutation) {
+    Stream cached = new Stream("cached", fluid);
+    double originalTemperature = cached.CCT("K");
+    double originalPressure = cached.CCB("bara");
+    mutation.accept(fluid);
+    Stream fresh = new Stream("fresh", fluid.clone());
+    double expectedTemperature = fresh.CCT("K");
+    double expectedPressure = fresh.CCB("bara");
+    assertTrue(Double.isFinite(expectedTemperature) && Double.isFinite(expectedPressure));
+    assertTrue(
+        Math.abs(expectedTemperature - originalTemperature) > 1.0e-4
+            || Math.abs(expectedPressure - originalPressure) > 1.0e-4,
+        "The EOS mutation must measurably change the independently traced envelope");
+    assertEquals(expectedTemperature, cached.CCT("K"), 1.0e-6,
+        "CCT must match a fresh envelope after direct EOS tuning");
+    assertEquals(expectedPressure, cached.CCB("bara"), 1.0e-6,
+        "CCB must match a fresh envelope after direct EOS tuning");
+  }
+
+  @Test
+  void changingAttractiveTermInvalidatesEnvelope() {
+    assertMutationRecalculates(createFluid(), fluid -> fluid.setAttractiveTerm(5));
+  }
+
+  @Test
+  void changingAttractiveParametersInvalidatesEnvelope() {
+    SystemInterface fluid = createFluid();
+    fluid.setAttractiveTerm(4);
+    assertMutationRecalculates(fluid, system -> {
+      for (int phase = 0; phase < system.getMaxNumberOfPhases(); phase++) {
+        if (system.getPhase(phase) != null) {
+          system.getPhase(phase).getComponent(2).getAttractiveTerm().setParameters(1, 0.5);
+        }
+      }
+    });
+  }
+
+  @Test
+  void changingCovolumeMixingRuleInvalidatesEnvelope() {
+    assertMutationRecalculates(createFluid(), system -> {
+      for (int phase = 0; phase < system.getMaxNumberOfPhases(); phase++) {
+        if (system.getPhase(phase) instanceof PhaseEosInterface) {
+          ((PhaseEosInterface) system.getPhase(phase)).getEosMixingRule().setBmixType(1);
+        }
+      }
+    });
+  }
+
+  @Test
+  void changingFifthAttractiveCoefficientInvalidatesEnvelope() {
+    SystemInterface fluid = createFluid();
+    fluid.setAttractiveTerm(19);
+    assertMutationRecalculates(fluid, system -> {
+      for (int phase = 0; phase < system.getMaxNumberOfPhases(); phase++) {
+        if (system.getPhase(phase) != null) {
+          assertEquals(5, system.getPhase(phase).getComponent(2).getAttractiveTerm().getNumberOfParameters());
+          system.getPhase(phase).getComponent(2).getAttractiveTerm().setParameters(4, 5.0);
+        }
+      }
+    });
+  }
+
+  @Test
+  void changingLiquidPhaseInteractionInvalidatesEnvelope() {
+    assertMutationRecalculates(createFluid(), system -> {
+      ((PhaseEosInterface) system.getPhase(1)).getEosMixingRule().setBinaryInteractionParameter(0, 2, 0.05);
+    });
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/RunStatusTest.java
+++ b/src/test/java/neqsim/process/processmodel/RunStatusTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
@@ -168,6 +170,43 @@ class RunStatusTest {
     assertEquals(1, process.getRunStatus().getUnits().size());
     assertFalse(process.getRunStatus().getUnits().get(0).isSuccess());
     assertEquals("BrokenUnit", process.getRunStatus().getFailedUnitName());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  void testRecordedFailureDoesNotAlsoReceiveCachedSuccess(boolean optimized) {
+    final ProcessSystem process = new ProcessSystem();
+    final boolean[] reject = { false };
+    process.setUseOptimizedExecution(optimized);
+    process.add(new ProcessEquipmentBaseClass("ValidatedUnit") {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public void run(UUID id) {
+        if (reject[0]) {
+          process.getRunStatus().recordFailure(getName(), "ValidatedUnit", "Validation rejected result");
+        }
+        setCalculationIdentifier(id);
+      }
+    });
+    process.run();
+    UnitRunStatus cachedSuccess = process.getRunStatus().getUnits().get(0);
+    assertTrue(cachedSuccess.isSuccess());
+    reject[0] = true;
+    process.run();
+
+    RunStatus status = process.getRunStatus();
+    assertTrue(status.isCompleted());
+    assertFalse(status.isSuccess());
+    assertEquals("ValidatedUnit", status.getFailedUnitName());
+    assertEquals(1, status.getUnits().size(), "A failed unit must not also appear as successful");
+    assertFalse(status.getUnits().get(0).isSuccess());
+    assertEquals(1, status.toJsonObject().get("unitCount").getAsInt());
+
+    reject[0] = false;
+    process.run();
+    assertTrue(process.getRunStatus().isSuccess());
+    assertSame(cachedSuccess, process.getRunStatus().getUnits().get(0));
   }
 
   @Test


### PR DESCRIPTION
## Problem

The 6 August–6 September commit review confirmed two regressions still present on master `6bdb326a3d662f90172f91e70268438cf766c86c`:

1. **Stale CCT/CCB after EOS tuning**, introduced by #3003 (`d317e63c7316581d53be20568b14f67cdd8e8115`, 14 August). The envelope cache omitted attraction models/coefficients and covolume mixing, and inspected only phase 0. A warmed accessor could return a plausible value from the previous model.
2. **Contradictory per-unit run status**, introduced by #2896 (`174a30d7dd`, 9 August). Cached success records were appended even when the same unit had already recorded a nonthrowing failure. The overall success flag was still false, but the unit list incorrectly contained both failure and success.

The original four targeted cases all failed before the fixes.

| EOS change | Stale CCT (K) | Fresh trace (K) |
| --- | ---: | ---: |
| Change attraction model | 264.192197 | 258.809056 |
| Tune Mathias–Copeman coefficient | 263.110761 | 228.257652 |
| Change covolume mixing | 264.192197 | 243.100586 |

These values compare the accessor with an independent uncached trace using identical mutated inputs; they are regression evidence, not experimental EOS qualification.

## Changes

- Include phase-local component properties, attraction-model identity/type, m and indexed coefficients, covolume mixing type and binary interactions in the envelope fingerprint.
- Inspect inactive allocated phases as well as the active phase.
- Add a Java 8 default `getNumberOfParameters()` for coefficient introspection; the base implementation returns its actual indexed coefficient count, including the five-coefficient variant.
- Retain shared CCT/CCB caching for unchanged inputs.
- Restore failed-unit filtering while retaining success-object reuse and avoiding a failure-set allocation on successful runs.
- Add coverage for model/coefficient/covolume changes, fifth coefficients, liquid-phase interaction changes, sequential/optimized status recording, and successful recovery after failure.

## Validation

NeqSim 3.19.0 source on the exact master base above; OpenJDK 17.0.20. Maven was configured with the work-with-neqsim bootstrap helper and validation used the existing dependency cache.

- `./mvnw -o -q -DskipTests compile`: exit 0.
- `./mvnw -o -q -Dtest=StreamCricondenMutationTest,StreamCricondenTest,RunStatusTest,StreamTest,StreamTransientStateTransactionTest,ComponentEosCloneAttractiveTermTest,ProcessModelExecutionOptimizationTest,ProcessSystemDataflowDispatchTest,ProcessSystemMultiInputDataflowTest,ProcessSystemSerializationTest,ProcessSystemExecutionPreparationTest test`: exit 0; **59 tests in 10 executed classes, 0 failures, 0 errors**. The selected serialization class is tagged slow and was excluded by the default profile.
- `python devtools/run_spotless.py apply`: exit 0, repeated; final repeat made no further changes.
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0; 690 Markdown pages and one standalone HTML page audited.
- `git diff --check`: exit 0.

The environment-provided Python interpreter ran the direct scripts. The pre-commit executable/module is unavailable, so the configured formatting and documentation gates were run directly. No full repository suite or actual Java 8 JVM run was claimed locally. Hosted exact-head CI at `40753d86e9d1ffbc40eb45a5a931bd8e31c107e5` passes Java 8/21 on Ubuntu and Windows, all four slow shards, Javadocs, Spotless, pre-commit, documentation, PaperLab, CodeQL, engineering-diagram performance, and reference checks. The PR is open and mergeable with no reviews or unresolved threads. **READY TO MERGE**.

## Documentation and review scope

Updated the stream guide and coefficient-introspection Javadoc. Documentation impact for the status fix: none; it restores the existing documented rule that a unit with a recorded failure does not receive a success entry.

The review inventoried **600 commits** in the month, checked current master and open PRs, and investigated selected behavior and caching changes. It does not certify every commit as defect-free. Existing valve/cooler fixes in #3507 and campaign branches remain separate. This draft changes seven intended files and does not request a merge or release. Autonomous portfolio occupancy is **9/10**, below the absolute ceiling.

Generated with AI assistance.