### PR TITLE
[AI-Assisted] feat(dexpi): expose transition cycle evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -274,13 +274,19 @@ process intent.
 connection occurrences crossing directed-cycle boundaries. Each immutable
 `DexpiConnectionCycleTransitionInfo` contains the complete `DexpiConnectionInfo`, complete
 from/to `DexpiConnectionEndpointInfo` records, optional from/to cycle IDs, and an `ENTERING`,
-`LEAVING`, or `BETWEEN_CYCLES` classification. A connection from one cyclic strongly connected
-group to another appears once with both cycle IDs; callers do not need to reconcile the outgoing
-boundary projection of one cycle with the incoming projection of the other. Parallel occurrences
-remain distinct, unresolved non-empty endpoints remain visible, and connections with a blank endpoint
-stay in the global connection and diagnostic evidence because a transition cannot assign them to a
-cycle. This exact-once inventory remains source-reference evidence only; it does not prove hydraulic
-continuity, identify a physical recycle, enumerate paths, or alter simulation topology.
+`LEAVING`, or `BETWEEN_CYCLES` classification. Reader-produced values also expose the exact
+immutable cycle objects from `ImportResult.getConnectionCycles()` through `getFromCycle()` and
+`getToCycle()`. The corresponding evidence markers distinguish this projection from values created
+with the legacy constructor, whose cycle-object getters return `null` while their scalar IDs remain
+unchanged. A connection entering or leaving a cycle has complete evidence only on the cyclic side.
+A connection from one cyclic strongly connected group to another appears once with both cycle IDs
+and both complete cycle objects; callers do not need to reconcile the outgoing boundary projection
+of one cycle with the incoming projection of the other. Parallel occurrences remain distinct,
+unresolved non-empty endpoints remain visible, and connections with a blank endpoint stay in the
+global connection and diagnostic evidence because a transition cannot assign them to a cycle.
+`toJson()` includes the cycle-evidence markers and nested from/to cycle objects when present. This
+exact-once inventory remains source-reference evidence only; it does not prove hydraulic continuity,
+identify a physical recycle, enumerate paths, or alter simulation topology.
 
 `toJson()` includes `instrumentCount`, `instrumentationLoopCount`,
 `actuatingFunctionCount`, `informationFlowCount`, `connectionCount`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -32,6 +32,8 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
 
   private final String fromCycleId;
   private final String toCycleId;
+  private final DexpiConnectionCycleInfo fromCycle;
+  private final DexpiConnectionCycleInfo toCycle;
   private final Kind kind;
   private final DexpiConnectionInfo connection;
   private final DexpiConnectionEndpointInfo fromEndpoint;
