### PR TITLE
[AI-Assisted] Qualify Sarir plant-yield comparison basis

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -151,7 +151,26 @@ procedure or compliance determination.
 | Diesel | 425.018 | 393.0 | 7.533 |
 | Residual | 646.5 | 706.1 | 9.219 |
 
-Unlike the Al-Diwiniya reference, the Sarir paper does not say these HYSYS rates were imposed. It describes calculated production rates compared with actual refinery data, so the rows are retained as independent validation targets. The API recomputes absolute relative errors from the raw published values instead of copying rounded percentages.
+Unlike the Al-Diwiniya reference, the Sarir paper does not say these HYSYS rates were
+imposed. It describes calculated production rates compared with actual refinery data, so the
+rows are retained as independent validation targets. The API recomputes absolute relative
+errors from the raw published values instead of copying rounded percentages.
+
+The conversion to kg/h uses exactly 1000 kg per metric tonne and 24 hours per day. Each Table 5
+plant row is also bound to its matching Table 3 ADU hydrocarbon outlet:
+
+| Product | Table 3 outlet | Plant (kg/h) | Table 3 (kg/h) |
+| --- | --- | ---: | ---: |
+| Total naphtha | Naphtha | 8706.25 | 8706.00 |
+| Kerosene | Kerosene product | 952.083333 | 952.20 |
+| Diesel | Diesel product | 17709.083333 | 17709.24 |
+| Residual | Residual | 26937.50 | 26937.99 |
+| **Total** | | **54304.916667** | **54305.43** |
+
+The absolute difference between those independently published totals is 0.513333 kg/h, less
+than (10^{-5}) of the plant total. This is a transcription and unit-basis reconciliation
+between source tables, not proof of plant mass conservation or model agreement. The gas-to-flare,
+water, and steam rows are therefore excluded from this hydrocarbon-product comparison.
 
 ## Java and Python access
 
@@ -181,8 +200,12 @@ boolean residualSpecificationIsNumeric =
 
 SarirAtmosphericReference.ProductYieldReference diesel =
     SarirAtmosphericReference.getProductYield("Diesel");
-double plantRate = diesel.getPlantMetricTonPerDay();
-double errorPercent = diesel.getAbsoluteRelativeErrorPercent();
+double plantRateKgPerHour = diesel.getPlantMassFlowRateKgPerHour();
+double hysysRateKgPerHour = diesel.getSimulationMassFlowRateKgPerHour();
+String tableThreeOutlet = diesel.getAduStreamName();
+double calculatedErrorPercent =
+    diesel.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(
+        calculatedDieselRateKgPerHour);
 
 SarirAtmosphericReference.PumparoundReference topPumparound =
     SarirAtmosphericReference.getPumparound("Top pump around (TPA)");
