### PR TITLE
[AI-Assisted] feat(dexpi): expose transition component evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -277,14 +277,17 @@ from/to `DexpiConnectionEndpointInfo` records, optional from/to cycle IDs, and a
 `LEAVING`, or `BETWEEN_CYCLES` classification. Reader-produced values also expose the exact
 immutable cycle objects from `ImportResult.getConnectionCycles()` through `getFromCycle()` and
 `getToCycle()`. They also expose the exact boundary objects already present in those cycles through
-`getFromCycleBoundary()` and `getToCycleBoundary()`. An entering transition carries only the
-target cycle's `INCOMING` boundary, a leaving transition carries only the source cycle's
-`OUTGOING` boundary, and a between-cycle transition carries both. Corresponding evidence markers
-distinguish this reader projection from values created with either legacy constructor, whose cycle
-and boundary object getters return `null` while their scalar cycle IDs remain unchanged. A
-connection from one cyclic strongly connected group to another appears once with both cycle IDs,
-both complete cycle objects, and both directional boundary objects; callers do not need to scan or
-join the two cycle inventories. Parallel occurrences remain distinct, unresolved non-empty endpoints
+`getFromCycleBoundary()` and `getToCycleBoundary()`, and the exact immutable owning
+`DexpiConnectionComponentInfo` objects through `getFromCycleComponent()` and
+`getToCycleComponent()`. An entering transition carries only the target cycle's component and
+`INCOMING` boundary, a leaving transition carries only the source cycle's component and
+`OUTGOING` boundary, and a between-cycle transition carries both component and boundary pairs.
+Corresponding evidence markers distinguish this reader projection from values created with the
+ID-only legacy constructor, whose cycle, component, and boundary object getters return `null`
+while scalar cycle IDs remain unchanged. A connection from one cyclic strongly connected group to
+another appears once with both cycle IDs, both complete cycle objects, both exact owning components,
+and both directional boundary objects; callers do not need to scan or join the cycle or component
+inventories. Parallel occurrences remain distinct, unresolved non-empty endpoints
 remain visible, and connections with a blank endpoint stay in the global connection and diagnostic
 evidence because a transition cannot assign them to a cycle. `toJson()` includes the cycle- and
 boundary-evidence markers and nested from/to cycle and boundary objects when present. This
@@ -298,7 +301,7 @@ identify a physical recycle, enumerate paths, or alter simulation topology.
 component, directed-cycle, and cycle-transition inventories, including reference resolution,
 incidence roles, review subsets, complete component- and cycle-local endpoint and connection
 occurrences, explicit cycle-boundary occurrences, and exact-once transitions with nested connection, endpoint,
-cycle, and directional boundary evidence, alongside the process-unit count and findings. Python callers through JPype use the same
+cycle, exact owning-component, and directional boundary evidence, alongside the process-unit count and findings. Python callers through JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getInstrumentationLoops()`,
 `ImportResult.getActuatingFunctions()`, `ImportResult.getInformationFlows()`,
 `ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -249,8 +249,7 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     result.put("kind", kind.name());
     result.put("fromCycle", fromCycle == null ? null : fromCycle.toMap());
     result.put("toCycle", toCycle == null ? null : toCycle.toMap());
-    result.put("fromCycleComponent",
-        getFromCycleComponent() == null ? null : getFromCycleComponent().toMap());
+    result.put("fromCycleComponent", getFromCycleComponent() == null ? null : getFromCycleComponent().toMap());
     result.put("toCycleComponent", getToCycleComponent() == null ? null : getToCycleComponent().toMap());
     result.put("fromCycleBoundary", fromCycleBoundary == null ? null : fromCycleBoundary.toMap());
     result.put("toCycleBoundary", toCycleBoundary == null ? null : toCycleBoundary.toMap());

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -155,6 +155,16 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     return fromCycle != null;
   }
 