@@ -50,16 +52,44 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
    */
   public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection, DexpiConnectionEndpointInfo fromEndpoint,
       DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId) {
+    this(connection, fromEndpoint, toEndpoint, fromCycleId, toCycleId, null, null);
+  }
+
+  /**
+   * Creates complete immutable evidence with the source and target cycle records available to the reader.
+   *
+   * @param connection complete source connection occurrence
+   * @param fromEndpoint complete source-endpoint evidence
+   * @param toEndpoint complete target-endpoint evidence
+   * @param fromCycleId source directed-cycle identity, or empty when outside every cycle
+   * @param toCycleId target directed-cycle identity, or empty when outside every cycle
+   * @param fromCycle complete source directed-cycle evidence, or {@code null} when outside or unavailable
+   * @param toCycle complete target directed-cycle evidence, or {@code null} when outside or unavailable
+   * @throws NullPointerException if connection or endpoint evidence is null
+   * @throws IllegalArgumentException if cycle identities do not describe a boundary crossing or disagree with the
+   * cycle records
+   */
+  public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection, DexpiConnectionEndpointInfo fromEndpoint,
+      DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId,
+      DexpiConnectionCycleInfo fromCycle, DexpiConnectionCycleInfo toCycle) {
     this.connection = Objects.requireNonNull(connection, "connection");
     this.fromEndpoint = Objects.requireNonNull(fromEndpoint, "fromEndpoint");
     this.toEndpoint = Objects.requireNonNull(toEndpoint, "toEndpoint");
     this.fromCycleId = normalize(fromCycleId);
     this.toCycleId = normalize(toCycleId);
+    this.fromCycle = fromCycle;
+    this.toCycle = toCycle;
     if (this.fromCycleId.isEmpty() && this.toCycleId.isEmpty()) {
       throw new IllegalArgumentException("At least one endpoint must belong to a directed cycle");
     }
     if (!this.fromCycleId.isEmpty() && this.fromCycleId.equals(this.toCycleId)) {
       throw new IllegalArgumentException("A transition must cross a directed-cycle boundary");
+    }
+    if (fromCycle != null && !this.fromCycleId.equals(fromCycle.getId())) {
+      throw new IllegalArgumentException("Source cycle evidence must match fromCycleId");
+    }
+    if (toCycle != null && !this.toCycleId.equals(toCycle.getId())) {
+      throw new IllegalArgumentException("Target cycle evidence must match toCycleId");
     }
     if (this.fromCycleId.isEmpty()) {
       kind = Kind.ENTERING;
@@ -85,6 +115,16 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     return !fromCycleId.isEmpty();
   }
 
+  /** @return complete source directed-cycle evidence, or {@code null} when outside or unavailable */
+  public DexpiConnectionCycleInfo getFromCycle() {
+    return fromCycle;
+  }
+
+  /** @return whether complete source directed-cycle evidence is available */
+  public boolean hasFromCycleEvidence() {
+    return fromCycle != null;
+  }
+
   /** @return target directed-cycle identity, or empty when outside every cyclic group */
   public String getToCycleId() {
     return toCycleId;
@@ -93,6 +133,16 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
   /** @return whether the target endpoint belongs to a directed-cycle group */
   public boolean hasToCycle() {
     return !toCycleId.isEmpty();
+  }
+
+  /** @return complete target directed-cycle evidence, or {@code null} when outside or unavailable */
+  public DexpiConnectionCycleInfo getToCycle() {
+    return toCycle;
+  }
+
+  /** @return whether complete target directed-cycle evidence is available */
+  public boolean hasToCycleEvidence() {
+    return toCycle != null;
   }
 
   /** @return transition classification relative to the cyclic groups */
@@ -120,7 +170,11 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     result.put("connectionId", connection.getId());
     result.put("fromCycleId", fromCycleId);
     result.put("toCycleId", toCycleId);
+    result.put("hasFromCycleEvidence", Boolean.valueOf(hasFromCycleEvidence()));
+    result.put("hasToCycleEvidence", Boolean.valueOf(hasToCycleEvidence()));
     result.put("kind", kind.name());
+    result.put("fromCycle", fromCycle == null ? null : fromCycle.toMap());
+    result.put("toCycle", toCycle == null ? null : toCycle.toMap());
     result.put("connection", connection.toMap());
     result.put("fromEndpoint", fromEndpoint.toMap());
     result.put("toEndpoint", toEndpoint.toMap());

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -66,12 +66,12 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
    * @param fromCycle complete source directed-cycle evidence, or {@code null} when outside or unavailable
    * @param toCycle complete target directed-cycle evidence, or {@code null} when outside or unavailable
    * @throws NullPointerException if connection or endpoint evidence is null
-   * @throws IllegalArgumentException if cycle identities do not describe a boundary crossing or disagree with the
-   * cycle records
+   * @throws IllegalArgumentException if cycle identities do not describe a boundary crossing or disagree with the cycle
+   * records
    */
   public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection, DexpiConnectionEndpointInfo fromEndpoint,
-      DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId,
-      DexpiConnectionCycleInfo fromCycle, DexpiConnectionCycleInfo toCycle) {
+      DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId, DexpiConnectionCycleInfo fromCycle,
+      DexpiConnectionCycleInfo toCycle) {
     this.connection = Objects.requireNonNull(connection, "connection");
     this.fromEndpoint = Objects.requireNonNull(fromEndpoint, "fromEndpoint");
     this.toEndpoint = Objects.requireNonNull(toEndpoint, "toEndpoint");

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1356,10 +1356,10 @@ public final class DexpiXmlReader {
       endpointById.put(endpoint.getEndpointId(), endpoint);
     }
 
-    Map<String, String> cycleByEndpointId = new HashMap<String, String>();
+    Map<String, DexpiConnectionCycleInfo> cycleByEndpointId = new HashMap<String, DexpiConnectionCycleInfo>();
     for (DexpiConnectionCycleInfo cycle : connectionCycles) {
       for (String endpointId : cycle.getEndpointIds()) {
-        cycleByEndpointId.put(endpointId, cycle.getId());
+        cycleByEndpointId.put(endpointId, cycle);
       }
     }
 
@@ -1368,16 +1368,18 @@ public final class DexpiXmlReader {
       if (isBlank(connection.getFromId()) || isBlank(connection.getToId())) {
         continue;
       }
-      String fromCycleId = cycleByEndpointId.get(connection.getFromId());
-      String toCycleId = cycleByEndpointId.get(connection.getToId());
-      if (fromCycleId == null && toCycleId == null) {
+      DexpiConnectionCycleInfo fromCycle = cycleByEndpointId.get(connection.getFromId());
+      DexpiConnectionCycleInfo toCycle = cycleByEndpointId.get(connection.getToId());
+      if (fromCycle == null && toCycle == null) {
         continue;
       }
-      if (fromCycleId != null && fromCycleId.equals(toCycleId)) {
+      if (fromCycle != null && toCycle != null && fromCycle.getId().equals(toCycle.getId())) {
         continue;
       }
+      String fromCycleId = fromCycle == null ? "" : fromCycle.getId();
+      String toCycleId = toCycle == null ? "" : toCycle.getId();
       result.add(new DexpiConnectionCycleTransitionInfo(connection, endpointById.get(connection.getFromId()),
-          endpointById.get(connection.getToId()), fromCycleId, toCycleId));
+          endpointById.get(connection.getToId()), fromCycleId, toCycleId, fromCycle, toCycle));
     }
     return result;
   }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -1253,8 +1253,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(DexpiConnectionCycleTransitionInfo.Kind.ENTERING, entering.getKind());
     assertEquals("", entering.getFromCycleId());
     assertFalse(entering.hasFromCycle());
+    assertFalse(entering.hasFromCycleEvidence());
+    assertNull(entering.getFromCycle());
     assertEquals("cycle-1", entering.getToCycleId());
     assertTrue(entering.hasToCycle());
+    assertTrue(entering.hasToCycleEvidence());
+    assertSame(first.getConnectionCycles().get(0), entering.getToCycle());
     assertEquals("S-IN-1", entering.getConnection().getSegmentId());
     assertEquals("UNKNOWN-U", entering.getFromEndpoint().getEndpointId());
     assertFalse(entering.getFromEndpoint().isResolved());
@@ -1266,6 +1270,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionCycleTransitionInfo parallelEntering = transitions.get(1);
     assertEquals(DexpiConnectionCycleTransitionInfo.Kind.ENTERING, parallelEntering.getKind());
     assertEquals("cycle-1", parallelEntering.getToCycleId());
+    assertSame(first.getConnectionCycles().get(0), parallelEntering.getToCycle());
     assertEquals("S-IN-2", parallelEntering.getConnection().getSegmentId());
 
     DexpiConnectionCycleTransitionInfo between = transitions.get(2);
@@ -1274,6 +1279,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("cycle-2", between.getToCycleId());
     assertTrue(between.hasFromCycle());
     assertTrue(between.hasToCycle());
+    assertTrue(between.hasFromCycleEvidence());
+    assertTrue(between.hasToCycleEvidence());
+    assertSame(first.getConnectionCycles().get(0), between.getFromCycle());
+    assertSame(first.getConnectionCycles().get(1), between.getToCycle());
     assertEquals("N-B", between.getFromEndpoint().getEndpointId());
     assertEquals("N-X", between.getToEndpoint().getEndpointId());
 
@@ -1282,7 +1291,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("cycle-2", leaving.getFromCycleId());
     assertEquals("", leaving.getToCycleId());
     assertTrue(leaving.hasFromCycle());
+    assertTrue(leaving.hasFromCycleEvidence());
+    assertSame(first.getConnectionCycles().get(1), leaving.getFromCycle());
     assertFalse(leaving.hasToCycle());
+    assertFalse(leaving.hasToCycleEvidence());
+    assertNull(leaving.getToCycle());
     assertEquals("E-V", leaving.getToEndpoint().getOwnerId());
 
     assertThrows(UnsupportedOperationException.class, () -> transitions.clear());
@@ -1292,10 +1305,24 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         entering.getFromEndpoint(), entering.getToEndpoint(), "", ""));
     assertThrows(IllegalArgumentException.class, () -> new DexpiConnectionCycleTransitionInfo(between.getConnection(),
         between.getFromEndpoint(), between.getToEndpoint(), "cycle-1", "cycle-1"));
