### PR TITLE
[AI-Assisted] feat(diagram): coordinate PFD and P&ID acceptance

### DIFF
--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -1,3 +1,8 @@
+---
+title: Separation/compression PFD and P&ID visual acceptance
+description: Coordinated dual-profile source-fidelity, exchange, rendering, and qualification requirements for the public comparesimulations2 model.
+---
+
 # Separation/compression PFD and P&ID visual acceptance
 
 This reference tracks the coordinated visual-acceptance milestone in

--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -1,0 +1,65 @@
+# Separation/compression PFD and P&ID visual acceptance
+
+This reference tracks the coordinated visual-acceptance milestone in
+[#1332](https://github.com/equinor/neqsim/issues/1332) and
+[#2899](https://github.com/equinor/neqsim/issues/2899). It uses the public
+`EvenSol/NeqSim-Colab/notebooks/process/comparesimulations2.ipynb` source model.
+
+## Source fidelity
+
+The inspected notebook is blob `68f13ad17dce03ee343e2f711437d57cdcb58f19`.
+Cell `b46addc3` defines reusable `getprocess()`; cell `63e9cf5b` contains a
+detailed reference illustration. Cell `78f9c5ff` is a retained historical
+Graphviz output and is not fresh visual-acceptance evidence.
+
+The runnable model contains 39 named process elements covering three separation
+stages, flash-gas cooling/scrubbing/recompression, liquid returns, two-sided gas
+heat exchange, fuel-gas splitting, gas export, and oil export. The illustration
+shows `24-VB-01`, but `getprocess()` does not contain that equipment or a
+water-removal duty. Implementations must not invent either to resemble the
+illustration.
+
+## Coordinated delivery API
+
+`EngineeringDiagramDualProfileDelivery` publishes `pfd/` and `pid/`
+sub-deliveries from the same `ProcessSystem`. It fails when either delivery is
+incomplete or the canonical source-graph fingerprints differ.
+
+Each sub-delivery contains controlled document JSON, native SVG sheet(s), a
+native PDF drawing set, native DEXPI 2.0 Process XML, and a delivery manifest.
+The bundle manifest labels the PFD exchange as `DEXPI_2_0_PROCESS`. For the
+P&ID proposal, the same exchange is labelled
+`PROCESS_PFD_BFD_COMPANION_ONLY`: it is not a DEXPI Plant or Proteus P&ID
+exchange.
+
+The facade is intentionally opt-in. Existing Graphviz, native DEXPI Process and
+Plant, Proteus, simulation, and document APIs are unchanged.
+
+## Requirement and evidence matrix
+
+| Requirement | Current implementation | Automated evidence | Remaining acceptance work |
+| --- | --- | --- | --- |
+| One canonical plant, distinct PFD/P&ID profiles | Dual-profile facade and shared source fingerprint | `EngineeringDiagramDualProfileDeliveryTest` | Run and qualify the full notebook model |
+| Reviewable vector and PDF sheets | Existing native SVG/PDF renderer, A3 default, fixed-port orthogonal routing | Existing renderer tests plus bundle artifact checks | Full-sheet and detail inspection of every new reference sheet |
+| Stable regeneration | Deterministic child and bundle manifests | Fresh-model repeated-delivery test | Normalized reference baselines for the full model |
+| Native PFD exchange | Native DEXPI 2.0 Process artifact | Existing delivery assessment and bundle labels | Full-model topology/loss evidence |
+| P&ID exchange identity | Fail-closed companion-only label | Manifest assertion | Add and qualify a separately labelled Plant/Proteus proposal artifact |
+| Stream and H&MB companions | Existing governed stream and balance models | Existing focused tests | Publish full-model companions and boundary assignments |
+| Piping and instrumentation content | Existing governed proposal, Proteus writer, and detailed DEXPI paths | Existing DEXPI/P&ID tests | Bind explicit line/nozzle/valve/reducer/instrument/control/interface registers to this model |
+| Manual layout and routing | Existing evidence-bearing layout register | Existing layout and renderer tests | Declare full-model sheets, pins, protected routes, and stale-reference regeneration |
+| Standards alignment | Explicit scope and no-conformance boundary | Manifest flags and documentation checks | Licensed clause mapping and accountable review |
+
+## Engineering and qualification boundary
+
+The target scope uses ISO 10628-1:2014 and ISO 10628-2:2012 for process-diagram
+content and symbols, ANSI/ISA-5.1-2024 for instrumentation/control
+identification, and applicable ISO 14617, ISO 5457, ISO 7200, ISO 3098, and IEC
+62424 requirements. Public catalog metadata establishes scope only. Licensed
+clause mapping, project convention approval, external DEXPI qualification,
+discipline checking, certification, and construction fitness remain gaps.
+
+The P&ID output is a teaching proposal until project line classes, sizes,
+specifications, nozzles, valves, reducers, instruments, control functions,
+isolation, drains, vents, and relief/blowdown interfaces have explicit governed
+evidence. Missing data must remain visible; the steady-state model does not
+supply a complete control or safety design.

--- a/docs/integration/engineering-diagram-delivery.md
+++ b/docs/integration/engineering-diagram-delivery.md
@@ -5,6 +5,9 @@ description: Fail-closed publication of assessed DEXPI, controlled semantic JSON
 
 # Engineering diagram delivery workflow
 
+For the coordinated dual-profile reference workflow and its source-fidelity, exchange-profile, and visual-acceptance
+boundaries, see [Separation/compression PFD and P&ID visual acceptance](comparesimulations-pfd-pid-acceptance.md).
+
 `EngineeringDiagramDelivery` is an opt-in Java facade for publishing the related engineering-diagram
 projections of one canonical NeqSim model as a single assessed delivery. It supports both a
 `ProcessSystem` and a multi-area `ProcessModel` without changing the existing DOT/Graphviz, Classic,

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
@@ -1,0 +1,335 @@
+package neqsim.process.processmodel.diagram;
+
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister;
+import neqsim.process.processmodel.ProcessSystem;
+
+/**
+ * Publishes coordinated PFD and review-required P&amp;ID proposal deliveries from one canonical
+ * {@link ProcessSystem}.
+ *
+ * <p>
+ * Both views are generated from the same process object and must retain the same canonical source-graph fingerprint.
+ * The P&amp;ID view is not a complete control, piping, or safety design. Its accompanying native DEXPI 2.0 Process file
+ * is a PFD/BFD information-model companion only; it is not represented as a DEXPI Plant or Proteus P&amp;ID exchange.
+ * </p>
+ *
+ * <p>
+ * This opt-in facade does not claim ISO 10628, ISO 14617, ISA-5.1, DEXPI interoperability, discipline approval, or
+ * fitness for construction.
+ * </p>
+ */
+public final class EngineeringDiagramDualProfileDelivery {
+  private static final String SCHEMA_VERSION = "neqsim_engineering_diagram_dual_profile_delivery.v1";
+  private static final String MANIFEST_FILE = "dual-profile-manifest.json";
+
+  private EngineeringDiagramDualProfileDelivery() {
+  }
+
+  /** Immutable coordinated delivery request. */
+  public static final class Request {
+    private final String plantId;
+    private final String revision;
+    private final String pfdDrawingNumber;
+    private final String pidDrawingNumber;
+    private final String title;
+    private final String operatingCaseId;
+    private final NativeEngineeringDiagramRenderer.SheetFormat sheetFormat;
+    private final NativeEngineeringDiagramRenderer.RoutingMode routingMode;
+    private final EngineeringDiagramDesignationRegister designationRegister;
+    private final EngineeringDiagramLayoutRegister layoutRegister;
+    private final EngineeringDiagramConventionRegister conventionRegister;
+
+    private Request(Builder builder) {
+      plantId = requireText(builder.plantId, "plantId");
+      revision = requireText(builder.revision, "revision");
+      pfdDrawingNumber = requireText(builder.pfdDrawingNumber, "pfdDrawingNumber");
+      pidDrawingNumber = requireText(builder.pidDrawingNumber, "pidDrawingNumber");
+      title = requireText(builder.title, "title");
+      operatingCaseId = optionalText(builder.operatingCaseId);
+      sheetFormat = requireNonNull(builder.sheetFormat, "sheetFormat");
+      routingMode = requireNonNull(builder.routingMode, "routingMode");
+      designationRegister = requireNonNull(builder.designationRegister, "designationRegister");
+      layoutRegister = requireNonNull(builder.layoutRegister, "layoutRegister");
+      conventionRegister = requireNonNull(builder.conventionRegister, "conventionRegister");
+      if (pfdDrawingNumber.equals(pidDrawingNumber)) {
+        throw new IllegalArgumentException("PFD and P&ID drawing numbers must be distinct");
+      }
+    }
+
+    /**
+     * Starts a request for coordinated PFD and P&amp;ID proposal deliveries.
+     *
+     * @param plantId persistent plant identity
+     * @param revision controlled source-model revision
+     * @param pfdDrawingNumber controlled PFD drawing number
+     * @param pidDrawingNumber controlled P&amp;ID drawing number
+     * @param title common drawing-set title
+     * @return request builder
+     */
+    public static Builder builder(String plantId, String revision, String pfdDrawingNumber, String pidDrawingNumber,
+        String title) {
+      return new Builder(plantId, revision, pfdDrawingNumber, pidDrawingNumber, title);
+    }
+
+    /** Mutable builder for a coordinated request. */
+    public static final class Builder {
+      private final String plantId;
+      private final String revision;
+      private final String pfdDrawingNumber;
+      private final String pidDrawingNumber;
+      private final String title;
+      private String operatingCaseId;
+      private NativeEngineeringDiagramRenderer.SheetFormat sheetFormat =
+          NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE;
+      private NativeEngineeringDiagramRenderer.RoutingMode routingMode =
+          NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL;
+      private EngineeringDiagramDesignationRegister designationRegister =
+          new EngineeringDiagramDesignationRegister();
+      private EngineeringDiagramLayoutRegister layoutRegister = new EngineeringDiagramLayoutRegister();
+      private EngineeringDiagramConventionRegister conventionRegister =
+          new EngineeringDiagramConventionRegister();
+
+      private Builder(String plantId, String revision, String pfdDrawingNumber, String pidDrawingNumber,
+          String title) {
+        this.plantId = plantId;
+        this.revision = revision;
+        this.pfdDrawingNumber = pfdDrawingNumber;
+        this.pidDrawingNumber = pidDrawingNumber;
+        this.title = title;
+      }
+
+      /** @param value successfully-run operating-case identity @return this builder */
+      public Builder operatingCaseId(String value) {
+        operatingCaseId = requireText(value, "operatingCaseId");
+        return this;
+      }
+
+      /** @param value common sheet format @return this builder */
+      public Builder sheetFormat(NativeEngineeringDiagramRenderer.SheetFormat value) {
+        sheetFormat = requireNonNull(value, "sheetFormat");
+        return this;
+      }
+
+      /** @param value common routing mode @return this builder */
+      public Builder routingMode(NativeEngineeringDiagramRenderer.RoutingMode value) {
+        routingMode = requireNonNull(value, "routingMode");
+        return this;
+      }
+
+      /** @param value common designation evidence @return this builder */
+      public Builder designationRegister(EngineeringDiagramDesignationRegister value) {
+        designationRegister = requireNonNull(value, "designationRegister");
+        return this;
+      }
+
+      /** @param value common manual layout evidence @return this builder */
+      public Builder layoutRegister(EngineeringDiagramLayoutRegister value) {
+        layoutRegister = requireNonNull(value, "layoutRegister");
+        return this;
+      }
+
+      /** @param value common project symbol conventions @return this builder */
+      public Builder conventionRegister(EngineeringDiagramConventionRegister value) {
+        conventionRegister = requireNonNull(value, "conventionRegister");
+        return this;
+      }
+
+      /** @return validated immutable request */
+      public Request build() {
+        return new Request(this);
+      }
+    }
+  }
+
+  /** Immutable coordinated-delivery evidence. */
+  public static final class Report {
+    private final Path directory;
+    private final EngineeringDiagramDelivery.Report pfd;
+    private final EngineeringDiagramDelivery.Report pid;
+    private final String fingerprint;
+
+    private Report(Path directory, EngineeringDiagramDelivery.Report pfd,
+        EngineeringDiagramDelivery.Report pid) {
+      this.directory = directory;
+      this.pfd = pfd;
+      this.pid = pid;
+      fingerprint = sha256(new GsonBuilder().create().toJson(toMapWithoutFingerprint()));
+    }
+
+    /** @return published bundle directory */
+    public Path getDirectory() {
+      return directory;
+    }
+
+    /** @return PFD delivery evidence */
+    public EngineeringDiagramDelivery.Report getPfd() {
+      return pfd;
+    }
+
+    /** @return review-required P&amp;ID proposal delivery evidence */
+    public EngineeringDiagramDelivery.Report getPid() {
+      return pid;
+    }
+
+    /** @return deterministic manifest fingerprint */
+    public String getFingerprint() {
+      return fingerprint;
+    }
+
+    /** @return whether both deliveries passed and retained one canonical source graph */
+    public boolean isComplete() {
+      return pfd.isComplete() && pid.isComplete()
+          && pfd.getDocumentSet().getSourceGraphFingerprint()
+              .equals(pid.getDocumentSet().getSourceGraphFingerprint());
+    }
+
+    /** @return deterministic machine-readable evidence */
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = toMapWithoutFingerprint();
+      result.put("fingerprint", fingerprint);
+      return result;
+    }
+
+    /** @return pretty-printed deterministic manifest JSON */
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+
+    private Map<String, Object> toMapWithoutFingerprint() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", SCHEMA_VERSION);
+      result.put("plantId", pfd.getDocumentSet().getPlantId());
+      result.put("revision", pfd.getDocumentSet().getRevision());
+      result.put("sourceGraphFingerprint", pfd.getDocumentSet().getSourceGraphFingerprint());
+      result.put("pfdContentProfile", ContentProfile.PFD.name());
+      result.put("pidContentProfile", ContentProfile.PID.name());
+      result.put("pfdDexpiInformationModel", "DEXPI_2_0_PROCESS");
+      result.put("pidDexpiInformationModel", "PROCESS_PFD_BFD_COMPANION_ONLY");
+      result.put("pidApprovalStatus", "REVIEW_REQUIRED");
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("iso10628ConformanceClaimed", Boolean.FALSE);
+      result.put("sameCanonicalPlant", Boolean.valueOf(isComplete()));
+      result.put("pfdDelivery", pfd.toMap());
+      result.put("pidDelivery", pid.toMap());
+      return result;
+    }
+  }
+
+  /**
+   * Publishes coordinated PFD and P&amp;ID proposal deliveries.
+   *
+   * @param processSystem successfully configured process model
+   * @param directory new destination directory
+   * @param request controlled coordinated request
+   * @return coordinated delivery report
+   * @throws IOException when either bounded delivery or final manifest publication fails
+   */
+  public static Report deliver(ProcessSystem processSystem, Path directory, Request request) throws IOException {
+    if (processSystem == null || directory == null || request == null) {
+      throw new IllegalArgumentException("processSystem, directory, and request must not be null");
+    }
+    Path target = directory.toAbsolutePath().normalize();
+    if (Files.exists(target)) {
+      throw new IllegalArgumentException("delivery directory must not already exist: " + target);
+    }
+    Files.createDirectories(target);
+    try {
+      EngineeringDiagramDelivery.Report pfd = EngineeringDiagramDelivery.deliver(processSystem,
+          target.resolve("pfd"), deliveryRequest(request, ContentProfile.PFD, request.pfdDrawingNumber));
+      EngineeringDiagramDelivery.Report pid = EngineeringDiagramDelivery.deliver(processSystem,
+          target.resolve("pid"), deliveryRequest(request, ContentProfile.PID, request.pidDrawingNumber));
+      Report report = new Report(target, pfd, pid);
+      if (!report.isComplete()) {
+        throw new IOException("PFD and P&ID deliveries do not retain one complete canonical plant");
+      }
+      Files.write(target.resolve(MANIFEST_FILE), report.toJson().getBytes(StandardCharsets.UTF_8));
+      return report;
+    } catch (IOException ex) {
+      deleteRecursively(target);
+      throw ex;
+    } catch (RuntimeException ex) {
+      deleteRecursively(target);
+      throw ex;
+    }
+  }
+
+  private static EngineeringDiagramDelivery.Request deliveryRequest(Request request, ContentProfile profile,
+      String drawingNumber) {
+    EngineeringDiagramDelivery.Request.Builder builder = EngineeringDiagramDelivery.Request
+        .builder(request.plantId, request.revision, drawingNumber,
+            request.title + (profile == ContentProfile.PFD ? " — PFD" : " — P&ID proposal"), profile)
+        .sheetFormat(request.sheetFormat).routingMode(request.routingMode)
+        .designationRegister(request.designationRegister).layoutRegister(request.layoutRegister)
+        .conventionRegister(request.conventionRegister);
+    if (!request.operatingCaseId.isEmpty()) {
+      builder.operatingCaseId(request.operatingCaseId);
+    }
+    return builder.build();
+  }
+
+  private static void deleteRecursively(Path path) {
+    if (path == null || !Files.exists(path)) {
+      return;
+    }
+    try {
+      if (Files.isDirectory(path)) {
+        DirectoryStream<Path> children = Files.newDirectoryStream(path);
+        try {
+          for (Path child : children) {
+            deleteRecursively(child);
+          }
+        } finally {
+          children.close();
+        }
+      }
+      Files.deleteIfExists(path);
+    } catch (IOException ignored) {
+      // Best-effort cleanup must not hide the original publication failure.
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    String result = optionalText(value);
+    if (result.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be null or blank");
+    }
+    return result;
+  }
+
+  private static String optionalText(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static <T> T requireNonNull(T value, String name) {
+    if (value == null) {
+      throw new IllegalArgumentException(name + " must not be null");
+    }
+    return value;
+  }
+
+  private static String sha256(String value) {
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder result = new StringBuilder();
+      for (byte item : digest) {
+        result.append(String.format("%02x", item & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is required by the Java runtime", ex);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
@@ -17,8 +17,7 @@ import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
- * Publishes coordinated PFD and review-required P&amp;ID proposal deliveries from one canonical
- * {@link ProcessSystem}.
+ * Publishes coordinated PFD and review-required P&amp;ID proposal deliveries from one canonical {@link ProcessSystem}.
  *
  * <p>
  * Both views are generated from the same process object and must retain the same canonical source-graph fingerprint.
@@ -92,18 +91,13 @@ public final class EngineeringDiagramDualProfileDelivery {
       private final String pidDrawingNumber;
       private final String title;
       private String operatingCaseId;
-      private NativeEngineeringDiagramRenderer.SheetFormat sheetFormat =
-          NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE;
-      private NativeEngineeringDiagramRenderer.RoutingMode routingMode =
-          NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL;
-      private EngineeringDiagramDesignationRegister designationRegister =
-          new EngineeringDiagramDesignationRegister();
+      private NativeEngineeringDiagramRenderer.SheetFormat sheetFormat = NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE;
+      private NativeEngineeringDiagramRenderer.RoutingMode routingMode = NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL;
+      private EngineeringDiagramDesignationRegister designationRegister = new EngineeringDiagramDesignationRegister();
       private EngineeringDiagramLayoutRegister layoutRegister = new EngineeringDiagramLayoutRegister();
-      private EngineeringDiagramConventionRegister conventionRegister =
-          new EngineeringDiagramConventionRegister();
+      private EngineeringDiagramConventionRegister conventionRegister = new EngineeringDiagramConventionRegister();
 
-      private Builder(String plantId, String revision, String pfdDrawingNumber, String pidDrawingNumber,
-          String title) {
+      private Builder(String plantId, String revision, String pfdDrawingNumber, String pidDrawingNumber, String title) {
         this.plantId = plantId;
         this.revision = revision;
         this.pfdDrawingNumber = pfdDrawingNumber;
@@ -161,8 +155,7 @@ public final class EngineeringDiagramDualProfileDelivery {
     private final EngineeringDiagramDelivery.Report pid;
     private final String fingerprint;
 
-    private Report(Path directory, EngineeringDiagramDelivery.Report pfd,
-        EngineeringDiagramDelivery.Report pid) {
+    private Report(Path directory, EngineeringDiagramDelivery.Report pfd, EngineeringDiagramDelivery.Report pid) {
       this.directory = directory;
       this.pfd = pfd;
       this.pid = pid;
@@ -192,8 +185,7 @@ public final class EngineeringDiagramDualProfileDelivery {
     /** @return whether both deliveries passed and retained one canonical source graph */
     public boolean isComplete() {
       return pfd.isComplete() && pid.isComplete()
-          && pfd.getDocumentSet().getSourceGraphFingerprint()
-              .equals(pid.getDocumentSet().getSourceGraphFingerprint());
+          && pfd.getDocumentSet().getSourceGraphFingerprint().equals(pid.getDocumentSet().getSourceGraphFingerprint());
     }
 
     /** @return deterministic machine-readable evidence */
@@ -247,10 +239,10 @@ public final class EngineeringDiagramDualProfileDelivery {
     }
     Files.createDirectories(target);
     try {
-      EngineeringDiagramDelivery.Report pfd = EngineeringDiagramDelivery.deliver(processSystem,
-          target.resolve("pfd"), deliveryRequest(request, ContentProfile.PFD, request.pfdDrawingNumber));
-      EngineeringDiagramDelivery.Report pid = EngineeringDiagramDelivery.deliver(processSystem,
-          target.resolve("pid"), deliveryRequest(request, ContentProfile.PID, request.pidDrawingNumber));
+      EngineeringDiagramDelivery.Report pfd = EngineeringDiagramDelivery.deliver(processSystem, target.resolve("pfd"),
+          deliveryRequest(request, ContentProfile.PFD, request.pfdDrawingNumber));
+      EngineeringDiagramDelivery.Report pid = EngineeringDiagramDelivery.deliver(processSystem, target.resolve("pid"),
+          deliveryRequest(request, ContentProfile.PID, request.pidDrawingNumber));
       Report report = new Report(target, pfd, pid);
       if (!report.isComplete()) {
         throw new IOException("PFD and P&ID deliveries do not retain one complete canonical plant");

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -1,0 +1,74 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import neqsim.process.processmodel.ProcessSystem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EngineeringDiagramDualProfileDeliveryTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void publishesPfdAndReviewRequiredPidFromOneCanonicalPlant() throws IOException {
+    ProcessSystem process = EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem();
+    String classicDot = process.toDOT();
+    EngineeringDiagramDualProfileDelivery.Request request = EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build();
+
+    EngineeringDiagramDualProfileDelivery.Report report = EngineeringDiagramDualProfileDelivery.deliver(process,
+        temporaryDirectory.resolve("dual-profile"), request);
+
+    assertTrue(report.isComplete(), report.toJson());
+    assertEquals(report.getPfd().getDocumentSet().getSourceGraphFingerprint(),
+        report.getPid().getDocumentSet().getSourceGraphFingerprint());
+    assertEquals(classicDot, process.toDOT());
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("pfd/drawing-set.pdf")));
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("pid/drawing-set.pdf")));
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("dual-profile-manifest.json")));
+    assertTrue(report.toJson().contains("\"pfdContentProfile\": \"PFD\""));
+    assertTrue(report.toJson().contains("\"pidContentProfile\": \"PID\""));
+    assertTrue(report.toJson().contains("\"pidApprovalStatus\": \"REVIEW_REQUIRED\""));
+    assertTrue(report.toJson().contains("\"pidDexpiInformationModel\": \"PROCESS_PFD_BFD_COMPANION_ONLY\""));
+    assertFalse(report.toJson().contains("\"fitnessForConstruction\": true"));
+  }
+
+  @Test
+  void isDeterministicAcrossFreshDestinations() throws IOException {
+    EngineeringDiagramDualProfileDelivery.Request request = EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-20", "B", "PFD-20-001", "PID-20-001", "Branched separation and compression").build();
+
+    EngineeringDiagramDualProfileDelivery.Report first = EngineeringDiagramDualProfileDelivery.deliver(
+        EngineeringDiagramReferenceFixtures.branchedSeparatorCompressionTrain().getProcessSystem(),
+        temporaryDirectory.resolve("first"), request);
+    EngineeringDiagramDualProfileDelivery.Report second = EngineeringDiagramDualProfileDelivery.deliver(
+        EngineeringDiagramReferenceFixtures.branchedSeparatorCompressionTrain().getProcessSystem(),
+        temporaryDirectory.resolve("second"), request);
+
+    assertEquals(first.toJson(), second.toJson());
+    assertEquals(first.getFingerprint(), second.getFingerprint());
+    assertEquals(first.getPfd().getFingerprint(), second.getPfd().getFingerprint());
+    assertEquals(first.getPid().getFingerprint(), second.getPid().getFingerprint());
+  }
+
+  @Test
+  void refusesExistingDestinationAndMismatchedPlantIdentity() throws IOException {
+    Path existing = Files.createDirectory(temporaryDirectory.resolve("existing"));
+    EngineeringDiagramDualProfileDelivery.Request request = EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDualProfileDelivery.deliver(
+            EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), existing, request));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDualProfileDelivery.Request
+            .builder(" ", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build());
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -64,11 +64,9 @@ class EngineeringDiagramDualProfileDeliveryTest {
     EngineeringDiagramDualProfileDelivery.Request request = EngineeringDiagramDualProfileDelivery.Request
         .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build();
 
-    assertThrows(IllegalArgumentException.class,
-        () -> EngineeringDiagramDualProfileDelivery.deliver(
-            EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), existing, request));
-    assertThrows(IllegalArgumentException.class,
-        () -> EngineeringDiagramDualProfileDelivery.Request
-            .builder(" ", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build());
+    assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramDualProfileDelivery
+        .deliver(EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), existing, request));
+    assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramDualProfileDelivery.Request
+        .builder(" ", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build());
   }
 }


### PR DESCRIPTION
## Summary

Begins the user-prioritized `comparesimulations2.ipynb` dual-profile visual-acceptance milestone for #1332 and #2899.

- Adds an opt-in fail-closed facade that publishes PFD and review-required P&ID proposal deliveries from one canonical `ProcessSystem`.
- Requires identical canonical source-graph fingerprints across both profiles.
- Preserves distinct drawing identities and emits native SVG/PDF, controlled document JSON, native DEXPI 2.0 Process companions, and deterministic child/bundle manifests.
- Labels the P&ID exchange as `PROCESS_PFD_BFD_COMPANION_ONLY`; it is not misrepresented as DEXPI Plant or Proteus P&ID evidence.
- Records the inspected notebook source, the 39-unit runnable-model boundary, the absent illustrated `24-VB-01`, the standards/approval limits, and the full requirement/evidence backlog.

Capability contracts: [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5570453447) and [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5570461069).

## Exact continuity

- Exact base: `f96e1dbfb5b33105ed1f3f788f5b350ee2be057c`
- Exact head: `9f80bfa8c7c7b7e7c114688d47ddbf29784b4492`
- Branch: `ai/comparesimulations-pfd-pid-acceptance`
- Four ordered commits; four intended files
- Tests were authored first

## Frozen concept and continuation

This is the sole shared #1332/#2899 lane. Continue this same draft with the largest coherent acceptance batch: the exact notebook-model reference fixture and governed base case; stream/H&MB companions; explicit P&ID engineering/gap registers; separately labelled Plant/Proteus proposal evidence; persistent sheets/pins/routes; full-model topology and regeneration checks; and retained full-sheet/detail visual evidence.

Do not add unrelated DEXPI metadata. The NeqSim-Colab notebook publication remains a real subsequent boundary: it must wait for the library API/reference batch to merge and then be clean-executed with retained outputs and complete visual/equation inspection.

## Source and engineering boundary

Source notebook: `EvenSol/NeqSim-Colab/notebooks/process/comparesimulations2.ipynb`, inspected blob `68f13ad17dce03ee343e2f711437d57cdcb58f19`, reusable model cell `b46addc3`. The historical Graphviz output in cell `78f9c5ff` is not acceptance evidence. The detailed illustration contains `24-VB-01`, but the runnable model does not; this PR must not invent water-removal equipment or duty.

Generated PFDs and P&IDs are proposals. No complete control or safety design, ISO/ISA conformance, DEXPI interoperability, certification, discipline approval, or construction fitness is claimed. Public standards catalogs establish scope only; licensed clause mapping and accountable review remain gaps.

## Compatibility

Opt-in only. Preserve Java 8, simulation state/results/topology, legacy Graphviz, existing BFD/PFD/PID profiles, current JSON fields, native DEXPI 2.0 Process/Plant, Proteus, and deterministic ordering.

## Validation status

**DRAFT — INITIAL EXACT-HEAD CI PENDING**

No local Maven, Spotless, pre-commit, or runtime result is claimed in this connector-only run. GitHub Actions on the exact head are authoritative. The draft must remain open for in-scope implementation and all fast/slow Java 8/21, Javadocs, formatting, documentation, notebook, visual, CodeQL, and reference gates.

## Portfolio and stop boundary

Six positively identified autonomous NeqSim capabilities were open before this draft; including it, occupancy is **7/10**. No active PR overlaps the four diagram/documentation paths in this initial tree.

Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon this draft. Do not claim standards conformance, certification, safety credit, or engineering approval.

Generated with AI assistance.