### PR TITLE
[AI-Assisted] feat(dexpi): expose transition boundary evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -276,15 +276,18 @@ connection occurrences crossing directed-cycle boundaries. Each immutable
 from/to `DexpiConnectionEndpointInfo` records, optional from/to cycle IDs, and an `ENTERING`,
 `LEAVING`, or `BETWEEN_CYCLES` classification. Reader-produced values also expose the exact
 immutable cycle objects from `ImportResult.getConnectionCycles()` through `getFromCycle()` and
-`getToCycle()`. The corresponding evidence markers distinguish this projection from values created
-with the legacy constructor, whose cycle-object getters return `null` while their scalar IDs remain
-unchanged. A connection entering or leaving a cycle has complete evidence only on the cyclic side.
-A connection from one cyclic strongly connected group to another appears once with both cycle IDs
-and both complete cycle objects; callers do not need to reconcile the outgoing boundary projection
-of one cycle with the incoming projection of the other. Parallel occurrences remain distinct,
-unresolved non-empty endpoints remain visible, and connections with a blank endpoint stay in the
-global connection and diagnostic evidence because a transition cannot assign them to a cycle.
-`toJson()` includes the cycle-evidence markers and nested from/to cycle objects when present. This
+`getToCycle()`. They also expose the exact boundary objects already present in those cycles through
+`getFromCycleBoundary()` and `getToCycleBoundary()`. An entering transition carries only the
+target cycle's `INCOMING` boundary, a leaving transition carries only the source cycle's
+`OUTGOING` boundary, and a between-cycle transition carries both. Corresponding evidence markers
+distinguish this reader projection from values created with either legacy constructor, whose cycle
+and boundary object getters return `null` while their scalar cycle IDs remain unchanged. A
+connection from one cyclic strongly connected group to another appears once with both cycle IDs,
+both complete cycle objects, and both directional boundary objects; callers do not need to scan or
+join the two cycle inventories. Parallel occurrences remain distinct, unresolved non-empty endpoints
+remain visible, and connections with a blank endpoint stay in the global connection and diagnostic
+evidence because a transition cannot assign them to a cycle. `toJson()` includes the cycle- and
+boundary-evidence markers and nested from/to cycle and boundary objects when present. This
 exact-once inventory remains source-reference evidence only; it does not prove hydraulic continuity,
 identify a physical recycle, enumerate paths, or alter simulation topology.
 
@@ -294,8 +297,8 @@ identify a physical recycle, enumerate paths, or alter simulation topology.
 `connectionCycleTransitionCount`, and the ordered instrumentation-loop, actuating-function, information-flow, connection, endpoint,
 component, directed-cycle, and cycle-transition inventories, including reference resolution,
 incidence roles, review subsets, complete component- and cycle-local endpoint and connection
-occurrences, explicit cycle-boundary occurrences, and exact-once transitions with nested connection and endpoint
-evidence, alongside the process-unit count and findings. Python callers through JPype use the same
+occurrences, explicit cycle-boundary occurrences, and exact-once transitions with nested connection, endpoint,
+cycle, and directional boundary evidence, alongside the process-unit count and findings. Python callers through JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getInstrumentationLoops()`,
 `ImportResult.getActuatingFunctions()`, `ImportResult.getInformationFlows()`,
 `ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -34,6 +34,8 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
   private final String toCycleId;
   private final DexpiConnectionCycleInfo fromCycle;
   private final DexpiConnectionCycleInfo toCycle;
+  private final DexpiConnectionCycleBoundaryInfo fromCycleBoundary;
+  private final DexpiConnectionCycleBoundaryInfo toCycleBoundary;
   private final Kind kind;
   private final DexpiConnectionInfo connection;
   private final DexpiConnectionEndpointInfo fromEndpoint;
