### PR TITLE
Add temperature units to column endpoint setters

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
@@ -9,6 +9,7 @@ import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.util.unit.TemperatureUnit;
 
 /**
  * SimpleTray class.
@@ -67,6 +68,30 @@ public class SimpleTray extends neqsim.process.equipment.mixer.Mixer implements 
    */
   public SimpleTray(String name) {
     super(name);
+  }
+
+  /**
+   * Set the tray outlet temperature with unit conversion.
+   *
+   * @param outTemperature outlet temperature
+   * @param unit temperature unit, for example {@code "K"}, {@code "C"}, {@code "F"}, or {@code "R"}
+   * @throws IllegalArgumentException if the temperature unit is unsupported
+   */
+  public void setOutletTemperature(double outTemperature, String unit) {
+    setOutletTemperature(new TemperatureUnit(outTemperature, unit).getValue("K"));
+  }
+
+  /**
+   * Set the tray outlet temperature with unit conversion.
+   *
+   * @param outTemperature outlet temperature
+   * @param unit temperature unit, for example {@code "K"}, {@code "C"}, {@code "F"}, or {@code "R"}
+   * @throws IllegalArgumentException if the temperature unit is unsupported
+   * @deprecated use {@link #setOutletTemperature(double, String)} instead
+   */
+  @Deprecated
+  public void setOutTemperature(double outTemperature, String unit) {
+    setOutletTemperature(outTemperature, unit);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
@@ -548,6 +548,18 @@ public class DistillationColumnTest {
   }
 
   @Test
+  public void endpointTraysSupportTemperatureUnits() {
+    DistillationColumn column = new DistillationColumn("endpoint temperature units", 3, true, true);
+
+    column.getReboiler().setOutTemperature(164.0, "C");
+    column.getCondenser().setOutletTemperature(176.0, "F");
+
+    assertEquals(437.15, column.getReboiler().getOutTemperature(), 1.0e-12);
+    assertEquals(353.15, column.getCondenser().getOutTemperature(), 1.0e-12);
+    assertThrows(IllegalArgumentException.class, () -> column.getReboiler().setOutletTemperature(164.0, "degC"));
+  }
+
+  @Test
   public void condenserRefluxFlashIncludesAllInletStreams() {
     Stream firstFeed = createTerminalRegressionStream("condenser first", 100.0);
     Stream secondFeed = createTerminalRegressionStream("condenser second", 25.0);


### PR DESCRIPTION
Adds unit-aware outlet-temperature setters to `SimpleTray`, enabling direct reboiler and condenser calls such as `setOutTemperature(164.0, "C")` and `setOutletTemperature(176.0, "F")`.

The existing single-argument Kelvin setters remain backward compatible. Focused tests cover Celsius, Fahrenheit, and unsupported-unit handling.

Validation:
- `mvnw.cmd test -Dtest=DistillationColumnTest#endpointTraysSupportTemperatureUnits`
- `mvnw.cmd javadoc:javadoc`
- `mvnw.cmd spotless:apply`