@@ -202,7 +225,10 @@ boolean steamStateIsExplicit =
     SarirAtmosphericReference.hasExplicitSteamThermodynamicState();
 ```
 
-Static methods are directly accessible through JPype. Arrays are defensive copies, and unknown product labels or invalid error inputs fail closed.
+Static methods are directly accessible through JPype. Arrays are defensive copies, and unknown
+product labels, negative calculated rates, and non-finite error inputs fail closed. A zero
+calculated rate remains a valid comparison value. Plant and HYSYS rates are read-only evidence:
+the comparison API neither changes a stream nor imposes an accuracy acceptance threshold.
 
 ## Constrained pseudo-component input
 

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -29,6 +29,9 @@ public final class SarirAtmosphericReference {
   /** Source publication date in ISO-8601 format. */
   public static final String PUBLICATION_DATE = "2022-03-31";
 
+  private static final double KILOGRAMS_PER_METRIC_TONNE = 1000.0;
+  private static final double HOURS_PER_DAY = 24.0;
+
   private static final double[] TBP_TEMPERATURE_CELSIUS = { 70.0, 90.0, 110.0, 150.0, 195.0, 215.0, 255.0, 275.0, 295.0,
       335.0, 370.0, 400.0, 460.0, 480.0, 500.0, 520.0, 550.0 };
   private static final double[] TBP_VOLUME_PERCENT = { 7.44, 10.47, 13.83, 21.16, 28.52, 31.54, 38.03, 41.76, 44.68,
@@ -48,8 +51,10 @@ public final class SarirAtmosphericReference {
       new ProductSpecificationReference("Residual", Double.NaN, "<550+", true) };
 
   private static final ProductYieldReference[] PRODUCT_YIELDS = {
-      new ProductYieldReference("Total Naphtha", 208.95, 208.2), new ProductYieldReference("Kerosene", 22.85, 20.0),
-      new ProductYieldReference("Diesel", 425.018, 393.0), new ProductYieldReference("Residual", 646.5, 706.1) };
+      new ProductYieldReference("Total Naphtha", "Naphtha", 208.95, 208.2),
+      new ProductYieldReference("Kerosene", "Kerosene product", 22.85, 20.0),
+      new ProductYieldReference("Diesel", "Diesel product", 425.018, 393.0),
+      new ProductYieldReference("Residual", "Residual", 646.5, 706.1) };
 
   private static final PumparoundReference[] PUMPAROUNDS = {
       new PumparoundReference("Top pump around (TPA)", 3, 1, 29777.64, 143.9, 80.99),
@@ -164,6 +169,53 @@ public final class SarirAtmosphericReference {
   /** @return defensive copy of independent plant/simulation product-yield comparison rows */
   public static ProductYieldReference[] getProductYields() {
     return PRODUCT_YIELDS.clone();
+  }
+
+  /** @return total measured plant rate for the four hydrocarbon products, in kg/h */
+  public static double getPublishedPlantProductMassFlowTotalKgPerHour() {
+    double total = 0.0;
+    for (ProductYieldReference product : PRODUCT_YIELDS) {
+      total += product.getPlantMassFlowRateKgPerHour();
+    }
+    return total;
+  }
+
+  /** @return total source-simulated rate for the four hydrocarbon products, in kg/h */
+  public static double getPublishedSimulationProductMassFlowTotalKgPerHour() {
+    double total = 0.0;
+    for (ProductYieldReference product : PRODUCT_YIELDS) {
+      total += product.getSimulationMassFlowRateKgPerHour();
+    }
+    return total;
+  }
+
+  /** @return total Table 3 rate for the corresponding hydrocarbon outlets, in kg/h */
+  public static double getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour() {
+    double total = 0.0;
+    for (ProductYieldReference product : PRODUCT_YIELDS) {
+      total += product.getPublishedAduMassFlowRateKgPerHour();
+    }
+    return total;
+  }
+
+  /**
+   * Calculate the absolute difference between the converted plant total and the Table 3 hydrocarbon outlet total.
+   *
+   * @return source cross-table difference in kg/h
+   */
+  public static double calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceKgPerHour() {
+    return Math.abs(getPublishedPlantProductMassFlowTotalKgPerHour()
+        - getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour());
+  }
+
+  /**
+   * Calculate the fractional source cross-table difference relative to the converted plant total.
+   *
+   * @return dimensionless absolute difference fraction
+   */
+  public static double calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceFraction() {
+    return calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceKgPerHour()
+        / getPublishedPlantProductMassFlowTotalKgPerHour();
   }
 
   /**
@@ -758,11 +810,14 @@ public final class SarirAtmosphericReference {
   public static final class ProductYieldReference implements Serializable {
     private static final long serialVersionUID = 1000L;
     private final String name;
+    private final String aduStreamName;
     private final double plantMetricTonPerDay;
     private final double simulationMetricTonPerDay;
 
-    private ProductYieldReference(String name, double plantMetricTonPerDay, double simulationMetricTonPerDay) {
+    private ProductYieldReference(String name, String aduStreamName, double plantMetricTonPerDay,
+        double simulationMetricTonPerDay) {
       this.name = name;
+      this.aduStreamName = aduStreamName;
       this.plantMetricTonPerDay = plantMetricTonPerDay;
       this.simulationMetricTonPerDay = simulationMetricTonPerDay;
     }
@@ -770,6 +825,11 @@ public final class SarirAtmosphericReference {
     /** @return exact source-table product label */
     public String getName() {
       return name;
+    }
+
+    /** @return exact corresponding outlet label from the published ADU stream table */
+    public String getAduStreamName() {
+      return aduStreamName;
     }
 
     /** @return measured refinery product rate in metric tonnes/day */
@@ -782,9 +842,49 @@ public final class SarirAtmosphericReference {
       return simulationMetricTonPerDay;
     }
 
+    /** @return measured refinery product rate converted to kg/h */
+    public double getPlantMassFlowRateKgPerHour() {
+      return plantMetricTonPerDay * KILOGRAMS_PER_METRIC_TONNE / HOURS_PER_DAY;
+    }
+
+    /** @return source-simulated product rate converted to kg/h */
+    public double getSimulationMassFlowRateKgPerHour() {
+      return simulationMetricTonPerDay * KILOGRAMS_PER_METRIC_TONNE / HOURS_PER_DAY;
+    }
+
+    /** @return corresponding source Table 3 outlet rate in kg/h */
+    public double getPublishedAduMassFlowRateKgPerHour() {
+      return getAduStream(aduStreamName).getMassFlowRateKgPerHour();
+    }
+
+    /** @return measured plant rate divided by the published crude feed rate */
+    public double getPlantFractionOfCrudeFeed() {
+      return getPlantMassFlowRateKgPerHour() / getColumnCrudeFeedRateKgPerHour();
+    }
+
+    /** @return source-simulated rate divided by the published crude feed rate */
+    public double getSimulationFractionOfCrudeFeed() {
+      return getSimulationMassFlowRateKgPerHour() / getColumnCrudeFeedRateKgPerHour();
+    }
+
     /** @return absolute relative rate error against the measured plant value, in percent */
     public double getAbsoluteRelativeErrorPercent() {
       return calculateAbsoluteRelativeErrorPercent(plantMetricTonPerDay, simulationMetricTonPerDay);
+    }
+
+    /**
+     * Compare a calculated product mass flow with the measured plant value.
+     *
+     * @param calculatedMassFlowRateKgPerHour finite non-negative calculated rate in kg/h
+     * @return absolute relative error against the measured plant value, in percent
+     * @throws IllegalArgumentException if the calculated rate is negative or non-finite
+     */
+    public double calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(
+        double calculatedMassFlowRateKgPerHour) {
+      if (!Double.isFinite(calculatedMassFlowRateKgPerHour) || calculatedMassFlowRateKgPerHour < 0.0) {
+        throw new IllegalArgumentException("Calculated product mass flow must be finite and non-negative");
+      }
+      return calculateAbsoluteRelativeErrorPercent(getPlantMassFlowRateKgPerHour(), calculatedMassFlowRateKgPerHour);
     }
   }
 }

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -204,8 +204,8 @@ public final class SarirAtmosphericReference {
    * @return source cross-table difference in kg/h
    */
   public static double calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceKgPerHour() {
-    return Math.abs(getPublishedPlantProductMassFlowTotalKgPerHour()
-        - getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour());
+    return Math.abs(
+        getPublishedPlantProductMassFlowTotalKgPerHour() - getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour());
   }
 
   /**
@@ -879,8 +879,7 @@ public final class SarirAtmosphericReference {
      * @return absolute relative error against the measured plant value, in percent
      * @throws IllegalArgumentException if the calculated rate is negative or non-finite
      */
-    public double calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(
-        double calculatedMassFlowRateKgPerHour) {
+    public double calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(double calculatedMassFlowRateKgPerHour) {
       if (!Double.isFinite(calculatedMassFlowRateKgPerHour) || calculatedMassFlowRateKgPerHour < 0.0) {
         throw new IllegalArgumentException("Calculated product mass flow must be finite and non-negative");
       }

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
@@ -81,6 +81,7 @@ public class SarirAtmosphericFractionationSensitivityTest {
     StreamInterface[] products = { overhead, kerosene, diesel, bottoms };
 
     assertBalances(column, feed, products);
+    assertReadOnlyPlantYieldComparisons(products);
 
     double feedMassFlow = feed.getFlowRate("kg/hr");
     double[] productMassFractions = new double[products.length];
@@ -199,6 +200,17 @@ public class SarirAtmosphericFractionationSensitivityTest {
     assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
         column.getConvergenceDiagnostics());
     assertComponentMolarBalance(feed, products);
+  }
+
+  private static void assertReadOnlyPlantYieldComparisons(StreamInterface[] products) {
+    String[] productLabels = { "Total Naphtha", "Kerosene", "Diesel", "Residual" };
+    assertEquals(productLabels.length, products.length);
+    for (int i = 0; i < products.length; i++) {
+      ProductYieldReference target = SarirAtmosphericReference.getProductYield(productLabels[i]);
+      double errorPercent = target
+          .calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(products[i].getFlowRate("kg/hr"));
+      assertTrue(Double.isFinite(errorPercent) && errorPercent >= 0.0);
+    }
   }
 
   private static void assertComponentMolarBalance(Stream feed, StreamInterface... products) {

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -138,22 +138,19 @@ public class SarirAtmosphericReferenceTest {
           yield.getPlantFractionOfCrudeFeed(), 1.0e-15);
       assertEquals(simulationKgPerHour[i] / SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(),
           yield.getSimulationFractionOfCrudeFeed(), 1.0e-15);
-      assertEquals(0.0,
-          yield.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(plantKgPerHour[i]), 1.0e-12);
+      assertEquals(0.0, yield.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(plantKgPerHour[i]), 1.0e-12);
       assertEquals(yield.getAbsoluteRelativeErrorPercent(),
           yield.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(simulationKgPerHour[i]), 1.0e-9);
     }
 
-    assertEquals(54304.916666666664,
-        SarirAtmosphericReference.getPublishedPlantProductMassFlowTotalKgPerHour(), 1.0e-9);
-    assertEquals(55304.16666666668,
-        SarirAtmosphericReference.getPublishedSimulationProductMassFlowTotalKgPerHour(), 1.0e-9);
-    assertEquals(54305.43,
-        SarirAtmosphericReference.getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour(), 1.0e-9);
+    assertEquals(54304.916666666664, SarirAtmosphericReference.getPublishedPlantProductMassFlowTotalKgPerHour(),
+        1.0e-9);
+    assertEquals(55304.16666666668, SarirAtmosphericReference.getPublishedSimulationProductMassFlowTotalKgPerHour(),
+        1.0e-9);
+    assertEquals(54305.43, SarirAtmosphericReference.getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour(), 1.0e-9);
     assertEquals(0.5133333333357584,
         SarirAtmosphericReference.calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceKgPerHour(), 1.0e-9);
-    assertTrue(
-        SarirAtmosphericReference.calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceFraction() < 1.0e-5);
+    assertTrue(SarirAtmosphericReference.calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceFraction() < 1.0e-5);
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -120,6 +120,43 @@ public class SarirAtmosphericReferenceTest {
   }
 
   @Test
+  public void productYieldUnitsAndAduMappingsReconcileAcrossPublishedTables() {
+    ProductYieldReference[] yields = SarirAtmosphericReference.getProductYields();
+    String[] aduNames = { "Naphtha", "Kerosene product", "Diesel product", "Residual" };
+    double[] plantKgPerHour = { 8706.25, 952.0833333333334, 17709.083333333332, 26937.5 };
+    double[] simulationKgPerHour = { 8675.0, 833.3333333333334, 16375.0, 29420.833333333332 };
+
+    for (int i = 0; i < yields.length; i++) {
+      ProductYieldReference yield = yields[i];
+      assertEquals(aduNames[i], yield.getAduStreamName());
+      assertEquals(plantKgPerHour[i], yield.getPlantMassFlowRateKgPerHour(), 1.0e-12);
+      assertEquals(simulationKgPerHour[i], yield.getSimulationMassFlowRateKgPerHour(), 1.0e-12);
+      assertEquals(SarirAtmosphericReference.getAduStream(aduNames[i]).getMassFlowRateKgPerHour(),
+          yield.getPublishedAduMassFlowRateKgPerHour(), 0.0);
+      assertTrue(Math.abs(plantKgPerHour[i] - yield.getPublishedAduMassFlowRateKgPerHour()) <= 0.5);
+      assertEquals(plantKgPerHour[i] / SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(),
+          yield.getPlantFractionOfCrudeFeed(), 1.0e-15);
+      assertEquals(simulationKgPerHour[i] / SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(),
+          yield.getSimulationFractionOfCrudeFeed(), 1.0e-15);
+      assertEquals(0.0,
+          yield.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(plantKgPerHour[i]), 1.0e-12);
+      assertEquals(yield.getAbsoluteRelativeErrorPercent(),
+          yield.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(simulationKgPerHour[i]), 1.0e-9);
+    }
+
+    assertEquals(54304.916666666664,
+        SarirAtmosphericReference.getPublishedPlantProductMassFlowTotalKgPerHour(), 1.0e-9);
+    assertEquals(55304.16666666668,
+        SarirAtmosphericReference.getPublishedSimulationProductMassFlowTotalKgPerHour(), 1.0e-9);
+    assertEquals(54305.43,
+        SarirAtmosphericReference.getPublishedAduHydrocarbonProductMassFlowTotalKgPerHour(), 1.0e-9);
+    assertEquals(0.5133333333357584,
+        SarirAtmosphericReference.calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceKgPerHour(), 1.0e-9);
+    assertTrue(
+        SarirAtmosphericReference.calculatePublishedPlantToAduHydrocarbonMassFlowDifferenceFraction() < 1.0e-5);
+  }
+
+  @Test
   public void operatingConfigurationAndProvenanceAreExplicit() {
     assertEquals("10.66411/jer.v33i.46", SarirAtmosphericReference.DOI);
     assertEquals("CC BY 4.0", SarirAtmosphericReference.LICENSE);
@@ -234,6 +271,15 @@ public class SarirAtmosphericReferenceTest {
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(Double.NaN, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(1.0, Double.POSITIVE_INFINITY));
+
+    ProductYieldReference diesel = SarirAtmosphericReference.getProductYield("Diesel");
+    assertEquals(100.0, diesel.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(0.0), 1.0e-12);
+    assertThrows(IllegalArgumentException.class,
+        () -> diesel.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(-1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> diesel.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(Double.NaN));
+    assertThrows(IllegalArgumentException.class,
+        () -> diesel.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(Double.POSITIVE_INFINITY));
   }
 
   private static void assertAduStream(AduStreamReference stream, String name, AduStreamDirection direction,


### PR DESCRIPTION
## Summary

Advances #3305 with a bounded, source-traceable plant-yield comparison contract for the public Sarir atmospheric-distillation reference.

- Converts all four published plant and HYSYS product rates from metric t/day to kg/h.
- Binds each Table 5 product row to its exact matching Table 3 ADU hydrocarbon outlet label.
- Exposes plant, HYSYS, and Table 3 hydrocarbon totals plus the plant-to-Table 3 reconciliation difference.
- Provides a fail-closed per-row comparison for finite non-negative calculated kg/h rates.
- Exercises the comparison from the existing 34-tray property-profile sensitivity qualification without imposing any accuracy threshold or changing column controls.

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5569789799

## Exact-head contract

- Exact base: `f96e1dbfb5b33105ed1f3f788f5b350ee2be057c`
- Exact head: `a142ae73bbe17b2cda9cf6fdcff28aaef05108dc`
- Branch: `codex/3305-sarir-yield-comparison`
- Four intended files and five commits; 0 commits behind the exact base. The fifth commit applies the exact hosted Spotless patch without engineering changes.

## Provenance and engineering acceptance

Source: Almansouri, published 2022-03-31, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), CC BY 4.0.

The published plant total is `54304.916666666664 kg/h`; the matching Table 3 hydrocarbon-outlet total is `54305.43 kg/h`. Their absolute difference is `0.5133333333357584 kg/h`, below `1e-5` of the plant total. Each mapped row differs by no more than `0.5 kg/h`. These are source transcription and unit-basis checks, not plant mass-conservation or model-agreement claims.

Regression acceptance requires exact row mappings and conversions, aggregate arithmetic, defensive reference behavior, fail-closed negative/non-finite inputs, valid zero-rate comparison, and finite non-negative process-comparison outputs. No model-agreement tolerance is introduced.

## Frozen scientific boundary

This PR does not change the TBP assay, pseudo-component property profiles, whole-crude constraints, tray mapping, steam state or injection locations, pump-around/side-stripper topology, correlations, column endpoint or side-draw controls, product specifications, production solver code, or established engineering acceptance limits. Plant and HYSYS rates remain read-only evidence and never become tuning targets.

## Validation

**VALIDATION PENDING EXACT-HEAD CI**

The exact hosted Spotless patch repaired formatting only; scientific behavior, APIs, tests, documentation meaning, and acceptance limits are unchanged.

Hosted GitHub Actions on the exact head are authoritative. Required gates include Spotless, Java 8/21 on Ubuntu and Windows, slow-test shards, full tests and Javadocs, documentation, pre-commit, CodeQL, PaperLab, and agent-skill checks.

## Documentation impact

The Sarir refinery guide now documents exact unit conversion, Table 3 bindings, aggregate reconciliation, Java/JPype access, invalid-input behavior, and the distinction between cross-table evidence and model validation.

## Portfolio and overlap

Open autonomous PRs #3514, #3533, and #3534 touch no refinery-owned path in this increment. Including this draft, occupancy is **4/10**. This is the sole active #3305 PR.

## Stop boundary

Keep this PR draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it as part of the campaign.

Generated with AI assistance.