+  /** @return source cycle's exact owning component evidence, or {@code null} when outside or unavailable */
+  public DexpiConnectionComponentInfo getFromCycleComponent() {
+    return fromCycle == null ? null : fromCycle.getConnectionComponent();
+  }
+
+  /** @return whether exact owning-component evidence is available for the source cycle */
+  public boolean hasFromCycleComponentEvidence() {
+    return getFromCycleComponent() != null;
+  }
+
   /** @return source cycle's outgoing boundary evidence, or {@code null} when outside or unavailable */
   public DexpiConnectionCycleBoundaryInfo getFromCycleBoundary() {
     return fromCycleBoundary;
@@ -183,6 +193,16 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
   /** @return whether complete target directed-cycle evidence is available */
   public boolean hasToCycleEvidence() {
     return toCycle != null;
+  }
+
+  /** @return target cycle's exact owning component evidence, or {@code null} when outside or unavailable */
+  public DexpiConnectionComponentInfo getToCycleComponent() {
+    return toCycle == null ? null : toCycle.getConnectionComponent();
+  }
+
+  /** @return whether exact owning-component evidence is available for the target cycle */
+  public boolean hasToCycleComponentEvidence() {
+    return getToCycleComponent() != null;
   }
 
   /** @return target cycle's incoming boundary evidence, or {@code null} when outside or unavailable */
@@ -224,9 +244,14 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
     result.put("hasToCycleEvidence", Boolean.valueOf(hasToCycleEvidence()));
     result.put("hasFromCycleBoundaryEvidence", Boolean.valueOf(hasFromCycleBoundaryEvidence()));
     result.put("hasToCycleBoundaryEvidence", Boolean.valueOf(hasToCycleBoundaryEvidence()));
+    result.put("hasFromCycleComponentEvidence", Boolean.valueOf(hasFromCycleComponentEvidence()));
+    result.put("hasToCycleComponentEvidence", Boolean.valueOf(hasToCycleComponentEvidence()));
     result.put("kind", kind.name());
     result.put("fromCycle", fromCycle == null ? null : fromCycle.toMap());
     result.put("toCycle", toCycle == null ? null : toCycle.toMap());
+    result.put("fromCycleComponent",
+        getFromCycleComponent() == null ? null : getFromCycleComponent().toMap());
+    result.put("toCycleComponent", getToCycleComponent() == null ? null : getToCycleComponent().toMap());
     result.put("fromCycleBoundary", fromCycleBoundary == null ? null : fromCycleBoundary.toMap());
     result.put("toCycleBoundary", toCycleBoundary == null ? null : toCycleBoundary.toMap());
     result.put("connection", connection.toMap());

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -1257,10 +1257,14 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertNull(entering.getFromCycle());
     assertFalse(entering.hasFromCycleBoundaryEvidence());
     assertNull(entering.getFromCycleBoundary());
+    assertFalse(entering.hasFromCycleComponentEvidence());
+    assertNull(entering.getFromCycleComponent());
     assertEquals("cycle-1", entering.getToCycleId());
     assertTrue(entering.hasToCycle());
     assertTrue(entering.hasToCycleEvidence());
     assertSame(first.getConnectionCycles().get(0), entering.getToCycle());
+    assertTrue(entering.hasToCycleComponentEvidence());
+    assertSame(first.getConnectionCycles().get(0).getConnectionComponent(), entering.getToCycleComponent());
     assertTrue(entering.hasToCycleBoundaryEvidence());
     assertSame(findCycleBoundary(first.getConnectionCycles().get(0), "C-IN-1",
         DexpiConnectionCycleBoundaryInfo.Direction.INCOMING), entering.getToCycleBoundary());
@@ -1277,6 +1281,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(DexpiConnectionCycleTransitionInfo.Kind.ENTERING, parallelEntering.getKind());
     assertEquals("cycle-1", parallelEntering.getToCycleId());
     assertSame(first.getConnectionCycles().get(0), parallelEntering.getToCycle());
+    assertFalse(parallelEntering.hasFromCycleComponentEvidence());
+    assertNull(parallelEntering.getFromCycleComponent());
+    assertTrue(parallelEntering.hasToCycleComponentEvidence());
+    assertSame(first.getConnectionCycles().get(0).getConnectionComponent(), parallelEntering.getToCycleComponent());
     assertFalse(parallelEntering.hasFromCycleBoundaryEvidence());
     assertNull(parallelEntering.getFromCycleBoundary());
     assertTrue(parallelEntering.hasToCycleBoundaryEvidence());
@@ -1294,6 +1302,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(between.hasToCycleEvidence());
     assertSame(first.getConnectionCycles().get(0), between.getFromCycle());
     assertSame(first.getConnectionCycles().get(1), between.getToCycle());
+    assertTrue(between.hasFromCycleComponentEvidence());
+    assertTrue(between.hasToCycleComponentEvidence());
+    assertSame(first.getConnectionCycles().get(0).getConnectionComponent(), between.getFromCycleComponent());
+    assertSame(first.getConnectionCycles().get(1).getConnectionComponent(), between.getToCycleComponent());
     assertTrue(between.hasFromCycleBoundaryEvidence());
     assertTrue(between.hasToCycleBoundaryEvidence());
     assertSame(findCycleBoundary(first.getConnectionCycles().get(0), "C-BX",
@@ -1312,9 +1324,13 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(leaving.hasFromCycle());
     assertTrue(leaving.hasFromCycleEvidence());
     assertSame(first.getConnectionCycles().get(1), leaving.getFromCycle());
+    assertTrue(leaving.hasFromCycleComponentEvidence());
+    assertSame(first.getConnectionCycles().get(1).getConnectionComponent(), leaving.getFromCycleComponent());
     assertFalse(leaving.hasToCycle());
     assertFalse(leaving.hasToCycleEvidence());
     assertNull(leaving.getToCycle());
+    assertFalse(leaving.hasToCycleComponentEvidence());
+    assertNull(leaving.getToCycleComponent());
     assertTrue(leaving.hasFromCycleBoundaryEvidence());
     assertSame(findCycleBoundary(first.getConnectionCycles().get(1), "C-OUT",
         DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING), leaving.getFromCycleBoundary());
@@ -1343,6 +1359,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(legacy.hasToCycleBoundaryEvidence());
     assertNull(legacy.getFromCycleBoundary());
     assertNull(legacy.getToCycleBoundary());
+    assertFalse(legacy.hasFromCycleComponentEvidence());
+    assertFalse(legacy.hasToCycleComponentEvidence());
+    assertNull(legacy.getFromCycleComponent());
+    assertNull(legacy.getToCycleComponent());
 
     assertTrue(first.toJson().contains("\"connectionCycleTransitionCount\": 4"));
     assertTrue(first.toJson().contains("\"kind\": \"BETWEEN_CYCLES\""));
@@ -1356,6 +1376,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"hasToCycleBoundaryEvidence\": true"));
     assertTrue(first.toJson().contains("\"fromCycleBoundary\": {"));
     assertTrue(first.toJson().contains("\"toCycleBoundary\": {"));
+    assertTrue(first.toJson().contains("\"hasFromCycleComponentEvidence\": true"));
+    assertTrue(first.toJson().contains("\"hasToCycleComponentEvidence\": true"));
+    assertTrue(first.toJson().contains("\"fromCycleComponent\": {"));
+    assertTrue(first.toJson().contains("\"toCycleComponent\": {"));
     assertTrue(first.toJson().contains("\"fromEndpoint\": {"));
     assertTrue(first.toJson().contains("\"toEndpoint\": {"));
     assertEquals(first.toJson(), second.toJson());


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 with direct exact owning-component evidence on DEXPI directed-cycle transitions.

- Exposes `getFromCycleComponent()` and `getToCycleComponent()` plus explicit evidence markers.
- Reuses the exact immutable `DexpiConnectionComponentInfo` already owned by each transition's cycle.
- Entering transitions expose only the target-cycle component; leaving transitions expose only the source-cycle component; between-cycle transitions expose both.
- ID-only legacy values retain scalar cycle IDs while component evidence remains absent.
- Adds deterministic nullable nested component evidence to JSON.
- Adds no reader graph scan and preserves O(V+E) import behavior, Java 8 compatibility, ordering, parallel/unresolved occurrences, existing fields, topology, simulation, rendering, layout, and exports.

Capability contracts:
- #1332: https://github.com/equinor/neqsim/issues/1332#issuecomment-5567378503
- #2899: https://github.com/equinor/neqsim/issues/2899#issuecomment-5567382532

## Exact continuity and scope

- Exact reserved base: `db59960405882d9cd30b960517f9460e06da4120`
- Current master at publication: `4ee1e4adbd951c7621a80a7c1ad592f40882f04e`
- Exact head: `d01ea5155590df04a740753a55534b466c93bdee`
- Branch: `ai/dexpi-transition-component-evidence`
- Four ordered commits across three intended files; tests authored first.
- Master is one unrelated commit ahead, changing only the real-time documentation example and its documentation compilation fixture; no file overlap and no rebase occurred.
- Open autonomous drafts #3514, #3527, #3528, #3530, and #3531 do not overlap this DEXPI scope.
- This is the sole active PFD/P&ID/DEXPI shared-lane PR.
- Portfolio occupancy including this draft: **6/10**.

## Acceptance evidence

Focused regression assertions require exact object identity for reader-produced transition components:
- entering and parallel-entering: target component only;
- leaving: source component only;
- between cycles: both components;
- ID-only legacy constructor: neither component;
- deterministic JSON: evidence booleans and nested component records.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

The prior head's only branch-attributable failure was Spotless in pre-commit. The exact hosted one-file `spotless-format-patch` artifact (digest `sha256:6b13577f7a014ad5d98c7d9c353b1fa728de08585c42c154cfa2ab47f02a8ce0`) was applied without semantic or scope changes. GitHub Actions on exact head `d01ea5155590df04a740753a55534b466c93bdee` are authoritative. Required gates include focused regression coverage, Java 8/21 on Ubuntu and Windows, all slow shards, Javadocs, Spotless/pre-commit, documentation search, engineering-diagram performance, CodeQL, PaperLab, and reference checks.

## Documentation and boundary

The DEXPI reader guide documents object identity, one-sided transition rules, legacy behavior, and JSON projection.

This remains source-document evidence only. It does not infer a hydraulic recycle, enumerate paths, repair or rewire topology, change simulation/rendering/layout/export behavior, assign safety credit, claim DEXPI/ISO/ISA conformance, certify a diagram, or provide accountable engineering approval. The whole-sheet visual defect gate is not applicable because rendering is unchanged.

## Draft-only workflow

Keep this PR open and draft. Do not merge, enable auto-merge, mark ready for review, rebase, synchronize with `master`, force-push, close, replace, or abandon it as part of campaign automation.