@@ -72,6 +74,28 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
   public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection, DexpiConnectionEndpointInfo fromEndpoint,
       DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId, DexpiConnectionCycleInfo fromCycle,
       DexpiConnectionCycleInfo toCycle) {
+    this(connection, fromEndpoint, toEndpoint, fromCycleId, toCycleId, fromCycle, toCycle, null, null);
+  }
+
+  /**
+   * Creates complete immutable evidence with cycle and boundary records available to the reader.
+   *
+   * @param connection complete source connection occurrence
+   * @param fromEndpoint complete source-endpoint evidence
+   * @param toEndpoint complete target-endpoint evidence
+   * @param fromCycleId source directed-cycle identity, or empty when outside every cycle
+   * @param toCycleId target directed-cycle identity, or empty when outside every cycle
+   * @param fromCycle complete source directed-cycle evidence, or {@code null} when outside or unavailable
+   * @param toCycle complete target directed-cycle evidence, or {@code null} when outside or unavailable
+   * @param fromCycleBoundary source cycle's outgoing boundary evidence, or {@code null} when outside or unavailable
+   * @param toCycleBoundary target cycle's incoming boundary evidence, or {@code null} when outside or unavailable
+   * @throws NullPointerException if connection or endpoint evidence is null
+   * @throws IllegalArgumentException if cycle identities do not describe a boundary crossing or evidence disagrees
+   */
+  public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection, DexpiConnectionEndpointInfo fromEndpoint,
+      DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId, DexpiConnectionCycleInfo fromCycle,
+      DexpiConnectionCycleInfo toCycle, DexpiConnectionCycleBoundaryInfo fromCycleBoundary,
+      DexpiConnectionCycleBoundaryInfo toCycleBoundary) {
     this.connection = Objects.requireNonNull(connection, "connection");
     this.fromEndpoint = Objects.requireNonNull(fromEndpoint, "fromEndpoint");
     this.toEndpoint = Objects.requireNonNull(toEndpoint, "toEndpoint");
@@ -79,6 +103,8 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     this.toCycleId = normalize(toCycleId);
     this.fromCycle = fromCycle;
     this.toCycle = toCycle;
+    this.fromCycleBoundary = fromCycleBoundary;
+    this.toCycleBoundary = toCycleBoundary;
     if (this.fromCycleId.isEmpty() && this.toCycleId.isEmpty()) {
       throw new IllegalArgumentException("At least one endpoint must belong to a directed cycle");
     }
@@ -91,6 +117,10 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     if (toCycle != null && !this.toCycleId.equals(toCycle.getId())) {
       throw new IllegalArgumentException("Target cycle evidence must match toCycleId");
     }
+    validateBoundaryEvidence(fromCycleBoundary, this.fromCycleId,
+        DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, "Source");
+    validateBoundaryEvidence(toCycleBoundary, this.toCycleId,
+        DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, "Target");
     if (this.fromCycleId.isEmpty()) {
       kind = Kind.ENTERING;
     } else if (this.toCycleId.isEmpty()) {
@@ -125,6 +155,16 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     return fromCycle != null;
   }
 
+  /** @return source cycle's outgoing boundary evidence, or {@code null} when outside or unavailable */
+  public DexpiConnectionCycleBoundaryInfo getFromCycleBoundary() {
+    return fromCycleBoundary;
+  }
+
+  /** @return whether complete source cycle-boundary evidence is available */
+  public boolean hasFromCycleBoundaryEvidence() {
+    return fromCycleBoundary != null;
+  }
+
   /** @return target directed-cycle identity, or empty when outside every cyclic group */
   public String getToCycleId() {
     return toCycleId;
@@ -143,6 +183,16 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
   /** @return whether complete target directed-cycle evidence is available */
   public boolean hasToCycleEvidence() {
     return toCycle != null;
+  }
+
+  /** @return target cycle's incoming boundary evidence, or {@code null} when outside or unavailable */
+  public DexpiConnectionCycleBoundaryInfo getToCycleBoundary() {
+    return toCycleBoundary;
+  }
+
+  /** @return whether complete target cycle-boundary evidence is available */
+  public boolean hasToCycleBoundaryEvidence() {
+    return toCycleBoundary != null;
   }
 
   /** @return transition classification relative to the cyclic groups */
@@ -172,13 +222,33 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     result.put("toCycleId", toCycleId);
     result.put("hasFromCycleEvidence", Boolean.valueOf(hasFromCycleEvidence()));
     result.put("hasToCycleEvidence", Boolean.valueOf(hasToCycleEvidence()));
+    result.put("hasFromCycleBoundaryEvidence", Boolean.valueOf(hasFromCycleBoundaryEvidence()));
+    result.put("hasToCycleBoundaryEvidence", Boolean.valueOf(hasToCycleBoundaryEvidence()));
     result.put("kind", kind.name());
     result.put("fromCycle", fromCycle == null ? null : fromCycle.toMap());
     result.put("toCycle", toCycle == null ? null : toCycle.toMap());
+    result.put("fromCycleBoundary", fromCycleBoundary == null ? null : fromCycleBoundary.toMap());
+    result.put("toCycleBoundary", toCycleBoundary == null ? null : toCycleBoundary.toMap());
     result.put("connection", connection.toMap());
     result.put("fromEndpoint", fromEndpoint.toMap());
     result.put("toEndpoint", toEndpoint.toMap());
     return result;
+  }
+
+  private void validateBoundaryEvidence(DexpiConnectionCycleBoundaryInfo boundary, String cycleId,
+      DexpiConnectionCycleBoundaryInfo.Direction expectedDirection, String label) {
+    if (boundary == null) {
+      return;
+    }
+    if (cycleId.isEmpty()) {
+      throw new IllegalArgumentException(label + " boundary evidence requires a cycle identity");
+    }
+    if (!Objects.equals(connection.getId(), boundary.getConnectionId())) {
+      throw new IllegalArgumentException(label + " boundary evidence must match the connection identity");
+    }
+    if (boundary.getDirection() != expectedDirection) {
+      throw new IllegalArgumentException(label + " boundary evidence has the wrong direction");
+    }
   }
 
   private static String normalize(String value) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -117,10 +117,10 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     if (toCycle != null && !this.toCycleId.equals(toCycle.getId())) {
       throw new IllegalArgumentException("Target cycle evidence must match toCycleId");
     }
-    validateBoundaryEvidence(fromCycleBoundary, this.fromCycleId,
-        DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, "Source");
-    validateBoundaryEvidence(toCycleBoundary, this.toCycleId,
-        DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, "Target");
+    validateBoundaryEvidence(fromCycleBoundary, this.fromCycleId, DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
+        "Source");
+    validateBoundaryEvidence(toCycleBoundary, this.toCycleId, DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
+        "Target");
     if (this.fromCycleId.isEmpty()) {
       kind = Kind.ENTERING;
     } else if (this.toCycleId.isEmpty()) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1357,9 +1357,20 @@ public final class DexpiXmlReader {
     }
 
     Map<String, DexpiConnectionCycleInfo> cycleByEndpointId = new HashMap<String, DexpiConnectionCycleInfo>();
+    Map<String, DexpiConnectionCycleBoundaryInfo> incomingBoundaryByConnectionId =
+        new HashMap<String, DexpiConnectionCycleBoundaryInfo>();
+    Map<String, DexpiConnectionCycleBoundaryInfo> outgoingBoundaryByConnectionId =
+        new HashMap<String, DexpiConnectionCycleBoundaryInfo>();
     for (DexpiConnectionCycleInfo cycle : connectionCycles) {
       for (String endpointId : cycle.getEndpointIds()) {
         cycleByEndpointId.put(endpointId, cycle);
+      }
+      for (DexpiConnectionCycleBoundaryInfo boundary : cycle.getBoundaryConnections()) {
+        if (boundary.getDirection() == DexpiConnectionCycleBoundaryInfo.Direction.INCOMING) {
+          incomingBoundaryByConnectionId.put(boundary.getConnectionId(), boundary);
+        } else {
+          outgoingBoundaryByConnectionId.put(boundary.getConnectionId(), boundary);
+        }
       }
     }
 
@@ -1379,7 +1390,9 @@ public final class DexpiXmlReader {
       String fromCycleId = fromCycle == null ? "" : fromCycle.getId();
       String toCycleId = toCycle == null ? "" : toCycle.getId();
       result.add(new DexpiConnectionCycleTransitionInfo(connection, endpointById.get(connection.getFromId()),
-          endpointById.get(connection.getToId()), fromCycleId, toCycleId, fromCycle, toCycle));
+          endpointById.get(connection.getToId()), fromCycleId, toCycleId, fromCycle, toCycle,
+          outgoingBoundaryByConnectionId.get(connection.getId()),
+          incomingBoundaryByConnectionId.get(connection.getId())));
     }
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1357,10 +1357,8 @@ public final class DexpiXmlReader {
     }
 
     Map<String, DexpiConnectionCycleInfo> cycleByEndpointId = new HashMap<String, DexpiConnectionCycleInfo>();
