### PR TITLE
[AI-Assisted] Add strict Sarir product T95 comparison

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -114,6 +114,34 @@ Four products have numeric laboratory and simulated ASTM D86 T5/T95 evidence:
 
 The residual laboratory curve is explicitly excluded from the numeric API because the paper states that it was unavailable and presents a non-numeric `550+` limit.
 
+
+### Strict NeqSim T95 comparison
+
+A calculated product standard can be compared with the three published Sarir T95 references
+through the strict 95 liquid-volume-percent Riazi-Daubert path:
+
+```java
+Standard_ASTM_D86 d86 = new Standard_ASTM_D86(productFluid);
+d86.calculate();
+
+SarirD86ProductComparison.Result comparison =
+    SarirD86ProductComparison.compareT95(d86, "Diesel");
+double neqsimT95C = comparison.getNeqsimT95Celsius();
+double laboratoryErrorPercent =
+    comparison.getNeqsimAbsoluteRelativeErrorPercent();
+double specificationMarginC = comparison.getSpecificationMarginCelsius();
+```
+
+The workflow delegates the NeqSim value to
+`Standard_ASTM_D86.getQualifiedD86Temperature(95.0)`. It retains the laboratory, HYSYS, and
+numeric specification values as read-only comparison evidence. Neither the source HYSYS value nor
+the specification is a tuning target, and no laboratory-agreement threshold is imposed.
+
+Sarir T5 values are not converted because 5 volume% is outside the qualified Riazi-Daubert
+recovery set. The residual `550+` specification also remains nonnumeric and fails closed. A
+specification margin is only arithmetic against the published reference; it is not an ASTM
+procedure or compliance determination.
+
 ## Independent product-rate evidence
 
 | Product | Plant (metric t/day) | HYSYS (metric t/day) | Absolute error (%) |

--- a/src/main/java/neqsim/standards/oilquality/SarirD86ProductComparison.java
+++ b/src/main/java/neqsim/standards/oilquality/SarirD86ProductComparison.java
@@ -9,10 +9,9 @@ import neqsim.thermo.characterization.SarirAtmosphericReference.ProductSpecifica
  * Strict comparison of a calculated NeqSim product T95 with the published Sarir refinery evidence.
  *
  * <p>
