### PR TITLE
[AI-Assisted] Fix invalid tieback hydraulic screening before 3.20.0

### DIFF
--- a/docs/fielddevelopment/DIGITAL_FIELD_TWIN.md
+++ b/docs/fielddevelopment/DIGITAL_FIELD_TWIN.md
@@ -205,51 +205,33 @@ ranker.setWeight(Criterion.EXECUTION_RISK, 0.25);
 
 ### Multiphase Flow Correlations
 
-The `MultiphaseFlowIntegrator` implements Beggs & Brill correlation for pipeline hydraulics:
+The `MultiphaseFlowIntegrator` defaults to `TwoFluidPipe` for the pressure and
+thermal traverse. `HydraulicModel.BEGGS_BRILL` selects the alternative correlation.
+The reported flow-regime and holdup screening estimates are separate simplified
+estimates; they are not resolved profiles or an experimental slugging qualification.
 
-#### Liquid Holdup Calculation
-
-$$H_L(\theta) = H_L(0) \cdot \psi$$
-
-Where horizontal holdup:
-$$H_L(0) = \frac{a \cdot \lambda_L^b}{Fr^c}$$
-
-Inclination correction:
-$$\psi = 1 + C \cdot [\sin(1.8\theta) - \frac{1}{3}\sin^3(1.8\theta)]$$
-
-#### Froude Number
-
-$$Fr = \frac{v_m^2}{g \cdot D}$$
-
-Where:
-- $v_m$ = mixture velocity (m/s)
-- $g$ = gravitational acceleration (9.81 m/s²)
-- $D$ = pipe diameter (m)
-
-#### Flow Regime Determination
-
-| Regime | $L_1$ | $L_2$ | Condition |
-|--------|-------|-------|-----------|
-| Segregated | $316 \lambda_L^{0.302}$ | $0.0009252 \lambda_L^{-2.4684}$ | $\lambda_L < 0.01$ and $Fr < L_1$ |
-| Intermittent | - | - | $0.01 \leq \lambda_L \leq 0.4$ and $L_3 < Fr \leq L_1$ |
-| Distributed | - | - | $\lambda_L \geq 0.4$ and $Fr \geq L_1$ |
+Non-converged two-fluid traverses and non-finite feasibility evidence are rejected.
+Always inspect `isFeasible()` and `getInfeasibilityReason()` before using a result.
 
 ```java
 MultiphaseFlowIntegrator integrator = new MultiphaseFlowIntegrator();
+integrator.setPipelineLength(1.0); // km
+integrator.setPipelineDiameter(0.3); // m
+integrator.setOverallHeatTransferCoeff(0.0);
+integrator.setMinArrivalPressure(1.0); // bara, for the curve
 
-// Single calculation
-PipelineResult result = integrator.calculateHydraulics(
-    stream, length, diameter, inclination);
-
-// Generate hydraulic curve
+PipelineResult result = integrator.calculateHydraulics(stream, 1.0);
 List<PipelineResult> curve = integrator.calculateHydraulicsCurve(
-    stream, length, diameter, inclination,
-    minFlowRate, maxFlowRate, numPoints);
+    stream.getFluid(), 60.0, new double[] {5000.0, 10000.0}); // kg/hr
 
-// Pipe sizing
-double optimalDiameter = integrator.sizePipeline(
-    stream, length, inclination, maxPressureDrop, minVelocity, maxVelocity);
+// Throws IllegalStateException if no standard size passes. Handle that failure
+// before reporting a recommended size. The configured diameter is preserved.
+double optimalDiameter = integrator.sizePipeline(stream, 1.0, 0.8);
 ```
+
+The velocity-ratio limit is inclusive and must be finite and positive. See
+[early-phase tie-back design](../process/tieback_early_phase_design.md) for the
+convergence and sizing failure contracts.
 
 ---
 
@@ -1045,3 +1027,4 @@ FieldConcept concept = FieldConcept.builder("My Field")
 - [Integrated Field Development Framework](INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK)
 - [Process Simulation Guide](../process/)
 - [PVT Simulation Guide](../pvtsimulation/)
+

