### PR TITLE
[AI-Assisted] feat(pitzer): add parameter-neutral volumetric kernel

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -1,7 +1,7 @@
 ---
 title: Density Models
-description: "Density correction models in NeqSim: COSTALD (Hankinson-Thomson), Peneloux volume translation, Rackett equation. Covers liquid density for pure compounds, mixtures, TBP fractions, aqueous/polar systems (water, MEG, TEG, methanol). setLiquidDensityModel API."
-keywords: "COSTALD, density, liquid density, Hankinson-Thomson, Peneloux, volume translation, Rackett, molar volume, specific gravity, TBP fraction, pseudo-component, aqueous, polar, water density, MEG, TEG, glycol, methanol, ethanol, setLiquidDensityModel, compressed liquid, characteristic volume, V-star"
+description: "Density correction models in NeqSim: COSTALD (Hankinson-Thomson), Peneloux volume translation, Rackett equation, and the parameter-neutral binary volumetric Pitzer kernel. Covers liquid density for pure compounds, mixtures, TBP fractions, aqueous/polar systems, and electrolytes."
+keywords: "COSTALD, density, liquid density, Hankinson-Thomson, Peneloux, volume translation, Rackett, Pitzer, apparent molar volume, electrolyte density, molar volume, specific gravity, TBP fraction, pseudo-component, aqueous, polar, water density, MEG, TEG, glycol, methanol, ethanol, setLiquidDensityModel, compressed liquid, characteristic volume, V-star"
 ---
 
 This guide documents the density correction models available in NeqSim for improving volumetric predictions.