-    Map<String, DexpiConnectionCycleBoundaryInfo> incomingBoundaryByConnectionId =
-        new HashMap<String, DexpiConnectionCycleBoundaryInfo>();
-    Map<String, DexpiConnectionCycleBoundaryInfo> outgoingBoundaryByConnectionId =
-        new HashMap<String, DexpiConnectionCycleBoundaryInfo>();
+    Map<String, DexpiConnectionCycleBoundaryInfo> incomingBoundaryByConnectionId = new HashMap<String, DexpiConnectionCycleBoundaryInfo>();
+    Map<String, DexpiConnectionCycleBoundaryInfo> outgoingBoundaryByConnectionId = new HashMap<String, DexpiConnectionCycleBoundaryInfo>();
     for (DexpiConnectionCycleInfo cycle : connectionCycles) {
       for (String endpointId : cycle.getEndpointIds()) {
         cycleByEndpointId.put(endpointId, cycle);

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -1255,10 +1255,17 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(entering.hasFromCycle());
     assertFalse(entering.hasFromCycleEvidence());
     assertNull(entering.getFromCycle());
+    assertFalse(entering.hasFromCycleBoundaryEvidence());
+    assertNull(entering.getFromCycleBoundary());
     assertEquals("cycle-1", entering.getToCycleId());
     assertTrue(entering.hasToCycle());
     assertTrue(entering.hasToCycleEvidence());
     assertSame(first.getConnectionCycles().get(0), entering.getToCycle());
+    assertTrue(entering.hasToCycleBoundaryEvidence());
+    assertSame(findCycleBoundary(first.getConnectionCycles().get(0), "C-IN-1",
+        DexpiConnectionCycleBoundaryInfo.Direction.INCOMING), entering.getToCycleBoundary());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
+        entering.getToCycleBoundary().getDirection());
     assertEquals("S-IN-1", entering.getConnection().getSegmentId());
     assertEquals("UNKNOWN-U", entering.getFromEndpoint().getEndpointId());
     assertFalse(entering.getFromEndpoint().isResolved());
@@ -1271,6 +1278,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(DexpiConnectionCycleTransitionInfo.Kind.ENTERING, parallelEntering.getKind());
     assertEquals("cycle-1", parallelEntering.getToCycleId());
     assertSame(first.getConnectionCycles().get(0), parallelEntering.getToCycle());
+    assertFalse(parallelEntering.hasFromCycleBoundaryEvidence());
+    assertNull(parallelEntering.getFromCycleBoundary());
+    assertTrue(parallelEntering.hasToCycleBoundaryEvidence());
+    assertSame(findCycleBoundary(first.getConnectionCycles().get(0), "C-IN-2",
+        DexpiConnectionCycleBoundaryInfo.Direction.INCOMING), parallelEntering.getToCycleBoundary());
     assertEquals("S-IN-2", parallelEntering.getConnection().getSegmentId());
 
     DexpiConnectionCycleTransitionInfo between = transitions.get(2);
@@ -1283,6 +1295,16 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(between.hasToCycleEvidence());
     assertSame(first.getConnectionCycles().get(0), between.getFromCycle());
     assertSame(first.getConnectionCycles().get(1), between.getToCycle());
+    assertTrue(between.hasFromCycleBoundaryEvidence());
+    assertTrue(between.hasToCycleBoundaryEvidence());
+    assertSame(findCycleBoundary(first.getConnectionCycles().get(0), "C-BX",
+        DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING), between.getFromCycleBoundary());
+    assertSame(findCycleBoundary(first.getConnectionCycles().get(1), "C-BX",
+        DexpiConnectionCycleBoundaryInfo.Direction.INCOMING), between.getToCycleBoundary());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
+        between.getFromCycleBoundary().getDirection());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
+        between.getToCycleBoundary().getDirection());
     assertEquals("N-B", between.getFromEndpoint().getEndpointId());
     assertEquals("N-X", between.getToEndpoint().getEndpointId());
 
