### PR TITLE
[AI-Assisted] feat(kinetics): locate piecewise H2S target crossings

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -146,6 +146,37 @@ molality. It retains the same constant-oxygen and unidentified-product boundary 
 screen. Within this first-order screening model, only cumulative exposure controls the final
 fraction; the ordered diagnostics do not introduce path-dependent chemistry.
 
+## Piecewise target crossing
+
+`AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a
+requested remaining-total-sulfide fraction is first reached inside a finite ordered segment list.
+It reuses the segment rates and the same required exposure as the single-state inverse:
+
+$E_{\mathrm{target}}=-\ln f.$
+
+For each lower, nominal, and upper fit-scatter path, cumulative exposure is summed through complete
+segments. Inside the crossing segment, the remaining exposure is divided by that segment's
+pseudo-first-order rate. The immutable result reports:
+
+- the requested fraction and required exposure;
+- shortest, nominal, and longest elapsed crossing times;
+- the source-order segment index for each crossing;
+- the total duration supplied by the caller.
+
+The upper-rate path gives the shortest time and the lower-rate path gives the longest. A target
+fraction of one crosses at exact time zero in segment zero. An unchanged-state segment split cannot
+change any reported crossing time. Substituting each result back into the corresponding piecewise
+cumulative exposure recovers `-ln(f)`.
+
+The target interval remains `(0, 1]`. Every lower, nominal, and upper path must reach the target
+within the supplied finite trajectory. If even the slow lower-rate path does not reach it, the
+method throws an `IllegalArgumentException`; it does not extend the final state, extrapolate a
+residence time, or return infinity.
+
+This diagnostic identifies a crossing within caller-defined aqueous screening segments. It does
+not locate a position in a pipeline, calculate flow residence time, size equipment, or couple the
+reaction to phase behavior, mass transfer, oxygen depletion, or a transient solver.
+
 ## Scientific stop boundary
 
 This capability does not:

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -185,6 +185,43 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.trajectory_test)
 
+    def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
+        for token in (
+            "Piecewise target crossing",
+            "`AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)`",
+            r"E_{\mathrm{target}}=-\ln f",
+            "shortest, nominal, and longest elapsed crossing times",
+            "source-order segment index for each crossing",
+            "fraction of one crosses at exact time zero",
+            "unchanged-state segment split cannot change",
+            "Every lower, nominal, and upper path must reach the target",
+            "does not extend the final state",
+            "does not locate a position in a pipeline",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static TargetCrossingRangeResult timeToRemainingFractionRange(",
+            "private static Crossing locateCrossing(",
+            "private enum RateCase",
+            "public static final class TargetCrossingRangeResult",
+            "getShortestTimeHours()",
+            "getNominalTimeHours()",
+            "getLongestTimeHours()",
+            "getShortestCrossingSegmentIndex()",
+            "getNominalCrossingSegmentIndex()",
+            "getLongestCrossingSegmentIndex()",
+        ):
+            self.assertIn(token, self.trajectory)
+
+        for token in (
+            "testPiecewiseTargetCrossingMatchesSingleStateInverse",
+            "testPiecewiseTargetCrossingMatchesForwardExposure",
+            "testTargetCrossingIsSplitInvariantMonotonicAndDeterministic",
+            "testTargetCrossingIdentityAndInvalidTrajectoryFailClosed",
+        ):
+            self.assertIn(token, self.trajectory_test)
+
     def test_stop_boundary_prevents_pipeline_overclaim(self):
         for token in (
             "does not assign products or consume oxygen",

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -107,6 +107,117 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
         segmentResults);
   }
 
+  /**
+   * Locate the first time a remaining-total-sulfide target is reached within ordered exposure segments.
+   *
+   * <p>
+   * The calculation analytically inverts cumulative exposure for the lower, nominal, and upper rates. All three
+   * fit-scatter paths must reach the requested target within the supplied finite trajectory. The result therefore never
+   * extrapolates the final segment or returns an infinite crossing time.
+   * </p>
+   *
+   * @param targetRemainingFraction target total-sulfide fraction in the interval (0, 1]
+   * @param segments non-empty ordered exposure segments
+   * @return immutable shortest, nominal, and longest target-crossing evidence
+   * @throws IllegalArgumentException when the target or trajectory is invalid, a calculated value is not finite, or
+   * the target is not reached for every fit-scatter path
+   */
+  public static TargetCrossingRangeResult timeToRemainingFractionRange(double targetRemainingFraction,
+      List<Segment> segments) {
+    Result trajectory = advance(AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY,
+        segments);
+    Segment firstSegment = trajectory.getSegmentResults().get(0).getSegment();
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult singleStateTarget = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(firstSegment.getAirSaturatedOxygenMolality(), targetRemainingFraction,
+            firstSegment.getTemperatureK(), firstSegment.getPH(), firstSegment.getIonicStrengthMolPerKgWater());
+    double requiredExposure = singleStateTarget.getRequiredExposure();
+
+    Crossing longest = locateCrossing(requiredExposure, trajectory.getSegmentResults(), RateCase.LOWER);
+    Crossing nominal = locateCrossing(requiredExposure, trajectory.getSegmentResults(), RateCase.NOMINAL);
+    Crossing shortest = locateCrossing(requiredExposure, trajectory.getSegmentResults(), RateCase.UPPER);
+
+    return new TargetCrossingRangeResult(targetRemainingFraction, requiredExposure, shortest.timeHours,
+        nominal.timeHours, longest.timeHours, shortest.segmentIndex, nominal.segmentIndex, longest.segmentIndex,
+        trajectory.getTotalTimeHours());
+  }
+
+  private static Crossing locateCrossing(double requiredExposure, List<SegmentResult> segmentResults,
+      RateCase rateCase) {
+    if (requiredExposure == 0.0) {
+      return new Crossing(0, 0.0);
+    }
+
+    double cumulativeExposure = 0.0;
+    double elapsedTimeHours = 0.0;
+    for (SegmentResult segmentResult : segmentResults) {
+      double segmentExposure = rateCase.segmentExposure(segmentResult);
+      double nextExposure = finiteSum(cumulativeExposure, segmentExposure, "target-crossing cumulative exposure");
+      if (nextExposure >= requiredExposure) {
+        double exposureWithinSegment = requiredExposure - cumulativeExposure;
+        double timeWithinSegment = exposureWithinSegment / rateCase.pseudoFirstOrderRate(segmentResult);
+        requireFiniteNonNegative(timeWithinSegment, "target-crossing time within segment");
+        return new Crossing(segmentResult.getIndex(),
+            finiteSum(elapsedTimeHours, timeWithinSegment, "target-crossing elapsed time"));
+      }
+      cumulativeExposure = nextExposure;
+      elapsedTimeHours = finiteSum(elapsedTimeHours, segmentResult.getSegment().getDurationHours(),
+          "target-crossing elapsed time");
+    }
+
+    throw new IllegalArgumentException(
+        "target remaining fraction is not reached by every fit-scatter path within the supplied trajectory");
+  }
+
+  private enum RateCase {
+    LOWER {
+      @Override
+      double segmentExposure(SegmentResult result) {
+        return result.getLowerRateExposure();
+      }
+
+      @Override
+      double pseudoFirstOrderRate(SegmentResult result) {
+        return result.getLowerPseudoFirstOrderRate();
+      }
+    },
+    NOMINAL {
+      @Override
+      double segmentExposure(SegmentResult result) {
+        return result.getNominalExposure();
+      }
+
+      @Override
+      double pseudoFirstOrderRate(SegmentResult result) {
+        return result.getNominalPseudoFirstOrderRate();
+      }
+    },
+    UPPER {
+      @Override
+      double segmentExposure(SegmentResult result) {
+        return result.getUpperRateExposure();
+      }
+
+      @Override
+      double pseudoFirstOrderRate(SegmentResult result) {
+        return result.getUpperPseudoFirstOrderRate();
+      }
+    };
+
+    abstract double segmentExposure(SegmentResult result);
+
+    abstract double pseudoFirstOrderRate(SegmentResult result);
+  }
+
+  private static final class Crossing {
+    private final int segmentIndex;
+    private final double timeHours;
+
+    private Crossing(int segmentIndex, double timeHours) {
+      this.segmentIndex = segmentIndex;
+      this.timeHours = timeHours;
+    }
+  }
+
   private static void requireInitialTotalSulfide(double molality) {
     if (!Double.isFinite(molality) || molality < MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY
         || molality > MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY) {
@@ -132,6 +243,81 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
   private static void requireFiniteNonNegative(double value, String name) {
     if (!Double.isFinite(value) || value < 0.0) {
       throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  /** Immutable target-crossing range within a finite piecewise exposure trajectory. */
+  public static final class TargetCrossingRangeResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double targetRemainingFraction;
+    private final double requiredExposure;
+    private final double shortestTimeHours;
+    private final double nominalTimeHours;
+    private final double longestTimeHours;
+    private final int shortestCrossingSegmentIndex;
+    private final int nominalCrossingSegmentIndex;
+    private final int longestCrossingSegmentIndex;
+    private final double suppliedTrajectoryTimeHours;
+
+    private TargetCrossingRangeResult(double targetRemainingFraction, double requiredExposure,
+        double shortestTimeHours, double nominalTimeHours, double longestTimeHours,
+        int shortestCrossingSegmentIndex, int nominalCrossingSegmentIndex, int longestCrossingSegmentIndex,
+        double suppliedTrajectoryTimeHours) {
+      this.targetRemainingFraction = targetRemainingFraction;
+      this.requiredExposure = requiredExposure;
+      this.shortestTimeHours = shortestTimeHours;
+      this.nominalTimeHours = nominalTimeHours;
+      this.longestTimeHours = longestTimeHours;
+      this.shortestCrossingSegmentIndex = shortestCrossingSegmentIndex;
+      this.nominalCrossingSegmentIndex = nominalCrossingSegmentIndex;
+      this.longestCrossingSegmentIndex = longestCrossingSegmentIndex;
+      this.suppliedTrajectoryTimeHours = suppliedTrajectoryTimeHours;
+    }
+
+    /** @return requested remaining total-sulfide fraction. */
+    public double getTargetRemainingFraction() {
+      return targetRemainingFraction;
+    }
+
+    /** @return dimensionless cumulative exposure required to reach the target. */
+    public double getRequiredExposure() {
+      return requiredExposure;
+    }
+
+    /** @return earliest crossing time, obtained with the upper fit-scatter rates [h]. */
+    public double getShortestTimeHours() {
+      return shortestTimeHours;
+    }
+
+    /** @return nominal crossing time [h]. */
+    public double getNominalTimeHours() {
+      return nominalTimeHours;
+    }
+
+    /** @return latest crossing time, obtained with the lower fit-scatter rates [h]. */
+    public double getLongestTimeHours() {
+      return longestTimeHours;
+    }
+
+    /** @return source-order segment index containing the shortest crossing. */
+    public int getShortestCrossingSegmentIndex() {
+      return shortestCrossingSegmentIndex;
+    }
+
+    /** @return source-order segment index containing the nominal crossing. */
+    public int getNominalCrossingSegmentIndex() {
+      return nominalCrossingSegmentIndex;
+    }
+
+    /** @return source-order segment index containing the longest crossing. */
+    public int getLongestCrossingSegmentIndex() {
+      return longestCrossingSegmentIndex;
+    }
+
+    /** @return total duration of the supplied finite trajectory [h]. */
+    public double getSuppliedTrajectoryTimeHours() {
+      return suppliedTrajectoryTimeHours;
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -119,8 +119,8 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
    * @param targetRemainingFraction target total-sulfide fraction in the interval (0, 1]
    * @param segments non-empty ordered exposure segments
    * @return immutable shortest, nominal, and longest target-crossing evidence
-   * @throws IllegalArgumentException when the target or trajectory is invalid, a calculated value is not finite, or
-   * the target is not reached for every fit-scatter path
+   * @throws IllegalArgumentException when the target or trajectory is invalid, a calculated value is not finite, or the
+   * target is not reached for every fit-scatter path
    */
   public static TargetCrossingRangeResult timeToRemainingFractionRange(double targetRemainingFraction,
       List<Segment> segments) {
@@ -260,10 +260,9 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
     private final int longestCrossingSegmentIndex;
     private final double suppliedTrajectoryTimeHours;
 
-    private TargetCrossingRangeResult(double targetRemainingFraction, double requiredExposure,
-        double shortestTimeHours, double nominalTimeHours, double longestTimeHours,
-        int shortestCrossingSegmentIndex, int nominalCrossingSegmentIndex, int longestCrossingSegmentIndex,
-        double suppliedTrajectoryTimeHours) {
+    private TargetCrossingRangeResult(double targetRemainingFraction, double requiredExposure, double shortestTimeHours,
+        double nominalTimeHours, double longestTimeHours, int shortestCrossingSegmentIndex,
+        int nominalCrossingSegmentIndex, int longestCrossingSegmentIndex, double suppliedTrajectoryTimeHours) {
       this.targetRemainingFraction = targetRemainingFraction;
       this.requiredExposure = requiredExposure;
       this.shortestTimeHours = shortestTimeHours;

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -149,6 +149,123 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
         .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(overflow, overflow)));
   }
 
+  @Test
+  void testPiecewiseTargetCrossingMatchesSingleStateInverse() {
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult single = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments = Collections
+        .singletonList(referenceSegment(single.getLongestRequiredTimeHours()));
+
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossing = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, segments);
+
+    assertEquals(0.5, crossing.getTargetRemainingFraction(), 0.0);
+    assertEquals(Math.log(2.0), crossing.getRequiredExposure(), 0.0);
+    assertEquals(single.getShortestRequiredTimeHours(), crossing.getShortestTimeHours(), 1.0e-14);
+    assertEquals(single.getNominalRequiredTimeHours(), crossing.getNominalTimeHours(), 1.0e-14);
+    assertEquals(single.getLongestRequiredTimeHours(), crossing.getLongestTimeHours(), 1.0e-14);
+    assertEquals(0, crossing.getShortestCrossingSegmentIndex());
+    assertEquals(0, crossing.getNominalCrossingSegmentIndex());
+    assertEquals(0, crossing.getLongestCrossingSegmentIndex());
+    assertEquals(single.getLongestRequiredTimeHours(), crossing.getSuppliedTrajectoryTimeHours(), 0.0);
+  }
+
+  @Test
+  void testPiecewiseTargetCrossingMatchesForwardExposure() {
+    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments = Arrays.asList(referenceSegment(10.0),
+        new AqueousHydrogenSulfideOxidationTrajectory.Segment(100.0, 310.15, 7.0, 1.5, 220.0e-6));
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossing = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, segments);
+
+    assertEquals(crossing.getRequiredExposure(),
+        exposureAtTime(segments, crossing.getShortestTimeHours(), 2), 1.0e-14);
+    assertEquals(crossing.getRequiredExposure(),
+        exposureAtTime(segments, crossing.getNominalTimeHours(), 1), 1.0e-14);
+    assertEquals(crossing.getRequiredExposure(),
+        exposureAtTime(segments, crossing.getLongestTimeHours(), 0), 1.0e-14);
+    assertTrue(crossing.getShortestTimeHours() < crossing.getNominalTimeHours());
+    assertTrue(crossing.getNominalTimeHours() < crossing.getLongestTimeHours());
+    assertTrue(crossing.getShortestCrossingSegmentIndex() <= crossing.getNominalCrossingSegmentIndex());
+    assertTrue(crossing.getNominalCrossingSegmentIndex() <= crossing.getLongestCrossingSegmentIndex());
+  }
+
+  @Test
+  void testTargetCrossingIsSplitInvariantMonotonicAndDeterministic() {
+    double longestHalfLife = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH)
+        .getLongestRequiredTimeHours();
+    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> unsplit = Collections
+        .singletonList(referenceSegment(2.0 * longestHalfLife));
+    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> split = Arrays.asList(referenceSegment(longestHalfLife),
+        referenceSegment(longestHalfLife));
+
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult loose = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.8, split);
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult strict = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, split);
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult repeat = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, split);
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult unsplitResult = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, unsplit);
+
+    assertTrue(loose.getShortestTimeHours() < strict.getShortestTimeHours());
+    assertTrue(loose.getNominalTimeHours() < strict.getNominalTimeHours());
+    assertTrue(loose.getLongestTimeHours() < strict.getLongestTimeHours());
+    assertEquals(unsplitResult.getShortestTimeHours(), strict.getShortestTimeHours(), 1.0e-14);
+    assertEquals(unsplitResult.getNominalTimeHours(), strict.getNominalTimeHours(), 1.0e-14);
+    assertEquals(unsplitResult.getLongestTimeHours(), strict.getLongestTimeHours(), 1.0e-14);
+    assertEquals(strict.getShortestTimeHours(), repeat.getShortestTimeHours(), 0.0);
+    assertEquals(strict.getNominalTimeHours(), repeat.getNominalTimeHours(), 0.0);
+    assertEquals(strict.getLongestTimeHours(), repeat.getLongestTimeHours(), 0.0);
+  }
+
+  @Test
+  void testTargetCrossingIdentityAndInvalidTrajectoryFailClosed() {
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult identity = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(1.0, Collections.singletonList(referenceSegment(0.0)));
+
+    assertEquals(0.0, identity.getRequiredExposure(), 0.0);
+    assertEquals(0.0, identity.getShortestTimeHours(), 0.0);
+    assertEquals(0.0, identity.getNominalTimeHours(), 0.0);
+    assertEquals(0.0, identity.getLongestTimeHours(), 0.0);
+    assertEquals(0, identity.getShortestCrossingSegmentIndex());
+    assertEquals(0, identity.getNominalCrossingSegmentIndex());
+    assertEquals(0, identity.getLongestCrossingSegmentIndex());
+
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, Collections.singletonList(referenceSegment(1.0))));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.0, Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(1.01, Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(Double.NaN, Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(0.5, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(0.5,
+            Collections.<AqueousHydrogenSulfideOxidationTrajectory.Segment>emptyList()));
+  }
+
+  private static double exposureAtTime(List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments,
+      double timeHours, int rateCase) {
+    double remainingTime = timeHours;
+    double exposure = 0.0;
+    for (AqueousHydrogenSulfideOxidationTrajectory.Segment segment : segments) {
+      double duration = Math.min(remainingTime, segment.getDurationHours());
+      AqueousHydrogenSulfideOxidationKinetics.RateConstantRange range = AqueousHydrogenSulfideOxidationKinetics
+          .secondOrderRateConstantRange(segment.getTemperatureK(), segment.getPH(),
+              segment.getIonicStrengthMolPerKgWater());
+      double secondOrderRate = rateCase == 0 ? range.getLower() : rateCase == 1 ? range.getNominal() : range.getUpper();
+      exposure += secondOrderRate * segment.getAirSaturatedOxygenMolality() * duration;
+      remainingTime -= duration;
+      if (remainingTime <= 0.0) {
+        break;
+      }
+    }
+    return exposure;
+  }
+
   private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(double durationHours) {
     return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, TEMPERATURE_K, PH, IONIC_STRENGTH,
         AIR_SATURATED_OXYGEN_MOLALITY);

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -177,12 +177,9 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
     AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossing = AqueousHydrogenSulfideOxidationTrajectory
         .timeToRemainingFractionRange(0.5, segments);
 
-    assertEquals(crossing.getRequiredExposure(),
-        exposureAtTime(segments, crossing.getShortestTimeHours(), 2), 1.0e-14);
-    assertEquals(crossing.getRequiredExposure(),
-        exposureAtTime(segments, crossing.getNominalTimeHours(), 1), 1.0e-14);
-    assertEquals(crossing.getRequiredExposure(),
-        exposureAtTime(segments, crossing.getLongestTimeHours(), 0), 1.0e-14);
+    assertEquals(crossing.getRequiredExposure(), exposureAtTime(segments, crossing.getShortestTimeHours(), 2), 1.0e-14);
+    assertEquals(crossing.getRequiredExposure(), exposureAtTime(segments, crossing.getNominalTimeHours(), 1), 1.0e-14);
+    assertEquals(crossing.getRequiredExposure(), exposureAtTime(segments, crossing.getLongestTimeHours(), 0), 1.0e-14);
     assertTrue(crossing.getShortestTimeHours() < crossing.getNominalTimeHours());
     assertTrue(crossing.getNominalTimeHours() < crossing.getLongestTimeHours());
     assertTrue(crossing.getShortestCrossingSegmentIndex() <= crossing.getNominalCrossingSegmentIndex());
@@ -242,9 +239,8 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
         .timeToRemainingFractionRange(Double.NaN, Collections.singletonList(referenceSegment(100.0))));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(0.5, null));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(0.5,
-            Collections.<AqueousHydrogenSulfideOxidationTrajectory.Segment>emptyList()));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(0.5, Collections.<AqueousHydrogenSulfideOxidationTrajectory.Segment>emptyList()));
   }
 
   private static double exposureAtTime(List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments,


### PR DESCRIPTION
## Summary

Advances #3318 with analytical target-crossing diagnostics for finite ordered aqueous H₂S/O₂ exposure segments.

- Locates the first elapsed time and source-order segment in which a requested remaining-total-sulfide fraction is reached.
- Reports shortest, nominal, and longest crossing evidence from the already-qualified lower/nominal/upper Millero fit-scatter rates.
- Requires all three paths to reach the target within the supplied finite trajectory; otherwise fails closed instead of extending the last segment.
- Reuses the merged trajectory rates and merged `-ln(f)` target exposure. No kinetic equation or parameter is duplicated or refitted.

Scientific source: Millero et al. (1987), https://doi.org/10.1021/es00159a003

Capability contract and overlap gate: https://github.com/equinor/neqsim/issues/3318#issuecomment-5562093746

## Exact-head contract

- Base: `517880420b0e5c42107ad9f68d8cea949cb99ae7`
- Head: `6731af027d4d52838f2a713ed9751a0232d798a8`
- Branch: `codex/3318-h2s-piecewise-target-crossing`
- Six ordered commits and four intended files; the two additional commits apply CI's exact hosted Spotless artifact to the two Java files.

## Numerical and evidence gates

- One constant segment reproduces the merged single-state inverse.
- Target `f = 1` crosses at exact time zero.
- Reference-state `f = 0.5` reproduces the nominal half-life.
- Forward piecewise exposure at each returned crossing equals `-ln(f)`.
- Physical ordering is shortest (upper rate), nominal, longest (lower rate).
- Unchanged-state segment splitting preserves all crossing times.
- Stricter reachable targets cross later; repeated execution is deterministic.
- Invalid target/segments, overflow, or a finite trajectory insufficient for the slowest rate fail closed.

The independent varying-state audit gives a lower-rate exposure of `0.20418324143445812` after the first 10 h and reaches `ln(2)` at `20.982606017652294 h`; `exp(-ln(2)) = 0.5`.

## Validation status

**DRAFT — VALIDATION PENDING TARGETED JAVA 8 WINDOWS RETRY**

The predecessor head `696c1bd61fe92aef0ce4c66be3b033b5251b40ee` passed the complete Java 8/21 Ubuntu/Windows matrix, all four slow shards, Javadocs, documentation, PaperLab, and CodeQL. Its only failure was Spotless in pre-commit. CI's exact hosted `spotless-format-patch` artifact (digest `sha256:633fa2d63fa7ce786a57b9b1f398f3eaf4a7b7fb1bbde8f13303e5cd7a57663f`) was applied without changing scientific behavior, assertions, tolerances, or documentation semantics.

On exact head `6731af027d4d52838f2a713ed9751a0232d798a8`, Java 8 Ubuntu, Java 21 Ubuntu/Windows, all four slow shards, Javadocs, Spotless, pre-commit, documentation, PaperLab, CodeQL, and reference checks pass. Java 8 Windows alone failed the unrelated `MultiInputMixerPhaseRegressionTest` with outlet enthalpy `164152.95362982` versus `164152.8145645417`; none of the four kinetics files touches that mixer path. A targeted retry of only the failed Java 8 Windows job is active on the unchanged head. GitHub Actions remain authoritative.

## Documentation impact

Updated `docs/chemicalreactions/h2s_oxygen_kinetics.md`, its executable documentation contract, API Javadocs, and focused trajectory tests.

## Coordination and stop boundary

This is the sole active #3318 implementation PR. Autonomous portfolio occupancy was **8/10** after publication and is currently **4/10**, below the ten-capability ceiling. Other PR heads are unchanged.

Screening only: no extrapolation beyond supplied segments, equipment sizing, categorical threshold, O₂ solubility/depletion, products, pH/speciation (#3144), pressure, TP-flash (#2937), transient mutation (#2911), pipeline source term, corrosion, R1–R8 binding, MCP (#3153), facility data, or Huldra change.

Keep this PR draft-only. Do not rebase, synchronize with `master`, force-push, merge, enable auto-merge, mark ready, close, or replace work for capacity.