### PR TITLE
[AI-Assisted] Add whole-assay blend property screening

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -13,7 +13,8 @@ The `neqsim.thermo.characterization` package converts petroleum assay, TBP, and 
 | --- | --- | --- |
 | Pre-binned TBP fractions | `SystemInterface.addTBPfraction(...)` | Add a petroleum cut from moles, molar mass, and specific gravity |
 | Plus fraction | `SystemInterface.addPlusFraction(...)` + `Characterise` | Represent and split a C7+/C20+ heavy end |
-| Refinery assay | `OilAssayCharacterisation` | Convert mass- or volume-basis refinery cuts/TBP boundaries to pseudo-components |\n| Assay blend screening | `RefineryAssayBlend` | Combine whole-assay SG/API and optional sulfur/nitrogen on an explicit mass basis |
+| Refinery assay | `OilAssayCharacterisation` | Convert mass- or volume-basis refinery cuts/TBP boundaries to pseudo-components |
+| Assay blend screening | `RefineryAssayBlend` | Combine whole-assay SG/API and optional sulfur/nitrogen on an explicit mass basis |
 | TBP property model selection | `Characterise.setTBPModel(...)` | Select Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing, and related models |
 | Lumping | `Characterise.configureLumping()` | Reduce a detailed heavy-end slate while preserving configured grouping rules |
 | Common-slate characterization | `PseudoComponentCombiner` | Align multiple characterized fluids to a shared pseudo-component definition |
@@ -48,7 +49,8 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - volume-to-mass conversion using cut density;
 - kg/mol and g/mol explicit molar-mass helpers;
 - specific-gravity, kg/m3, and API-gravity density inputs;
-- exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;\n- immutable whole-assay blend screening with ideal additive liquid volumes and mass-linear sulfur/nitrogen;
+- exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
+- immutable whole-assay blend screening with ideal additive liquid volumes and mass-linear sulfur/nitrogen;
 - forward and inverse UOP/Watson characterization between representative boiling point and specific gravity;
 - mass-basis mapping of known assay light ends to authoritative NeqSim standard components;
 - number-average molar mass from mass-basis PIANO family/carbon-number data;

--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -13,7 +13,7 @@ The `neqsim.thermo.characterization` package converts petroleum assay, TBP, and 
 | --- | --- | --- |
 | Pre-binned TBP fractions | `SystemInterface.addTBPfraction(...)` | Add a petroleum cut from moles, molar mass, and specific gravity |
 | Plus fraction | `SystemInterface.addPlusFraction(...)` + `Characterise` | Represent and split a C7+/C20+ heavy end |
-| Refinery assay | `OilAssayCharacterisation` | Convert mass- or volume-basis refinery cuts/TBP boundaries to pseudo-components |
+| Refinery assay | `OilAssayCharacterisation` | Convert mass- or volume-basis refinery cuts/TBP boundaries to pseudo-components |\n| Assay blend screening | `RefineryAssayBlend` | Combine whole-assay SG/API and optional sulfur/nitrogen on an explicit mass basis |
 | TBP property model selection | `Characterise.setTBPModel(...)` | Select Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing, and related models |
 | Lumping | `Characterise.configureLumping()` | Reduce a detailed heavy-end slate while preserving configured grouping rules |
 | Common-slate characterization | `PseudoComponentCombiner` | Align multiple characterized fluids to a shared pseudo-component definition |
@@ -48,7 +48,7 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - volume-to-mass conversion using cut density;
 - kg/mol and g/mol explicit molar-mass helpers;
 - specific-gravity, kg/m3, and API-gravity density inputs;
-- exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
+- exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;\n- immutable whole-assay blend screening with ideal additive liquid volumes and mass-linear sulfur/nitrogen;
 - forward and inverse UOP/Watson characterization between representative boiling point and specific gravity;
 - mass-basis mapping of known assay light ends to authoritative NeqSim standard components;
 - number-average molar mass from mass-basis PIANO family/carbon-number data;

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -137,6 +137,44 @@ where `w_i` is the resolved mass fraction and `SG_i` is the cut specific gravity
 
 These methods are screening calculations at the density reference condition represented by the inputs. They assume ideal additive liquid volumes and do not apply temperature correction, excess-volume, or blend-contraction models. They are not custody-transfer or certified blend-design calculations. The public validation and numerical error boundary are documented in [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation).
 