@@ -1296,6 +1318,13 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(leaving.hasToCycle());
     assertFalse(leaving.hasToCycleEvidence());
     assertNull(leaving.getToCycle());
+    assertTrue(leaving.hasFromCycleBoundaryEvidence());
+    assertSame(findCycleBoundary(first.getConnectionCycles().get(1), "C-OUT",
+        DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING), leaving.getFromCycleBoundary());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
+        leaving.getFromCycleBoundary().getDirection());
+    assertFalse(leaving.hasToCycleBoundaryEvidence());
+    assertNull(leaving.getToCycleBoundary());
     assertEquals("E-V", leaving.getToEndpoint().getOwnerId());
 
     assertThrows(UnsupportedOperationException.class, () -> transitions.clear());
@@ -1314,6 +1343,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(legacy.hasToCycleEvidence());
     assertNull(legacy.getFromCycle());
     assertNull(legacy.getToCycle());
+    assertFalse(legacy.hasFromCycleBoundaryEvidence());
+    assertFalse(legacy.hasToCycleBoundaryEvidence());
+    assertNull(legacy.getFromCycleBoundary());
+    assertNull(legacy.getToCycleBoundary());
 
     assertTrue(first.toJson().contains("\"connectionCycleTransitionCount\": 4"));
     assertTrue(first.toJson().contains("\"kind\": \"BETWEEN_CYCLES\""));
