### PR TITLE
[AI-Assisted] fix(control): decay derivative output and honor action changes

### DIFF
--- a/docs/simulation/dynamic_simulation_guide.md
+++ b/docs/simulation/dynamic_simulation_guide.md
@@ -377,6 +377,13 @@ controller.setReverseActing(true);   // Increase output to decrease PV
 controller.setReverseActing(false);  // Increase output to increase PV
 ```
 
+With an explicit engineering unit (for example, `setControllerSetPoint(50.0, "bara")`),
+the controller uses velocity-form PID: each step adds the proportional change,
+the integral increment, and the change in the derivative contribution to the
+previous output. Once an error stops changing, derivative action disappears;
+with a derivative filter it decays gradually. Switching `setReverseActing`
+between `true` and `false` takes effect on the next automatic control step.
+
 ### System-Level Controller Registration
 
 In addition to attaching controllers to individual equipment, controllers can be registered directly on the `ProcessSystem`. During each `runTransient()` call, the system automatically scans and executes all registered controllers **after** all equipment has been stepped and **before** measurements are collected:

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -169,9 +169,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
     }
 
     totalTime += dt;
-    if (isReverseActing()) {
-      propConstant = -1;
-    }
+    propConstant = isReverseActing() ? -1 : 1;
     double measurement = getMeasuredValue(unit);
     applyGainSchedule(measurement);
     oldoldError = oldError;
@@ -241,6 +239,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
           TintValue = 0.0;
         }
 
+        double previousDerivativeState = derivativeState;
         derivative = (error - oldError) / dt;
         if (Td > 0) {
           if (derivativeFilterTime > 0) {
@@ -255,7 +254,9 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
         // Velocity-form PI/PID adds only this step's integral increment to the
         // previous manipulated output. Adding the accumulated integral state here
         // integrates the error twice and causes accelerating drift.
-        delta = bumplessOffset + Kp * propStep + TintIncrement + Kp * Td * derivativeState;
+        // The derivative is also an absolute contribution: add its change so it
+        // decays out of the output when the error stops changing.
+        delta = bumplessOffset + Kp * propStep + TintIncrement + Kp * Td * (derivativeState - previousDerivativeState);
 
         response = initResponse + propConstant * delta;
 

--- a/src/test/java/neqsim/process/controllerdevice/ControllerDevicePIDEnhancementsTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerDevicePIDEnhancementsTest.java
@@ -65,6 +65,56 @@ class ControllerDevicePIDEnhancementsTest {
   }
 
   @Test
+  void testDerivativeContributionDisappearsAfterMeasurementStepSettles() {
+    assertDerivativeStepResponse(0.0);
+  }
+
+  @Test
+  void testFilteredDerivativeContributionDecaysAfterMeasurementStep() {
+    assertDerivativeStepResponse(1.0);
+  }
+
+  private void assertDerivativeStepResponse(double filterTime) {
+    DummyTransmitter transmitter = new DummyTransmitter("trans", "%");
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("derivative-step");
+    controller.setTransmitter(transmitter);
+    controller.setControllerSetPoint(0.0, "%");
+    controller.setControllerParameters(2.0, 0.0, 3.0);
+    controller.setDerivativeFilterTime(filterTime);
+    double dt = 0.5;
+    controller.runTransient(40.0, dt, UUID.randomUUID());
+    transmitter.setValue(10.0);
+    double derivative = 10.0 / (filterTime + dt);
+    controller.runTransient(controller.getResponse(), dt, UUID.randomUUID());
+    Assertions.assertEquals(60.0 + 6.0 * derivative, controller.getResponse(), 1.0e-10);
+    for (int i = 0; i < 20; i++) {
+      derivative *= filterTime / (filterTime + dt);
+      controller.runTransient(controller.getResponse(), dt, UUID.randomUUID());
+      Assertions.assertEquals(60.0 + 6.0 * derivative, controller.getResponse(), 1.0e-10,
+          "Derivative action must decay while the proportional contribution remains");
+    }
+  }
+
+  @Test
+  void testSwitchingBackToDirectActionReversesIntegralDirection() {
+    DummyTransmitter transmitter = new DummyTransmitter("trans", "%");
+    transmitter.setValue(60.0);
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("action-switch");
+    controller.setTransmitter(transmitter);
+    controller.setControllerSetPoint(50.0, "%");
+    controller.setControllerParameters(2.0, 10.0, 0.0);
+    controller.setReverseActing(true);
+    controller.runTransient(100.0, 1.0, UUID.randomUUID());
+    Assertions.assertEquals(98.0, controller.getResponse(), 1.0e-12);
+    controller.setReverseActing(false);
+    controller.runTransient(controller.getResponse(), 1.0, UUID.randomUUID());
+    Assertions.assertEquals(100.0, controller.getResponse(), 1.0e-12);
+    controller.setReverseActing(true);
+    controller.runTransient(controller.getResponse(), 1.0, UUID.randomUUID());
+    Assertions.assertEquals(98.0, controller.getResponse(), 1.0e-12);
+  }
+
+  @Test
   void testDerivativeFiltering() {
     DummyTransmitter trans1 = new DummyTransmitter("t1", "%");
     trans1.setMinimumValue(0.0);


### PR DESCRIPTION
The engineering-unit PID path adds the absolute derivative contribution to the previous output on every scan. A measurement step therefore leaves a permanent derivative offset, and filtering adds further drift while the derivative decays. Separately, switching from reverse to direct action leaves the internal output multiplier at -1.

This change adds only the change in filtered derivative state to the velocity-form output and recomputes the action multiplier on each automatic scan. It documents both behaviors and adds three regression tests covering unfiltered decay, filtered decay with a non-unit timestep, and reverse/direct/reverse switching.

Found during a follow-up review of recently changed controller code. Both defects are also present in July 31 commit c80a31794a; they are not attributed to last month's commits. This is separate from cache/status PR #3513.

Validation:
- Before the fix, all three new tests fail: settled output 180 instead of 60; filtered output 126.6667 instead of 86.6667; direct-action output 96 instead of 100.
- After the fix, 116 tests across 13 classes pass, including controller state transactions, tuning, benchmarks, dynamic improvements and process-system controller integration.
- Spotless apply repeated, Spotless check, documentation search audit and git diff --check pass.
- Tested on Java 17 with Java 8-compatible source. A Java 8 runtime and the full repository suite were not run. pre-commit is unavailable; its formatting/documentation gates were run directly.

AI-assisted implementation and regression tests.