@@ -16,6 +16,7 @@ This guide documents the density correction models available in NeqSim for impro
   - [COSTALD](#costald)
   - [NASTALD (COSTALD with Polar Correction)](#nastald-costald-with-polar-correction)
   - [Rackett Equation](#rackett-equation)
+- [Binary Electrolyte Volumetric Pitzer Kernel](#binary-electrolyte-volumetric-pitzer-kernel)
 - [Usage Examples](#usage-examples)
 - [Model Selection Guide](#model-selection-guide)
 - [API Reference](#api-reference)
@@ -623,6 +624,87 @@ double Zra = fluid.getPhase(1).getComponent("n-pentane").getRacketZ();
 
 ---
 
+## Binary Electrolyte Volumetric Pitzer Kernel
+
+`PitzerBinaryVolumetricModel` evaluates the standard pressure derivative of
+the binary-electrolyte Pitzer excess Gibbs energy. It is a parameter-neutral
+thermodynamic kernel: it does not contain a built-in coefficient table and it
+is not selected by `setLiquidDensityModel(...)`.
+
+For a binary salt $M_{\nu_M}X_{\nu_X}$ with formula-unit molality $m$,
+
+$$\begin{aligned}
+\phi_V={}&V^\circ+\nu|z_Mz_X|\frac{A_V}{2b}\ln(1+b\sqrt{I})\\
+&+\nu_M\nu_XRT\left[2mB^V_{MX}+m^2\sqrt{\nu_M\nu_X}C^{\phi V}_{MX}\right],\\
+B^V_{MX}={}&\beta^{(0)V}_{MX}+\beta^{(1)V}_{MX}g(\alpha\sqrt{I}),\\
+g(x)={}&\frac{2[1-(1+x)e^{-x}]}{x^2},\\
+I={}&\frac{1}{2}\nu|z_Mz_X|m.
+\end{aligned}$$
+
+The implementation uses the standard $b=1.2$ and $\alpha=2.0$ values and an
+analytical small-$x$ expansion for $g(x)$ to prevent dilute-limit
+cancellation. All inputs use SI units. The pressure derivatives
+$\beta^{(0)V}$, $\beta^{(1)V}$, and $C^{\phi V}$ must already be evaluated at
+the temperature and pressure stored in `StateParameters`.
+
+The non-zero reference form is also available:
+
+$$\phi_V(m)=\phi_V(m_r)+F(m)-F(m_r),$$
+
+where $F$ is the Debye–Hückel plus binary-interaction contribution in the
+equation above. This form avoids deriving $V^\circ$ from small differences of
+dilute-solution densities.
+
+Density conversion uses an exact one-kilogram-solvent balance:
+
+$$\rho=\frac{1+mM}{1/\rho_w+m\phi_V}.$$
+
+The inverse conversion is provided for auditable data preparation.
+
+```java
+PitzerBinaryVolumetricModel calciumChloride =
+    new PitzerBinaryVolumetricModel(1, 2, 2, -1);
+
+PitzerBinaryVolumetricModel.StateParameters state =
+    new PitzerBinaryVolumetricModel.StateParameters(
+        temperatureK,
+        pressurePa,
+        debyeHuckelVolumeSlope,
+        beta0PressureDerivative,
+        beta1PressureDerivative,
+        cphiPressureDerivative);
+
+double apparentMolarVolume = calciumChloride.calculateApparentMolarVolumeFromReference(
+    molality,
+    referenceMolality,
+    referenceApparentMolarVolume,
+    state);
+
+double density = PitzerBinaryVolumetricModel.calculateDensity(
+    molality,
+    calciumChlorideMolarMass,
+    pureWaterDensity,
+    apparentMolarVolume);
+```
+
+### Qualification boundary
+
+- The caller owns coefficient provenance and must keep calibration and
+  validation sources independent.
+- No Rowland–May coefficient table or PHREEQC volume fit is bundled.
+- The 197-point Al Ghafri/NIST ThermoML CaCl2 pressure series remains reserved
+  as validation evidence and is not fitted by this kernel.
+- The current `Water` salt-density correlation and every default density
+  result remain unchanged.
+- Quantitative high-pressure calcium-sulfate prediction remains unqualified
+  until a redistribution-compatible calibration dataset and independent
+  grouped-source validation pass the campaign acceptance gates.
+
+Reference: Rowland and May (2013),
+[doi:10.1016/j.fluid.2012.10.021](https://doi.org/10.1016/j.fluid.2012.10.021).
+
+---
+
 ## Usage Examples
 
 ### Comparing Density Models
@@ -765,6 +847,7 @@ System.out.println("High-P density: " + rho + " kg/m³");
 | Near saturation | COSTALD | Better for saturated liquids |
 | Polar compounds (water, glycols) | COSTALD | V\* from density handles polarity |
 | Polar with database V\* | NASTALD | Adds explicit polar correction term |
+| Binary electrolyte with qualified volumetric parameters | `PitzerBinaryVolumetricModel` | Low-level opt-in kernel; no bundled coefficient set |
 | Multi-phase (gas-oil-water) | COSTALD | Single call applies to oil + aqueous |
 | Different model per phase | Per-phase API | e.g. COSTALD on oil, Peneloux on aqueous |
 | TBP/plus fractions | COSTALD | V\* from density input, no tuning needed |
@@ -788,6 +871,7 @@ System.out.println("High-P density: " + rho + " kg/m³");
 | NASTALD (polar with database V\*) | 1–3% | N/A |
 | Rackett (hydrocarbons) | 2–5% | N/A |
 | GERG-2008 | 0.1–0.5% | 0.1–0.5% |
+| Binary volumetric Pitzer kernel | Dataset-dependent | N/A |
 
 ---
 
@@ -870,6 +954,19 @@ double Vstar = component.getCostaldCharacteristicVolume();
 component.setCostaldCharacteristicVolume(newValue);  // cm³/mol
 ```
 
+### Binary Volumetric Pitzer API
+
+| Method | Purpose |
+|--------|---------|
+| `calculateApparentMolarVolume(...)` | Evaluate the standard infinite-dilution form |
+| `calculateApparentMolarVolumeFromReference(...)` | Evaluate the numerically stable non-zero reference form |
+| `calculateDensity(...)` | Convert apparent molar volume to density on a 1 kg solvent basis |
+| `calculateApparentMolarVolumeFromDensity(...)` | Invert a density observation to apparent molar volume |
+| `calculateIonicStrength(...)` | Return the binary salt's stoichiometric ionic strength |
+
+These methods do not install a parameter dataset or alter a phase. A caller
+must explicitly supply a provenance-qualified `StateParameters` instance.
+
 ---
 
 ## References
@@ -884,3 +981,4 @@ component.setCostaldCharacteristicVolume(newValue);  // cm³/mol
 8. Li, C.C. (1971). Critical Temperature Estimation for Simple Mixtures. *Can. J. Chem. Eng.* 49, 709–710.
 9. Jhaveri, B.S. and Youngren, G.K. (1988). Three-Parameter Modification of the Peng-Robinson Equation of State. *SPE Reservoir Eng.* 3, 1033–1040.
 10. Poling, B.E., Prausnitz, J.M. and O'Connell, J.P. (2001). *The Properties of Gases and Liquids*, 5th ed. McGraw-Hill.
+11. Rowland, D. and May, P.M. (2013). A Pitzer-Based Characterization of Aqueous Magnesium Chloride, Calcium Chloride and Potassium Iodide Solution Densities to High Temperature and Pressure. *Fluid Phase Equilib.* 338, 54–62. [doi:10.1016/j.fluid.2012.10.021](https://doi.org/10.1016/j.fluid.2012.10.021).

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricModel.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricModel.java
@@ -1,0 +1,302 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+
+/**
+ * Parameter-neutral standard Pitzer apparent-molar-volume model for one binary electrolyte.
+ *
+ * <p>
+ * This class evaluates the pressure derivative of the standard binary Pitzer excess-Gibbs-energy equation. It
+ * deliberately contains no salt-specific coefficients. Callers must supply parameters evaluated at the same temperature
+ * and pressure as the requested state. The class is therefore a thermodynamic kernel, not a qualified density
+ * correlation or a replacement for NeqSim's default aqueous-density model.
+ * </p>
+ *
+ * <p>
+ * All quantities use SI units. Apparent molar volumes are in m<sup>3</sup>/mol, molality is in mol/kg solvent, pressure
+ * is in Pa, and electrolyte molar mass is in kg/mol.
+ * </p>
+ */
+public final class PitzerBinaryVolumetricModel implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Universal gas constant in J/(mol K). */
+  private static final double GAS_CONSTANT = 8.31446261815324;
+
+  /** Standard Pitzer b parameter in (kg/mol)<sup>1/2</sup>. */
+  public static final double STANDARD_B = 1.2;
+
+  /** Standard Pitzer alpha parameter in (kg/mol)<sup>1/2</sup>. */
+  public static final double STANDARD_ALPHA = 2.0;
+
+  private final int cationStoichiometry;
+  private final int anionStoichiometry;
+  private final int cationCharge;
+  private final int anionCharge;
+
+  /**
+   * Construct a standard binary-electrolyte volumetric model.
+   *
+   * @param cationStoichiometry number of cations in one neutral formula unit
+   * @param anionStoichiometry number of anions in one neutral formula unit
+   * @param cationCharge positive integer cation charge
+   * @param anionCharge negative integer anion charge
+   */
+  public PitzerBinaryVolumetricModel(int cationStoichiometry, int anionStoichiometry, int cationCharge,
+      int anionCharge) {
+    if (cationStoichiometry <= 0 || anionStoichiometry <= 0) {
+      throw new IllegalArgumentException("Pitzer stoichiometric coefficients must be positive");
+    }
+    if (cationCharge <= 0 || anionCharge >= 0) {
+      throw new IllegalArgumentException("Pitzer binary model requires positive cation and negative anion charges");
+    }
+    long formulaCharge = (long) cationStoichiometry * cationCharge + (long) anionStoichiometry * anionCharge;
+    if (formulaCharge != 0L) {
+      throw new IllegalArgumentException("Pitzer binary formula unit must be electrically neutral");
+    }
+    this.cationStoichiometry = cationStoichiometry;
+    this.anionStoichiometry = anionStoichiometry;
+    this.cationCharge = cationCharge;
+    this.anionCharge = anionCharge;
+  }
+
+  /**
+   * Calculate apparent molar volume from the infinite-dilution standard state.
+   *
+   * @param molality electrolyte formula-unit molality in mol/kg solvent
+   * @param limitingApparentMolarVolume apparent molar volume at infinite dilution in m<sup>3</sup>/mol
+   * @param parameters caller-supplied parameters evaluated at the requested temperature and pressure
+   * @return apparent molar volume in m<sup>3</sup>/mol
+   */
+  public double calculateApparentMolarVolume(double molality, double limitingApparentMolarVolume,
+      StateParameters parameters) {
+    requireMolality(molality, true);
+    requireFinite(limitingApparentMolarVolume, "Limiting apparent molar volume");
+    requireParameters(parameters);
+    return checkedVolume(limitingApparentMolarVolume + calculateExcessVolume(molality, parameters));
+  }
+
+  /**
+   * Calculate apparent molar volume relative to a measured non-zero reference molality.
+   *
+   * <p>
+   * This difference form avoids estimating an infinite-dilution volume from small differences of dilute-solution
+   * densities. The reference value and all state parameters must describe the same temperature and pressure.
+   * </p>
+   *
+   * @param molality requested formula-unit molality in mol/kg solvent
+   * @param referenceMolality non-zero reference molality in mol/kg solvent
+   * @param referenceApparentMolarVolume apparent molar volume at the reference molality in m<sup>3</sup>/mol
+   * @param parameters caller-supplied parameters evaluated at the common temperature and pressure
+   * @return apparent molar volume in m<sup>3</sup>/mol
+   */
+  public double calculateApparentMolarVolumeFromReference(double molality, double referenceMolality,
+      double referenceApparentMolarVolume, StateParameters parameters) {
+    requireMolality(molality, true);
+    requireMolality(referenceMolality, false);
+    requireFinite(referenceApparentMolarVolume, "Reference apparent molar volume");
+    requireParameters(parameters);
+    return checkedVolume(referenceApparentMolarVolume + calculateExcessVolume(molality, parameters)
+        - calculateExcessVolume(referenceMolality, parameters));
+  }
+
+  /**
+   * Convert apparent molar volume to solution density on a one-kilogram solvent basis.
+   *
+   * @param molality electrolyte molality in mol/kg solvent
+   * @param electrolyteMolarMass neutral formula-unit molar mass in kg/mol
+   * @param pureSolventDensity pure-solvent density at the same temperature and pressure in kg/m<sup>3</sup>
+   * @param apparentMolarVolume apparent molar volume in m<sup>3</sup>/mol
+   * @return solution density in kg/m<sup>3</sup>
+   */
+  public static double calculateDensity(double molality, double electrolyteMolarMass, double pureSolventDensity,
+      double apparentMolarVolume) {
+    requireMolality(molality, true);
+    requirePositive(electrolyteMolarMass, "Electrolyte molar mass");
+    requirePositive(pureSolventDensity, "Pure-solvent density");
+    requireFinite(apparentMolarVolume, "Apparent molar volume");
+
+    double solutionMass = 1.0 + molality * electrolyteMolarMass;
+    double solutionVolume = 1.0 / pureSolventDensity + molality * apparentMolarVolume;
+    if (!Double.isFinite(solutionVolume) || solutionVolume <= 0.0) {
+      throw new IllegalArgumentException("Apparent molar volume produces a non-physical solution volume");
+    }
+    double density = solutionMass / solutionVolume;
+    if (!Double.isFinite(density) || density <= 0.0) {
+      throw new IllegalArgumentException("Apparent molar volume produces a non-physical solution density");
+    }
+    return density;
+  }
+
+  /**
+   * Convert solution density to apparent molar volume on a one-kilogram solvent basis.
+   *
+   * @param molality non-zero electrolyte molality in mol/kg solvent
+   * @param electrolyteMolarMass neutral formula-unit molar mass in kg/mol
+   * @param pureSolventDensity pure-solvent density at the same temperature and pressure in kg/m<sup>3</sup>
+   * @param solutionDensity measured or modelled solution density in kg/m<sup>3</sup>
+   * @return apparent molar volume in m<sup>3</sup>/mol
+   */
+  public static double calculateApparentMolarVolumeFromDensity(double molality, double electrolyteMolarMass,
+      double pureSolventDensity, double solutionDensity) {
+    requireMolality(molality, false);
+    requirePositive(electrolyteMolarMass, "Electrolyte molar mass");
+    requirePositive(pureSolventDensity, "Pure-solvent density");
+    requirePositive(solutionDensity, "Solution density");
+
+    double solutionVolume = (1.0 + molality * electrolyteMolarMass) / solutionDensity;
+    return checkedVolume((solutionVolume - 1.0 / pureSolventDensity) / molality);
+  }
+
+  /**
+   * Calculate stoichiometric ionic strength for the binary electrolyte.
+   *
+   * @param molality formula-unit molality in mol/kg solvent
+   * @return ionic strength in mol/kg solvent
+   */
+  public double calculateIonicStrength(double molality) {
+    requireMolality(molality, true);
+    double ionCount = (double) cationStoichiometry + anionStoichiometry;
+    double chargeProduct = Math.abs((double) cationCharge * anionCharge);
+    return 0.5 * ionCount * chargeProduct * molality;
+  }
+
+  /**
+   * Evaluate the standard Pitzer attenuation function.
+   *
+   * @param x non-negative dimensionless argument
+   * @return {@code 2 * (1 - (1 + x) * exp(-x)) / x^2}, with its analytical limit at zero
+   */
+  static double attenuation(double x) {
+    if (!Double.isFinite(x) || x < 0.0) {
+      throw new IllegalArgumentException("Pitzer attenuation argument must be finite and non-negative");
+    }
+    if (x < 1.0e-4) {
+      return 1.0 + x * (-2.0 / 3.0 + x * (1.0 / 4.0 + x * (-1.0 / 15.0 + x / 72.0)));
+    }
+    return 2.0 * (1.0 - (1.0 + x) * Math.exp(-x)) / (x * x);
+  }
+
+  private double calculateExcessVolume(double molality, StateParameters parameters) {
+    double ionicStrength = calculateIonicStrength(molality);
+    double squareRootIonicStrength = Math.sqrt(ionicStrength);
+    double ionCount = (double) cationStoichiometry + anionStoichiometry;
+    double chargeProduct = Math.abs((double) cationCharge * anionCharge);
+
+    double debyeHuckelVolume = ionCount * chargeProduct * parameters.getDebyeHuckelVolumeSlope() / (2.0 * STANDARD_B)
+        * Math.log1p(STANDARD_B * squareRootIonicStrength);
+
+    double bVolume = parameters.getBeta0PressureDerivative()
+        + parameters.getBeta1PressureDerivative() * attenuation(STANDARD_ALPHA * squareRootIonicStrength);
+    double stoichiometricProduct = cationStoichiometry * anionStoichiometry;
+    double interactionVolume = stoichiometricProduct * GAS_CONSTANT * parameters.getTemperatureK()
+        * (2.0 * molality * bVolume
+            + molality * molality * Math.sqrt(stoichiometricProduct) * parameters.getCphiPressureDerivative());
+
+    double excessVolume = debyeHuckelVolume + interactionVolume;
+    if (!Double.isFinite(excessVolume)) {
+      throw new IllegalArgumentException("Pitzer volumetric parameters produce a non-finite apparent molar volume");
+    }
+    return excessVolume;
+  }
+
+  private static void requireParameters(StateParameters parameters) {
+    if (parameters == null) {
+      throw new IllegalArgumentException("Pitzer volumetric state parameters must not be null");
+    }
+  }
+
+  private static void requireMolality(double molality, boolean allowZero) {
+    if (!Double.isFinite(molality) || molality < 0.0 || (!allowZero && molality == 0.0)) {
+      throw new IllegalArgumentException(
+          allowZero ? "Molality must be finite and non-negative" : "Molality must be finite and positive");
+    }
+  }
+
+  private static void requirePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static void requireFinite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+
+  private static double checkedVolume(double volume) {
+    if (!Double.isFinite(volume)) {
+      throw new IllegalArgumentException("Pitzer volumetric calculation produced a non-finite volume");
+    }
+    return volume;
+  }
+
+  /** Parameters evaluated at one common temperature and pressure. */
+  public static final class StateParameters implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double temperatureK;
+    private final double pressurePa;
+    private final double debyeHuckelVolumeSlope;
+    private final double beta0PressureDerivative;
+    private final double beta1PressureDerivative;
+    private final double cphiPressureDerivative;
+
+    /**
+     * Construct already-evaluated SI volumetric parameters for one state.
+     *
+     * @param temperatureK temperature in K
+     * @param pressurePa absolute pressure in Pa
+     * @param debyeHuckelVolumeSlope Debye-Huckel volume slope in m<sup>3</sup> kg<sup>1/2</sup> mol<sup>-3/2</sup>
+     * @param beta0PressureDerivative pressure derivative of beta zero in Pa<sup>-1</sup> kg/mol
+     * @param beta1PressureDerivative pressure derivative of beta one in Pa<sup>-1</sup> kg/mol
+     * @param cphiPressureDerivative pressure derivative of C phi in Pa<sup>-1</sup> kg<sup>2</sup>/mol<sup>2</sup>
+     */
+    public StateParameters(double temperatureK, double pressurePa, double debyeHuckelVolumeSlope,
+        double beta0PressureDerivative, double beta1PressureDerivative, double cphiPressureDerivative) {
+      requirePositive(temperatureK, "Pitzer volumetric temperature");
+      requirePositive(pressurePa, "Pitzer volumetric pressure");
+      requireFinite(debyeHuckelVolumeSlope, "Debye-Huckel volume slope");
+      requireFinite(beta0PressureDerivative, "Beta-zero pressure derivative");
+      requireFinite(beta1PressureDerivative, "Beta-one pressure derivative");
+      requireFinite(cphiPressureDerivative, "C-phi pressure derivative");
+      this.temperatureK = temperatureK;
+      this.pressurePa = pressurePa;
+      this.debyeHuckelVolumeSlope = debyeHuckelVolumeSlope;
+      this.beta0PressureDerivative = beta0PressureDerivative;
+      this.beta1PressureDerivative = beta1PressureDerivative;
+      this.cphiPressureDerivative = cphiPressureDerivative;
+    }
+
+    /** @return temperature in K */
+    public double getTemperatureK() {
+      return temperatureK;
+    }
+
+    /** @return absolute pressure in Pa */
+    public double getPressurePa() {
+      return pressurePa;
+    }
+
+    /** @return Debye-Huckel volume slope in SI units */
+    public double getDebyeHuckelVolumeSlope() {
+      return debyeHuckelVolumeSlope;
+    }
+
+    /** @return pressure derivative of beta zero in SI units */
+    public double getBeta0PressureDerivative() {
+      return beta0PressureDerivative;
+    }
+
+    /** @return pressure derivative of beta one in SI units */
+    public double getBeta1PressureDerivative() {
+      return beta1PressureDerivative;
+    }
+
+    /** @return pressure derivative of C phi in SI units */
+    public double getCphiPressureDerivative() {
+      return cphiPressureDerivative;
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricModelTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricModelTest.java
@@ -1,0 +1,112 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+/** Tests the parameter-neutral standard binary Pitzer volumetric equation. */
+class PitzerBinaryVolumetricModelTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 298.15;
+  private static final double PRESSURE_PA = 10.0e6;
+  private static final double CACL2_MOLAR_MASS = 0.11098;
+
+  @Test
+  void returnsLimitingVolumeAtZeroMolality() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricModel.StateParameters parameters = representativeParameters();
+
+    assertEquals(17.6e-6, model.calculateApparentMolarVolume(0.0, 17.6e-6, parameters), 0.0);
+    assertEquals(0.0, model.calculateIonicStrength(0.0), 0.0);
+  }
+
+  @Test
+  void matchesHandCalculatedBinaryInteractionTerm() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    double beta0PressureDerivative = 2.0e-10;
+    PitzerBinaryVolumetricModel.StateParameters parameters = new PitzerBinaryVolumetricModel.StateParameters(
+        TEMPERATURE_K, PRESSURE_PA, 0.0, beta0PressureDerivative, 0.0, 0.0);
+
+    double molality = 1.5;
+    double limitingVolume = 17.6e-6;
+    double expectedInteraction = 2.0 * 8.31446261815324 * TEMPERATURE_K * (2.0 * molality * beta0PressureDerivative);
+
+    assertEquals(3.0 * molality, model.calculateIonicStrength(molality), 0.0);
+    assertEquals(limitingVolume + expectedInteraction,
+        model.calculateApparentMolarVolume(molality, limitingVolume, parameters), 1.0e-19);
+  }
+
+  @Test
+  void evaluatesAttenuationWithoutDiluteCancellation() {
+    assertEquals(1.0, PitzerBinaryVolumetricModel.attenuation(0.0), 0.0);
+    assertEquals(1.0 - 2.0e-12 / 3.0, PitzerBinaryVolumetricModel.attenuation(1.0e-12), 1.0e-16);
+
+    double x = 2.0;
+    double expected = 2.0 * (1.0 - (1.0 + x) * Math.exp(-x)) / (x * x);
+    assertEquals(expected, PitzerBinaryVolumetricModel.attenuation(x), 0.0);
+  }
+
+  @Test
+  void referenceFormMatchesInfiniteDilutionForm() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricModel.StateParameters parameters = representativeParameters();
+    double limitingVolume = 17.6e-6;
+    double referenceMolality = 1.0;
+    double referenceVolume = model.calculateApparentMolarVolume(referenceMolality, limitingVolume, parameters);
+
+    for (double molality : new double[] { 0.0, 0.25, 1.0, 3.0, 6.0 }) {
+      double direct = model.calculateApparentMolarVolume(molality, limitingVolume, parameters);
+      double relative = model.calculateApparentMolarVolumeFromReference(molality, referenceMolality, referenceVolume,
+          parameters);
+      assertEquals(direct, relative, 2.0e-19);
+    }
+  }
+
+  @Test
+  void densityConversionRoundTripsAndRecoversPureWaterLimit() {
+    double molality = 3.0;
+    double waterDensity = 997.0474;
+    double apparentVolume = 28.0e-6;
+
+    double solutionDensity = PitzerBinaryVolumetricModel.calculateDensity(molality, CACL2_MOLAR_MASS, waterDensity,
+        apparentVolume);
+    double recoveredVolume = PitzerBinaryVolumetricModel.calculateApparentMolarVolumeFromDensity(molality,
+        CACL2_MOLAR_MASS, waterDensity, solutionDensity);
+
+    assertEquals(apparentVolume, recoveredVolume, 2.0e-19);
+    assertEquals(waterDensity,
+        PitzerBinaryVolumetricModel.calculateDensity(0.0, CACL2_MOLAR_MASS, waterDensity, apparentVolume), 0.0);
+  }
+
+  @Test
+  void rejectsInvalidFormulaStateAndConversions() {
+    assertThrows(IllegalArgumentException.class, () -> new PitzerBinaryVolumetricModel(1, 2, 1, -1));
+    assertThrows(IllegalArgumentException.class, () -> new PitzerBinaryVolumetricModel(0, 1, 1, -1));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricModel.StateParameters(0.0, PRESSURE_PA, 0.0, 0.0, 0.0, 0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricModel.StateParameters(TEMPERATURE_K, PRESSURE_PA, 0.0, Double.NaN, 0.0, 0.0));
+
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricModel.StateParameters parameters = representativeParameters();
+    assertThrows(IllegalArgumentException.class, () -> model.calculateApparentMolarVolume(-0.1, 17.6e-6, parameters));
+    assertThrows(IllegalArgumentException.class,
+        () -> model.calculateApparentMolarVolumeFromReference(1.0, 0.0, 25.0e-6, parameters));
+    assertThrows(IllegalArgumentException.class, () -> model.calculateApparentMolarVolume(1.0, 17.6e-6, null));
+    assertThrows(IllegalArgumentException.class, () -> model.calculateApparentMolarVolume(1.0, Double.MAX_VALUE,
+        new PitzerBinaryVolumetricModel.StateParameters(TEMPERATURE_K, PRESSURE_PA, Double.MAX_VALUE, 0.0, 0.0, 0.0)));
+    assertThrows(IllegalArgumentException.class, () -> PitzerBinaryVolumetricModel
+        .calculateApparentMolarVolumeFromDensity(0.0, CACL2_MOLAR_MASS, 997.0, 1100.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> PitzerBinaryVolumetricModel.calculateDensity(10.0, CACL2_MOLAR_MASS, 997.0, -2.0e-4));
+    assertThrows(IllegalArgumentException.class, () -> PitzerBinaryVolumetricModel.attenuation(Double.NaN));
+  }
+
+  private static PitzerBinaryVolumetricModel calciumChlorideModel() {
+    return new PitzerBinaryVolumetricModel(1, 2, 2, -1);
+  }
+
+  private static PitzerBinaryVolumetricModel.StateParameters representativeParameters() {
+    return new PitzerBinaryVolumetricModel.StateParameters(TEMPERATURE_K, PRESSURE_PA, 1.0e-6, 2.0e-10, -1.0e-10,
+        5.0e-11);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3144 with the parameter-neutral thermodynamic kernel required before a scientifically qualified high-pressure electrolyte-density model can be installed.

- Implements the standard binary Pitzer apparent-molar-volume equation using caller-supplied, already state-evaluated SI parameters.
- Adds a non-zero reference-molality difference form that avoids numerically fragile infinite-dilution extrapolation.
- Adds exact density ↔ apparent-molar-volume conversion on a 1 kg solvent basis.
- Uses a small-argument analytical expansion for the Pitzer attenuation function.
- Fails closed on invalid stoichiometry, charge balance, state, composition, parameters, or non-physical volume/density.
- Contains no built-in salt coefficients and changes no default NeqSim density result.

Scientific formalism: [Rowland and May (2013)](https://doi.org/10.1016/j.fluid.2012.10.021).  
Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5563981665

## Exact continuity and scope

- Exact base: `48e79395bb6c6c96362a7e2f3fc926bb0b9d94ba`
- Exact head: `833ae0744428b715aecda6d7a10f7722ae949da0`
- Branch: `ai/3144-binary-volumetric-pitzer`
- Three ordered commits and three intended files
- Connector-published blobs are byte-identical to the locally validated files
- Seven pre-existing autonomous drafts were checked before publication; none owns these files
- Portfolio occupancy after publication: **8/10**

## Scientific and model-semantics boundary

This PR does **not** copy the restricted Rowland–May coefficient table, import PHREEQC volume fits, or fit the 197-point Al Ghafri/NIST ThermoML series reserved as independent validation evidence. It does not change `Water`, Ksp, `Vdelta`, activity coefficients, reactions, speciation, phase selection, solver behavior, tolerances, or MCP payloads.

`StateParameters` explicitly carries temperature and pressure and accepts only SI `A_V`, `β⁽⁰⁾_V`, `β⁽¹⁾_V`, and `Cφ_V` values already evaluated at that same state. Dataset qualification and installation into the default aqueous-density path remain a separate provenance-gated increment.

High-pressure aqueous density and calcium-sulfate prediction remain fail-closed.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local validation on Java 17:

- `PitzerBinaryVolumetricModelTest`: **6/6 passed**
- direct and reference formulations agree at 0, 0.25, 1, 3, and 6 mol/kg
- zero-molality limit returns exactly `V°`
- CaCl₂ ionic strength and a hand-calculated binary interaction term agree
- small-`x` attenuation is stable
- density conversion round-trips and recovers the pure-water limit
- invalid and overflowing inputs fail closed
- `python devtools/run_spotless.py apply`: passed
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (690 Markdown pages and one standalone HTML page)
- pre-commit stage: passed
- pre-push stage: passed

Local Javadocs could not run because this runtime has no `javadoc` executable. No Javadoc result is claimed; hosted exact-head CI is authoritative.

The kernel is O(1), allocation-free per evaluation, and absent from every existing default calculation path.

## Documentation impact

Updated `docs/physical_properties/density_models.md` with:

- the equation and SI units;
- direct and non-zero reference forms;
- density conversion;
- Java API usage;
- provenance, calibration/validation, and fail-closed boundaries;
- model-selection and API-reference entries.

## Stop boundary

This is the reusable formalism only. A later increment may add a coefficient dataset or connect it to aqueous physical properties only after redistribution-compatible calibration rows, complete uncertainties, laboratory-grouped acceptance, and an untouched independent validation source are available.

Keep this PR draft-only. Do not merge, enable auto-merge, mark ready for review, rebase, synchronize with `master`, force-push, close, replace, or abandon it for capacity.