@@ -1323,9 +1356,23 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"hasToCycleEvidence\": true"));
     assertTrue(first.toJson().contains("\"fromCycle\": {"));
     assertTrue(first.toJson().contains("\"toCycle\": {"));
+    assertTrue(first.toJson().contains("\"hasFromCycleBoundaryEvidence\": true"));
+    assertTrue(first.toJson().contains("\"hasToCycleBoundaryEvidence\": true"));
+    assertTrue(first.toJson().contains("\"fromCycleBoundary\": {"));
+    assertTrue(first.toJson().contains("\"toCycleBoundary\": {"));
     assertTrue(first.toJson().contains("\"fromEndpoint\": {"));
     assertTrue(first.toJson().contains("\"toEndpoint\": {"));
     assertEquals(first.toJson(), second.toJson());
+  }
+
+  private static DexpiConnectionCycleBoundaryInfo findCycleBoundary(DexpiConnectionCycleInfo cycle,
+      String connectionId, DexpiConnectionCycleBoundaryInfo.Direction direction) {
+    for (DexpiConnectionCycleBoundaryInfo boundary : cycle.getBoundaryConnections()) {
+      if (connectionId.equals(boundary.getConnectionId()) && direction == boundary.getDirection()) {
+        return boundary;
+      }
+    }
+    throw new AssertionError("Missing " + direction + " boundary " + connectionId + " in " + cycle.getCycleId());
   }
 
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -1264,8 +1264,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(entering.hasToCycleBoundaryEvidence());
     assertSame(findCycleBoundary(first.getConnectionCycles().get(0), "C-IN-1",
         DexpiConnectionCycleBoundaryInfo.Direction.INCOMING), entering.getToCycleBoundary());
-    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
-        entering.getToCycleBoundary().getDirection());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, entering.getToCycleBoundary().getDirection());
     assertEquals("S-IN-1", entering.getConnection().getSegmentId());
     assertEquals("UNKNOWN-U", entering.getFromEndpoint().getEndpointId());
     assertFalse(entering.getFromEndpoint().isResolved());
@@ -1301,10 +1300,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING), between.getFromCycleBoundary());
     assertSame(findCycleBoundary(first.getConnectionCycles().get(1), "C-BX",
         DexpiConnectionCycleBoundaryInfo.Direction.INCOMING), between.getToCycleBoundary());
-    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
-        between.getFromCycleBoundary().getDirection());
-    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
-        between.getToCycleBoundary().getDirection());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, between.getFromCycleBoundary().getDirection());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, between.getToCycleBoundary().getDirection());
     assertEquals("N-B", between.getFromEndpoint().getEndpointId());
     assertEquals("N-X", between.getToEndpoint().getEndpointId());
 
@@ -1321,8 +1318,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(leaving.hasFromCycleBoundaryEvidence());
     assertSame(findCycleBoundary(first.getConnectionCycles().get(1), "C-OUT",
         DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING), leaving.getFromCycleBoundary());
-    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
-        leaving.getFromCycleBoundary().getDirection());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, leaving.getFromCycleBoundary().getDirection());
     assertFalse(leaving.hasToCycleBoundaryEvidence());
     assertNull(leaving.getToCycleBoundary());
     assertEquals("E-V", leaving.getToEndpoint().getOwnerId());
@@ -1365,8 +1361,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(first.toJson(), second.toJson());
   }
 
