### PR TITLE
[AI-Assisted] feat(pitzer): add weighted volumetric regression diagnostics

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -687,6 +687,30 @@ double density = PitzerBinaryVolumetricModel.calculateDensity(
     apparentMolarVolume);
 ```
 
+### Parameter regression and identifiability
+
+`PitzerBinaryVolumetricRegression` performs weighted linear regression for one
+common temperature-pressure state. The caller supplies every apparent-molar-
+volume observation, its absolute one-sigma uncertainty, a laboratory or
+source-lineage identifier, and the Debye-Hückel volume slope. The regression
+fits `V°`, `β⁽⁰⁾_V`, `β⁽¹⁾_V`, and `Cφ_V` without installing the result
+in a phase or changing a default model.
+
+The weighted design matrix is column-scaled and solved by singular-value
+decomposition. A fit fails closed when the concentration design is rank
+deficient or excessively ill-conditioned. `FitResult` reports coefficient
+covariance and standard uncertainties, chi-square, reduced chi-square,
+weighted RMS residual, maximum standardized residual, and deterministic
+per-source-group residual diagnostics. Covariance assumes that input
+uncertainties are absolute one-sigma values.
+
+Regression capability does not make an input dataset acceptable. Callers must
+separately establish row provenance, redistribution rights, uncertainty
+meaning, species and composition basis, validity range, and an independent
+laboratory-grouped validation split. The reserved Al Ghafri/NIST ThermoML
+pressure series must not be supplied as calibration input when it is retained
+as the campaign hold-out.
+
 ### Qualification boundary
 
 - The caller owns coefficient provenance and must keep calibration and
@@ -963,6 +987,8 @@ component.setCostaldCharacteristicVolume(newValue);  // cm³/mol
 | `calculateDensity(...)` | Convert apparent molar volume to density on a 1 kg solvent basis |
 | `calculateApparentMolarVolumeFromDensity(...)` | Invert a density observation to apparent molar volume |
 | `calculateIonicStrength(...)` | Return the binary salt's stoichiometric ionic strength |
+| `PitzerBinaryVolumetricRegression.fit(...)` | Fit caller-supplied one-state observations with SVD rank checks |
+| `FitResult.getGroupStatistics()` | Inspect residuals by laboratory or source lineage |
 
 These methods do not install a parameter dataset or alter a phase. A caller
 must explicitly supply a provenance-qualified `StateParameters` instance.

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegression.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegression.java
@@ -1,0 +1,490 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.apache.commons.math3.linear.SingularValueDecomposition;
+
+/**
+ * Weighted linear regression for one-state binary-electrolyte volumetric Pitzer parameters.
+ *
+ * <p>
+ * The regression is parameter and dataset neutral. Callers supply apparent-molar-volume
+ * observations, one-sigma uncertainties, source-group identifiers, and the Debye-Huckel volume
+ * slope at a common temperature and pressure. The fit estimates the limiting apparent molar
+ * volume and the three binary interaction pressure derivatives used by
+ * {@link PitzerBinaryVolumetricModel}.
+ * </p>
+ *
+ * <p>
+ * Weighted design columns are normalized before singular-value decomposition. Rank-deficient and
+ * excessively ill-conditioned designs fail closed. Returned covariance assumes that the supplied
+ * standard uncertainties are absolute one-sigma uncertainties.
+ * </p>
+ */
+public final class PitzerBinaryVolumetricRegression implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final int PARAMETER_COUNT = 4;
+  private static final double RELATIVE_RANK_TOLERANCE = 1.0e-12;
+  private static final double MAXIMUM_CONDITION_NUMBER = 1.0e10;
+
+  private final PitzerBinaryVolumetricModel model;
+
+  /**
+   * Construct a regression for one binary-electrolyte model.
+   *
+   * @param model parameter-neutral binary volumetric Pitzer model
+   */
+  public PitzerBinaryVolumetricRegression(PitzerBinaryVolumetricModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException("Binary volumetric Pitzer model must not be null");
+    }
+    this.model = model;
+  }
+
+  /**
+   * Fit one common temperature-pressure state.
+   *
+   * @param observations apparent-molar-volume observations with absolute one-sigma uncertainties
+   * @param temperatureK common temperature in K
+   * @param pressurePa common absolute pressure in Pa
+   * @param debyeHuckelVolumeSlope caller-supplied Debye-Huckel volume slope in SI units
+   * @return immutable fit result and diagnostics
+   */
+  public FitResult fit(List<Observation> observations, double temperatureK, double pressurePa,
+      double debyeHuckelVolumeSlope) {
+    requirePositive(temperatureK, "Regression temperature");
+    requirePositive(pressurePa, "Regression pressure");
+    requireFinite(debyeHuckelVolumeSlope, "Debye-Huckel volume slope");
+    if (observations == null || observations.size() <= PARAMETER_COUNT) {
+      throw new IllegalArgumentException(
+          "Volumetric Pitzer regression requires at least five observations");
+    }
+
+    int observationCount = observations.size();
+    double[][] weightedDesign = new double[observationCount][PARAMETER_COUNT];
+    double[] weightedResponse = new double[observationCount];
+    double[][] unweightedDesign = new double[observationCount][PARAMETER_COUNT];
+    double[] debyeContributions = new double[observationCount];
+
+    PitzerBinaryVolumetricModel.StateParameters debyeParameters =
+        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa,
+            debyeHuckelVolumeSlope, 0.0, 0.0, 0.0);
+    PitzerBinaryVolumetricModel.StateParameters beta0Unit =
+        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa, 0.0, 1.0, 0.0,
+            0.0);
+    PitzerBinaryVolumetricModel.StateParameters beta1Unit =
+        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa, 0.0, 0.0, 1.0,
+            0.0);
+    PitzerBinaryVolumetricModel.StateParameters cphiUnit =
+        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa, 0.0, 0.0, 0.0,
+            1.0);
+
+    for (int row = 0; row < observationCount; row++) {
+      Observation observation = observations.get(row);
+      if (observation == null) {
+        throw new IllegalArgumentException("Volumetric Pitzer observations must not contain null");
+      }
+      double molality = observation.getMolality();
+      double debyeContribution =
+          model.calculateApparentMolarVolume(molality, 0.0, debyeParameters);
+      debyeContributions[row] = debyeContribution;
+
+      double[] designRow = unweightedDesign[row];
+      designRow[0] = 1.0;
+      designRow[1] = model.calculateApparentMolarVolume(molality, 0.0, beta0Unit);
+      designRow[2] = model.calculateApparentMolarVolume(molality, 0.0, beta1Unit);
+      designRow[3] = model.calculateApparentMolarVolume(molality, 0.0, cphiUnit);
+
+      double inverseUncertainty = 1.0 / observation.getStandardUncertainty();
+      weightedResponse[row] =
+          (observation.getApparentMolarVolume() - debyeContribution) * inverseUncertainty;
+      for (int column = 0; column < PARAMETER_COUNT; column++) {
+        weightedDesign[row][column] = designRow[column] * inverseUncertainty;
+      }
+    }
+
+    double[] columnNorms = calculateColumnNorms(weightedDesign);
+    double[][] scaledDesign = new double[observationCount][PARAMETER_COUNT];
+    for (int row = 0; row < observationCount; row++) {
+      for (int column = 0; column < PARAMETER_COUNT; column++) {
+        scaledDesign[row][column] = weightedDesign[row][column] / columnNorms[column];
+      }
+    }
+
+    RealMatrix designMatrix = new Array2DRowRealMatrix(scaledDesign, false);
+    SingularValueDecomposition decomposition = new SingularValueDecomposition(designMatrix);
+    double[] singularValues = decomposition.getSingularValues();
+    double largestSingularValue = singularValues[0];
+    double rankTolerance = RELATIVE_RANK_TOLERANCE * largestSingularValue;
+    int rank = 0;
+    double smallestRetainedSingularValue = Double.POSITIVE_INFINITY;
+    for (double singularValue : singularValues) {
+      if (singularValue > rankTolerance) {
+        rank++;
+        smallestRetainedSingularValue =
+            Math.min(smallestRetainedSingularValue, singularValue);
+      }
+    }
+    if (rank < PARAMETER_COUNT) {
+      throw new IllegalArgumentException(
+          "Volumetric Pitzer regression design is rank deficient: rank " + rank + " of "
+              + PARAMETER_COUNT);
+    }
+
+    double conditionNumber = largestSingularValue / smallestRetainedSingularValue;
+    if (!Double.isFinite(conditionNumber) || conditionNumber > MAXIMUM_CONDITION_NUMBER) {
+      throw new IllegalArgumentException(
+          "Volumetric Pitzer regression design is ill-conditioned: scaled condition number "
+              + conditionNumber);
+    }
+
+    RealVector scaledSolution =
+        decomposition.getSolver().solve(new ArrayRealVector(weightedResponse, false));
+    double[] coefficients = new double[PARAMETER_COUNT];
+    for (int index = 0; index < PARAMETER_COUNT; index++) {
+      coefficients[index] = scaledSolution.getEntry(index) / columnNorms[index];
+      requireFinite(coefficients[index], "Fitted volumetric Pitzer coefficient");
+    }
+
+    double[][] covariance = calculateCovariance(decomposition, singularValues, columnNorms);
+    double[] standardUncertainties = new double[PARAMETER_COUNT];
+    for (int index = 0; index < PARAMETER_COUNT; index++) {
+      double variance = covariance[index][index];
+      if (!Double.isFinite(variance) || variance < 0.0) {
+        throw new IllegalArgumentException(
+            "Volumetric Pitzer regression produced an invalid coefficient variance");
+      }
+      standardUncertainties[index] = Math.sqrt(variance);
+    }
+
+    PitzerBinaryVolumetricModel.StateParameters fittedParameters =
+        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa,
+            debyeHuckelVolumeSlope, coefficients[1], coefficients[2], coefficients[3]);
+
+    double chiSquare = 0.0;
+    double maximumAbsoluteStandardizedResidual = 0.0;
+    Map<String, MutableGroupStatistics> mutableGroups =
+        new TreeMap<String, MutableGroupStatistics>();
+    for (int row = 0; row < observationCount; row++) {
+      Observation observation = observations.get(row);
+      double fittedVolume = debyeContributions[row];
+      for (int column = 0; column < PARAMETER_COUNT; column++) {
+        fittedVolume += unweightedDesign[row][column] * coefficients[column];
+      }
+      double residual = observation.getApparentMolarVolume() - fittedVolume;
+      double standardizedResidual = residual / observation.getStandardUncertainty();
+      requireFinite(standardizedResidual, "Standardized volumetric Pitzer residual");
+      chiSquare += standardizedResidual * standardizedResidual;
+      maximumAbsoluteStandardizedResidual =
+          Math.max(maximumAbsoluteStandardizedResidual, Math.abs(standardizedResidual));
+
+      MutableGroupStatistics group = mutableGroups.get(observation.getSourceGroup());
+      if (group == null) {
+        group = new MutableGroupStatistics(observation.getSourceGroup());
+        mutableGroups.put(observation.getSourceGroup(), group);
+      }
+      group.add(residual, standardizedResidual);
+    }
+
+    int degreesOfFreedom = observationCount - PARAMETER_COUNT;
+    List<GroupStatistics> groups = new ArrayList<GroupStatistics>();
+    for (MutableGroupStatistics group : mutableGroups.values()) {
+      groups.add(group.toImmutable());
+    }
+
+    return new FitResult(coefficients[0], fittedParameters, standardUncertainties, covariance,
+        observationCount, degreesOfFreedom, chiSquare, conditionNumber,
+        maximumAbsoluteStandardizedResidual, groups);
+  }
+
+  private static double[] calculateColumnNorms(double[][] design) {
+    double[] norms = new double[PARAMETER_COUNT];
+    for (double[] row : design) {
+      for (int column = 0; column < PARAMETER_COUNT; column++) {
+        norms[column] = Math.hypot(norms[column], row[column]);
+      }
+    }
+    for (int column = 0; column < PARAMETER_COUNT; column++) {
+      if (!Double.isFinite(norms[column]) || norms[column] <= 0.0) {
+        throw new IllegalArgumentException(
+            "Volumetric Pitzer regression has an empty or non-finite design column");
+      }
+    }
+    return norms;
+  }
+
+  private static double[][] calculateCovariance(SingularValueDecomposition decomposition,
+      double[] singularValues, double[] columnNorms) {
+    RealMatrix rightSingularVectors = decomposition.getV();
+    double[][] covariance = new double[PARAMETER_COUNT][PARAMETER_COUNT];
+    for (int row = 0; row < PARAMETER_COUNT; row++) {
+      for (int column = 0; column < PARAMETER_COUNT; column++) {
+        double scaledCovariance = 0.0;
+        for (int mode = 0; mode < PARAMETER_COUNT; mode++) {
+          scaledCovariance += rightSingularVectors.getEntry(row, mode)
+              * rightSingularVectors.getEntry(column, mode)
+              / (singularValues[mode] * singularValues[mode]);
+        }
+        covariance[row][column] =
+            scaledCovariance / (columnNorms[row] * columnNorms[column]);
+        requireFinite(covariance[row][column], "Volumetric Pitzer coefficient covariance");
+      }
+    }
+    return covariance;
+  }
+
+  private static void requirePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static void requireFinite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+
+  private static double[][] copyMatrix(double[][] source) {
+    double[][] copy = new double[source.length][];
+    for (int row = 0; row < source.length; row++) {
+      copy[row] = source[row].clone();
+    }
+    return copy;
+  }
+
+  /** One caller-supplied apparent-molar-volume observation. */
+  public static final class Observation implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double molality;
+    private final double apparentMolarVolume;
+    private final double standardUncertainty;
+    private final String sourceGroup;
+
+    /**
+     * Construct an observation.
+     *
+     * @param molality formula-unit molality in mol/kg solvent
+     * @param apparentMolarVolume apparent molar volume in m3/mol
+     * @param standardUncertainty absolute one-sigma uncertainty in m3/mol
+     * @param sourceGroup non-empty laboratory or source-lineage identifier
+     */
+    public Observation(double molality, double apparentMolarVolume, double standardUncertainty,
+        String sourceGroup) {
+      if (!Double.isFinite(molality) || molality < 0.0) {
+        throw new IllegalArgumentException("Observation molality must be finite and non-negative");
+      }
+      requireFinite(apparentMolarVolume, "Observed apparent molar volume");
+      requirePositive(standardUncertainty, "Observed apparent-molar-volume uncertainty");
+      if (sourceGroup == null || sourceGroup.trim().isEmpty()) {
+        throw new IllegalArgumentException("Observation source group must not be empty");
+      }
+      this.molality = molality;
+      this.apparentMolarVolume = apparentMolarVolume;
+      this.standardUncertainty = standardUncertainty;
+      this.sourceGroup = sourceGroup.trim();
+    }
+
+    /** @return formula-unit molality in mol/kg solvent */
+    public double getMolality() {
+      return molality;
+    }
+
+    /** @return apparent molar volume in m3/mol */
+    public double getApparentMolarVolume() {
+      return apparentMolarVolume;
+    }
+
+    /** @return absolute one-sigma uncertainty in m3/mol */
+    public double getStandardUncertainty() {
+      return standardUncertainty;
+    }
+
+    /** @return laboratory or source-lineage identifier */
+    public String getSourceGroup() {
+      return sourceGroup;
+    }
+  }
+
+  /** Immutable weighted-regression result. */
+  public static final class FitResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double limitingApparentMolarVolume;
+    private final PitzerBinaryVolumetricModel.StateParameters stateParameters;
+    private final double[] parameterStandardUncertainties;
+    private final double[][] parameterCovariance;
+    private final int observationCount;
+    private final int degreesOfFreedom;
+    private final double chiSquare;
+    private final double conditionNumber;
+    private final double maximumAbsoluteStandardizedResidual;
+    private final List<GroupStatistics> groupStatistics;
+
+    private FitResult(double limitingApparentMolarVolume,
+        PitzerBinaryVolumetricModel.StateParameters stateParameters,
+        double[] parameterStandardUncertainties, double[][] parameterCovariance,
+        int observationCount, int degreesOfFreedom, double chiSquare, double conditionNumber,
+        double maximumAbsoluteStandardizedResidual, List<GroupStatistics> groupStatistics) {
+      this.limitingApparentMolarVolume = limitingApparentMolarVolume;
+      this.stateParameters = stateParameters;
+      this.parameterStandardUncertainties = parameterStandardUncertainties.clone();
+      this.parameterCovariance = copyMatrix(parameterCovariance);
+      this.observationCount = observationCount;
+      this.degreesOfFreedom = degreesOfFreedom;
+      this.chiSquare = chiSquare;
+      this.conditionNumber = conditionNumber;
+      this.maximumAbsoluteStandardizedResidual = maximumAbsoluteStandardizedResidual;
+      this.groupStatistics =
+          Collections.unmodifiableList(new ArrayList<GroupStatistics>(groupStatistics));
+    }
+
+    /** @return fitted limiting apparent molar volume in m3/mol */
+    public double getLimitingApparentMolarVolume() {
+      return limitingApparentMolarVolume;
+    }
+
+    /** @return fitted state parameters including the caller-supplied Debye-Huckel slope */
+    public PitzerBinaryVolumetricModel.StateParameters getStateParameters() {
+      return stateParameters;
+    }
+
+    /**
+     * Return parameter standard uncertainties.
+     *
+     * @return defensive copy ordered as V0, beta0 derivative, beta1 derivative, C-phi derivative
+     */
+    public double[] getParameterStandardUncertainties() {
+      return parameterStandardUncertainties.clone();
+    }
+
+    /**
+     * Return parameter covariance.
+     *
+     * @return defensive covariance copy in the same parameter order as the uncertainties
+     */
+    public double[][] getParameterCovariance() {
+      return copyMatrix(parameterCovariance);
+    }
+
+    /** @return number of fitted observations */
+    public int getObservationCount() {
+      return observationCount;
+    }
+
+    /** @return observation count minus four fitted parameters */
+    public int getDegreesOfFreedom() {
+      return degreesOfFreedom;
+    }
+
+    /** @return sum of squared standardized residuals */
+    public double getChiSquare() {
+      return chiSquare;
+    }
+
+    /** @return chi-square divided by degrees of freedom */
+    public double getReducedChiSquare() {
+      return chiSquare / degreesOfFreedom;
+    }
+
+    /** @return root-mean-square standardized residual */
+    public double getWeightedRootMeanSquareResidual() {
+      return Math.sqrt(chiSquare / observationCount);
+    }
+
+    /** @return maximum absolute standardized residual */
+    public double getMaximumAbsoluteStandardizedResidual() {
+      return maximumAbsoluteStandardizedResidual;
+    }
+
+    /** @return condition number of the column-scaled weighted design matrix */
+    public double getConditionNumber() {
+      return conditionNumber;
+    }
+
+    /** @return immutable source-group diagnostics sorted by source identifier */
+    public List<GroupStatistics> getGroupStatistics() {
+      return groupStatistics;
+    }
+  }
+
+  /** Immutable residual diagnostics for one source lineage. */
+  public static final class GroupStatistics implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String sourceGroup;
+    private final int count;
+    private final double meanResidual;
+    private final double weightedRootMeanSquareResidual;
+    private final double maximumAbsoluteStandardizedResidual;
+
+    private GroupStatistics(String sourceGroup, int count, double meanResidual,
+        double weightedRootMeanSquareResidual, double maximumAbsoluteStandardizedResidual) {
+      this.sourceGroup = sourceGroup;
+      this.count = count;
+      this.meanResidual = meanResidual;
+      this.weightedRootMeanSquareResidual = weightedRootMeanSquareResidual;
+      this.maximumAbsoluteStandardizedResidual = maximumAbsoluteStandardizedResidual;
+    }
+
+    /** @return laboratory or source-lineage identifier */
+    public String getSourceGroup() {
+      return sourceGroup;
+    }
+
+    /** @return number of observations in the source group */
+    public int getCount() {
+      return count;
+    }
+
+    /** @return arithmetic mean volume residual in m3/mol */
+    public double getMeanResidual() {
+      return meanResidual;
+    }
+
+    /** @return root-mean-square standardized residual for the group */
+    public double getWeightedRootMeanSquareResidual() {
+      return weightedRootMeanSquareResidual;
+    }
+
+    /** @return maximum absolute standardized residual for the group */
+    public double getMaximumAbsoluteStandardizedResidual() {
+      return maximumAbsoluteStandardizedResidual;
+    }
+  }
+
+  private static final class MutableGroupStatistics {
+    private final String sourceGroup;
+    private int count;
+    private double residualSum;
+    private double standardizedResidualSquareSum;
+    private double maximumAbsoluteStandardizedResidual;
+
+    private MutableGroupStatistics(String sourceGroup) {
+      this.sourceGroup = sourceGroup;
+    }
+
+    private void add(double residual, double standardizedResidual) {
+      count++;
+      residualSum += residual;
+      standardizedResidualSquareSum += standardizedResidual * standardizedResidual;
+      maximumAbsoluteStandardizedResidual =
+          Math.max(maximumAbsoluteStandardizedResidual, Math.abs(standardizedResidual));
+    }
+
+    private GroupStatistics toImmutable() {
+      return new GroupStatistics(sourceGroup, count, residualSum / count,
+          Math.sqrt(standardizedResidualSquareSum / count),
+          maximumAbsoluteStandardizedResidual);
+    }
+  }
+}

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegression.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegression.java
@@ -16,17 +16,16 @@ import org.apache.commons.math3.linear.SingularValueDecomposition;
  * Weighted linear regression for one-state binary-electrolyte volumetric Pitzer parameters.
  *
  * <p>
- * The regression is parameter and dataset neutral. Callers supply apparent-molar-volume
- * observations, one-sigma uncertainties, source-group identifiers, and the Debye-Huckel volume
- * slope at a common temperature and pressure. The fit estimates the limiting apparent molar
- * volume and the three binary interaction pressure derivatives used by
+ * The regression is parameter and dataset neutral. Callers supply apparent-molar-volume observations, one-sigma
+ * uncertainties, source-group identifiers, and the Debye-Huckel volume slope at a common temperature and pressure. The
+ * fit estimates the limiting apparent molar volume and the three binary interaction pressure derivatives used by
  * {@link PitzerBinaryVolumetricModel}.
  * </p>
  *
  * <p>
- * Weighted design columns are normalized before singular-value decomposition. Rank-deficient and
- * excessively ill-conditioned designs fail closed. Returned covariance assumes that the supplied
- * standard uncertainties are absolute one-sigma uncertainties.
+ * Weighted design columns are normalized before singular-value decomposition. Rank-deficient and excessively
+ * ill-conditioned designs fail closed. Returned covariance assumes that the supplied standard uncertainties are
+ * absolute one-sigma uncertainties.
  * </p>
  */
 public final class PitzerBinaryVolumetricRegression implements Serializable {
@@ -64,8 +63,7 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     requirePositive(pressurePa, "Regression pressure");
     requireFinite(debyeHuckelVolumeSlope, "Debye-Huckel volume slope");
     if (observations == null || observations.size() <= PARAMETER_COUNT) {
-      throw new IllegalArgumentException(
-          "Volumetric Pitzer regression requires at least five observations");
+      throw new IllegalArgumentException("Volumetric Pitzer regression requires at least five observations");
     }
 
     int observationCount = observations.size();
@@ -74,18 +72,14 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     double[][] unweightedDesign = new double[observationCount][PARAMETER_COUNT];
     double[] debyeContributions = new double[observationCount];
 
-    PitzerBinaryVolumetricModel.StateParameters debyeParameters =
-        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa,
-            debyeHuckelVolumeSlope, 0.0, 0.0, 0.0);
-    PitzerBinaryVolumetricModel.StateParameters beta0Unit =
-        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa, 0.0, 1.0, 0.0,
-            0.0);
-    PitzerBinaryVolumetricModel.StateParameters beta1Unit =
-        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa, 0.0, 0.0, 1.0,
-            0.0);
-    PitzerBinaryVolumetricModel.StateParameters cphiUnit =
-        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa, 0.0, 0.0, 0.0,
-            1.0);
+    PitzerBinaryVolumetricModel.StateParameters debyeParameters = new PitzerBinaryVolumetricModel.StateParameters(
+        temperatureK, pressurePa, debyeHuckelVolumeSlope, 0.0, 0.0, 0.0);
+    PitzerBinaryVolumetricModel.StateParameters beta0Unit = new PitzerBinaryVolumetricModel.StateParameters(
+        temperatureK, pressurePa, 0.0, 1.0, 0.0, 0.0);
+    PitzerBinaryVolumetricModel.StateParameters beta1Unit = new PitzerBinaryVolumetricModel.StateParameters(
+        temperatureK, pressurePa, 0.0, 0.0, 1.0, 0.0);
+    PitzerBinaryVolumetricModel.StateParameters cphiUnit = new PitzerBinaryVolumetricModel.StateParameters(temperatureK,
+        pressurePa, 0.0, 0.0, 0.0, 1.0);
 
     for (int row = 0; row < observationCount; row++) {
       Observation observation = observations.get(row);
@@ -93,8 +87,7 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
         throw new IllegalArgumentException("Volumetric Pitzer observations must not contain null");
       }
       double molality = observation.getMolality();
-      double debyeContribution =
-          model.calculateApparentMolarVolume(molality, 0.0, debyeParameters);
+      double debyeContribution = model.calculateApparentMolarVolume(molality, 0.0, debyeParameters);
       debyeContributions[row] = debyeContribution;
 
       double[] designRow = unweightedDesign[row];
@@ -104,8 +97,7 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
       designRow[3] = model.calculateApparentMolarVolume(molality, 0.0, cphiUnit);
 
       double inverseUncertainty = 1.0 / observation.getStandardUncertainty();
-      weightedResponse[row] =
-          (observation.getApparentMolarVolume() - debyeContribution) * inverseUncertainty;
+      weightedResponse[row] = (observation.getApparentMolarVolume() - debyeContribution) * inverseUncertainty;
       for (int column = 0; column < PARAMETER_COUNT; column++) {
         weightedDesign[row][column] = designRow[column] * inverseUncertainty;
       }
@@ -129,25 +121,21 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     for (double singularValue : singularValues) {
       if (singularValue > rankTolerance) {
         rank++;
-        smallestRetainedSingularValue =
-            Math.min(smallestRetainedSingularValue, singularValue);
+        smallestRetainedSingularValue = Math.min(smallestRetainedSingularValue, singularValue);
       }
     }
     if (rank < PARAMETER_COUNT) {
       throw new IllegalArgumentException(
-          "Volumetric Pitzer regression design is rank deficient: rank " + rank + " of "
-              + PARAMETER_COUNT);
+          "Volumetric Pitzer regression design is rank deficient: rank " + rank + " of " + PARAMETER_COUNT);
     }
 
     double conditionNumber = largestSingularValue / smallestRetainedSingularValue;
     if (!Double.isFinite(conditionNumber) || conditionNumber > MAXIMUM_CONDITION_NUMBER) {
       throw new IllegalArgumentException(
-          "Volumetric Pitzer regression design is ill-conditioned: scaled condition number "
-              + conditionNumber);
+          "Volumetric Pitzer regression design is ill-conditioned: scaled condition number " + conditionNumber);
     }
 
-    RealVector scaledSolution =
-        decomposition.getSolver().solve(new ArrayRealVector(weightedResponse, false));
+    RealVector scaledSolution = decomposition.getSolver().solve(new ArrayRealVector(weightedResponse, false));
     double[] coefficients = new double[PARAMETER_COUNT];
     for (int index = 0; index < PARAMETER_COUNT; index++) {
       coefficients[index] = scaledSolution.getEntry(index) / columnNorms[index];
@@ -159,20 +147,17 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     for (int index = 0; index < PARAMETER_COUNT; index++) {
       double variance = covariance[index][index];
       if (!Double.isFinite(variance) || variance < 0.0) {
-        throw new IllegalArgumentException(
-            "Volumetric Pitzer regression produced an invalid coefficient variance");
+        throw new IllegalArgumentException("Volumetric Pitzer regression produced an invalid coefficient variance");
       }
       standardUncertainties[index] = Math.sqrt(variance);
     }
 
-    PitzerBinaryVolumetricModel.StateParameters fittedParameters =
-        new PitzerBinaryVolumetricModel.StateParameters(temperatureK, pressurePa,
-            debyeHuckelVolumeSlope, coefficients[1], coefficients[2], coefficients[3]);
+    PitzerBinaryVolumetricModel.StateParameters fittedParameters = new PitzerBinaryVolumetricModel.StateParameters(
+        temperatureK, pressurePa, debyeHuckelVolumeSlope, coefficients[1], coefficients[2], coefficients[3]);
 
     double chiSquare = 0.0;
     double maximumAbsoluteStandardizedResidual = 0.0;
-    Map<String, MutableGroupStatistics> mutableGroups =
-        new TreeMap<String, MutableGroupStatistics>();
+    Map<String, MutableGroupStatistics> mutableGroups = new TreeMap<String, MutableGroupStatistics>();
     for (int row = 0; row < observationCount; row++) {
       Observation observation = observations.get(row);
       double fittedVolume = debyeContributions[row];
@@ -183,8 +168,8 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
       double standardizedResidual = residual / observation.getStandardUncertainty();
       requireFinite(standardizedResidual, "Standardized volumetric Pitzer residual");
       chiSquare += standardizedResidual * standardizedResidual;
-      maximumAbsoluteStandardizedResidual =
-          Math.max(maximumAbsoluteStandardizedResidual, Math.abs(standardizedResidual));
+      maximumAbsoluteStandardizedResidual = Math.max(maximumAbsoluteStandardizedResidual,
+          Math.abs(standardizedResidual));
 
       MutableGroupStatistics group = mutableGroups.get(observation.getSourceGroup());
       if (group == null) {
@@ -200,9 +185,8 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
       groups.add(group.toImmutable());
     }
 
-    return new FitResult(coefficients[0], fittedParameters, standardUncertainties, covariance,
-        observationCount, degreesOfFreedom, chiSquare, conditionNumber,
-        maximumAbsoluteStandardizedResidual, groups);
+    return new FitResult(coefficients[0], fittedParameters, standardUncertainties, covariance, observationCount,
+        degreesOfFreedom, chiSquare, conditionNumber, maximumAbsoluteStandardizedResidual, groups);
   }
 
   private static double[] calculateColumnNorms(double[][] design) {
@@ -214,27 +198,24 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     }
     for (int column = 0; column < PARAMETER_COUNT; column++) {
       if (!Double.isFinite(norms[column]) || norms[column] <= 0.0) {
-        throw new IllegalArgumentException(
-            "Volumetric Pitzer regression has an empty or non-finite design column");
+        throw new IllegalArgumentException("Volumetric Pitzer regression has an empty or non-finite design column");
       }
     }
     return norms;
   }
 
-  private static double[][] calculateCovariance(SingularValueDecomposition decomposition,
-      double[] singularValues, double[] columnNorms) {
+  private static double[][] calculateCovariance(SingularValueDecomposition decomposition, double[] singularValues,
+      double[] columnNorms) {
     RealMatrix rightSingularVectors = decomposition.getV();
     double[][] covariance = new double[PARAMETER_COUNT][PARAMETER_COUNT];
     for (int row = 0; row < PARAMETER_COUNT; row++) {
       for (int column = 0; column < PARAMETER_COUNT; column++) {
         double scaledCovariance = 0.0;
         for (int mode = 0; mode < PARAMETER_COUNT; mode++) {
-          scaledCovariance += rightSingularVectors.getEntry(row, mode)
-              * rightSingularVectors.getEntry(column, mode)
+          scaledCovariance += rightSingularVectors.getEntry(row, mode) * rightSingularVectors.getEntry(column, mode)
               / (singularValues[mode] * singularValues[mode]);
         }
-        covariance[row][column] =
-            scaledCovariance / (columnNorms[row] * columnNorms[column]);
+        covariance[row][column] = scaledCovariance / (columnNorms[row] * columnNorms[column]);
         requireFinite(covariance[row][column], "Volumetric Pitzer coefficient covariance");
       }
     }
@@ -278,8 +259,7 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
      * @param standardUncertainty absolute one-sigma uncertainty in m3/mol
      * @param sourceGroup non-empty laboratory or source-lineage identifier
      */
-    public Observation(double molality, double apparentMolarVolume, double standardUncertainty,
-        String sourceGroup) {
+    public Observation(double molality, double apparentMolarVolume, double standardUncertainty, String sourceGroup) {
       if (!Double.isFinite(molality) || molality < 0.0) {
         throw new IllegalArgumentException("Observation molality must be finite and non-negative");
       }
@@ -330,11 +310,10 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     private final double maximumAbsoluteStandardizedResidual;
     private final List<GroupStatistics> groupStatistics;
 
-    private FitResult(double limitingApparentMolarVolume,
-        PitzerBinaryVolumetricModel.StateParameters stateParameters,
-        double[] parameterStandardUncertainties, double[][] parameterCovariance,
-        int observationCount, int degreesOfFreedom, double chiSquare, double conditionNumber,
-        double maximumAbsoluteStandardizedResidual, List<GroupStatistics> groupStatistics) {
+    private FitResult(double limitingApparentMolarVolume, PitzerBinaryVolumetricModel.StateParameters stateParameters,
+        double[] parameterStandardUncertainties, double[][] parameterCovariance, int observationCount,
+        int degreesOfFreedom, double chiSquare, double conditionNumber, double maximumAbsoluteStandardizedResidual,
+        List<GroupStatistics> groupStatistics) {
       this.limitingApparentMolarVolume = limitingApparentMolarVolume;
       this.stateParameters = stateParameters;
       this.parameterStandardUncertainties = parameterStandardUncertainties.clone();
@@ -344,8 +323,7 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
       this.chiSquare = chiSquare;
       this.conditionNumber = conditionNumber;
       this.maximumAbsoluteStandardizedResidual = maximumAbsoluteStandardizedResidual;
-      this.groupStatistics =
-          Collections.unmodifiableList(new ArrayList<GroupStatistics>(groupStatistics));
+      this.groupStatistics = Collections.unmodifiableList(new ArrayList<GroupStatistics>(groupStatistics));
     }
 
     /** @return fitted limiting apparent molar volume in m3/mol */
@@ -427,8 +405,8 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
     private final double weightedRootMeanSquareResidual;
     private final double maximumAbsoluteStandardizedResidual;
 
-    private GroupStatistics(String sourceGroup, int count, double meanResidual,
-        double weightedRootMeanSquareResidual, double maximumAbsoluteStandardizedResidual) {
+    private GroupStatistics(String sourceGroup, int count, double meanResidual, double weightedRootMeanSquareResidual,
+        double maximumAbsoluteStandardizedResidual) {
       this.sourceGroup = sourceGroup;
       this.count = count;
       this.meanResidual = meanResidual;
@@ -477,14 +455,13 @@ public final class PitzerBinaryVolumetricRegression implements Serializable {
       count++;
       residualSum += residual;
       standardizedResidualSquareSum += standardizedResidual * standardizedResidual;
-      maximumAbsoluteStandardizedResidual =
-          Math.max(maximumAbsoluteStandardizedResidual, Math.abs(standardizedResidual));
+      maximumAbsoluteStandardizedResidual = Math.max(maximumAbsoluteStandardizedResidual,
+          Math.abs(standardizedResidual));
     }
 
     private GroupStatistics toImmutable() {
       return new GroupStatistics(sourceGroup, count, residualSum / count,
-          Math.sqrt(standardizedResidualSquareSum / count),
-          maximumAbsoluteStandardizedResidual);
+          Math.sqrt(standardizedResidualSquareSum / count), maximumAbsoluteStandardizedResidual);
     }
   }
 }

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegressionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegressionTest.java
@@ -1,0 +1,182 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests parameter-neutral weighted regression for the binary volumetric Pitzer kernel. */
+class PitzerBinaryVolumetricRegressionTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 323.15;
+  private static final double PRESSURE_PA = 20.0e6;
+  private static final double DEBYE_HUCKEL_VOLUME_SLOPE = 1.2e-6;
+  private static final double LIMITING_VOLUME = 17.6e-6;
+  private static final double BETA0_DERIVATIVE = 2.0e-10;
+  private static final double BETA1_DERIVATIVE = -0.7e-10;
+  private static final double CPHI_DERIVATIVE = 1.1e-11;
+  private static final double STANDARD_UNCERTAINTY = 2.0e-8;
+  private static final double[] MOLALITIES = {0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0};
+
+  @Test
+  void recoversExactSyntheticParametersAndCovariance() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(model);
+
+    PitzerBinaryVolumetricRegression.FitResult result =
+        regression.fit(syntheticObservations(model, null), TEMPERATURE_K, PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE);
+
+    assertEquals(LIMITING_VOLUME, result.getLimitingApparentMolarVolume(), 1.0e-17);
+    assertEquals(BETA0_DERIVATIVE, result.getStateParameters().getBeta0PressureDerivative(),
+        1.0e-21);
+    assertEquals(BETA1_DERIVATIVE, result.getStateParameters().getBeta1PressureDerivative(),
+        1.0e-21);
+    assertEquals(CPHI_DERIVATIVE, result.getStateParameters().getCphiPressureDerivative(),
+        1.0e-21);
+    assertEquals(DEBYE_HUCKEL_VOLUME_SLOPE,
+        result.getStateParameters().getDebyeHuckelVolumeSlope(), 0.0);
+    assertEquals(MOLALITIES.length, result.getObservationCount());
+    assertEquals(MOLALITIES.length - 4, result.getDegreesOfFreedom());
+    assertTrue(result.getChiSquare() < 1.0e-20);
+    assertTrue(result.getConditionNumber() < 100.0);
+
+    double[][] covariance = result.getParameterCovariance();
+    double[] standardUncertainties = result.getParameterStandardUncertainties();
+    for (int row = 0; row < covariance.length; row++) {
+      assertTrue(Double.isFinite(standardUncertainties[row]));
+      assertTrue(standardUncertainties[row] > 0.0);
+      assertEquals(standardUncertainties[row] * standardUncertainties[row],
+          covariance[row][row], 1.0e-30);
+      for (int column = 0; column < covariance.length; column++) {
+        assertEquals(covariance[row][column], covariance[column][row], 1.0e-30);
+      }
+    }
+
+    covariance[0][0] = -1.0;
+    standardUncertainties[0] = -1.0;
+    assertTrue(result.getParameterCovariance()[0][0] > 0.0);
+    assertTrue(result.getParameterStandardUncertainties()[0] > 0.0);
+  }
+
+  @Test
+  void reportsDeterministicSourceGroupedResidualsAndOrderInvariantFit() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(model);
+    double[] noiseInSigma = {0.2, -0.5, 0.4, -0.1, 0.0, 0.3, -0.2, 0.1, -0.4};
+    List<PitzerBinaryVolumetricRegression.Observation> observations =
+        syntheticObservations(model, noiseInSigma);
+
+    PitzerBinaryVolumetricRegression.FitResult forward =
+        regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE);
+    Collections.reverse(observations);
+    PitzerBinaryVolumetricRegression.FitResult reversed =
+        regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE);
+
+    assertEquals(forward.getLimitingApparentMolarVolume(),
+        reversed.getLimitingApparentMolarVolume(), 1.0e-15);
+    assertEquals(forward.getStateParameters().getBeta0PressureDerivative(),
+        reversed.getStateParameters().getBeta0PressureDerivative(), 1.0e-20);
+    assertEquals(forward.getStateParameters().getBeta1PressureDerivative(),
+        reversed.getStateParameters().getBeta1PressureDerivative(), 1.0e-20);
+    assertEquals(forward.getStateParameters().getCphiPressureDerivative(),
+        reversed.getStateParameters().getCphiPressureDerivative(), 1.0e-20);
+    assertEquals(forward.getChiSquare(), reversed.getChiSquare(), 1.0e-12);
+
+    assertEquals(2, forward.getGroupStatistics().size());
+    assertEquals("laboratory-a", forward.getGroupStatistics().get(0).getSourceGroup());
+    assertEquals("laboratory-b", forward.getGroupStatistics().get(1).getSourceGroup());
+    assertEquals(5, forward.getGroupStatistics().get(0).getCount());
+    assertEquals(4, forward.getGroupStatistics().get(1).getCount());
+    assertTrue(forward.getReducedChiSquare() > 0.0);
+    assertTrue(forward.getWeightedRootMeanSquareResidual() > 0.0);
+    assertTrue(forward.getMaximumAbsoluteStandardizedResidual() > 0.0);
+    for (PitzerBinaryVolumetricRegression.GroupStatistics group :
+        forward.getGroupStatistics()) {
+      assertTrue(Double.isFinite(group.getMeanResidual()));
+      assertTrue(group.getWeightedRootMeanSquareResidual() >= 0.0);
+      assertTrue(group.getMaximumAbsoluteStandardizedResidual() >= 0.0);
+    }
+  }
+
+  @Test
+  void rejectsRankDeficientConcentrationDesign() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(model);
+    List<PitzerBinaryVolumetricRegression.Observation> observations =
+        new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    for (int index = 0; index < 6; index++) {
+      observations.add(new PitzerBinaryVolumetricRegression.Observation(1.0, 25.0e-6,
+          STANDARD_UNCERTAINTY, "same-state"));
+    }
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+            () -> regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
+                DEBYE_HUCKEL_VOLUME_SLOPE));
+    assertTrue(exception.getMessage().contains("rank deficient"));
+  }
+
+  @Test
+  void rejectsInvalidModelsObservationsAndFitState() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricRegression(null));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricRegression.Observation(-0.1, 20.0e-6,
+            STANDARD_UNCERTAINTY, "source"));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6, 0.0,
+            "source"));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6,
+            STANDARD_UNCERTAINTY, " "));
+
+    PitzerBinaryVolumetricRegression regression =
+        new PitzerBinaryVolumetricRegression(calciumChlorideModel());
+    List<PitzerBinaryVolumetricRegression.Observation> tooFew = Arrays.asList(
+        new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6,
+            STANDARD_UNCERTAINTY, "source"),
+        new PitzerBinaryVolumetricRegression.Observation(0.2, 21.0e-6,
+            STANDARD_UNCERTAINTY, "source"),
+        new PitzerBinaryVolumetricRegression.Observation(0.3, 22.0e-6,
+            STANDARD_UNCERTAINTY, "source"),
+        new PitzerBinaryVolumetricRegression.Observation(0.4, 23.0e-6,
+            STANDARD_UNCERTAINTY, "source"));
+    assertThrows(IllegalArgumentException.class,
+        () -> regression.fit(tooFew, TEMPERATURE_K, PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE));
+    assertThrows(IllegalArgumentException.class,
+        () -> regression.fit(syntheticObservations(calciumChlorideModel(), null), 0.0,
+            PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+  }
+
+  private static List<PitzerBinaryVolumetricRegression.Observation> syntheticObservations(
+      PitzerBinaryVolumetricModel model, double[] noiseInSigma) {
+    PitzerBinaryVolumetricModel.StateParameters parameters =
+        new PitzerBinaryVolumetricModel.StateParameters(TEMPERATURE_K, PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE, BETA0_DERIVATIVE, BETA1_DERIVATIVE,
+            CPHI_DERIVATIVE);
+    List<PitzerBinaryVolumetricRegression.Observation> observations =
+        new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    for (int index = 0; index < MOLALITIES.length; index++) {
+      double volume =
+          model.calculateApparentMolarVolume(MOLALITIES[index], LIMITING_VOLUME, parameters);
+      if (noiseInSigma != null) {
+        volume += noiseInSigma[index] * STANDARD_UNCERTAINTY;
+      }
+      String group = index % 2 == 0 ? "laboratory-a" : "laboratory-b";
+      observations.add(new PitzerBinaryVolumetricRegression.Observation(MOLALITIES[index],
+          volume, STANDARD_UNCERTAINTY, group));
+    }
+    return observations;
+  }
+
+  private static PitzerBinaryVolumetricModel calciumChlorideModel() {
+    return new PitzerBinaryVolumetricModel(1, 2, 2, -1);
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegressionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricRegressionTest.java
@@ -19,26 +19,21 @@ class PitzerBinaryVolumetricRegressionTest extends neqsim.NeqSimTest {
   private static final double BETA1_DERIVATIVE = -0.7e-10;
   private static final double CPHI_DERIVATIVE = 1.1e-11;
   private static final double STANDARD_UNCERTAINTY = 2.0e-8;
-  private static final double[] MOLALITIES = {0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0};
+  private static final double[] MOLALITIES = { 0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0 };
 
   @Test
   void recoversExactSyntheticParametersAndCovariance() {
     PitzerBinaryVolumetricModel model = calciumChlorideModel();
     PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(model);
 
-    PitzerBinaryVolumetricRegression.FitResult result =
-        regression.fit(syntheticObservations(model, null), TEMPERATURE_K, PRESSURE_PA,
-            DEBYE_HUCKEL_VOLUME_SLOPE);
+    PitzerBinaryVolumetricRegression.FitResult result = regression.fit(syntheticObservations(model, null),
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE);
 
     assertEquals(LIMITING_VOLUME, result.getLimitingApparentMolarVolume(), 1.0e-17);
-    assertEquals(BETA0_DERIVATIVE, result.getStateParameters().getBeta0PressureDerivative(),
-        1.0e-21);
-    assertEquals(BETA1_DERIVATIVE, result.getStateParameters().getBeta1PressureDerivative(),
-        1.0e-21);
-    assertEquals(CPHI_DERIVATIVE, result.getStateParameters().getCphiPressureDerivative(),
-        1.0e-21);
-    assertEquals(DEBYE_HUCKEL_VOLUME_SLOPE,
-        result.getStateParameters().getDebyeHuckelVolumeSlope(), 0.0);
+    assertEquals(BETA0_DERIVATIVE, result.getStateParameters().getBeta0PressureDerivative(), 1.0e-21);
+    assertEquals(BETA1_DERIVATIVE, result.getStateParameters().getBeta1PressureDerivative(), 1.0e-21);
+    assertEquals(CPHI_DERIVATIVE, result.getStateParameters().getCphiPressureDerivative(), 1.0e-21);
+    assertEquals(DEBYE_HUCKEL_VOLUME_SLOPE, result.getStateParameters().getDebyeHuckelVolumeSlope(), 0.0);
     assertEquals(MOLALITIES.length, result.getObservationCount());
     assertEquals(MOLALITIES.length - 4, result.getDegreesOfFreedom());
     assertTrue(result.getChiSquare() < 1.0e-20);
@@ -49,8 +44,7 @@ class PitzerBinaryVolumetricRegressionTest extends neqsim.NeqSimTest {
     for (int row = 0; row < covariance.length; row++) {
       assertTrue(Double.isFinite(standardUncertainties[row]));
       assertTrue(standardUncertainties[row] > 0.0);
-      assertEquals(standardUncertainties[row] * standardUncertainties[row],
-          covariance[row][row], 1.0e-30);
+      assertEquals(standardUncertainties[row] * standardUncertainties[row], covariance[row][row], 1.0e-30);
       for (int column = 0; column < covariance.length; column++) {
         assertEquals(covariance[row][column], covariance[column][row], 1.0e-30);
       }
@@ -66,20 +60,16 @@ class PitzerBinaryVolumetricRegressionTest extends neqsim.NeqSimTest {
   void reportsDeterministicSourceGroupedResidualsAndOrderInvariantFit() {
     PitzerBinaryVolumetricModel model = calciumChlorideModel();
     PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(model);
-    double[] noiseInSigma = {0.2, -0.5, 0.4, -0.1, 0.0, 0.3, -0.2, 0.1, -0.4};
-    List<PitzerBinaryVolumetricRegression.Observation> observations =
-        syntheticObservations(model, noiseInSigma);
+    double[] noiseInSigma = { 0.2, -0.5, 0.4, -0.1, 0.0, 0.3, -0.2, 0.1, -0.4 };
+    List<PitzerBinaryVolumetricRegression.Observation> observations = syntheticObservations(model, noiseInSigma);
 
-    PitzerBinaryVolumetricRegression.FitResult forward =
-        regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
-            DEBYE_HUCKEL_VOLUME_SLOPE);
+    PitzerBinaryVolumetricRegression.FitResult forward = regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
+        DEBYE_HUCKEL_VOLUME_SLOPE);
     Collections.reverse(observations);
-    PitzerBinaryVolumetricRegression.FitResult reversed =
-        regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
-            DEBYE_HUCKEL_VOLUME_SLOPE);
+    PitzerBinaryVolumetricRegression.FitResult reversed = regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
+        DEBYE_HUCKEL_VOLUME_SLOPE);
 
-    assertEquals(forward.getLimitingApparentMolarVolume(),
-        reversed.getLimitingApparentMolarVolume(), 1.0e-15);
+    assertEquals(forward.getLimitingApparentMolarVolume(), reversed.getLimitingApparentMolarVolume(), 1.0e-15);
     assertEquals(forward.getStateParameters().getBeta0PressureDerivative(),
         reversed.getStateParameters().getBeta0PressureDerivative(), 1.0e-20);
     assertEquals(forward.getStateParameters().getBeta1PressureDerivative(),
@@ -96,8 +86,7 @@ class PitzerBinaryVolumetricRegressionTest extends neqsim.NeqSimTest {
     assertTrue(forward.getReducedChiSquare() > 0.0);
     assertTrue(forward.getWeightedRootMeanSquareResidual() > 0.0);
     assertTrue(forward.getMaximumAbsoluteStandardizedResidual() > 0.0);
-    for (PitzerBinaryVolumetricRegression.GroupStatistics group :
-        forward.getGroupStatistics()) {
+    for (PitzerBinaryVolumetricRegression.GroupStatistics group : forward.getGroupStatistics()) {
       assertTrue(Double.isFinite(group.getMeanResidual()));
       assertTrue(group.getWeightedRootMeanSquareResidual() >= 0.0);
       assertTrue(group.getMaximumAbsoluteStandardizedResidual() >= 0.0);
@@ -108,70 +97,52 @@ class PitzerBinaryVolumetricRegressionTest extends neqsim.NeqSimTest {
   void rejectsRankDeficientConcentrationDesign() {
     PitzerBinaryVolumetricModel model = calciumChlorideModel();
     PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(model);
-    List<PitzerBinaryVolumetricRegression.Observation> observations =
-        new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    List<PitzerBinaryVolumetricRegression.Observation> observations = new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
     for (int index = 0; index < 6; index++) {
-      observations.add(new PitzerBinaryVolumetricRegression.Observation(1.0, 25.0e-6,
-          STANDARD_UNCERTAINTY, "same-state"));
+      observations
+          .add(new PitzerBinaryVolumetricRegression.Observation(1.0, 25.0e-6, STANDARD_UNCERTAINTY, "same-state"));
     }
 
-    IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class,
-            () -> regression.fit(observations, TEMPERATURE_K, PRESSURE_PA,
-                DEBYE_HUCKEL_VOLUME_SLOPE));
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> regression.fit(observations, TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
     assertTrue(exception.getMessage().contains("rank deficient"));
   }
 
   @Test
   void rejectsInvalidModelsObservationsAndFitState() {
+    assertThrows(IllegalArgumentException.class, () -> new PitzerBinaryVolumetricRegression(null));
     assertThrows(IllegalArgumentException.class,
-        () -> new PitzerBinaryVolumetricRegression(null));
+        () -> new PitzerBinaryVolumetricRegression.Observation(-0.1, 20.0e-6, STANDARD_UNCERTAINTY, "source"));
     assertThrows(IllegalArgumentException.class,
-        () -> new PitzerBinaryVolumetricRegression.Observation(-0.1, 20.0e-6,
-            STANDARD_UNCERTAINTY, "source"));
+        () -> new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6, 0.0, "source"));
     assertThrows(IllegalArgumentException.class,
-        () -> new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6, 0.0,
-            "source"));
-    assertThrows(IllegalArgumentException.class,
-        () -> new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6,
-            STANDARD_UNCERTAINTY, " "));
+        () -> new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6, STANDARD_UNCERTAINTY, " "));
 
-    PitzerBinaryVolumetricRegression regression =
-        new PitzerBinaryVolumetricRegression(calciumChlorideModel());
+    PitzerBinaryVolumetricRegression regression = new PitzerBinaryVolumetricRegression(calciumChlorideModel());
     List<PitzerBinaryVolumetricRegression.Observation> tooFew = Arrays.asList(
-        new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6,
-            STANDARD_UNCERTAINTY, "source"),
-        new PitzerBinaryVolumetricRegression.Observation(0.2, 21.0e-6,
-            STANDARD_UNCERTAINTY, "source"),
-        new PitzerBinaryVolumetricRegression.Observation(0.3, 22.0e-6,
-            STANDARD_UNCERTAINTY, "source"),
-        new PitzerBinaryVolumetricRegression.Observation(0.4, 23.0e-6,
-            STANDARD_UNCERTAINTY, "source"));
+        new PitzerBinaryVolumetricRegression.Observation(0.1, 20.0e-6, STANDARD_UNCERTAINTY, "source"),
+        new PitzerBinaryVolumetricRegression.Observation(0.2, 21.0e-6, STANDARD_UNCERTAINTY, "source"),
+        new PitzerBinaryVolumetricRegression.Observation(0.3, 22.0e-6, STANDARD_UNCERTAINTY, "source"),
+        new PitzerBinaryVolumetricRegression.Observation(0.4, 23.0e-6, STANDARD_UNCERTAINTY, "source"));
     assertThrows(IllegalArgumentException.class,
-        () -> regression.fit(tooFew, TEMPERATURE_K, PRESSURE_PA,
-            DEBYE_HUCKEL_VOLUME_SLOPE));
-    assertThrows(IllegalArgumentException.class,
-        () -> regression.fit(syntheticObservations(calciumChlorideModel(), null), 0.0,
-            PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+        () -> regression.fit(tooFew, TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+    assertThrows(IllegalArgumentException.class, () -> regression
+        .fit(syntheticObservations(calciumChlorideModel(), null), 0.0, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
   }
 
   private static List<PitzerBinaryVolumetricRegression.Observation> syntheticObservations(
       PitzerBinaryVolumetricModel model, double[] noiseInSigma) {
-    PitzerBinaryVolumetricModel.StateParameters parameters =
-        new PitzerBinaryVolumetricModel.StateParameters(TEMPERATURE_K, PRESSURE_PA,
-            DEBYE_HUCKEL_VOLUME_SLOPE, BETA0_DERIVATIVE, BETA1_DERIVATIVE,
-            CPHI_DERIVATIVE);
-    List<PitzerBinaryVolumetricRegression.Observation> observations =
-        new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    PitzerBinaryVolumetricModel.StateParameters parameters = new PitzerBinaryVolumetricModel.StateParameters(
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE, BETA0_DERIVATIVE, BETA1_DERIVATIVE, CPHI_DERIVATIVE);
+    List<PitzerBinaryVolumetricRegression.Observation> observations = new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
     for (int index = 0; index < MOLALITIES.length; index++) {
-      double volume =
-          model.calculateApparentMolarVolume(MOLALITIES[index], LIMITING_VOLUME, parameters);
+      double volume = model.calculateApparentMolarVolume(MOLALITIES[index], LIMITING_VOLUME, parameters);
       if (noiseInSigma != null) {
         volume += noiseInSigma[index] * STANDARD_UNCERTAINTY;
       }
       String group = index % 2 == 0 ? "laboratory-a" : "laboratory-b";
-      observations.add(new PitzerBinaryVolumetricRegression.Observation(MOLALITIES[index],
-          volume, STANDARD_UNCERTAINTY, group));
+      observations.add(
+          new PitzerBinaryVolumetricRegression.Observation(MOLALITIES[index], volume, STANDARD_UNCERTAINTY, group));
     }
     return observations;
   }


### PR DESCRIPTION
## Summary

Advances #3144 with a parameter-neutral weighted regression layer for the binary volumetric-Pitzer kernel merged in #3522.

- Fits `V°`, `β⁽⁰⁾_V`, `β⁽¹⁾_V`, and `Cφ_V` for one common temperature-pressure state.
- Requires caller-supplied apparent-molar-volume observations, absolute 1σ uncertainties, and explicit laboratory/source-lineage identifiers.
- Column-scales the uncertainty-weighted design and solves it by SVD.
- Fails closed on rank deficiency or excessive condition number.
- Returns coefficient covariance and standard uncertainties, χ², reduced χ², weighted RMS, maximum standardized residual, and deterministic source-group diagnostics.
- Bundles no experimental rows or salt-specific coefficients and changes no default model.

Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5569741418

## Exact continuity and scope

- Exact base: `f96e1dbfb5b33105ed1f3f788f5b350ee2be057c`
- Exact head: `6c3869dc1ee55058b286c4ea27bcc134d908caa5`
- Branch: `ai/3144-volumetric-pitzer-regression`
- Five ordered commits; three intended files
- Branch is 5 commits ahead and 0 behind its exact base
- No active #3144 PR existed before publication
- Open autonomous PRs #3514, #3533, and #3534 do not overlap this package or documentation scope

## Numerical and scientific contract

For each observation, the existing kernel supplies the Debye–Hückel offset and the linear basis for the four fitted coefficients. The weighted matrix uses the supplied absolute standard uncertainty. Column normalization makes the reported SVD condition number dimensionless; the fit rejects rank below four and scaled condition number above `1e10`.

Independent numerical audit of the frozen nine-molality synthetic matrix gives:

- scaled condition number: **25.494416020081804**
- rank: **4/4**
- `V°` recovery error: **1.016e-20 m³/mol**
- `β⁽⁰⁾_V` recovery error: **7.755e-26**
- `β⁽¹⁾_V` recovery error: **−1.383e-24**
- `Cφ_V` recovery error: **−4.524e-26**
- χ²: **2.15e-24**

The NIST/Al Ghafri 197-point pressure series is not read or fitted and remains the independent hold-out. Regression tooling does not establish dataset provenance or authorize parameter adoption.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local validation on files byte-identical to the published branch:

- `PitzerBinaryVolumetricModelTest`: **6/6 passed**
- `PitzerBinaryVolumetricRegressionTest`: **4/4 passed**
- `python3 devtools/run_spotless.py apply`: passed
- `python3 devtools/run_spotless.py check`: passed
- `python3 devtools/check_documentation_search.py`: passed
- pre-commit executable: unavailable; no local pre-commit result is claimed

Hosted Java 8/21, Windows/Ubuntu, slow shards, Javadocs, Spotless, documentation, CodeQL, PaperLab, and repository policy checks remain authoritative.

## Documentation impact

`docs/physical_properties/density_models.md` now documents regression inputs, fitted quantities, SVD identifiability gates, uncertainty interpretation, group diagnostics, and the provenance/hold-out boundary. No untested executable documentation example was added.

## Stop boundary

This PR installs no dataset or coefficient table and does not connect the fitter to `Water` or another default density path. It changes no Ksp, `Vdelta`, activity coefficient, reaction/speciation behavior, phase selection, solver tolerance, or MCP payload. Quantitative high-pressure aqueous density and calcium-sulfate prediction remain fail-closed until a redistribution-compatible calibration corpus and independent laboratory-grouped validation pass.

Portfolio occupancy becomes **4/10**. Keep the PR draft-only: do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity.

Generated with AI assistance.