+
+    DexpiConnectionCycleTransitionInfo legacy = new DexpiConnectionCycleTransitionInfo(between.getConnection(),
+        between.getFromEndpoint(), between.getToEndpoint(), "cycle-1", "cycle-2");
+    assertTrue(legacy.hasFromCycle());
+    assertTrue(legacy.hasToCycle());
+    assertFalse(legacy.hasFromCycleEvidence());
+    assertFalse(legacy.hasToCycleEvidence());
+    assertNull(legacy.getFromCycle());
+    assertNull(legacy.getToCycle());
+
     assertTrue(first.toJson().contains("\"connectionCycleTransitionCount\": 4"));
     assertTrue(first.toJson().contains("\"kind\": \"BETWEEN_CYCLES\""));
     assertTrue(first.toJson().contains("\"fromCycleId\": \"cycle-1\""));
     assertTrue(first.toJson().contains("\"toCycleId\": \"cycle-2\""));
+    assertTrue(first.toJson().contains("\"hasFromCycleEvidence\": true"));
+    assertTrue(first.toJson().contains("\"hasToCycleEvidence\": true"));
+    assertTrue(first.toJson().contains("\"fromCycle\": {"));
+    assertTrue(first.toJson().contains("\"toCycle\": {"));
     assertTrue(first.toJson().contains("\"fromEndpoint\": {"));
     assertTrue(first.toJson().contains("\"toEndpoint\": {"));
     assertEquals(first.toJson(), second.toJson());


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 with complete immutable directed-cycle evidence on source-ordered DEXPI connection-cycle transitions.