--- a/docs/process/tieback_early_phase_design.md
+++ b/docs/process/tieback_early_phase_design.md
@@ -76,20 +76,39 @@ runs well below that, where the two-phase friction multiplier is extrapolated
 and over-predicts the pressure drop substantially. Prefer
 `TwoFluidPipe`, which resolves the phases separately.
 
-Always assert both conditions before believing a two-fluid profile:
+Always check the solver's convergence status before using a two-fluid profile:
 
 ```java
 pipe.run();
-if (!pipe.isSteadyStateConverged() || pipe.getSteadyStateIterationsUsed() <= 1) {
-  // A single-iteration exit means the pressure profile was frozen on the inlet
-  // densities and never picked up the flash. Reject it.
+if (!pipe.isSteadyStateConverged()) {
+  throw new IllegalStateException("Unconverged two-fluid profile");
 }
 ```
 
-`MultiphaseFlowIntegrator` now defaults to `HydraulicModel.TWO_FLUID` and warns
-when the solve exits after one iteration. Set
+`MultiphaseFlowIntegrator` defaults to `HydraulicModel.TWO_FLUID` and rejects
+non-converged profiles. Such a result
+has `isFeasible() == false` and an explanatory `getInfeasibilityReason()`;
+it must not be used as evidence of a feasible tie-back. Non-finite arrival
+pressure, temperature, velocity ratio or screening limits are also rejected. Set
 `setHydraulicModel(HydraulicModel.BEGGS_BRILL)` for a fast correlation check on
 a liquid-dominated line inside the correlation's calibration range.
+
+Before calculating screening velocities, the integrator refreshes outlet volume
+and mass density after the pipe has set its outlet flow. This prevents invalidated
+property caches from producing infinite velocities and a `NaN` erosional ratio.
+
+`sizePipeline(inlet, minimumArrivalPressureBara, maximumVelocityRatio)` returns
+the smallest standard diameter that passes the screening constraints, including
+equality at the specified velocity-ratio limit. If no candidate passes, it throws
+`IllegalStateException` rather than recommending the largest failed candidate.
+The configured diameter is restored after success, exhaustion or an exception.
+Callers must handle sizing failure explicitly; this is a behavior change from the
+previous fallback. The velocity-ratio limit must be finite and positive, and the
+minimum arrival pressure must be finite and positive in bara.
+
+Iteration count alone is not a validity gate: a short line can converge on the
+first refinement sweep. The solver's pressure-floor, time-budget and convergence
+status determine whether its profile is usable.
 
 ### Feeding it a real seabed
 
@@ -218,7 +237,7 @@ characterisation carried.
 - [ ] Shut-in wellhead pressure calculated, not assumed.
 - [ ] Flowline sized at the least-dense condition.
 - [ ] Wellstream hydraulics run with the two-fluid model.
-- [ ] Two-fluid solve converged in more than one iteration.
+- [ ] Two-fluid solver reports convergence.
 - [ ] Route elevations from a real survey, not a flat default.
 - [ ] Wall thickness passes every DNV-ST-F101 limit state.
 - [ ] Insulation checked against the **selected** wall thickness.

--- a/src/main/java/neqsim/process/fielddevelopment/network/MultiphaseFlowIntegrator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/network/MultiphaseFlowIntegrator.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.physicalproperties.PhysicalPropertyType;
 import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.stream.Stream;