+## Whole-assay blend screening
+
+`RefineryAssayBlend` combines already-resolved whole-assay properties on one explicit mass basis.
+Specific gravity uses ideal additive liquid volumes, while total sulfur and nitrogen use linear
+mass weighting:
+
+$SG_{blend}=\left(\sum_j\frac{x_j}{SG_j}\right)^{-1},\qquad
+S_{blend}=\sum_jx_jS_j,\qquad N_{blend}=\sum_jx_jN_j$
+
+Here `x_j` is the normalized source-assay mass fraction. Callers may supply bulk properties
+directly, or use `fromAssays(...)` to resolve complete density, sulfur, and nitrogen inputs from
+configured `OilAssayCharacterisation` instances before a result is returned. Property queries do
+not call `apply()`, create pseudo-components, or mutate the attached thermodynamic systems.
+
+```java
+RefineryAssayBlend densityBlend = RefineryAssayBlend.fromBulkProperties(
+    new double[] {60.0, 40.0},
+    new double[] {0.847, 0.771});
+
+double blendSpecificGravity = densityBlend.getSpecificGravity();
+double blendApi = densityBlend.getApiGravity();
+double blendDensityKgM3 = densityBlend.getDensityKgPerCubicMetreAt60F();
+```
+
+The two endpoint specific gravities above are published DOE/OEDI COA whole-crude values for samples
+50146 and 56337. They provide public endpoint evidence for an independently recomputable
+60/40 screening calculation; no measured property for that hypothetical blend is available or
+claimed. Source: [DOE/OEDI COA summary workbook](https://data.openei.org/submissions/23).
+
+All positive-mass sources must provide each property requested by the selected factory. Null,
+non-finite, negative, zero-total, length-mismatched, or incomplete positive-mass inputs fail closed.
+Zero-mass sources do not contribute. Returned normalized mass fractions are defensive copies.
+
+This is bulk bookkeeping, not a thermodynamic or empirical blend model. It does not predict
+temperature/pressure effects, excess volume or contraction, viscosity, cloud/pour point,
+asphaltene stability, phase equilibrium, TBP/pseudo-component compatibility, product
+specifications, or blend optimization.
+
 ## Per-cut UOP/Watson characterization factor
 
 `AssayCut.getWatsonCharacterizationFactor()` calculates the dimensionless UOP/Watson factor from the same authoritative density and representative-boiling-point inputs used by the assay workflow:
@@ -314,7 +352,7 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API, per-cut Watson and linear sulfur/nitrogen bookkeeping qualified over frozen public matrices; broader stream properties remain open |
 | Rigorous distillation columns | `DistillationColumn`, `SimpleTray`, Naphtali-Sandholm solver, side-draw support | Existing foundation; broad-boiling atmospheric/vacuum refinery benchmark remains open |
 | Crude preheat/fired heater | General heater/heat-exchanger process equipment | Refinery workflow and fuel/emission integration remain open |
-| Product blending/specification optimization | Generic optimization/process facilities | Refinery property/blending framework remains open |
+| Whole-assay bulk blend screening | `RefineryAssayBlend` | Qualified for ideal-volume SG/API and mass-linear sulfur/nitrogen bookkeeping; nonlinear properties and optimization remain open |
 | ASTM D86/D1160 to TBP conversion | No qualified refinery conversion API in this increment | Open; requires public correlation provenance and validation |
 | Atmospheric crude-unit benchmark | No campaign benchmark yet | Next high-value validation milestone |
 | Vacuum tower benchmark | No campaign benchmark yet | Open after atmospheric case |

--- a/src/main/java/neqsim/thermo/characterization/RefineryAssayBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryAssayBlend.java
@@ -7,9 +7,8 @@ import java.util.Arrays;
  * Immutable screening properties for a mass blend of resolved refinery assays.
  *
  * <p>
- * Blend specific gravity uses ideal additive liquid volumes. Sulfur and nitrogen, when supplied,
- * use linear mass-basis mixing. This class does not create pseudo-components or mutate an assay or
- * thermodynamic system.
+ * Blend specific gravity uses ideal additive liquid volumes. Sulfur and nitrogen, when supplied, use linear mass-basis
+ * mixing. This class does not create pseudo-components or mutate an assay or thermodynamic system.
  * </p>
  */
 public final class RefineryAssayBlend implements Serializable {
@@ -94,8 +93,7 @@ public final class RefineryAssayBlend implements Serializable {
    * @param sourceSpecificGravities source whole-assay specific gravities
    * @return immutable blend properties
    */
-  public static RefineryAssayBlend fromBulkProperties(double[] sourceMasses,
-      double[] sourceSpecificGravities) {
+  public static RefineryAssayBlend fromBulkProperties(double[] sourceMasses, double[] sourceSpecificGravities) {
     return new RefineryAssayBlend(sourceMasses, sourceSpecificGravities, null, null);
   }
 
@@ -108,29 +106,26 @@ public final class RefineryAssayBlend implements Serializable {
    * @param sourceNitrogenMassFractions source total-nitrogen mass fractions on a 0-1 basis
    * @return immutable blend properties
    */
-  public static RefineryAssayBlend fromBulkProperties(double[] sourceMasses,
-      double[] sourceSpecificGravities, double[] sourceSulfurMassFractions,
-      double[] sourceNitrogenMassFractions) {
-    return new RefineryAssayBlend(sourceMasses, sourceSpecificGravities,
-        sourceSulfurMassFractions, sourceNitrogenMassFractions);
+  public static RefineryAssayBlend fromBulkProperties(double[] sourceMasses, double[] sourceSpecificGravities,
+      double[] sourceSulfurMassFractions, double[] sourceNitrogenMassFractions) {
+    return new RefineryAssayBlend(sourceMasses, sourceSpecificGravities, sourceSulfurMassFractions,
+        sourceNitrogenMassFractions);
   }
 
   /**
    * Resolve complete density and quality inputs from configured assays before returning a blend.
    *
    * <p>
-   * Every positive-mass assay must support bulk specific gravity, sulfur, and nitrogen. Zero-mass
-   * assays are retained in the returned mass-fraction array but their properties are not queried.
+   * Every positive-mass assay must support bulk specific gravity, sulfur, and nitrogen. Zero-mass assays are retained
+   * in the returned mass-fraction array but their properties are not queried.
    * </p>
    *
    * @param assays configured source assays
    * @param sourceMasses non-negative source masses in any common mass unit
    * @return immutable blend properties
    */
-  public static RefineryAssayBlend fromAssays(OilAssayCharacterisation[] assays,
-      double[] sourceMasses) {
-    if (assays == null || sourceMasses == null || assays.length == 0
-        || assays.length != sourceMasses.length) {
+  public static RefineryAssayBlend fromAssays(OilAssayCharacterisation[] assays, double[] sourceMasses) {
+    if (assays == null || sourceMasses == null || assays.length == 0 || assays.length != sourceMasses.length) {
       throw new IllegalArgumentException("Assay and mass arrays must be non-empty and equal length");
     }
 
@@ -150,8 +145,8 @@ public final class RefineryAssayBlend implements Serializable {
         sourceNitrogenMassFractions[i] = assays[i].getBulkNitrogenMassFraction();
       }
     }
-    return fromBulkProperties(sourceMasses, sourceSpecificGravities,
-        sourceSulfurMassFractions, sourceNitrogenMassFractions);
+    return fromBulkProperties(sourceMasses, sourceSpecificGravities, sourceSulfurMassFractions,
+        sourceNitrogenMassFractions);
   }
 
   /** @return a defensive copy of normalized source mass fractions */
@@ -207,10 +202,8 @@ public final class RefineryAssayBlend implements Serializable {
     }
   }
 
-  private static void validateEqualLength(double[] sourceMasses, double[] values,
-      String propertyName) {
-    if (sourceMasses == null || values == null || sourceMasses.length == 0
-        || sourceMasses.length != values.length) {
+  private static void validateEqualLength(double[] sourceMasses, double[] values, String propertyName) {
+    if (sourceMasses == null || values == null || sourceMasses.length == 0 || sourceMasses.length != values.length) {
       throw new IllegalArgumentException(
           "Source mass and " + propertyName + " arrays must be non-empty and equal length");
     }

--- a/src/main/java/neqsim/thermo/characterization/RefineryAssayBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryAssayBlend.java
@@ -1,0 +1,230 @@
+package neqsim.thermo.characterization;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable screening properties for a mass blend of resolved refinery assays.
+ *
+ * <p>
+ * Blend specific gravity uses ideal additive liquid volumes. Sulfur and nitrogen, when supplied,
+ * use linear mass-basis mixing. This class does not create pseudo-components or mutate an assay or
+ * thermodynamic system.
+ * </p>
+ */
+public final class RefineryAssayBlend implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double WATER_DENSITY_60F_KG_M3 = 999.016;
+
+  private final double[] massFractions;
+  private final double specificGravity;
+  private final double sulfurMassFraction;
+  private final double nitrogenMassFraction;
+  private final boolean qualitiesAvailable;
+
+  private RefineryAssayBlend(double[] sourceMasses, double[] sourceSpecificGravities,
+      double[] sourceSulfurMassFractions, double[] sourceNitrogenMassFractions) {
+    validateEqualLength(sourceMasses, sourceSpecificGravities, "specific-gravity");
+    boolean hasQualities = sourceSulfurMassFractions != null || sourceNitrogenMassFractions != null;
+    if (hasQualities) {
+      if (sourceSulfurMassFractions == null || sourceNitrogenMassFractions == null) {
+        throw new IllegalArgumentException("Sulfur and nitrogen arrays must be supplied together");
+      }
+      validateEqualLength(sourceMasses, sourceSulfurMassFractions, "sulfur");
+      validateEqualLength(sourceMasses, sourceNitrogenMassFractions, "nitrogen");
+    }
+
+    double totalMass = 0.0;
+    for (double sourceMass : sourceMasses) {
+      if (!Double.isFinite(sourceMass) || sourceMass < 0.0) {
+        throw new IllegalArgumentException("Source masses must be finite and non-negative");
+      }
+      totalMass += sourceMass;
+      if (!Double.isFinite(totalMass)) {
+        throw new IllegalArgumentException("Total source mass must be finite");
+      }
+    }
+    if (!(totalMass > 0.0)) {
+      throw new IllegalArgumentException("Blend must contain positive source mass");
+    }
+
+    double[] resolvedMassFractions = new double[sourceMasses.length];
+    double additiveVolumePerUnitMass = 0.0;
+    double resolvedSulfurMassFraction = 0.0;
+    double resolvedNitrogenMassFraction = 0.0;
+    for (int i = 0; i < sourceMasses.length; i++) {
+      double massFraction = sourceMasses[i] / totalMass;
+      resolvedMassFractions[i] = massFraction;
+      if (!(massFraction > 0.0)) {
+        continue;
+      }
+
+      double sourceSpecificGravity = sourceSpecificGravities[i];
+      requirePositiveFinite(sourceSpecificGravity, "Source specific gravity");
+      additiveVolumePerUnitMass += massFraction / sourceSpecificGravity;
+
+      if (hasQualities) {
+        double sourceSulfurMassFraction = sourceSulfurMassFractions[i];
+        double sourceNitrogenMassFraction = sourceNitrogenMassFractions[i];
+        requireMassFraction(sourceSulfurMassFraction, "Source sulfur mass fraction");
+        requireMassFraction(sourceNitrogenMassFraction, "Source nitrogen mass fraction");
+        resolvedSulfurMassFraction += massFraction * sourceSulfurMassFraction;
+        resolvedNitrogenMassFraction += massFraction * sourceNitrogenMassFraction;
+      }
+    }
+
+    double resolvedSpecificGravity = 1.0 / additiveVolumePerUnitMass;
+    requirePositiveFinite(resolvedSpecificGravity, "Blend specific gravity");
+    if (hasQualities) {
+      requireMassFraction(resolvedSulfurMassFraction, "Blend sulfur mass fraction");
+      requireMassFraction(resolvedNitrogenMassFraction, "Blend nitrogen mass fraction");
+    }
+
+    massFractions = resolvedMassFractions;
+    specificGravity = resolvedSpecificGravity;
+    sulfurMassFraction = resolvedSulfurMassFraction;
+    nitrogenMassFraction = resolvedNitrogenMassFraction;
+    qualitiesAvailable = hasQualities;
+  }
+
+  /**
+   * Create a density/API screening blend from already-resolved whole-assay properties.
+   *
+   * @param sourceMasses non-negative source masses in any common mass unit
+   * @param sourceSpecificGravities source whole-assay specific gravities
+   * @return immutable blend properties
+   */
+  public static RefineryAssayBlend fromBulkProperties(double[] sourceMasses,
+      double[] sourceSpecificGravities) {
+    return new RefineryAssayBlend(sourceMasses, sourceSpecificGravities, null, null);
+  }
+
+  /**
+   * Create a density/API and sulfur/nitrogen screening blend from resolved bulk properties.
+   *
+   * @param sourceMasses non-negative source masses in any common mass unit
+   * @param sourceSpecificGravities source whole-assay specific gravities
+   * @param sourceSulfurMassFractions source total-sulfur mass fractions on a 0-1 basis
+   * @param sourceNitrogenMassFractions source total-nitrogen mass fractions on a 0-1 basis
+   * @return immutable blend properties
+   */
+  public static RefineryAssayBlend fromBulkProperties(double[] sourceMasses,
+      double[] sourceSpecificGravities, double[] sourceSulfurMassFractions,
+      double[] sourceNitrogenMassFractions) {
+    return new RefineryAssayBlend(sourceMasses, sourceSpecificGravities,
+        sourceSulfurMassFractions, sourceNitrogenMassFractions);
+  }
+
+  /**
+   * Resolve complete density and quality inputs from configured assays before returning a blend.
+   *
+   * <p>
+   * Every positive-mass assay must support bulk specific gravity, sulfur, and nitrogen. Zero-mass
+   * assays are retained in the returned mass-fraction array but their properties are not queried.
+   * </p>
+   *
+   * @param assays configured source assays
+   * @param sourceMasses non-negative source masses in any common mass unit
+   * @return immutable blend properties
+   */
+  public static RefineryAssayBlend fromAssays(OilAssayCharacterisation[] assays,
+      double[] sourceMasses) {
+    if (assays == null || sourceMasses == null || assays.length == 0
+        || assays.length != sourceMasses.length) {
+      throw new IllegalArgumentException("Assay and mass arrays must be non-empty and equal length");
+    }
+
+    double[] sourceSpecificGravities = new double[assays.length];
+    double[] sourceSulfurMassFractions = new double[assays.length];
+    double[] sourceNitrogenMassFractions = new double[assays.length];
+    for (int i = 0; i < assays.length; i++) {
+      if (assays[i] == null) {
+        throw new IllegalArgumentException("Source assays cannot be null");
+      }
+      if (!Double.isFinite(sourceMasses[i]) || sourceMasses[i] < 0.0) {
+        throw new IllegalArgumentException("Source masses must be finite and non-negative");
+      }
+      if (sourceMasses[i] > 0.0) {
+        sourceSpecificGravities[i] = assays[i].getBulkSpecificGravity();
+        sourceSulfurMassFractions[i] = assays[i].getBulkSulfurMassFraction();
+        sourceNitrogenMassFractions[i] = assays[i].getBulkNitrogenMassFraction();
+      }
+    }
+    return fromBulkProperties(sourceMasses, sourceSpecificGravities,
+        sourceSulfurMassFractions, sourceNitrogenMassFractions);
+  }
+
+  /** @return a defensive copy of normalized source mass fractions */
+  public double[] getMassFractions() {
+    return Arrays.copyOf(massFractions, massFractions.length);
+  }
+
+  /** @return ideal-additive-volume blend specific gravity */
+  public double getSpecificGravity() {
+    return specificGravity;
+  }
+
+  /** @return blend API gravity */
+  public double getApiGravity() {
+    return 141.5 / specificGravity - 131.5;
+  }
+
+  /** @return blend density at 60 degrees Fahrenheit in kg/m3 */
+  public double getDensityKgPerCubicMetreAt60F() {
+    return specificGravity * WATER_DENSITY_60F_KG_M3;
+  }
+
+  /** @return whether complete sulfur and nitrogen screening results are available */
+  public boolean hasAssayQualities() {
+    return qualitiesAvailable;
+  }
+
+  /** @return blend total-sulfur mass fraction on a 0-1 basis */
+  public double getSulfurMassFraction() {
+    requireQualities();
+    return sulfurMassFraction;
+  }
+
+  /** @return blend total sulfur in mass percent */
+  public double getSulfurMassPercent() {
+    return 100.0 * getSulfurMassFraction();
+  }
+
+  /** @return blend total-nitrogen mass fraction on a 0-1 basis */
+  public double getNitrogenMassFraction() {
+    requireQualities();
+    return nitrogenMassFraction;
+  }
+
+  /** @return blend total nitrogen in mass percent */
+  public double getNitrogenMassPercent() {
+    return 100.0 * getNitrogenMassFraction();
+  }
+
+  private void requireQualities() {
+    if (!qualitiesAvailable) {
+      throw new IllegalStateException("Complete sulfur and nitrogen inputs were not supplied");
+    }
+  }
+
+  private static void validateEqualLength(double[] sourceMasses, double[] values,
+      String propertyName) {
+    if (sourceMasses == null || values == null || sourceMasses.length == 0
+        || sourceMasses.length != values.length) {
+      throw new IllegalArgumentException(
+          "Source mass and " + propertyName + " arrays must be non-empty and equal length");
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String propertyName) {
+    if (!Double.isFinite(value) || !(value > 0.0)) {
+      throw new IllegalArgumentException(propertyName + " must be finite and positive");
+    }
+  }
+
+  private static void requireMassFraction(double value, String propertyName) {
+    if (!Double.isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException(propertyName + " must be finite and between 0 and 1");
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/RefineryAssayBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryAssayBlendTest.java
@@ -1,0 +1,122 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests fail-closed whole-assay bulk property blending. */
+public class RefineryAssayBlendTest {
+  @Test
+  public void publicOediEndpointsFollowIdealAdditiveVolumeRule() {
+    double[] masses = { 60.0, 40.0 };
+    double[] publishedSpecificGravities = { 0.847, 0.771 };
+    RefineryAssayBlend blend =
+        RefineryAssayBlend.fromBulkProperties(masses, publishedSpecificGravities);
+
+    double expectedSpecificGravity = 1.0 / (0.6 / 0.847 + 0.4 / 0.771);
+    assertEquals(expectedSpecificGravity, blend.getSpecificGravity(), 1.0e-15);
+    assertEquals(141.5 / expectedSpecificGravity - 131.5, blend.getApiGravity(), 1.0e-13);
+    assertEquals(expectedSpecificGravity * 999.016, blend.getDensityKgPerCubicMetreAt60F(), 1.0e-12);
+    assertFalse(blend.hasAssayQualities());
+    assertThrows(IllegalStateException.class, blend::getSulfurMassFraction);
+  }
+
+  @Test
+  public void assayFactoryResolvesCompletePropertiesWithoutMutation() {
+    SystemInterface firstSystem = new SystemSrkEos(298.15, 1.01325);
+    SystemInterface secondSystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation first = singleCutAssay(firstSystem, "First", 0.80, 0.01, 0.001);
+    OilAssayCharacterisation second = singleCutAssay(secondSystem, "Second", 0.90, 0.03, 0.002);
+
+    RefineryAssayBlend blend =
+        RefineryAssayBlend.fromAssays(new OilAssayCharacterisation[] { first, second },
+            new double[] { 2.0, 3.0 });
+
+    double expectedSpecificGravity = 1.0 / (0.4 / 0.80 + 0.6 / 0.90);
+    assertArrayEquals(new double[] { 0.4, 0.6 }, blend.getMassFractions(), 1.0e-15);
+    assertEquals(expectedSpecificGravity, blend.getSpecificGravity(), 1.0e-15);
+    assertEquals(0.022, blend.getSulfurMassFraction(), 1.0e-15);
+    assertEquals(2.2, blend.getSulfurMassPercent(), 1.0e-14);
+    assertEquals(0.0016, blend.getNitrogenMassFraction(), 1.0e-15);
+    assertEquals(0.16, blend.getNitrogenMassPercent(), 1.0e-14);
+    assertTrue(blend.hasAssayQualities());
+    assertEquals(0, firstSystem.getNumberOfComponents());
+    assertEquals(0, secondSystem.getNumberOfComponents());
+  }
+
+  @Test
+  public void resultIsScaleOrderAndDefensiveCopyInvariant() {
+    RefineryAssayBlend base = RefineryAssayBlend.fromBulkProperties(new double[] { 2.0, 3.0 },
+        new double[] { 0.80, 0.90 }, new double[] { 0.01, 0.03 },
+        new double[] { 0.001, 0.002 });
+    RefineryAssayBlend scaled = RefineryAssayBlend.fromBulkProperties(new double[] { 20.0, 30.0 },
+        new double[] { 0.80, 0.90 }, new double[] { 0.01, 0.03 },
+        new double[] { 0.001, 0.002 });
+    RefineryAssayBlend reversed = RefineryAssayBlend.fromBulkProperties(new double[] { 3.0, 2.0 },
+        new double[] { 0.90, 0.80 }, new double[] { 0.03, 0.01 },
+        new double[] { 0.002, 0.001 });
+
+    assertEquals(base.getSpecificGravity(), scaled.getSpecificGravity(), 0.0);
+    assertEquals(base.getSpecificGravity(), reversed.getSpecificGravity(), 0.0);
+    assertEquals(base.getSulfurMassFraction(), reversed.getSulfurMassFraction(), 0.0);
+    assertEquals(base.getNitrogenMassFraction(), reversed.getNitrogenMassFraction(), 0.0);
+
+    double[] returnedMassFractions = base.getMassFractions();
+    returnedMassFractions[0] = 1.0;
+    assertArrayEquals(new double[] { 0.4, 0.6 }, base.getMassFractions(), 1.0e-15);
+  }
+
+  @Test
+  public void zeroMassSourceDoesNotRequireFabricatedProperties() {
+    RefineryAssayBlend blend = RefineryAssayBlend.fromBulkProperties(new double[] { 1.0, 0.0 },
+        new double[] { 0.82, Double.NaN }, new double[] { 0.004, Double.NaN },
+        new double[] { 0.001, Double.NaN });
+
+    assertArrayEquals(new double[] { 1.0, 0.0 }, blend.getMassFractions(), 0.0);
+    assertEquals(0.82, blend.getSpecificGravity(), 0.0);
+    assertEquals(0.004, blend.getSulfurMassFraction(), 0.0);
+    assertEquals(0.001, blend.getNitrogenMassFraction(), 0.0);
+  }
+
+  @Test
+  public void invalidOrIncompleteInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(null, new double[] { 0.8 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] {}, new double[] {}));
+    assertThrows(IllegalArgumentException.class, () -> RefineryAssayBlend
+        .fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8, 0.9 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] { -1.0 }, new double[] { 0.8 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 0.0 }, new double[] { 0.8 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { Double.NaN }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8 },
+            new double[] { 1.01 }, new double[] { 0.001 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8 },
+            new double[] { 0.01 }, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromAssays(new OilAssayCharacterisation[] { null },
+            new double[] { 1.0 }));
+  }
+
+  private static OilAssayCharacterisation singleCutAssay(SystemInterface system, String name,
+      double specificGravity, double sulfurMassFraction, double nitrogenMassFraction) {
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.clearCuts();
+    assay.addCut(new AssayCut(name).withMassFraction(1.0).withSpecificGravity(specificGravity)
+        .withSulfurMassFraction(sulfurMassFraction)
+        .withNitrogenMassFraction(nitrogenMassFraction));
+    return assay;
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/RefineryAssayBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryAssayBlendTest.java
@@ -74,7 +74,8 @@ public class RefineryAssayBlendTest {
         new double[] { 0.82, Double.NaN }, new double[] { 0.004, Double.NaN }, new double[] { 0.001, Double.NaN });
 
     assertArrayEquals(new double[] { 1.0, 0.0 }, blend.getMassFractions(), 0.0);
-    assertEquals(0.82, blend.getSpecificGravity(), 0.0);
+    // The ideal-volume rule takes two reciprocals, which can differ by one ULP.
+    assertEquals(0.82, blend.getSpecificGravity(), Math.ulp(0.82));
     assertEquals(0.004, blend.getSulfurMassFraction(), 0.0);
     assertEquals(0.001, blend.getNitrogenMassFraction(), 0.0);
   }

--- a/src/test/java/neqsim/thermo/characterization/RefineryAssayBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryAssayBlendTest.java
@@ -17,8 +17,7 @@ public class RefineryAssayBlendTest {
   public void publicOediEndpointsFollowIdealAdditiveVolumeRule() {
     double[] masses = { 60.0, 40.0 };
     double[] publishedSpecificGravities = { 0.847, 0.771 };
-    RefineryAssayBlend blend =
-        RefineryAssayBlend.fromBulkProperties(masses, publishedSpecificGravities);
+    RefineryAssayBlend blend = RefineryAssayBlend.fromBulkProperties(masses, publishedSpecificGravities);
 
     double expectedSpecificGravity = 1.0 / (0.6 / 0.847 + 0.4 / 0.771);
     assertEquals(expectedSpecificGravity, blend.getSpecificGravity(), 1.0e-15);
@@ -35,9 +34,8 @@ public class RefineryAssayBlendTest {
     OilAssayCharacterisation first = singleCutAssay(firstSystem, "First", 0.80, 0.01, 0.001);
     OilAssayCharacterisation second = singleCutAssay(secondSystem, "Second", 0.90, 0.03, 0.002);
 
-    RefineryAssayBlend blend =
-        RefineryAssayBlend.fromAssays(new OilAssayCharacterisation[] { first, second },
-            new double[] { 2.0, 3.0 });
+    RefineryAssayBlend blend = RefineryAssayBlend.fromAssays(new OilAssayCharacterisation[] { first, second },
+        new double[] { 2.0, 3.0 });
 
     double expectedSpecificGravity = 1.0 / (0.4 / 0.80 + 0.6 / 0.90);
     assertArrayEquals(new double[] { 0.4, 0.6 }, blend.getMassFractions(), 1.0e-15);
@@ -54,14 +52,11 @@ public class RefineryAssayBlendTest {
   @Test
   public void resultIsScaleOrderAndDefensiveCopyInvariant() {
     RefineryAssayBlend base = RefineryAssayBlend.fromBulkProperties(new double[] { 2.0, 3.0 },
-        new double[] { 0.80, 0.90 }, new double[] { 0.01, 0.03 },
-        new double[] { 0.001, 0.002 });
+        new double[] { 0.80, 0.90 }, new double[] { 0.01, 0.03 }, new double[] { 0.001, 0.002 });
     RefineryAssayBlend scaled = RefineryAssayBlend.fromBulkProperties(new double[] { 20.0, 30.0 },
-        new double[] { 0.80, 0.90 }, new double[] { 0.01, 0.03 },
-        new double[] { 0.001, 0.002 });
+        new double[] { 0.80, 0.90 }, new double[] { 0.01, 0.03 }, new double[] { 0.001, 0.002 });
     RefineryAssayBlend reversed = RefineryAssayBlend.fromBulkProperties(new double[] { 3.0, 2.0 },
-        new double[] { 0.90, 0.80 }, new double[] { 0.03, 0.01 },
-        new double[] { 0.002, 0.001 });
+        new double[] { 0.90, 0.80 }, new double[] { 0.03, 0.01 }, new double[] { 0.002, 0.001 });
 
     assertEquals(base.getSpecificGravity(), scaled.getSpecificGravity(), 0.0);
     assertEquals(base.getSpecificGravity(), reversed.getSpecificGravity(), 0.0);
@@ -76,8 +71,7 @@ public class RefineryAssayBlendTest {
   @Test
   public void zeroMassSourceDoesNotRequireFabricatedProperties() {
     RefineryAssayBlend blend = RefineryAssayBlend.fromBulkProperties(new double[] { 1.0, 0.0 },
-        new double[] { 0.82, Double.NaN }, new double[] { 0.004, Double.NaN },
-        new double[] { 0.001, Double.NaN });
+        new double[] { 0.82, Double.NaN }, new double[] { 0.004, Double.NaN }, new double[] { 0.001, Double.NaN });
 
     assertArrayEquals(new double[] { 1.0, 0.0 }, blend.getMassFractions(), 0.0);
     assertEquals(0.82, blend.getSpecificGravity(), 0.0);
@@ -91,32 +85,28 @@ public class RefineryAssayBlendTest {
         () -> RefineryAssayBlend.fromBulkProperties(null, new double[] { 0.8 }));
     assertThrows(IllegalArgumentException.class,
         () -> RefineryAssayBlend.fromBulkProperties(new double[] {}, new double[] {}));
-    assertThrows(IllegalArgumentException.class, () -> RefineryAssayBlend
-        .fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8, 0.9 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8, 0.9 }));
     assertThrows(IllegalArgumentException.class,
         () -> RefineryAssayBlend.fromBulkProperties(new double[] { -1.0 }, new double[] { 0.8 }));
     assertThrows(IllegalArgumentException.class,
         () -> RefineryAssayBlend.fromBulkProperties(new double[] { 0.0 }, new double[] { 0.8 }));
     assertThrows(IllegalArgumentException.class,
         () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { Double.NaN }));
+    assertThrows(IllegalArgumentException.class, () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 },
+        new double[] { 0.8 }, new double[] { 1.01 }, new double[] { 0.001 }));
+    assertThrows(IllegalArgumentException.class, () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 },
+        new double[] { 0.8 }, new double[] { 0.01 }, null));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8 },
-            new double[] { 1.01 }, new double[] { 0.001 }));
-    assertThrows(IllegalArgumentException.class,
-        () -> RefineryAssayBlend.fromBulkProperties(new double[] { 1.0 }, new double[] { 0.8 },
-            new double[] { 0.01 }, null));
-    assertThrows(IllegalArgumentException.class,
-        () -> RefineryAssayBlend.fromAssays(new OilAssayCharacterisation[] { null },
-            new double[] { 1.0 }));
+        () -> RefineryAssayBlend.fromAssays(new OilAssayCharacterisation[] { null }, new double[] { 1.0 }));
   }
 
-  private static OilAssayCharacterisation singleCutAssay(SystemInterface system, String name,
-      double specificGravity, double sulfurMassFraction, double nitrogenMassFraction) {
+  private static OilAssayCharacterisation singleCutAssay(SystemInterface system, String name, double specificGravity,
+      double sulfurMassFraction, double nitrogenMassFraction) {
     OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
     assay.clearCuts();
     assay.addCut(new AssayCut(name).withMassFraction(1.0).withSpecificGravity(specificGravity)
-        .withSulfurMassFraction(sulfurMassFraction)
-        .withNitrogenMassFraction(nitrogenMassFraction));
+        .withSulfurMassFraction(sulfurMassFraction).withNitrogenMassFraction(nitrogenMassFraction));
     return assay;
   }
 }