-  private static DexpiConnectionCycleBoundaryInfo findCycleBoundary(DexpiConnectionCycleInfo cycle,
-      String connectionId, DexpiConnectionCycleBoundaryInfo.Direction direction) {
+  private static DexpiConnectionCycleBoundaryInfo findCycleBoundary(DexpiConnectionCycleInfo cycle, String connectionId,
+      DexpiConnectionCycleBoundaryInfo.Direction direction) {
     for (DexpiConnectionCycleBoundaryInfo boundary : cycle.getBoundaryConnections()) {
       if (connectionId.equals(boundary.getConnectionId()) && direction == boundary.getDirection()) {
         return boundary;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -1372,7 +1372,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         return boundary;
       }
     }
-    throw new AssertionError("Missing " + direction + " boundary " + connectionId + " in " + cycle.getCycleId());
+    throw new AssertionError("Missing " + direction + " boundary " + connectionId + " in " + cycle.getId());
   }
 
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 with complete immutable directed-cycle boundary evidence on source-ordered DEXPI cycle transitions.

- Reuses the exact `DexpiConnectionCycleBoundaryInfo` objects already exposed by `ImportResult.getConnectionCycles()`.
- Adds nullable from/to boundary accessors and explicit evidence markers.
- Entering transitions expose only the target cycle's `INCOMING` boundary; leaving transitions expose only the source cycle's `OUTGOING` boundary; between-cycle transitions expose both.
- Preserves legacy constructors, scalar cycle IDs, transition classification, source ordering, parallel occurrences, unresolved evidence, and existing JSON fields.
- Adds nested from/to boundary evidence to JSON only when available.
- Keeps transition construction O(V+E) and preserves Java 8 source compatibility.

Capability contracts:
- #1332: https://github.com/equinor/neqsim/issues/1332#issuecomment-5564847613
- #2899: https://github.com/equinor/neqsim/issues/2899#issuecomment-5564849140

## Exact continuity and scope

- Exact base/current master at publication: `e8895a9f2a400a5a989622c6976440852f7b5089`
- Current master: `a0dac90e6458f38684c70ac13e4a75039c23fb2d`
- Exact head: `a6dc2cce642e1f0e8b583e2682b23f22be37a057`
- Branch: `ai/dexpi-transition-boundary-evidence`
- Six ordered commits across four intended files; 6 ahead / 0 behind the recorded base.
- Current master is six unrelated commits ahead with no file overlap; no rebase occurred.
- Tests were authored first in the first two commits.
- The four pre-existing autonomous implementation PRs were checked before publication; none owns these DEXPI files.
- This is the sole active PFD/P&ID/DEXPI shared-lane PR.
- Portfolio occupancy after publication: **5/10**; current occupancy: **4/10**.

## Acceptance evidence

Focused regression assertions require:

- entering and parallel-entering transitions to expose the exact target `INCOMING` boundary object only;
- leaving transitions to expose the exact source `OUTGOING` boundary object only;
- between-cycle transitions to expose both exact directional boundary objects;
- legacy-constructor values to retain IDs while reporting absent boundary-object evidence;
- deterministic JSON to include evidence markers and nested boundary objects.

Connector-side audit confirms four intended files, six commits, no tabs or trailing whitespace, and no base drift. The predecessor head's only branch-attributable failure was Spotless in pre-commit. The exact hosted three-file `spotless-format-patch` artifact (digest `sha256:13658f4ce58158bc3c8d300b53f6c492427c0746a31a3ab7fd4aec514bde26ea`) was applied without changing capability semantics, assertions, or documentation meaning.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

On exact head `a6dc2cce642e1f0e8b583e2682b23f22be37a057`, seven of eight workflows pass. Java 21 Ubuntu/Windows, all four slow shards, Javadocs, formatting, documentation, notebook, engineering-diagram performance, CodeQL, PaperLab, and reference checks pass. Java 8 Ubuntu also passes; only Java 8 Windows remains active, with zero failures reported. GitHub Actions on this exact head are authoritative.

The draft remains open, unmerged, mergeable, and free of review threads.

## Documentation and boundary

The DEXPI reader guide documents exact object identity, one-sided entering/leaving rules, legacy behavior, and JSON projection.

This remains source-document evidence only. It does not infer a hydraulic recycle, enumerate paths, repair or rewire topology, change simulation/rendering/layout/export behavior, assign safety credit, claim DEXPI/ISO/ISA conformance, certify a diagram, or provide accountable engineering approval. The whole-sheet visual defect gate is not applicable because rendering is unchanged.

## Draft-only workflow

Keep this PR open and draft. Do not merge, enable auto-merge, mark ready for review, rebase, synchronize with `master`, force-push, close, replace, or abandon it as part of campaign automation.