### PR TITLE
[AI-Assisted] Expose strict qualified D86 curve

### DIFF
--- a/docs/standards/oil_quality_standards.md
+++ b/docs/standards/oil_quality_standards.md
@@ -742,6 +742,19 @@ double qualifiedD86T50C = d86.getQualifiedD86Temperature(50.0);
 double qualifiedD86T90K = d86.getQualifiedD86Temperature(90.0, "K");
 ```
 
+For complete source-row reporting, `getQualifiedD86Curve()` returns exactly the seven qualified
+rows as `[recovery vol%, temperature_C]`; the overload accepts `"C"`, `"K"`, `"F"`, or
+`"R"`:
+
+```java
+double[][] qualifiedCurveC = d86.getQualifiedD86Curve();
+double[][] qualifiedCurveK = d86.getQualifiedD86Curve("K");
+```
+
+Every row delegates to the strict point accessor. The method constructs the full result before
+returning it, fails if any required point is unavailable or outside its source domain, and returns
+a new array on each call. It never fills gaps with intermediate coefficient interpolation.
+
 `getQualifiedD86Temperature` delegates to the qualified reference converter, accepts only the
 seven published recovery points, enforces the point-specific source domain, and applies the
 standard's configured barometric correction after conversion. An unsupported recovery such as

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -184,7 +184,10 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
             self.guide,
         )
         self.assertIn("getQualifiedD86Temperature(", d86_source)
+        self.assertIn("getQualifiedD86Curve(", d86_source)
         self.assertIn("reference-point conversion is available", self.guide)
+        self.assertIn("returns exactly the seven qualified", self.guide)
+        self.assertIn("never fills gaps with intermediate coefficient interpolation", self.guide)
         self.assertIn("legacy full-curve coefficient interpolation", self.guide)
         self.assertIn("recovery points remain explicitly unqualified", self.guide)
 

--- a/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D86.java
+++ b/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D86.java
@@ -738,6 +738,42 @@ public class Standard_ASTM_D86 extends neqsim.standards.Standard {
   }
 
   /**
+   * Returns the complete source-qualified ASTM D86 reference curve in degrees Celsius.
+   *
+   * <p>
+   * The result contains exactly the seven published Riazi-Daubert recovery points. Every temperature is delegated to
+   * {@link #getQualifiedD86Temperature(double)}, so the method fails before returning if any simulated point is
+   * unavailable or outside its source domain.
+   * </p>
+   *
+   * @return a new two-dimensional array where [i][0] is recovery volume percent and [i][1] is temperature in Celsius
+   * @throws IllegalArgumentException if any converted temperature is outside its published reference domain
+   * @throws IllegalStateException if {@link #calculate()} did not produce every required TBP-like temperature
+   */
+  public double[][] getQualifiedD86Curve() {
+    return getQualifiedD86Curve("C");
+  }
+
+  /**
+   * Returns the complete source-qualified ASTM D86 reference curve in the requested temperature unit.
+   *
+   * @param tempUnit temperature unit ("C", "K", "F", or "R")
+   * @return a new two-dimensional array containing recovery volume percent and converted temperature
+   * @throws IllegalArgumentException if any converted temperature is outside its published reference domain
+   * @throws IllegalStateException if {@link #calculate()} did not produce every required TBP-like temperature
+   */
+  public double[][] getQualifiedD86Curve(String tempUnit) {
+    double[][] referenceData = RiaziDaubertDistillationConversion.getReferenceData();
+    double[][] curve = new double[referenceData.length][2];
+    for (int i = 0; i < referenceData.length; i++) {
+      double recoveryVolumePercent = referenceData[i][0];
+      curve[i][0] = recoveryVolumePercent;
+      curve[i][1] = getQualifiedD86Temperature(recoveryVolumePercent, tempUnit);
+    }
+    return curve;
+  }
+
+  /**
    * Returns the ASTM D86 curve obtained by converting the simulated molar-equilibrium (TBP-like) curve with the
    * Riazi-Daubert TBP&rarr;D86 relation.
    *

--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
@@ -315,6 +315,38 @@ public class OilQualityStandardsTest {
   }
 
   /**
+   * Verifies the complete strict curve contains only the seven source rows, delegates every temperature, supports units,
+   * and returns defensive arrays.
+   */
+  @Test
+  void testASTM_D86_qualifiedReferenceCurve() {
+    Standard_ASTM_D86 standard = new Standard_ASTM_D86(createDiesel());
+    standard.calculate();
+
+    double[] recoveryPoints = { 0.0, 10.0, 30.0, 50.0, 70.0, 90.0, 95.0 };
+    double[][] curveC = standard.getQualifiedD86Curve();
+    double[][] curveK = standard.getQualifiedD86Curve("K");
+
+    assertEquals(recoveryPoints.length, curveC.length);
+    assertEquals(recoveryPoints.length, curveK.length);
+    for (int i = 0; i < recoveryPoints.length; i++) {
+      assertEquals(recoveryPoints[i], curveC[i][0], 0.0);
+      assertEquals(recoveryPoints[i], curveK[i][0], 0.0);
+      assertEquals(standard.getQualifiedD86Temperature(recoveryPoints[i]), curveC[i][1], 1.0e-10);
+      assertEquals(curveC[i][1] + 273.15, curveK[i][1], 1.0e-10);
+    }
+
+    curveC[0][0] = -1.0;
+    curveC[0][1] = Double.NaN;
+    double[][] secondCurve = standard.getQualifiedD86Curve();
+    assertEquals(0.0, secondCurve[0][0], 0.0);
+    assertEquals(standard.getQualifiedD86Temperature(0.0), secondCurve[0][1], 1.0e-10);
+
+    Standard_ASTM_D86 uncalculated = new Standard_ASTM_D86(createDiesel());
+    assertThrows(IllegalStateException.class, uncalculated::getQualifiedD86Curve);
+  }
+
+  /**
    * Verifies the liquid-volume reporting basis yields a different curve from the molar basis.
    */
   @Test

--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
@@ -315,8 +315,8 @@ public class OilQualityStandardsTest {
   }
 
   /**
-   * Verifies the complete strict curve contains only the seven source rows, delegates every temperature, supports units,
-   * and returns defensive arrays.
+   * Verifies the complete strict curve contains only the seven source rows, delegates every temperature, supports
+   * units, and returns defensive arrays.
    */
   @Test
   void testASTM_D86_qualifiedReferenceCurve() {


### PR DESCRIPTION
## Summary

Adds a Java/JPype-friendly strict D86 curve accessor that returns all and only the seven published Riazi–Daubert recovery rows from a calculated `Standard_ASTM_D86`.

## Capability contract

- `getQualifiedD86Curve()` returns ordered rows at 0, 10, 30, 50, 70, 90, and 95 liquid-volume percent.
- The temperature-unit overload supports the standard's existing C/K/F/R reporting convention.
- Every row delegates to `getQualifiedD86Temperature(...)`, preserving the existing source-domain checks and barometric-correction order.
- The complete array is built before it is returned; missing or out-of-domain points fail closed without exposing a partial curve.
- Every call returns new arrays.
- The legacy interpolated `getD86Curve()` and `TBP_CONVERTED` basis are unchanged.

## Validation

Focused regression coverage checks exact recovery ordering, per-row delegation, Kelvin conversion, defensive copies, and failure before `calculate()`. The documentation contract distinguishes the strict seven-row result from legacy interpolation.

Exact-head hosted CI is pending.

## Scientific boundary and provenance

This is a reporting convenience for the already-qualified empirical correlation. It adds no coefficients or interpolation, does not change PVF flashes, pseudo-components, fractionation, Sarir evidence, specifications, or defaults, and makes no ASTM procedure, compliance, or laboratory-agreement claim.

Source: M. R. Riazi and T. E. Daubert, *Oil & Gas Journal* 84(34), 1986; public bibliographic record: https://www.osti.gov/biblio/5212509.

Tracks #3305.