@@ -476,7 +477,7 @@ public class MultiphaseFlowIntegrator implements Serializable {
    * @return the pipeline outlet stream
    */
   private StreamInterface runTwoFluid(Stream pipeInlet, PipelineResult result) {
-    TwoFluidPipe pipe = new TwoFluidPipe("Flowline", pipeInlet);
+    TwoFluidPipe pipe = createTwoFluidPipe(pipeInlet);
     pipe.setDiameter(pipelineDiameterM);
     pipe.setRoughness(pipelineRoughnessM);
     pipe.setNumberOfSections(numberOfSegments);
@@ -497,15 +498,23 @@ public class MultiphaseFlowIntegrator implements Serializable {
     pipe.setEnableJouleThomson(true);
     pipe.run();
 
-    // A single-iteration exit means the pressure profile was frozen on the inlet densities.
-    if (!pipe.isSteadyStateConverged() || pipe.getSteadyStateIterationsUsed() <= 1) {
-      logger.warn(
-          "TwoFluidPipe steady state did not converge properly for the {} km flowline "
-              + "(converged={}, iterations={}); treat the pressure drop as unreliable",
-          Double.valueOf(pipelineLengthKm), Boolean.valueOf(pipe.isSteadyStateConverged()),
-          Integer.valueOf(pipe.getSteadyStateIterationsUsed()));
+    // The solver owns convergence, including short lines that settle on the first sweep.
+    if (!pipe.isSteadyStateConverged()) {
+      throw new IllegalStateException("TwoFluidPipe steady state did not converge properly for the " + pipelineLengthKm
+          + " km flowline (converged=" + pipe.isSteadyStateConverged() + ", iterations="
+          + pipe.getSteadyStateIterationsUsed() + "); hydraulic screening was stopped");
     }
     return pipe.getOutletStream();
+  }
+
+  /**
+   * Create the two-fluid solver for a traverse.
+   *
+   * @param inlet the cloned pipeline inlet
+   * @return a new solver
+   */
+  TwoFluidPipe createTwoFluidPipe(Stream inlet) {
+    return new TwoFluidPipe("Flowline", inlet);
   }
 
   /**
@@ -594,7 +603,14 @@ public class MultiphaseFlowIntegrator implements Serializable {
       result.setPressureDropBar(result.getInletPressureBar() - result.getArrivalPressureBar());
 
       // Flow characteristics
+      // The two-fluid outlet sets the transported flow after its flash, invalidating density/volume caches.
+      // Refresh only the state and mass density needed by the velocity and holdup screening calculations.
+      outlet.getFluid().init(1);
+      outlet.getFluid().initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
       double mixtureDensity = outlet.getFluid().getDensity("kg/m3");
+      if (!Double.isFinite(mixtureDensity) || mixtureDensity <= 0.0) {
+        throw new IllegalStateException("Outlet mixture density must be finite and positive");
+      }
       double area = Math.PI * Math.pow(pipelineDiameterM / 2, 2);
       double volumeFlowRate = inlet.getFlowRate("kg/hr") / mixtureDensity / 3600; // m3/s
       double mixtureVelocity = volumeFlowRate / area;
@@ -668,29 +684,42 @@ public class MultiphaseFlowIntegrator implements Serializable {
   /**
    * Size pipeline diameter for given constraints.
    *
+   * <p>
+   * The velocity-ratio limit is inclusive. The configured diameter is restored on every exit, including solver
+   * exceptions. A failed search never returns an unqualified fallback diameter.
+   * </p>
+   *
    * @param inlet inlet stream
    * @param minArrivalP minimum arrival pressure (bara)
    * @param maxVelocityRatio maximum erosional velocity ratio
-   * @return recommended diameter in meters
+   * @return smallest passing standard diameter in meters
+   * @throws IllegalArgumentException if the pressure or velocity-ratio limit is not finite and positive
+   * @throws IllegalStateException if no standard diameter satisfies the screening constraints
    */
   public double sizePipeline(StreamInterface inlet, double minArrivalP, double maxVelocityRatio) {
+    if (!Double.isFinite(minArrivalP) || minArrivalP <= 0.0 || !Double.isFinite(maxVelocityRatio)
+        || maxVelocityRatio <= 0.0) {
+      throw new IllegalArgumentException("Arrival pressure and maximum velocity ratio must be finite and positive");
+    }
     // Try standard pipe sizes (inches to meters)
     double[] standardSizes = { 0.1524, 0.2032, 0.254, 0.3048, 0.3556, 0.4064, 0.4572, 0.508 };
 
     double originalDiameter = pipelineDiameterM;
 
-    for (double diameter : standardSizes) {
-      pipelineDiameterM = diameter;
-      PipelineResult result = calculateHydraulics(inlet, minArrivalP);
-
-      if (result.isFeasible() && result.getErosionalVelocityRatio() < maxVelocityRatio) {
-        pipelineDiameterM = originalDiameter;
-        return diameter;
+    try {
+      for (double diameter : standardSizes) {
+        pipelineDiameterM = diameter;
+        PipelineResult result = calculateHydraulics(inlet, minArrivalP);
+        double velocityRatio = result.getErosionalVelocityRatio();
+        if (result.isFeasible() && Double.isFinite(velocityRatio) && velocityRatio >= 0.0
+            && velocityRatio <= maxVelocityRatio) {
+          return diameter;
+        }
       }
+      throw new IllegalStateException("No standard pipeline diameter satisfies the hydraulic screening constraints");
+    } finally {
+      pipelineDiameterM = originalDiameter;
     }
-
-    pipelineDiameterM = originalDiameter;
-    return standardSizes[standardSizes.length - 1]; // Return largest if none work
   }
 
   // ============================================================================
@@ -786,7 +815,16 @@ public class MultiphaseFlowIntegrator implements Serializable {
    * @param minArrivalP minimum required arrival pressure in bar
    */
   private void checkFeasibility(PipelineResult result, double minArrivalP) {
+    if (!Double.isFinite(minArrivalP) || minArrivalP <= 0.0 || !Double.isFinite(seabedTemperatureC)
+        || !Double.isFinite(result.getArrivalPressureBar()) || result.getArrivalPressureBar() <= 0.0
+        || !Double.isFinite(result.getArrivalTemperatureC()) || !Double.isFinite(result.getErosionalVelocityRatio())
+        || result.getErosionalVelocityRatio() < 0.0) {
+      result.setFeasible(false);
+      result.setInfeasibilityReason("Hydraulic screening requires finite evidence and positive absolute pressures");
+      return;
+    }
     result.setFeasible(true);
+    result.setInfeasibilityReason(null);
 
     // Check arrival pressure
     if (result.getArrivalPressureBar() < minArrivalP) {

--- a/src/test/java/neqsim/process/fielddevelopment/network/MultiphaseFlowIntegratorValidationTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/network/MultiphaseFlowIntegratorValidationTest.java
@@ -1,0 +1,154 @@
+package neqsim.process.fielddevelopment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.fielddevelopment.network.MultiphaseFlowIntegrator.PipelineResult;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for failed and non-finite hydraulic screening results. */
+class MultiphaseFlowIntegratorValidationTest {
+  @Test
+  void documentedScreeningWorkflowRemainsExecutableForBothModels() {
+    for (MultiphaseFlowIntegrator.HydraulicModel model : MultiphaseFlowIntegrator.HydraulicModel.values()) {
+      Stream stream = feed();
+      MultiphaseFlowIntegrator integrator = new MultiphaseFlowIntegrator();
+      integrator.setHydraulicModel(model);
+      integrator.setPipelineLength(1.0);
+      integrator.setPipelineDiameter(0.3);
+      integrator.setOverallHeatTransferCoeff(0.0);
+      integrator.setMinArrivalPressure(1.0);
+      PipelineResult result = integrator.calculateHydraulics(stream, 1.0);
+      assertTrue(result.isFeasible(), result.getInfeasibilityReason());
+      for (PipelineResult point : integrator.calculateHydraulicsCurve(stream.getFluid(), 60.0,
+          new double[] { 5000.0, 10000.0 })) {
+        assertTrue(point.isFeasible(), point.getInfeasibilityReason());
+      }
+      double diameter = integrator.sizePipeline(stream, 1.0, 0.8);
+      integrator.setPipelineDiameter(diameter);
+      PipelineResult sized = integrator.calculateHydraulics(stream, 1.0);
+      assertTrue(sized.isFeasible(), sized.getInfeasibilityReason());
+      assertTrue(sized.getErosionalVelocityRatio() <= 0.8);
+    }
+  }
+
+  @Test
+  void rejectsUnconvergedTwoFluidProfile() {
+    final TwoFluidPipe[] solver = new TwoFluidPipe[1];
+    MultiphaseFlowIntegrator integrator = new MultiphaseFlowIntegrator() {
+      @Override
+      TwoFluidPipe createTwoFluidPipe(Stream inlet) {
+        TwoFluidPipe pipe = super.createTwoFluidPipe(inlet);
+        pipe.setSteadyStateMaxIterations(1);
+        solver[0] = pipe;
+        return pipe;
+      }
+    };
+    integrator.setPipelineLength(10.0);
+    integrator.setPipelineDiameter(0.1);
+    integrator.setNumberOfSegments(5);
+    PipelineResult result = integrator.calculateHydraulics(feed(), 1.0);
+    assertFalse(solver[0].isSteadyStateConverged(), "Fixture must exhaust the refinement budget");
+    assertFalse(result.isFeasible());
+    assertTrue(result.getInfeasibilityReason().contains("converg"), result.getInfeasibilityReason());
+  }
+
+  @Test
+  void rejectsNonFiniteFeasibilityEvidence() throws Exception {
+    MultiphaseFlowIntegrator integrator = new MultiphaseFlowIntegrator();
+    Method check = MultiphaseFlowIntegrator.class.getDeclaredMethod("checkFeasibility", PipelineResult.class,
+        double.class);
+    check.setAccessible(true);
+    for (int field = 0; field < 4; field++) {
+      PipelineResult result = validResult();
+      double minimumPressure = 10.0;
+      if (field == 0) {
+        result.setArrivalPressureBar(Double.NaN);
+      } else if (field == 1) {
+        result.setArrivalTemperatureC(Double.POSITIVE_INFINITY);
+      } else if (field == 2) {
+        result.setErosionalVelocityRatio(Double.NaN);
+      } else {
+        minimumPressure = Double.NaN;
+      }
+      check.invoke(integrator, result, minimumPressure);
+      assertFalse(result.isFeasible(), "Non-finite evidence field " + field);
+      assertTrue(result.getInfeasibilityReason().contains("finite"));
+    }
+    PipelineResult valid = validResult();
+    check.invoke(integrator, valid, 10.0);
+    assertTrue(valid.isFeasible());
+  }
+
+  @Test
+  void sizingRejectsAllFailedCandidatesAndRestoresDiameter() {
+    MultiphaseFlowIntegrator integrator = sizingStub(false, false);
+    integrator.setPipelineDiameter(0.3);
+    assertThrows(IllegalStateException.class, () -> integrator.sizePipeline(null, 10.0, 0.8));
+    assertEquals(0.3, integrator.getPipelineDiameterM());
+  }
+
+  @Test
+  void sizingRestoresDiameterAfterCalculationThrows() {
+    MultiphaseFlowIntegrator integrator = sizingStub(false, true);
+    integrator.setPipelineDiameter(0.3);
+    assertThrows(IllegalStateException.class, () -> integrator.sizePipeline(null, 10.0, 0.8));
+    assertEquals(0.3, integrator.getPipelineDiameterM());
+  }
+
+  @Test
+  void sizingSelectsFirstPassingCandidateAndAcceptsLimitEquality() {
+    MultiphaseFlowIntegrator integrator = sizingStub(true, false);
+    integrator.setPipelineDiameter(0.3);
+    assertEquals(0.254, integrator.sizePipeline(null, 10.0, 0.8));
+    assertEquals(0.3, integrator.getPipelineDiameterM());
+  }
+
+  @Test
+  void sizingRejectsInvalidVelocityLimit() {
+    MultiphaseFlowIntegrator integrator = sizingStub(true, false);
+    for (double limit : new double[] { 0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY }) {
+      assertThrows(IllegalArgumentException.class, () -> integrator.sizePipeline(null, 10.0, limit));
+    }
+  }
+
+  private static MultiphaseFlowIntegrator sizingStub(final boolean succeeds, final boolean throwsException) {
+    return new MultiphaseFlowIntegrator() {
+      @Override
+      public PipelineResult calculateHydraulics(StreamInterface inlet, double arrivalPressureBar) {
+        if (throwsException) {
+          throw new IllegalStateException("Synthetic solver failure");
+        }
+        PipelineResult result = validResult();
+        result.setFeasible(succeeds && getPipelineDiameterM() >= 0.254);
+        result.setErosionalVelocityRatio(0.8);
+        return result;
+      }
+    };
+  }
+
+  private static PipelineResult validResult() {
+    PipelineResult result = new PipelineResult();
+    result.setArrivalPressureBar(40.0);
+    result.setArrivalTemperatureC(50.0);
+    result.setErosionalVelocityRatio(0.5);
+    return result;
+  }
+
+  private static Stream feed() {
+    SystemSrkEos fluid = new SystemSrkEos(323.15, 60.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream("feed", fluid);
+    stream.setFlowRate(10000.0, "kg/hr");
+    stream.run();
+    return stream;
+  }
+}


### PR DESCRIPTION
## Why this is needed before 3.20.0

The release review found a connected set of failures in `MultiphaseFlowIntegrator`, which now defaults to TwoFluidPipe after #3463:

- Non-converged pipe profiles were logged and then still used for feasibility screening.
- The two-fluid outlet resets its flow after flashing. Its density/volume properties were not refreshed before screening, producing zero mixture density, infinite velocities and a NaN erosional ratio on an ordinary methane case. NaN comparisons then failed to reject invalid evidence.
- `sizePipeline()` returned the largest standard diameter when every candidate failed, rejected equality at the declared maximum velocity ratio, and left the configured diameter changed when a calculation threw.

## Changes

Refresh outlet thermodynamic state and mass density before deriving screening velocities; require positive finite density. Reject non-converged traverses and non-finite feasibility evidence. Use the solver convergence flag, not an iteration-count heuristic: a short line can legitimately converge on refinement index zero.

Sizing now returns the first passing candidate with an inclusive velocity limit, rejects invalid limits, throws explicitly when none pass, and restores the configured diameter in a finally block. A package-private solver factory lets the regression fixture exercise a real TwoFluidPipe with a one-iteration budget; production construction is unchanged.

Update the tieback guide and repair obsolete hydraulic API examples and default-model descriptions in the digital field twin guide. The documented example is exercised with both hydraulic models.

## Evidence and validation

Reviewed master `db59960405882d9cd30b960517f9460e06da4120`. The final seven tests fail against original production behavior with only the nonfunctional solver-construction seam added; all pass with this fix. These include actual non-convergence, non-finite evidence, failed sizing, exception restoration, limit equality, invalid limits, and a complete successful screening/curve/sizing workflow.

A pure methane case at 60 bara, 50 C, 10,000 kg/h, 1 km and 0.3 m previously returned infinite mixture/erosional velocities and NaN ratio on TWO_FLUID. After property initialization:
- velocity: 1.026454 m/s;
- erosional ratio: 0.05205861;
- outlet pressure and temperature remain 59.99057476 bara and 49.99692131 C;
- Beggs-Brill control: 1.026457 m/s and ratio 0.05205869.

Executed on OpenJDK 17.0.20:
- `./mvnw test -Dtest=MultiphaseFlowIntegratorValidationTest,TiebackTest -Djacoco.skip=true -ntp`: **32 passed, zero failures/errors/skips**.
- `python devtools/run_spotless.py apply` and `check`: passed.
- `python devtools/check_documentation_search.py`: passed, 691 Markdown pages and one HTML page.
- Changed production class compiled with `javac --release 8` through the installed JDK compiler module: passed.
- Scoped production Javadoc: passed; existing missing-comment warnings remain.
- `git diff --check`: passed.
- Pre-commit launcher unavailable; configured formatter and documentation checks ran directly.

**VALIDATION PENDING CI** for the published head and full supported runtime/platform matrix. Maven was bootstrapped with the work-with-neqsim helper.

## Release coordination and scope

Rechecked all six open PR file sets (#3460, #3514, #3527, #3528, #3529, #3530); no changed-file overlap. This branch does not modify TwoFluidPipe or duplicate its physics repairs in #3514. The optimizer/units/convergence repairs in #3527 also merit release attention; they remain owned by that PR.

Documentation impact: user-visible sizing failure semantics change. Callers must handle IllegalStateException when no standard diameter qualifies; the largest failing size is no longer presented as a recommendation. Hydraulic defaults, closure equations, pressure/thermal solver tolerances and severe-slug qualification are unchanged. This is screening reliability, not full physical qualification of the pipe model.

AI-assisted implementation. Draft for review and CI.