### PR DESCRIPTION
## Summary

Adds an immutable Java/JPype-friendly `RefineryAssayBlend` capability for bounded whole-assay property screening.

## Capability contract

- Normalizes non-negative source masses on any common mass unit.
- Calculates blend specific gravity with ideal additive liquid volumes.
- Reports API gravity and density at 60 °F consistently with existing assay accessors.
- Optionally blends complete total sulfur and nitrogen inputs linearly on a mass basis.
- Provides an assay-backed factory that resolves all required properties before returning.
- Returns defensive normalized mass-fraction arrays and is invariant to source order and common mass scaling.
- Fails closed for null, empty, mismatched, non-finite, negative, zero-total, or incomplete positive-mass inputs; zero-mass sources do not contribute.
- Does not call `apply()`, create pseudo-components, or mutate thermodynamic systems.

## Validation and provenance

Tests independently recompute density/API and sulfur/nitrogen balances, check scale/order invariance, defensive copies, zero-mass behavior, failure boundaries, and non-mutation. The density example uses the published DOE/OEDI COA whole-crude specific gravities for samples 50146 and 56337 as source endpoints: https://data.openei.org/submissions/23. It does not claim measured agreement for the hypothetical blend.

## Scientific boundary

This is bulk bookkeeping, not a thermodynamic or empirical blend model. It excludes temperature/pressure correction, excess volume and contraction, viscosity, cloud/pour point, asphaltene stability, phase equilibrium, TBP or pseudo-component compatibility, product specifications, and optimization. Existing defaults are unchanged.

Hosted exact-head CI is pending.

Tracks #3305.

## CI repair — 7 September 2026

Fixed the exact Windows failure in `zeroMassSourceDoesNotRequireFabricatedProperties` at `eb32afcad3d57059a4bac3c3710e103ceb126df7`. The ideal-volume calculation evaluates a double reciprocal, for which 0.82 becomes 0.8200000000000001. The specific-gravity assertion now permits exactly `Math.ulp(0.82)`; zero-mass, sulfur and nitrogen checks remain exact. No production calculation changed.

Local Java 17 / NeqSim 3.19.0: the original focused suite reproduced 1 failure out of 5; the repaired suite passes all 5 with zero failures/errors/skips. `./mvnw -o -Dtest=RefineryAssayBlendTest -Djacoco.skip=true test`, direct `python devtools/run_spotless.py apply`, `check`, `python devtools/check_documentation_search.py` and `git diff --check` all exited 0. Pre-commit executable unavailable; configured commands ran directly. The source tree was reconstructed from the exact remote head using the connector and a cached ancestor checkout.

Documentation impact: none; test precision only, no API, model, input or output change. **VALIDATION PENDING CI** on the new head. Draft status and branch history preserved.