- * The NeqSim value is obtained only through
- * {@link Standard_ASTM_D86#getQualifiedD86Temperature(double)}, at the qualified 95 liquid-volume-percent
- * Riazi-Daubert reference point. The published laboratory, HYSYS, and specification values are retained as read-only
- * comparison evidence and are never used to tune the NeqSim calculation.
+ * The NeqSim value is obtained only through {@link Standard_ASTM_D86#getQualifiedD86Temperature(double)}, at the
+ * qualified 95 liquid-volume-percent Riazi-Daubert reference point. The published laboratory, HYSYS, and specification
+ * values are retained as read-only comparison evidence and are never used to tune the NeqSim calculation.
  * </p>
  *
  * <p>
@@ -33,7 +32,7 @@ public final class SarirD86ProductComparison {
    * @param productName exact Sarir source-table product label
    * @return immutable comparison result
    * @throws IllegalArgumentException if the standard or label is null, the label has no numeric Table 5 row, or the
-   *     product has no numeric T95 specification
+   * product has no numeric T95 specification
    * @throws IllegalStateException if the standard has not produced a finite strict T95
    */
   public static Result compareT95(Standard_ASTM_D86 standard, String productName) {
@@ -41,25 +40,18 @@ public final class SarirD86ProductComparison {
       throw new IllegalArgumentException("ASTM D86 standard cannot be null");
     }
     ProductQualityReference quality = requireProductQuality(productName);
-    ProductSpecificationReference specification =
-        SarirAtmosphericReference.getProductSpecification(productName);
+    ProductSpecificationReference specification = SarirAtmosphericReference.getProductSpecification(productName);
     if (!specification.hasNumericSpecificationTemperature()) {
-      throw new IllegalArgumentException(
-          "Sarir product has no numeric T95 specification: " + productName);
+      throw new IllegalArgumentException("Sarir product has no numeric T95 specification: " + productName);
     }
 
-    double neqsimT95C =
-        standard.getQualifiedD86Temperature(RECOVERY_VOLUME_PERCENT, "C");
+    double neqsimT95C = standard.getQualifiedD86Temperature(RECOVERY_VOLUME_PERCENT, "C");
     if (!Double.isFinite(neqsimT95C)) {
       throw new IllegalStateException("Calculated strict NeqSim T95 must be finite");
     }
 
-    return new Result(
-        productName,
-        neqsimT95C,
-        quality.getLaboratoryNinetyFivePercentCelsius(),
-        quality.getSimulationNinetyFivePercentCelsius(),
-        specification.getSpecificationTemperatureCelsius());
+    return new Result(productName, neqsimT95C, quality.getLaboratoryNinetyFivePercentCelsius(),
+        quality.getSimulationNinetyFivePercentCelsius(), specification.getSpecificationTemperatureCelsius());
   }
 
   private static ProductQualityReference requireProductQuality(String productName) {
@@ -71,8 +63,7 @@ public final class SarirD86ProductComparison {
         return quality;
       }
     }
-    throw new IllegalArgumentException(
-        "Unknown or nonnumeric Sarir product-quality row: " + productName);
+    throw new IllegalArgumentException("Unknown or nonnumeric Sarir product-quality row: " + productName);
   }
 
   /** Immutable strict T95 comparison result. */
@@ -84,11 +75,7 @@ public final class SarirD86ProductComparison {
     private final double hysysT95Celsius;
     private final double specificationT95Celsius;
 
-    private Result(
-        String productName,
-        double neqsimT95Celsius,
-        double laboratoryT95Celsius,
-        double hysysT95Celsius,
+    private Result(String productName, double neqsimT95Celsius, double laboratoryT95Celsius, double hysysT95Celsius,
         double specificationT95Celsius) {
       this.productName = productName;
       this.neqsimT95Celsius = neqsimT95Celsius;
@@ -129,22 +116,20 @@ public final class SarirD86ProductComparison {
 
     /** @return absolute relative NeqSim-versus-laboratory T95 error in percent */
     public double getNeqsimAbsoluteRelativeErrorPercent() {
-      return SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(
-          laboratoryT95Celsius, neqsimT95Celsius);
+      return SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(laboratoryT95Celsius, neqsimT95Celsius);
     }
 
     /** @return absolute relative HYSYS-versus-laboratory T95 error in percent */
     public double getHysysAbsoluteRelativeErrorPercent() {
-      return SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(
-          laboratoryT95Celsius, hysysT95Celsius);
+      return SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(laboratoryT95Celsius, hysysT95Celsius);
     }
 
     /**
      * Return the published specification reference minus the calculated NeqSim T95.
      *
      * <p>
-     * A non-negative value means the calculated value is at or below the published numeric reference. It is not an
-     * ASTM compliance determination.
+     * A non-negative value means the calculated value is at or below the published numeric reference. It is not an ASTM
+     * compliance determination.
      * </p>
      *
      * @return specification margin in degrees Celsius

--- a/src/main/java/neqsim/standards/oilquality/SarirD86ProductComparison.java
+++ b/src/main/java/neqsim/standards/oilquality/SarirD86ProductComparison.java
@@ -1,0 +1,156 @@
+package neqsim.standards.oilquality;
+
+import java.io.Serializable;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductQualityReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductSpecificationReference;
+
+/**
+ * Strict comparison of a calculated NeqSim product T95 with the published Sarir refinery evidence.
+ *
+ * <p>
+ * The NeqSim value is obtained only through
+ * {@link Standard_ASTM_D86#getQualifiedD86Temperature(double)}, at the qualified 95 liquid-volume-percent
+ * Riazi-Daubert reference point. The published laboratory, HYSYS, and specification values are retained as read-only
+ * comparison evidence and are never used to tune the NeqSim calculation.
+ * </p>
+ *
+ * <p>
+ * Sarir T5 data are intentionally excluded because 5 liquid volume percent is not one of the seven qualified
+ * Riazi-Daubert recovery points. The open-ended residual specification is also excluded from numeric comparison.
+ * </p>
+ */
+public final class SarirD86ProductComparison {
+  private static final double RECOVERY_VOLUME_PERCENT = 95.0;
+
+  private SarirD86ProductComparison() {
+  }
+
+  /**
+   * Compare the strict NeqSim T95 with one numeric Sarir product row.
+   *
+   * @param standard successfully calculated ASTM D86 standard for the product stream
+   * @param productName exact Sarir source-table product label
+   * @return immutable comparison result
+   * @throws IllegalArgumentException if the standard or label is null, the label has no numeric Table 5 row, or the
+   *     product has no numeric T95 specification
+   * @throws IllegalStateException if the standard has not produced a finite strict T95
+   */
+  public static Result compareT95(Standard_ASTM_D86 standard, String productName) {
+    if (standard == null) {
+      throw new IllegalArgumentException("ASTM D86 standard cannot be null");
+    }
+    ProductQualityReference quality = requireProductQuality(productName);
+    ProductSpecificationReference specification =
+        SarirAtmosphericReference.getProductSpecification(productName);
+    if (!specification.hasNumericSpecificationTemperature()) {
+      throw new IllegalArgumentException(
+          "Sarir product has no numeric T95 specification: " + productName);
+    }
+
+    double neqsimT95C =
+        standard.getQualifiedD86Temperature(RECOVERY_VOLUME_PERCENT, "C");
+    if (!Double.isFinite(neqsimT95C)) {
+      throw new IllegalStateException("Calculated strict NeqSim T95 must be finite");
+    }
+
+    return new Result(
+        productName,
+        neqsimT95C,
+        quality.getLaboratoryNinetyFivePercentCelsius(),
+        quality.getSimulationNinetyFivePercentCelsius(),
+        specification.getSpecificationTemperatureCelsius());
+  }
+
+  private static ProductQualityReference requireProductQuality(String productName) {
+    if (productName == null) {
+      throw new IllegalArgumentException("Product name cannot be null");
+    }
+    for (ProductQualityReference quality : SarirAtmosphericReference.getProductQualities()) {
+      if (quality.getName().equals(productName)) {
+        return quality;
+      }
+    }
+    throw new IllegalArgumentException(
+        "Unknown or nonnumeric Sarir product-quality row: " + productName);
+  }
+
+  /** Immutable strict T95 comparison result. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String productName;
+    private final double neqsimT95Celsius;
+    private final double laboratoryT95Celsius;
+    private final double hysysT95Celsius;
+    private final double specificationT95Celsius;
+
+    private Result(
+        String productName,
+        double neqsimT95Celsius,
+        double laboratoryT95Celsius,
+        double hysysT95Celsius,
+        double specificationT95Celsius) {
+      this.productName = productName;
+      this.neqsimT95Celsius = neqsimT95Celsius;
+      this.laboratoryT95Celsius = laboratoryT95Celsius;
+      this.hysysT95Celsius = hysysT95Celsius;
+      this.specificationT95Celsius = specificationT95Celsius;
+    }
+
+    /** @return exact Sarir source-table product label */
+    public String getProductName() {
+      return productName;
+    }
+
+    /** @return qualified recovery point, always 95 liquid volume percent */
+    public double getRecoveryVolumePercent() {
+      return RECOVERY_VOLUME_PERCENT;
+    }
+
+    /** @return strict NeqSim ASTM D86 T95 in degrees Celsius */
+    public double getNeqsimT95Celsius() {
+      return neqsimT95Celsius;
+    }
+
+    /** @return published laboratory ASTM D86 T95 in degrees Celsius */
+    public double getLaboratoryT95Celsius() {
+      return laboratoryT95Celsius;
+    }
+
+    /** @return published HYSYS ASTM D86 T95 in degrees Celsius */
+    public double getHysysT95Celsius() {
+      return hysysT95Celsius;
+    }
+
+    /** @return published Sarir Table 2 ASTM D86 T95 specification in degrees Celsius */
+    public double getSpecificationT95Celsius() {
+      return specificationT95Celsius;
+    }
+
+    /** @return absolute relative NeqSim-versus-laboratory T95 error in percent */
+    public double getNeqsimAbsoluteRelativeErrorPercent() {
+      return SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(
+          laboratoryT95Celsius, neqsimT95Celsius);
+    }
+
+    /** @return absolute relative HYSYS-versus-laboratory T95 error in percent */
+    public double getHysysAbsoluteRelativeErrorPercent() {
+      return SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(
+          laboratoryT95Celsius, hysysT95Celsius);
+    }
+
+    /**
+     * Return the published specification reference minus the calculated NeqSim T95.
+     *
+     * <p>
+     * A non-negative value means the calculated value is at or below the published numeric reference. It is not an
+     * ASTM compliance determination.
+     * </p>
+     *
+     * @return specification margin in degrees Celsius
+     */
+    public double getSpecificationMarginCelsius() {
+      return specificationT95Celsius - neqsimT95Celsius;
+    }
+  }
+}

--- a/src/test/java/neqsim/standards/oilquality/SarirD86ProductComparisonTest.java
+++ b/src/test/java/neqsim/standards/oilquality/SarirD86ProductComparisonTest.java
@@ -1,0 +1,84 @@
+package neqsim.standards.oilquality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests the strict Sarir product T95 comparison workflow. */
+class SarirD86ProductComparisonTest {
+  private Standard_ASTM_D86 calculatedStandard() {
+    SystemInterface oil = new SystemSrkEos(273.15 + 25.0, 1.01325);
+    oil.addComponent("nC10", 0.05);
+    oil.addTBPfraction("C12", 0.20, 170.0 / 1000.0, 0.78);
+    oil.addTBPfraction("C14", 0.25, 198.0 / 1000.0, 0.80);
+    oil.addTBPfraction("C16", 0.25, 226.0 / 1000.0, 0.82);
+    oil.addTBPfraction("C18", 0.15, 254.0 / 1000.0, 0.83);
+    oil.addTBPfraction("C20", 0.10, 282.0 / 1000.0, 0.85);
+    oil.setMixingRule(2);
+    oil.init(0);
+
+    Standard_ASTM_D86 standard = new Standard_ASTM_D86(oil);
+    standard.calculate();
+    return standard;
+  }
+
+  @Test
+  void strictT95UsesQualifiedStandardAndPreservesSourceEvidence() {
+    Standard_ASTM_D86 standard = calculatedStandard();
+    String[] names = {"Light Naphtha", "Heavy Naphtha", "Kerosene", "Diesel"};
+    double[] laboratory = {90.0, 160.0, 221.0, 346.0};
+    double[] hysys = {97.0, 153.0, 214.0, 339.0};
+    double[] specifications = {90.0, 160.0, 221.0, 327.0};
+    double strictT95 = standard.getQualifiedD86Temperature(95.0);
+
+    for (int i = 0; i < names.length; i++) {
+      SarirD86ProductComparison.Result result =
+          SarirD86ProductComparison.compareT95(standard, names[i]);
+
+      assertEquals(names[i], result.getProductName());
+      assertEquals(95.0, result.getRecoveryVolumePercent(), 0.0);
+      assertEquals(strictT95, result.getNeqsimT95Celsius(), 1.0e-10);
+      assertEquals(laboratory[i], result.getLaboratoryT95Celsius(), 0.0);
+      assertEquals(hysys[i], result.getHysysT95Celsius(), 0.0);
+      assertEquals(specifications[i], result.getSpecificationT95Celsius(), 0.0);
+      assertEquals(
+          100.0 * Math.abs(strictT95 - laboratory[i]) / laboratory[i],
+          result.getNeqsimAbsoluteRelativeErrorPercent(),
+          1.0e-12);
+      assertEquals(
+          100.0 * Math.abs(hysys[i] - laboratory[i]) / laboratory[i],
+          result.getHysysAbsoluteRelativeErrorPercent(),
+          1.0e-12);
+      assertEquals(
+          specifications[i] - strictT95,
+          result.getSpecificationMarginCelsius(),
+          1.0e-12);
+    }
+  }
+
+  @Test
+  void unsupportedOrUnresolvedInputsFailClosed() {
+    Standard_ASTM_D86 standard = calculatedStandard();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SarirD86ProductComparison.compareT95(null, "Diesel"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SarirD86ProductComparison.compareT95(standard, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SarirD86ProductComparison.compareT95(standard, "diesel"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SarirD86ProductComparison.compareT95(standard, "Residual"));
+
+    Standard_ASTM_D86 uncalculated =
+        new Standard_ASTM_D86(new SystemSrkEos(273.15 + 25.0, 1.01325));
+    assertThrows(
+        IllegalStateException.class,
+        () -> SarirD86ProductComparison.compareT95(uncalculated, "Diesel"));
+  }
+}

--- a/src/test/java/neqsim/standards/oilquality/SarirD86ProductComparisonTest.java
+++ b/src/test/java/neqsim/standards/oilquality/SarirD86ProductComparisonTest.java
@@ -27,15 +27,14 @@ class SarirD86ProductComparisonTest {
   @Test
   void strictT95UsesQualifiedStandardAndPreservesSourceEvidence() {
     Standard_ASTM_D86 standard = calculatedStandard();
-    String[] names = {"Light Naphtha", "Heavy Naphtha", "Kerosene", "Diesel"};
-    double[] laboratory = {90.0, 160.0, 221.0, 346.0};
-    double[] hysys = {97.0, 153.0, 214.0, 339.0};
-    double[] specifications = {90.0, 160.0, 221.0, 327.0};
+    String[] names = { "Light Naphtha", "Heavy Naphtha", "Kerosene", "Diesel" };
+    double[] laboratory = { 90.0, 160.0, 221.0, 346.0 };
+    double[] hysys = { 97.0, 153.0, 214.0, 339.0 };
+    double[] specifications = { 90.0, 160.0, 221.0, 327.0 };
     double strictT95 = standard.getQualifiedD86Temperature(95.0);
 
     for (int i = 0; i < names.length; i++) {
-      SarirD86ProductComparison.Result result =
-          SarirD86ProductComparison.compareT95(standard, names[i]);
+      SarirD86ProductComparison.Result result = SarirD86ProductComparison.compareT95(standard, names[i]);
 
       assertEquals(names[i], result.getProductName());
       assertEquals(95.0, result.getRecoveryVolumePercent(), 0.0);
@@ -43,18 +42,11 @@ class SarirD86ProductComparisonTest {
       assertEquals(laboratory[i], result.getLaboratoryT95Celsius(), 0.0);
       assertEquals(hysys[i], result.getHysysT95Celsius(), 0.0);
       assertEquals(specifications[i], result.getSpecificationT95Celsius(), 0.0);
-      assertEquals(
-          100.0 * Math.abs(strictT95 - laboratory[i]) / laboratory[i],
-          result.getNeqsimAbsoluteRelativeErrorPercent(),
-          1.0e-12);
-      assertEquals(
-          100.0 * Math.abs(hysys[i] - laboratory[i]) / laboratory[i],
-          result.getHysysAbsoluteRelativeErrorPercent(),
-          1.0e-12);
-      assertEquals(
-          specifications[i] - strictT95,
-          result.getSpecificationMarginCelsius(),
-          1.0e-12);
+      assertEquals(100.0 * Math.abs(strictT95 - laboratory[i]) / laboratory[i],
+          result.getNeqsimAbsoluteRelativeErrorPercent(), 1.0e-12);
+      assertEquals(100.0 * Math.abs(hysys[i] - laboratory[i]) / laboratory[i],
+          result.getHysysAbsoluteRelativeErrorPercent(), 1.0e-12);
+      assertEquals(specifications[i] - strictT95, result.getSpecificationMarginCelsius(), 1.0e-12);
     }
   }
 
@@ -62,23 +54,12 @@ class SarirD86ProductComparisonTest {
   void unsupportedOrUnresolvedInputsFailClosed() {
     Standard_ASTM_D86 standard = calculatedStandard();
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> SarirD86ProductComparison.compareT95(null, "Diesel"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> SarirD86ProductComparison.compareT95(standard, null));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> SarirD86ProductComparison.compareT95(standard, "diesel"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> SarirD86ProductComparison.compareT95(standard, "Residual"));
+    assertThrows(IllegalArgumentException.class, () -> SarirD86ProductComparison.compareT95(null, "Diesel"));
+    assertThrows(IllegalArgumentException.class, () -> SarirD86ProductComparison.compareT95(standard, null));
+    assertThrows(IllegalArgumentException.class, () -> SarirD86ProductComparison.compareT95(standard, "diesel"));
+    assertThrows(IllegalArgumentException.class, () -> SarirD86ProductComparison.compareT95(standard, "Residual"));
 
-    Standard_ASTM_D86 uncalculated =
-        new Standard_ASTM_D86(new SystemSrkEos(273.15 + 25.0, 1.01325));
-    assertThrows(
-        IllegalStateException.class,
-        () -> SarirD86ProductComparison.compareT95(uncalculated, "Diesel"));
+    Standard_ASTM_D86 uncalculated = new Standard_ASTM_D86(new SystemSrkEos(273.15 + 25.0, 1.01325));
+    assertThrows(IllegalStateException.class, () -> SarirD86ProductComparison.compareT95(uncalculated, "Diesel"));
   }
 }


### PR DESCRIPTION
## Summary

Adds a Java/JPype-friendly refinery comparison workflow that evaluates a calculated NeqSim product T95 through the strict 95 vol% Riazi–Daubert path and returns it beside Sarir's published laboratory, HYSYS, and numeric specification evidence.

## Capability contract

- delegates the NeqSim value to `Standard_ASTM_D86.getQualifiedD86Temperature(95.0)`;
- preserves the four numeric Sarir Table 5 T95 rows and Table 2 specifications as read-only evidence;
- reports independently recomputable NeqSim/laboratory and HYSYS/laboratory absolute relative errors plus the specification margin;
- fails closed for null or uncalculated standards, unknown/non-numeric product rows, and open-ended residual specifications;
- intentionally does not convert Sarir T5 because 5 vol% is outside the qualified recovery set.

## Scientific boundary

This does not fabricate product streams or tune against laboratory, HYSYS, or specification values. It imposes no agreement threshold and makes no ASTM procedure or compliance claim. The legacy interpolated full-curve path, PVF flashes, source data, pseudo-components, fractionation controls, and defaults are unchanged.

## Provenance

- H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, published 2022-03-31, DOI `10.66411/jer.v33i.46`, CC BY 4.0.
- M. R. Riazi and T. E. Daubert, *Oil & Gas Journal* 84(34), 1986; public bibliographic record: https://www.osti.gov/biblio/5212509.

## Validation

- Focused source-value, strict-delegation, arithmetic, and fail-closed tests added.
- Exact-head hosted validation pending.

Tracks #3305.