- Reuses the exact cycle objects already exposed by `ImportResult.getConnectionCycles()`.
- Adds nullable `getFromCycle()` / `getToCycle()` accessors and explicit evidence markers.
- Preserves the legacy five-argument constructor, scalar cycle IDs, transition classification, source ordering, parallel occurrences, unresolved evidence, and JSON fields.
- Adds nested from/to cycle evidence to JSON only when available.
- Keeps transition construction O(V+E) and preserves Java 8 source compatibility.

Capability contracts:
- #1332: https://github.com/equinor/neqsim/issues/1332#issuecomment-5562472864
- #2899: https://github.com/equinor/neqsim/issues/2899#issuecomment-5562474272

## Exact continuity and scope

- Exact base/current master at publication: `517880420b0e5c42107ad9f68d8cea949cb99ae7`
- Exact head: `f98a9436fe16eb34a5886e039382fc23fba679c9`
- Branch: `ai/dexpi-transition-cycle-evidence`
- Five ordered commits across four intended files; 5 ahead / 0 behind the recorded base.
- Tests were authored first.
- The eight pre-existing autonomous implementation PRs were checked before publication; none owns these DEXPI files. This is the sole active PFD/P&ID/DEXPI shared-lane PR.
- Portfolio occupancy after publication: **9/10**. Current autonomous portfolio occupancy: **6/10**.

## Acceptance evidence

Focused regression assertions require:

- entering transitions to expose only the exact target-cycle object;
- leaving transitions to expose only the exact source-cycle object;
- between-cycle transitions to expose both exact cycle objects;
- parallel transition occurrences to preserve source identity and cycle evidence;
- legacy-constructor values to preserve cycle IDs while reporting absent object evidence;
- deterministic JSON to include evidence markers and nested cycle objects;
- invalid same-cycle transitions to remain rejected.

Connector-side prepublication audit confirms four intended files, five commits, no tabs or trailing whitespace, and no base drift. The predecessor head's sole branch-attributable failure was Spotless on the new transition class; the exact one-file hosted formatter patch was applied in the fifth commit without changing capability semantics or tests. **READY TO MERGE.** All eight exact-head workflows pass, including Java 8/21 on Ubuntu and Windows, all four slow-test shards, Javadocs, formatting, documentation, notebook, engineering-diagram performance, CodeQL, PaperLab, and reference checks. GitHub Actions on this exact head is authoritative.

## Documentation and boundary

The DEXPI reader guide documents object identity, legacy behavior, JSON projection, and the one-sided evidence rule for entering/leaving transitions.

This remains source-document evidence only. It does not infer a hydraulic recycle, enumerate paths, repair or rewire topology, change simulation/rendering/layout/export behavior, assign safety credit, claim DEXPI/ISO/ISA conformance, certify a diagram, or provide accountable engineering approval. The whole-sheet visual defect gate is not applicable because rendering is unchanged.

## Draft-only workflow

Keep this PR open and draft. Do not merge, enable auto-merge, mark ready for review, rebase, synchronize with `master`, force-push, close, replace, or abandon it as part of campaign automation.