### PR TITLE
Add named addTBPfraction overloads with an explicit closure model

### DIFF
--- a/devtools/analyze_rd1987_inversion.py
+++ b/devtools/analyze_rd1987_inversion.py
@@ -1,0 +1,156 @@
+"""Why RD-1987 can supply a molar mass but cannot supply a specific gravity.
+
+The two uses look symmetric but are not:
+
+    addTBPfraction_Tb_Kw   SG comes from the Watson *definition*, exactly.
+                           RD-1987 is then evaluated FORWARD: M = f(Tb, SG).
+
+    addTBPfraction_Mw_Tb   SG is the unknown. RD-1987 would have to be
+                           INVERTED: solve f(Tb, SG) = M for SG.
+
+Evaluating a correlation forward is always well posed. Inverting it is only
+well posed if it is monotonic. This script shows where RD-1987 turns over, how
+many roots the inverse has, and how badly conditioned it is in the band where
+petroleum fractions actually sit.
+
+Usage:
+    python devtools/analyze_rd1987_inversion.py
+"""
+
+from __future__ import annotations
+
+import math
+
+# Real components from COMP.csv, used to show where the turning point falls
+# relative to fractions people actually characterize.
+REFERENCE_COMPONENTS = [
+    ("n-heptane", 371.6, 0.690, 100.2),
+    ("nC10", 447.3, 0.734, 142.3),
+    ("nC14", 526.7, 0.764, 198.4),
+    ("toluene", 383.8, 0.871, 92.1),
+    ("m-Xylene", 412.3, 0.868, 106.2),
+]
+
+
+def molar_mass_rd1987(tb_k: float, sg: float) -> float:
+    """RD-1987, forward direction. Returns g/mol."""
+    return (
+        42.965
+        * math.exp(2.097e-4 * tb_k - 7.78712 * sg + 2.08476e-3 * tb_k * sg)
+        * tb_k**1.26007
+        * sg**4.98308
+    )
+
+
+def molar_mass_rd1980(tb_k: float, sg: float) -> float:
+    """RD-1980, forward direction. Returns g/mol."""
+    return 4.5673e-5 * (tb_k * 1.8) ** 2.1962 * sg**-1.0164
+
+
+def turning_point_sg(tb_k: float) -> float:
+    """Specific gravity at which dM/dSG = 0 for RD-1987.
+
+    d(ln M)/d(ln SG) = 4.98308 + SG*(-7.78712 + 2.08476e-3*Tb), which vanishes at
+    SG = 4.98308 / (7.78712 - 2.08476e-3*Tb).
+    """
+    return 4.98308 / (7.78712 - 2.08476e-3 * tb_k)
+
+
+def log_sensitivity_rd1987(tb_k: float, sg: float) -> float:
+    """d(ln M)/d(ln SG) for RD-1987."""
+    return 4.98308 + sg * (-7.78712 + 2.08476e-3 * tb_k)
+
+
+def count_roots(tb_k: float, target_molar_mass: float, lo: float = 0.60, hi: float = 1.00) -> int:
+    """Number of specific gravities in [lo, hi] that reproduce the target molar mass."""
+    steps = 4000
+    roots = 0
+    previous = molar_mass_rd1987(tb_k, lo) - target_molar_mass
+    for i in range(1, steps + 1):
+        sg = lo + (hi - lo) * i / steps
+        current = molar_mass_rd1987(tb_k, sg) - target_molar_mass
+        if previous == 0.0 or previous * current < 0.0:
+            roots += 1
+        previous = current
+    return roots
+
+
+def main() -> None:
+    print("=" * 76)
+    print("1. Where does RD-1987 turn over in specific gravity?")
+    print("=" * 76)
+    print(f"{'Tb / K':>8}{'SG at dM/dSG = 0':>20}{'sits inside 0.60-1.00?':>26}")
+    for tb in (350.0, 400.0, 450.0, 500.0, 550.0, 600.0):
+        sg_star = turning_point_sg(tb)
+        inside = "yes" if 0.60 <= sg_star <= 1.00 else "no"
+        print(f"{tb:>8.0f}{sg_star:>20.3f}{inside:>26}")
+    print(
+        "\nThe turning point lands at SG 0.71 to 0.77 - the middle of the petroleum\n"
+        "range, and exactly where paraffins live."
+    )
+
+    print("\n" + "=" * 76)
+    print("2. How many specific gravities reproduce a given (Tb, M)?")
+    print("=" * 76)
+    print(f"{'component':<14}{'Tb / K':>8}{'M g/mol':>10}{'RD-1987 roots':>16}{'RD-1980 roots':>16}")
+    for name, tb, _sg, molar_mass in REFERENCE_COMPONENTS:
+        n_1987 = count_roots(tb, molar_mass)
+        # RD-1980 is a pure power law in SG, so it has exactly one root wherever the
+        # target is inside the range spanned over the interval.
+        lo_value = molar_mass_rd1980(tb, 0.60)
+        hi_value = molar_mass_rd1980(tb, 1.00)
+        n_1980 = 1 if min(lo_value, hi_value) <= molar_mass <= max(lo_value, hi_value) else 0
+        print(f"{name:<14}{tb:>8.1f}{molar_mass:>10.1f}{n_1987:>16}{n_1980:>16}")
+    print(
+        "\nTwo roots means the inverse is ambiguous: one solution on the paraffinic\n"
+        "side of the turning point and one on the aromatic side, both reproducing the\n"
+        "same molar mass. Nothing in the inputs says which one the caller meant."
+    )
+
+    print("\n" + "=" * 76)
+    print("3. How well conditioned is the inverse where fractions actually sit?")
+    print("=" * 76)
+    print("Error amplification: a 1 % error in M becomes this many % error in SG.")
+    print(f"{'component':<14}{'SG':>7}{'dlnM/dlnSG':>13}{'amplification':>16}")
+    for name, tb, sg, _molar_mass in REFERENCE_COMPONENTS:
+        gain = log_sensitivity_rd1987(tb, sg)
+        amplification = float("inf") if abs(gain) < 1e-12 else abs(1.0 / gain)
+        shown = "infinite" if amplification > 1e6 else "{:.1f}x".format(amplification)
+        print(f"{name:<14}{sg:>7.3f}{gain:>13.3f}{shown:>16}")
+
+    print("\nSame quantity for RD-1980, whose exponent is constant:")
+    print(f"{'':<14}{'':>7}{'dlnM/dlnSG':>13}{'amplification':>16}")
+    print(f"{'any':<14}{'any':>7}{-1.0164:>13.3f}{'1.0x':>16}")
+
+    print(
+        "\nAcross these paraffins the amplification runs from 7x to 21x, worst at nC10\n"
+        "where the turning point almost coincides with the component. A 2 % uncertainty\n"
+        "in nC10's molar mass - better than most cuts are known - would move the\n"
+        "inferred specific gravity by about 40 %. That is not a usable inverse, which\n"
+        "is why addTBPfraction_Mw_Tb refuses RD-1987 and defaults to RD-1980 instead.\n"
+        "Note the aromatics are fine: they sit well away from the turning point. The\n"
+        "inverse fails precisely for the fractions most people characterize.\n"
+    )
+
+    print("=" * 76)
+    print("4. The forward direction, which is what addTBPfraction_Tb_Kw uses")
+    print("=" * 76)
+    print(f"{'component':<14}{'Tb / K':>8}{'Kw':>8}{'SG (exact)':>12}{'M RD-1987':>12}{'M actual':>10}{'dev':>8}")
+    for name, tb, sg, molar_mass in REFERENCE_COMPONENTS:
+        watson_k = (1.8 * tb) ** (1.0 / 3.0) / sg
+        sg_from_kw = (1.8 * tb) ** (1.0 / 3.0) / watson_k
+        predicted = molar_mass_rd1987(tb, sg_from_kw)
+        dev = 100.0 * (predicted - molar_mass) / molar_mass
+        print(
+            f"{name:<14}{tb:>8.1f}{watson_k:>8.3f}{sg_from_kw:>12.4f}"
+            f"{predicted:>12.1f}{molar_mass:>10.1f}{dev:>7.1f}%"
+        )
+    print(
+        "\nNo inversion anywhere: the Watson definition gives SG exactly, then RD-1987\n"
+        "is evaluated once, forward. The turning point is irrelevant because we never\n"
+        "have to ask which SG produced a given M."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/devtools/analyze_tbp_closure_invertibility.py
+++ b/devtools/analyze_tbp_closure_invertibility.py
@@ -1,0 +1,159 @@
+"""Determine which closure directions are numerically sound, and derive PNA Watson-K defaults.
+
+Two questions have to be answered with numbers before the named ``addTBPfraction_*``
+overloads can be written:
+
+1. Which closures can be inverted for specific gravity given (Tb, M)? A correlation
+   that is non-monotonic in SG over the range of interest has no unique inverse, and
+   an overload that pretends otherwise would silently return one of several roots.
+
+2. What Watson K should represent a pure paraffin, naphthene and aromatic in the
+   PNA-to-Kw blend? These are derived from COMP.csv rather than quoted from memory,
+   so the defaults are reproducible from data shipped with the code.
+
+Usage:
+    python devtools/analyze_tbp_closure_invertibility.py
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+
+COMP_CSV = Path(__file__).resolve().parents[1] / "src" / "main" / "resources" / "data" / "COMP.csv"
+PLACEHOLDER_NORMBOIL_C = 58.05
+
+# Representative members of each hydrocarbon family present in COMP.csv.
+PNA_FAMILIES = {
+    "paraffin": [
+        "n-pentane",
+        "n-hexane",
+        "n-heptane",
+        "n-octane",
+        "n-nonane",
+        "nC10",
+        "nC11",
+        "nC12",
+        "nC13",
+        "nC14",
+        "nC15",
+        "nC16",
+    ],
+    "naphthene": ["c-hexane", "c-C5", "c-pentane", "M-cyclopentane", "M-cyclohexane", "E-cy-C5"],
+    "aromatic": ["benzene", "toluene", "m-Xylene", "o-Xylene", "p-Xylene", "ethylbenzene"],
+}
+
+
+def molar_mass_rd1987(tb_k: float, sg: float) -> float:
+    return (
+        42.965
+        * math.exp(2.097e-4 * tb_k - 7.78712 * sg + 2.08476e-3 * tb_k * sg)
+        * tb_k**1.26007
+        * sg**4.98308
+    )
+
+
+def molar_mass_rd1980(tb_k: float, sg: float) -> float:
+    tb_r = tb_k * 1.8
+    return 4.5673e-5 * tb_r**2.1962 * sg**-1.0164
+
+
+def boiling_point_soreide(molar_mass: float, sg: float) -> float:
+    tb_r = 1928.3 - 1.695e5 * molar_mass**-0.03522 * sg**3.266 * math.exp(
+        -4.922e-3 * molar_mass - 4.7685 * sg + 3.462e-3 * molar_mass * sg
+    )
+    return tb_r / 1.8
+
+
+def report_sg_monotonicity() -> None:
+    """A closure is invertible for SG only if M varies monotonically with SG at fixed Tb."""
+    print("=" * 78)
+    print("Is molar mass monotonic in specific gravity at fixed boiling point?")
+    print("(needed to invert a closure for SG, i.e. for the _Mw_Tb overload)")
+    print("=" * 78)
+
+    sg_grid = [0.60 + 0.02 * i for i in range(21)]  # 0.60 .. 1.00
+    for label, fn in (("RD-1987", molar_mass_rd1987), ("RD-1980", molar_mass_rd1980)):
+        print(f"\n{label}: dM/dSG sign across SG = 0.60..1.00")
+        print(f"{'Tb/K':>8}{'signs':>26}{'verdict':>22}")
+        for tb in (350.0, 400.0, 450.0, 500.0, 550.0, 600.0):
+            values = [fn(tb, sg) for sg in sg_grid]
+            diffs = [b - a for a, b in zip(values, values[1:])]
+            positives = sum(1 for d in diffs if d > 0)
+            negatives = sum(1 for d in diffs if d < 0)
+            if positives and negatives:
+                verdict = "NOT monotonic"
+            else:
+                verdict = "monotonic"
+            print(f"{tb:>8.0f}{f'+{positives} / -{negatives}':>26}{verdict:>22}")
+
+    print("\nSoreide: dTb/dSG sign across SG = 0.60..1.00 at fixed molar mass")
+    print(f"{'M g/mol':>8}{'signs':>26}{'verdict':>22}")
+    for molar_mass in (80.0, 120.0, 160.0, 200.0, 260.0, 320.0):
+        values = [boiling_point_soreide(molar_mass, sg) for sg in sg_grid]
+        diffs = [b - a for a, b in zip(values, values[1:])]
+        positives = sum(1 for d in diffs if d > 0)
+        negatives = sum(1 for d in diffs if d < 0)
+        verdict = "NOT monotonic" if positives and negatives else "monotonic"
+        print(f"{molar_mass:>8.0f}{f'+{positives} / -{negatives}':>26}{verdict:>22}")
+
+
+def report_pna_watson_k() -> None:
+    """Derive the Watson K of a pure paraffin, naphthene and aromatic from COMP.csv."""
+    print("\n" + "=" * 78)
+    print("Watson K by hydrocarbon family, computed from COMP.csv")
+    print("Kw = (1.8 * Tb[K])^(1/3) / SG")
+    print("=" * 78)
+
+    rows = {}
+    with COMP_CSV.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            rows[row["NAME"]] = row
+
+    family_values = {}
+    for family, names in PNA_FAMILIES.items():
+        print(f"\n{family}")
+        values = []
+        for name in names:
+            row = rows.get(name)
+            if row is None:
+                continue
+            tb_c = float(row["NORMBOIL"])
+            sg = float(row["LIQDENS"])
+            if abs(tb_c - PLACEHOLDER_NORMBOIL_C) < 1e-9:
+                print(f"  {name:<16} skipped (placeholder boiling point)")
+                continue
+            watson_k = (1.8 * (tb_c + 273.15)) ** (1.0 / 3.0) / sg
+            # An SG far from the family norm means the row itself is suspect.
+            print(f"  {name:<16} Tb={tb_c + 273.15:7.1f} K  SG={sg:.3f}  Kw={watson_k:6.3f}")
+            values.append((name, watson_k, sg))
+        family_values[family] = values
+
+    print("\nFamily summary (median is used to reject rows with a corrupt density):")
+    print(f"{'family':<12}{'n':>4}{'min':>9}{'median':>9}{'max':>9}")
+    for family, values in family_values.items():
+        ks = sorted(v for _, v, _ in values)
+        if not ks:
+            continue
+        median = ks[len(ks) // 2] if len(ks) % 2 else 0.5 * (ks[len(ks) // 2 - 1] + ks[len(ks) // 2])
+        print(f"{family:<12}{len(ks):>4}{ks[0]:>9.3f}{median:>9.3f}{ks[-1]:>9.3f}")
+
+    print("\nOutliers worth a second look (Kw more than 0.6 from the family median):")
+    flagged = False
+    for family, values in family_values.items():
+        ks = sorted(v for _, v, _ in values)
+        if not ks:
+            continue
+        median = ks[len(ks) // 2] if len(ks) % 2 else 0.5 * (ks[len(ks) // 2 - 1] + ks[len(ks) // 2])
+        for name, watson_k, sg in values:
+            if abs(watson_k - median) > 0.6:
+                print(f"  {family:<11}{name:<16} Kw={watson_k:6.3f} vs median {median:6.3f}  (SG={sg:.3f})")
+                flagged = True
+    if not flagged:
+        print("  none")
+
+
+if __name__ == "__main__":
+    report_sg_monotonicity()
+    report_pna_watson_k()

--- a/devtools/validate_tbp_closures.py
+++ b/devtools/validate_tbp_closures.py
@@ -1,0 +1,180 @@
+"""Validate candidate Tb <-> molar mass <-> specific gravity closure correlations.
+
+The named ``addTBPfraction_*`` overloads need a closure that turns the two supplied
+properties into the third. This script checks each candidate correlation against the
+pure-component data already in ``COMP.csv``: for components whose molar mass, normal
+boiling point and liquid density are all known, it predicts molar mass from
+(Tb, SG) and reports the deviation.
+
+A correlation whose published coefficients have been transcribed correctly reproduces
+paraffins to a few percent. A transcription error shows up as a deviation of tens of
+percent or worse, so this doubles as a guard against mis-remembered constants.
+
+Usage:
+    python devtools/validate_tbp_closures.py
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+
+COMP_CSV = Path(__file__).resolve().parents[1] / "src" / "main" / "resources" / "data" / "COMP.csv"
+
+# Components with well-established Tb/SG/M used as the validation set. Grouped by
+# family so that a correlation biased towards paraffins is visible.
+VALIDATION_SET = {
+    "paraffin": [
+        "n-hexane",
+        "n-heptane",
+        "n-octane",
+        "n-nonane",
+        "nC10",
+        "nC11",
+        "nC12",
+        "nC13",
+        "nC14",
+        "nC15",
+        "nC16",
+    ],
+    "naphthene": ["c-hexane", "c-pentane", "c-heptane"],
+    "aromatic": ["benzene", "toluene", "m-Xylene", "o-Xylene", "p-Xylene", "ethylbenzene"],
+}
+
+# NORMBOIL is stored in degrees Celsius. A number of rows carry this value as a
+# placeholder rather than a measurement; they must not enter a correlation check.
+PLACEHOLDER_NORMBOIL_C = 58.05
+
+
+def molar_mass_rd1980(tb_k: float, sg: float) -> float:
+    """Riazi-Daubert (1980), M = 4.5673e-5 * Tb^2.1962 * SG^-1.0164, Tb in degrees Rankine."""
+    tb_r = tb_k * 1.8
+    return 4.5673e-5 * tb_r**2.1962 * sg**-1.0164
+
+
+def molar_mass_rd1987(tb_k: float, sg: float) -> float:
+    """Riazi-Daubert (1987) extended form, Tb in K.
+
+    M = 42.965 * exp(2.097e-4*Tb - 7.78712*SG + 2.08476e-3*Tb*SG) * Tb^1.26007 * SG^4.98308
+    """
+    return (
+        42.965
+        * math.exp(2.097e-4 * tb_k - 7.78712 * sg + 2.08476e-3 * tb_k * sg)
+        * tb_k**1.26007
+        * sg**4.98308
+    )
+
+
+def molar_mass_neqsim_k_form(tb_k: float, sg: float) -> float:
+    """The Riazi-Daubert style form already used by TBPfractionModel.calcTB, Tb in K.
+
+    Tb = (M / 5.805e-5 * SG^0.9371)^(1/2.3776)  ->  M = 5.805e-5 * Tb^2.3776 * SG^-0.9371
+    """
+    return 5.805e-5 * tb_k**2.3776 * sg**-0.9371
+
+
+def boiling_point_soreide(molar_mass: float, sg: float) -> float:
+    """Soreide (1989) as implemented in PedersenTBPModelPR2.calcTB. Returns Tb in K."""
+    tb_r = 1928.3 - 1.695e5 * molar_mass**-0.03522 * sg**3.266 * math.exp(
+        -4.922e-3 * molar_mass - 4.7685 * sg + 3.462e-3 * molar_mass * sg
+    )
+    return tb_r / 1.8
+
+
+def molar_mass_soreide(tb_k: float, sg: float) -> float:
+    """Invert the Soreide Tb correlation for molar mass by bisection."""
+    lo, hi = 10.0, 800.0
+    f_lo = boiling_point_soreide(lo, sg) - tb_k
+    f_hi = boiling_point_soreide(hi, sg) - tb_k
+    if f_lo * f_hi > 0.0:
+        return float("nan")
+    for _ in range(200):
+        mid = 0.5 * (lo + hi)
+        f_mid = boiling_point_soreide(mid, sg) - tb_k
+        if f_lo * f_mid <= 0.0:
+            hi, f_hi = mid, f_mid
+        else:
+            lo, f_lo = mid, f_mid
+    return 0.5 * (lo + hi)
+
+
+CORRELATIONS = {
+    "RD-1980": molar_mass_rd1980,
+    "RD-1987": molar_mass_rd1987,
+    "NeqSim K-form": molar_mass_neqsim_k_form,
+    "Soreide (inverted)": molar_mass_soreide,
+}
+
+
+def load_components() -> dict:
+    rows = {}
+    with COMP_CSV.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            rows[row["NAME"]] = row
+    return rows
+
+
+def main() -> None:
+    rows = load_components()
+    print(f"COMP.csv rows: {len(rows)}\n")
+
+    # Establish the unit convention of NORMBOIL and LIQDENS from a component whose
+    # values are beyond doubt, rather than assuming them.
+    probe = rows["n-heptane"]
+    print("Unit probe on n-heptane (accepted: M 100.2 g/mol, Tb 371.6 K, SG 0.684):")
+    print(f"  MOLARMASS = {probe['MOLARMASS']}")
+    print(f"  NORMBOIL  = {probe['NORMBOIL']}")
+    print(f"  LIQDENS   = {probe['LIQDENS']}\n")
+
+    results = {name: [] for name in CORRELATIONS}
+    print(f"{'component':<16}{'family':<11}{'Tb/K':>8}{'SG':>8}{'M':>8}" + "".join(f"{n:>20}" for n in CORRELATIONS))
+
+    for family, names in VALIDATION_SET.items():
+        for name in names:
+            row = rows.get(name)
+            if row is None:
+                print(f"{name:<16}{family:<11}  -- not found in COMP.csv --")
+                continue
+            molar_mass = float(row["MOLARMASS"])
+            tb_c = float(row["NORMBOIL"])
+            sg = float(row["LIQDENS"])
+            if abs(tb_c - PLACEHOLDER_NORMBOIL_C) < 1e-9:
+                print(f"{name:<16}{family:<11}  -- NORMBOIL is the {PLACEHOLDER_NORMBOIL_C} placeholder, skipped --")
+                continue
+            tb = tb_c + 273.15
+            if sg > 10.0:
+                sg /= 1000.0
+
+            cells = ""
+            for corr_name, fn in CORRELATIONS.items():
+                predicted = fn(tb, sg)
+                dev = 100.0 * (predicted - molar_mass) / molar_mass
+                results[corr_name].append((name, family, dev))
+                cells += f"{predicted:>11.1f} ({dev:+5.1f}%)"
+            print(f"{name:<16}{family:<11}{tb:>8.1f}{sg:>8.3f}{molar_mass:>8.1f}{cells}")
+
+    print("\nAbsolute average deviation in molar mass:")
+    print(f"{'correlation':<22}{'all':>10}{'paraffin':>12}{'naphthene':>12}{'aromatic':>12}")
+    for corr_name, entries in results.items():
+        if not entries:
+            continue
+
+        def aad(family=None, entries=entries):
+            vals = [abs(d) for _, f, d in entries if family is None or f == family]
+            return sum(vals) / len(vals) if vals else float("nan")
+
+        print(
+            f"{corr_name:<22}{aad():>9.1f}%{aad('paraffin'):>11.1f}%"
+            f"{aad('naphthene'):>11.1f}%{aad('aromatic'):>11.1f}%"
+        )
+
+    print(
+        "\nA correlation with correctly transcribed coefficients should land in the\n"
+        "single-digit percent range on paraffins. Anything far larger indicates a\n"
+        "wrong constant, not a limitation of the correlation."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/cookbook/thermodynamics-recipes.md
+++ b/docs/cookbook/thermodynamics-recipes.md
@@ -69,21 +69,99 @@ as `C7` when calling `characterisePlusFraction()`.
 
 #### Choosing an `addTBPfraction` overload
 
-| Overload | Supply | Derived from correlations |
-|----------|--------|---------------------------|
-| `addTBPfraction(name, moles, molarMass, density)` | molar mass, density | TC, PC, acentric factor, boiling point |
-| `addTBPfraction(name, moles, molarMass, density, TC, PC, acentricFactor)` | molar mass, density, TC, PC, acentric factor | boiling point |
-| `addTBPfraction2(name, moles, molarMass, boilingPoint)` | molar mass, boiling point | density, TC, PC, acentric factor |
-| `addTBPfraction3(name, moles, density, boilingPoint)` | density, boiling point | molar mass, TC, PC, acentric factor |
+The method name lists the properties you supply, in the order the arguments appear. The canonical
+token order is `Mw`, `Sg`, `Tb`, `Kw`, `Pna`, `Crit`, so there is never a question whether a method
+is `_Tb_Mw` or `_Mw_Tb`.
+
+| Overload | Supply | Derived | How the closure is used |
+|----------|--------|---------|-------------------------|
+| `addTBPfraction_Mw_Sg(name, moles, molarMass, density)` | molar mass, density | TC, PC, acentric factor, boiling point | not needed |
+| `addTBPfraction_Mw_Tb(name, moles, molarMass, boilingPoint)` | molar mass, boiling point | density, TC, PC, acentric factor | **inverted** for density |
+| `addTBPfraction_Sg_Tb(name, moles, density, boilingPoint)` | density, boiling point | molar mass, TC, PC, acentric factor | forward, for molar mass |
+| `addTBPfraction_Tb_Kw(name, moles, boilingPoint, watsonK)` | boiling point, Watson K | density (exact), molar mass, TC, PC, acentric factor | forward, for molar mass |
+| `addTBPfraction_Tb_Pna(name, moles, boilingPoint, xP, xN, xA)` | boiling point, PNA split | Watson K, density (exact), molar mass, TC, PC, acentric factor | forward, for molar mass |
+| `addTBPfraction_Mw_Sg_Tb(name, moles, molarMass, density, boilingPoint)` | molar mass, density, boiling point | TC, PC, acentric factor | not needed |
+| `addTBPfraction_Mw_Sg_Crit(name, moles, molarMass, density, TC, PC, acentricFactor)` | all of them | nothing | not needed |
 
 Units: `molarMass` in kg/mol, `density` as relative density (g/cm3), `TC` in K, `PC` in bara,
-`boilingPoint` in K, `acentricFactor` dimensionless.
+`boilingPoint` in K, `watsonK` and `acentricFactor` dimensionless, and the PNA fractions sum to 1.
 
-The seven argument overload exists so that measured or externally regressed values can be used
+The plain `addTBPfraction(...)` four and seven argument forms remain and are unchanged;
+`addTBPfraction_Mw_Sg` and `addTBPfraction_Mw_Sg_Crit` are named aliases for them. The numbered
+`addTBPfraction2`, `addTBPfraction3` and `addTBPfraction4` are deprecated in favour of
+`_Mw_Tb`, `_Sg_Tb` and `_Mw_Sg_Tb`; the suffixes carried no information about which properties
+they took, which is what let a boiling-point bug hide in `addTBPfraction2` for years.
+
+`addTBPfraction_Mw_Sg_Crit` exists so that measured or externally regressed values can be used
 instead of correlations. The values passed for `TC`, `PC` and `acentricFactor` are stored as
 given; the attractive term derives its `m` parameter from the supplied acentric factor rather
-than from the `calcm` correlation. Use the four argument overload when correlated values are
-wanted.
+than from the `calcm` correlation.
+
+#### Choosing the closure correlation
+
+Only two of molar mass, specific gravity and normal boiling point are usually measured. The
+correlation that supplies the third is the *closure*, selected with a `TbpClosure` argument on the
+overloads that need one:
+
+```python
+from neqsim import jneqsim
+TbpClosure = jneqsim.thermo.characterization.TbpClosure
+
+fluid.addTBPfraction_Sg_Tb("C10", 1.0, 0.734, 447.3)                              # default
+fluid.addTBPfraction_Sg_Tb("C10", 1.0, 0.734, 447.3, TbpClosure.RIAZI_DAUBERT_1980)  # explicit
+```
+
+Accuracy against the pure components in `COMP.csv`, as absolute average deviation in molar mass
+predicted from boiling point and specific gravity:
+
+| Closure | Paraffins | Aromatics | Can be inverted for density? |
+|---------|-----------|-----------|------------------------------|
+| `RIAZI_DAUBERT_1987` (default) | 1.7 % | 7.8 % | no |
+| `SOREIDE` | 3.0 % | 9.1 % | no |
+| `RIAZI_DAUBERT_1980` | 5.4 % | 13.6 % | yes |
+| `TBP_MODEL` | follows the fluid's characterization model | | no |
+
+Reproduce the table with `python devtools/validate_tbp_closures.py`.
+
+#### Forward use versus inverted use
+
+The last column above trips people up, because `addTBPfraction_Tb_Kw` produces a density while
+using `RIAZI_DAUBERT_1987`, which the table says cannot be inverted for density. Both are true,
+because the closure is never asked for the density there:
+
+- In `_Tb_Kw` and `_Tb_Pna` the specific gravity comes from the **definition** of the Watson factor,
+  `SG = (1.8*Tb)^(1/3) / Kw`, which is exact. The closure is then evaluated **forward**, once, to
+  get the molar mass. No inversion happens.
+- In `_Sg_Tb` the density is supplied, so again the closure only runs forward.
+- In `_Mw_Tb` the density *is* the unknown, so the closure has to be **inverted**. That is the only
+  overload where monotonicity matters, and the only one that rejects `RIAZI_DAUBERT_1987`.
+
+Evaluating a correlation forward is always well posed. Inverting one is not. RD-1987 turns over at
+`SG = 4.98308 / (7.78712 - 2.08476e-3*Tb)`, which lands between 0.71 and 0.77 over the usual
+boiling range — the middle of the petroleum band, and exactly where paraffins sit. So a given
+(Tb, M) has two specific gravities that reproduce it, and near the turning point a 1 % error in
+molar mass amplifies into a 7–21 % error in specific gravity. RD-1980's exponent is constant, so
+its inverse is unique and carries error 1:1. `addTBPfraction_Mw_Tb` therefore defaults to RD-1980,
+and asking a non-invertible closure for a density throws rather than returning one of two roots.
+
+Reproduce these numbers with `python devtools/analyze_rd1987_inversion.py`.
+
+#### Defining a cut from a detailed hydrocarbon analysis
+
+When a DHA gives a boiling point and a paraffin / naphthene / aromatic split but neither molar mass
+nor density, use `addTBPfraction_Tb_Pna`:
+
+```python
+fluid.addTBPfraction_Tb_Pna("cut1", 1.0, 450.0, 0.60, 0.25, 0.15)
+```
+
+The PNA fractions are blended linearly into a Watson factor using family values derived from the
+pure components in `COMP.csv` — 12.8 for paraffins, 11.0 for naphthenes, 10.1 for aromatics, each
+the median of the rows whose boiling point and density are both credible — and the fraction is then
+added as if `addTBPfraction_Tb_Kw` had been called. The Watson factor is
+conventionally blended on a volume or mass basis, so supply mass or volume fractions rather than
+mole fractions. Pass your own family values and closure with the ten argument overload when the
+cut is known to sit outside the usual families.
 
 ### Create a CO₂-Water Fluid with CPA
 

--- a/src/main/java/neqsim/thermo/characterization/TbpClosure.java
+++ b/src/main/java/neqsim/thermo/characterization/TbpClosure.java
@@ -1,0 +1,309 @@
+package neqsim.thermo.characterization;
+
+import neqsim.util.exception.InvalidInputException;
+
+/**
+ * Correlation used to close an under-determined TBP fraction definition.
+ *
+ * <p>
+ * A pseudo-component is fully defined by its molar mass, specific gravity and normal boiling point, but only two of the
+ * three are usually measured. A <code>TbpClosure</code> supplies the missing third property. Which closure was used
+ * materially changes the resulting critical properties, so it is recorded on the fraction rather than left implicit.
+ * </p>
+ *
+ * <p>
+ * Units throughout this enum: boiling point in K, molar mass in kg/mol, density as specific gravity (relative density,
+ * numerically equal to g/cm3).
+ * </p>
+ *
+ * <p>
+ * <b>Not every closure can be evaluated in both directions.</b> Solving for molar mass from (boiling point, specific
+ * gravity) is well posed for all four. Solving for specific gravity from (boiling point, molar mass) requires the
+ * correlation to be monotonic in specific gravity, and measurement over 0.60 to 1.00 specific gravity and 350 to 600 K
+ * shows that only {@link #RIAZI_DAUBERT_1980} is. {@link #supportsDensityFromMolarMass()} reports this, and the
+ * unsupported closures throw rather than return an arbitrary root.
+ * </p>
+ *
+ * <p>
+ * Accuracy against the pure components in COMP.csv, as absolute average deviation in molar mass predicted from boiling
+ * point and specific gravity (see <code>devtools/validate_tbp_closures.py</code>):
+ * </p>
+ *
+ * <table>
+ * <caption>Absolute average deviation in predicted molar mass</caption>
+ * <tr>
+ * <th>Closure</th>
+ * <th>Paraffins</th>
+ * <th>Aromatics</th>
+ * </tr>
+ * <tr>
+ * <td>RIAZI_DAUBERT_1987</td>
+ * <td>1.7 %</td>
+ * <td>7.8 %</td>
+ * </tr>
+ * <tr>
+ * <td>SOREIDE</td>
+ * <td>3.0 %</td>
+ * <td>9.1 %</td>
+ * </tr>
+ * <tr>
+ * <td>RIAZI_DAUBERT_1980</td>
+ * <td>5.4 %</td>
+ * <td>13.6 %</td>
+ * </tr>
+ * </table>
+ *
+ * <p>
+ * References: Riazi, M.R. and Daubert, T.E., Hydrocarbon Processing 59(3), 115 (1980); Riazi, M.R. and Daubert, T.E.,
+ * Ind. Eng. Chem. Res. 26, 755 (1987); Soreide, I., Improved Phase Behavior Predictions of Petroleum Reservoir Fluids
+ * from a Cubic Equation of State, Dr.Ing. thesis, NTH (1989).
+ * </p>
+ *
+ * @author ESOL
+ * @version $Id: $Id
+ */
+public enum TbpClosure {
+  /**
+   * Riazi-Daubert (1980), <code>M = 4.5673e-5 * Tb^2.1962 * SG^-1.0164</code> with Tb in degrees Rankine and M in
+   * g/mol. The only closure here that inverts analytically for specific gravity, which is why it is the default
+   * wherever specific gravity is the unknown.
+   */
+  RIAZI_DAUBERT_1980 {
+    /** {@inheritDoc} */
+    @Override
+    public double calcMolarMass(double boilingPoint, double density, TBPModelInterface model) {
+      double boilingPointRankine = boilingPoint * 1.8;
+      return 4.5673e-5 * Math.pow(boilingPointRankine, 2.1962) * Math.pow(density, -1.0164) / 1000.0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double calcDensity(double boilingPoint, double molarMass, TBPModelInterface model) {
+      double molarMassGmol = molarMass * 1000.0;
+      double boilingPointRankine = boilingPoint * 1.8;
+      return Math.pow(4.5673e-5 * Math.pow(boilingPointRankine, 2.1962) / molarMassGmol, -1.0 / -1.0164);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supportsDensityFromMolarMass() {
+      return true;
+    }
+  },
+
+  /**
+   * Riazi-Daubert (1987) extended form,
+   * <code>M = 42.965 * exp(2.097e-4*Tb - 7.78712*SG + 2.08476e-3*Tb*SG) * Tb^1.26007 *
+   * SG^4.98308</code> with Tb in K and M in g/mol. The most accurate of the four for molar mass, but not monotonic in
+   * specific gravity, so it cannot be inverted for density.
+   */
+  RIAZI_DAUBERT_1987 {
+    /** {@inheritDoc} */
+    @Override
+    public double calcMolarMass(double boilingPoint, double density, TBPModelInterface model) {
+      double molarMassGmol = 42.965
+          * Math.exp(2.097e-4 * boilingPoint - 7.78712 * density + 2.08476e-3 * boilingPoint * density)
+          * Math.pow(boilingPoint, 1.26007) * Math.pow(density, 4.98308);
+      return molarMassGmol / 1000.0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double calcDensity(double boilingPoint, double molarMass, TBPModelInterface model) {
+      throw new RuntimeException(new InvalidInputException("TbpClosure", "calcDensity", "molarMass",
+          "cannot be inverted with RIAZI_DAUBERT_1987: molar mass turns over in specific gravity at " + "SG = "
+              + (4.98308 / (7.78712 - 2.08476e-3 * boilingPoint)) + " for this boiling point, "
+              + "so two specific gravities reproduce the same molar mass and the inverse has no unique "
+              + "root. Use RIAZI_DAUBERT_1980 instead. Evaluating this closure forward, i.e. molar mass "
+              + "from boiling point and specific gravity, is unaffected and remains the default."));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supportsDensityFromMolarMass() {
+      return false;
+    }
+  },
+
+  /**
+   * Soreide (1989), the boiling point correlation used by <code>PedersenTBPModelPR2.calcTB</code>. Inverted numerically
+   * for molar mass. Not monotonic in specific gravity, so it cannot be inverted for density.
+   */
+  SOREIDE {
+    /** {@inheritDoc} */
+    @Override
+    public double calcMolarMass(double boilingPoint, double density, TBPModelInterface model) {
+      return solveMolarMass(this, boilingPoint, density, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double calcDensity(double boilingPoint, double molarMass, TBPModelInterface model) {
+      throw new RuntimeException(new InvalidInputException("TbpClosure", "calcDensity", "molarMass",
+          "cannot be inverted with SOREIDE: the boiling point is not monotonic in specific gravity "
+              + "over 0.60 to 1.00, so the inverse has no unique root. Use RIAZI_DAUBERT_1980 instead."));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supportsDensityFromMolarMass() {
+      return false;
+    }
+  },
+
+  /**
+   * The boiling point correlation of the fluid's own selected TBP characterization model, inverted numerically for
+   * molar mass. Use this to keep a fraction consistent with the rest of the characterization rather than with an
+   * external correlation.
+   *
+   * <p>
+   * Note that the Pedersen models carry no density dependence in <code>calcTB</code> below 540 g/mol, so for those the
+   * returned molar mass is a function of boiling point alone.
+   * </p>
+   */
+  TBP_MODEL {
+    /** {@inheritDoc} */
+    @Override
+    public double calcMolarMass(double boilingPoint, double density, TBPModelInterface model) {
+      if (model == null) {
+        throw new RuntimeException(new InvalidInputException("TbpClosure", "calcMolarMass", "model",
+            "must not be null for the TBP_MODEL closure."));
+      }
+      return solveMolarMass(this, boilingPoint, density, model);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double calcDensity(double boilingPoint, double molarMass, TBPModelInterface model) {
+      throw new RuntimeException(new InvalidInputException("TbpClosure", "calcDensity", "molarMass",
+          "cannot be inverted with TBP_MODEL: the Pedersen boiling point correlation is independent "
+              + "of density below 540 g/mol, so the inverse problem has no solution. "
+              + "Use RIAZI_DAUBERT_1980 instead."));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supportsDensityFromMolarMass() {
+      return false;
+    }
+  };
+
+  /** Lower bound of the molar mass bracket used by the numerical inversions, kg/mol. */
+  private static final double MOLAR_MASS_SEARCH_LOWER = 0.010;
+  /** Upper bound of the molar mass bracket used by the numerical inversions, kg/mol. */
+  private static final double MOLAR_MASS_SEARCH_UPPER = 0.800;
+
+  /**
+   * Molar mass of a fraction with the given normal boiling point and specific gravity.
+   *
+   * @param boilingPoint normal boiling point in K
+   * @param density specific gravity (relative density, g/cm3)
+   * @param model the fluid's TBP characterization model; used only by {@link #TBP_MODEL} and may be null for the others
+   * @return molar mass in kg/mol
+   */
+  public abstract double calcMolarMass(double boilingPoint, double density, TBPModelInterface model);
+
+  /**
+   * Specific gravity of a fraction with the given normal boiling point and molar mass.
+   *
+   * @param boilingPoint normal boiling point in K
+   * @param molarMass molar mass in kg/mol
+   * @param model the fluid's TBP characterization model; may be null
+   * @return specific gravity (relative density, g/cm3)
+   * @throws RuntimeException wrapping an {@link neqsim.util.exception.InvalidInputException} when this closure is not
+   * invertible for specific gravity, as reported by {@link #supportsDensityFromMolarMass()}
+   */
+  public abstract double calcDensity(double boilingPoint, double molarMass, TBPModelInterface model);
+
+  /**
+   * Whether {@link #calcDensity(double, double, TBPModelInterface)} is available for this closure.
+   *
+   * @return true when the correlation is monotonic in specific gravity and can be inverted
+   */
+  public abstract boolean supportsDensityFromMolarMass();
+
+  /**
+   * Boiling point predicted by the Soreide (1989) correlation.
+   *
+   * <p>
+   * Kept as a static helper rather than an instance method because it is the forward form that the {@link #SOREIDE}
+   * inversion brackets against, and it is also useful for verification.
+   * </p>
+   *
+   * @param molarMass molar mass in kg/mol
+   * @param density specific gravity (relative density, g/cm3)
+   * @return normal boiling point in K
+   */
+  public static double calcBoilingPointSoreide(double molarMass, double density) {
+    double molarMassGmol = molarMass * 1000.0;
+    double boilingPointRankine = 1928.3 - 1.695e5 * Math.pow(molarMassGmol, -0.03522) * Math.pow(density, 3.266)
+        * Math.exp(-4.922e-3 * molarMassGmol - 4.7685 * density + 3.462e-3 * molarMassGmol * density);
+    return boilingPointRankine / 1.8;
+  }
+
+  /**
+   * Boiling point used by a closure when inverting for molar mass.
+   *
+   * @param closure the closure whose forward correlation is wanted
+   * @param molarMass molar mass in kg/mol
+   * @param density specific gravity (relative density, g/cm3)
+   * @param model TBP characterization model, required for {@link #TBP_MODEL}
+   * @return normal boiling point in K
+   */
+  private static double forwardBoilingPoint(TbpClosure closure, double molarMass, double density,
+      TBPModelInterface model) {
+    if (closure == TBP_MODEL) {
+      return model.calcTB(molarMass * 1000.0, density);
+    }
+    return calcBoilingPointSoreide(molarMass, density);
+  }
+
+  /**
+   * Invert a boiling point correlation for molar mass by bisection.
+   *
+   * <p>
+   * Bisection rather than Newton because the bracket is known and narrow, and because a bracketed method cannot wander
+   * into the non-physical molar masses that the Soreide exponential produces outside the range.
+   * </p>
+   *
+   * @param closure the closure being inverted
+   * @param boilingPoint target normal boiling point in K
+   * @param density specific gravity (relative density, g/cm3)
+   * @param model TBP characterization model, required for {@link #TBP_MODEL}
+   * @return molar mass in kg/mol
+   * @throws RuntimeException wrapping an {@link neqsim.util.exception.InvalidInputException} when the boiling point is
+   * not attainable anywhere in the search bracket
+   */
+  private static double solveMolarMass(TbpClosure closure, double boilingPoint, double density,
+      TBPModelInterface model) {
+    double lower = MOLAR_MASS_SEARCH_LOWER;
+    double upper = MOLAR_MASS_SEARCH_UPPER;
+    double fLower = forwardBoilingPoint(closure, lower, density, model) - boilingPoint;
+    double fUpper = forwardBoilingPoint(closure, upper, density, model) - boilingPoint;
+
+    if (fLower * fUpper > 0.0) {
+      throw new RuntimeException(new InvalidInputException("TbpClosure", "calcMolarMass", "boilingPoint",
+          boilingPoint + " K is not attainable with closure " + closure + " at specific gravity " + density
+              + ". Attainable range is " + (fLower + boilingPoint) + " to " + (fUpper + boilingPoint)
+              + " K for molar mass " + (MOLAR_MASS_SEARCH_LOWER * 1000.0) + " to " + (MOLAR_MASS_SEARCH_UPPER * 1000.0)
+              + " g/mol."));
+    }
+
+    double tolerance = 1e-9;
+    double molarMass = 0.5 * (lower + upper);
+    for (int i = 0; i < 200 && (upper - lower) > tolerance; i++) {
+      molarMass = 0.5 * (lower + upper);
+      double fMid = forwardBoilingPoint(closure, molarMass, density, model) - boilingPoint;
+      if (fMid == 0.0) {
+        return molarMass;
+      }
+      if (fLower * fMid < 0.0) {
+        upper = molarMass;
+      } else {
+        lower = molarMass;
+        fLower = fMid;
+      }
+    }
+    return 0.5 * (lower + upper);
+  }
+}

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -9,6 +9,7 @@ import neqsim.physicalproperties.system.PhysicalPropertyModel;
 import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.characterization.OilAssayCharacterisation;
 import neqsim.thermo.characterization.PseudoComponentCombiner;
+import neqsim.thermo.characterization.TbpClosure;
 import neqsim.thermo.characterization.WaxModelInterface;
 import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.mixingrule.EosMixingRuleType;
@@ -346,8 +347,231 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
    * @param numberOfMoles number of moles to be added
    * @param molarMass molar mass in kg/mol. Correlation validated for 0.070 to 0.300 kg/mol.
    * @param boilingPoint normal boiling point in K. Correlation validated for 300 to 620 K.
+   * @deprecated use {@link #addTBPfraction_Mw_Tb(String, double, double, double)}, whose name states which two
+   * properties are supplied.
    */
+  @Deprecated
   public void addTBPfraction2(String componentName, double numberOfMoles, double molarMass, double boilingPoint);
+
+  /**
+   * Add a TBP fraction defined by molar mass and specific gravity.
+   *
+   * <p>
+   * The named <code>addTBPfraction_*</code> family states in the method name which properties the caller supplies, in
+   * the order the arguments appear. Canonical token order is <code>Mw</code>, <code>Sg</code>, <code>Tb</code>,
+   * <code>Kw</code>, <code>Pna</code>, <code>Crit</code>, so there is never a question whether a method is
+   * <code>_Tb_Mw</code> or <code>_Mw_Tb</code>. The correlation used to close the definition is selected with a
+   * {@link neqsim.thermo.characterization.TbpClosure} argument rather than being encoded in the name.
+   * </p>
+   *
+   * <p>
+   * This is the fully determined case for the characterization models: the boiling point and critical properties follow
+   * from molar mass and specific gravity with no closure needed. It is identical to
+   * {@link #addTBPfraction(String, double, double, double)}.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param molarMass molar mass in kg/mol
+   * @param density specific gravity (relative density), i.e. density in g/cm3
+   */
+  public void addTBPfraction_Mw_Sg(String componentName, double numberOfMoles, double molarMass, double density);
+
+  /**
+   * Add a TBP fraction defined by molar mass and normal boiling point.
+   *
+   * <p>
+   * Uses {@link neqsim.thermo.characterization.TbpClosure#RIAZI_DAUBERT_1980} to obtain the specific gravity. That
+   * closure is not the most accurate of the family, but it is the only one that is monotonic in specific gravity and
+   * therefore the only one that can be inverted for it; see {@link neqsim.thermo.characterization.TbpClosure}. Because
+   * molar mass and boiling point are not independent in the correlation, the resulting specific gravity carries roughly
+   * the same relative error as the supplied molar mass.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param molarMass molar mass in kg/mol
+   * @param boilingPoint normal boiling point in K
+   */
+  public void addTBPfraction_Mw_Tb(String componentName, double numberOfMoles, double molarMass, double boilingPoint);
+
+  /**
+   * Add a TBP fraction defined by molar mass and normal boiling point, with an explicit closure.
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param molarMass molar mass in kg/mol
+   * @param boilingPoint normal boiling point in K
+   * @param closure correlation used to obtain the specific gravity. Must satisfy
+   * {@link neqsim.thermo.characterization.TbpClosure#supportsDensityFromMolarMass()}.
+   */
+  public void addTBPfraction_Mw_Tb(String componentName, double numberOfMoles, double molarMass, double boilingPoint,
+      TbpClosure closure);
+
+  /**
+   * Add a TBP fraction defined by specific gravity and normal boiling point.
+   *
+   * <p>
+   * Uses {@link neqsim.thermo.characterization.TbpClosure#RIAZI_DAUBERT_1987} to obtain the molar mass, which
+   * reproduces the paraffins in the component database to about 1.7 % and is the most accurate closure available for
+   * this direction.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param density specific gravity (relative density), i.e. density in g/cm3
+   * @param boilingPoint normal boiling point in K
+   */
+  public void addTBPfraction_Sg_Tb(String componentName, double numberOfMoles, double density, double boilingPoint);
+
+  /**
+   * Add a TBP fraction defined by specific gravity and normal boiling point, with an explicit closure.
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param density specific gravity (relative density), i.e. density in g/cm3
+   * @param boilingPoint normal boiling point in K
+   * @param closure correlation used to obtain the molar mass
+   */
+  public void addTBPfraction_Sg_Tb(String componentName, double numberOfMoles, double density, double boilingPoint,
+      TbpClosure closure);
+
+  /**
+   * Add a TBP fraction defined by normal boiling point and Watson characterization factor.
+   *
+   * <p>
+   * The specific gravity follows exactly from the definition of the Watson factor,
+   * <code>SG = (1.8*Tb)^(1/3) / Kw</code>, with no correlation error. Only the molar mass needs a closure, which
+   * defaults to {@link neqsim.thermo.characterization.TbpClosure#RIAZI_DAUBERT_1987}.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param boilingPoint normal boiling point in K
+   * @param watsonK Watson characterization factor. About 12.8 for paraffins, 11.0 for naphthenes and 10.1 for
+   * aromatics.
+   */
+  public void addTBPfraction_Tb_Kw(String componentName, double numberOfMoles, double boilingPoint, double watsonK);
+
+  /**
+   * Add a TBP fraction defined by normal boiling point and Watson factor, with an explicit closure.
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param boilingPoint normal boiling point in K
+   * @param watsonK Watson characterization factor
+   * @param closure correlation used to obtain the molar mass
+   */
+  public void addTBPfraction_Tb_Kw(String componentName, double numberOfMoles, double boilingPoint, double watsonK,
+      TbpClosure closure);
+
+  /**
+   * Add a TBP fraction defined by normal boiling point and PNA distribution.
+   *
+   * <p>
+   * This is the overload for a cut characterized by a detailed hydrocarbon analysis, where the boiling point and the
+   * paraffin / naphthene / aromatic split are measured but neither molar mass nor density is. The PNA fractions are
+   * blended linearly into a Watson factor using the default family values of
+   * {@link #calculateWatsonKFromPna(double, double, double)}, and the fraction is then added as if
+   * {@link #addTBPfraction_Tb_Kw(String, double, double, double)} had been called.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param boilingPoint normal boiling point in K
+   * @param paraffinFraction paraffin fraction, 0 to 1
+   * @param naphtheneFraction naphthene fraction, 0 to 1
+   * @param aromaticFraction aromatic fraction, 0 to 1. The three fractions must sum to 1.
+   */
+  public void addTBPfraction_Tb_Pna(String componentName, double numberOfMoles, double boilingPoint,
+      double paraffinFraction, double naphtheneFraction, double aromaticFraction);
+
+  /**
+   * Add a TBP fraction defined by normal boiling point and PNA distribution, with explicit family Watson factors and
+   * closure.
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param boilingPoint normal boiling point in K
+   * @param paraffinFraction paraffin fraction, 0 to 1
+   * @param naphtheneFraction naphthene fraction, 0 to 1
+   * @param aromaticFraction aromatic fraction, 0 to 1. The three fractions must sum to 1.
+   * @param paraffinWatsonK Watson factor representing a pure paraffin
+   * @param naphtheneWatsonK Watson factor representing a pure naphthene
+   * @param aromaticWatsonK Watson factor representing a pure aromatic
+   * @param closure correlation used to obtain the molar mass
+   */
+  public void addTBPfraction_Tb_Pna(String componentName, double numberOfMoles, double boilingPoint,
+      double paraffinFraction, double naphtheneFraction, double aromaticFraction, double paraffinWatsonK,
+      double naphtheneWatsonK, double aromaticWatsonK, TbpClosure closure);
+
+  /**
+   * Add a TBP fraction with molar mass, specific gravity and normal boiling point all supplied.
+   *
+   * <p>
+   * Nothing is correlated. The boiling point is applied to the selected TBP model for the duration of the call only; it
+   * reaches the critical properties for the boiling-point-based models (Lee-Kesler, Twu, Cavett), while for the
+   * Pedersen models it affects only the stored boiling point and the ideal gas heat capacity.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param molarMass molar mass in kg/mol
+   * @param density specific gravity (relative density), i.e. density in g/cm3
+   * @param boilingPoint normal boiling point in K
+   */
+  public void addTBPfraction_Mw_Sg_Tb(String componentName, double numberOfMoles, double molarMass, double density,
+      double boilingPoint);
+
+  /**
+   * Add a TBP fraction with molar mass, specific gravity and measured critical properties.
+   *
+   * <p>
+   * Nothing is correlated. Use this when the critical properties come from measurement or an external regression rather
+   * than from a characterization correlation.
+   * </p>
+   *
+   * @param componentName name of the fraction, e.g. "C7"
+   * @param numberOfMoles number of moles to be added
+   * @param molarMass molar mass in kg/mol
+   * @param density specific gravity (relative density), i.e. density in g/cm3
+   * @param criticalTemperature critical temperature in K
+   * @param criticalPressure critical pressure in bara
+   * @param acentricFactor acentric factor (dimensionless)
+   */
+  public void addTBPfraction_Mw_Sg_Crit(String componentName, double numberOfMoles, double molarMass, double density,
+      double criticalTemperature, double criticalPressure, double acentricFactor);
+
+  /**
+   * Watson characterization factor of a cut from its PNA distribution.
+   *
+   * <p>
+   * Uses the default family values derived from the pure components in the shipped component database: 12.8 for
+   * paraffins, 11.0 for naphthenes and 10.1 for aromatics. The blend is linear in the supplied fractions; the Watson
+   * factor is conventionally blended on a volume or mass basis, so mass or volume fractions are expected rather than
+   * mole fractions.
+   * </p>
+   *
+   * @param paraffinFraction paraffin fraction, 0 to 1
+   * @param naphtheneFraction naphthene fraction, 0 to 1
+   * @param aromaticFraction aromatic fraction, 0 to 1. The three fractions must sum to 1.
+   * @return Watson characterization factor
+   */
+  public double calculateWatsonKFromPna(double paraffinFraction, double naphtheneFraction, double aromaticFraction);
+
+  /**
+   * Watson characterization factor of a cut from its PNA distribution and explicit family values.
+   *
+   * @param paraffinFraction paraffin fraction, 0 to 1
+   * @param naphtheneFraction naphthene fraction, 0 to 1
+   * @param aromaticFraction aromatic fraction, 0 to 1. The three fractions must sum to 1.
+   * @param paraffinWatsonK Watson factor representing a pure paraffin
+   * @param naphtheneWatsonK Watson factor representing a pure naphthene
+   * @param aromaticWatsonK Watson factor representing a pure aromatic
+   * @return Watson characterization factor
+   */
+  public double calculateWatsonKFromPna(double paraffinFraction, double naphtheneFraction, double aromaticFraction,
+      double paraffinWatsonK, double naphtheneWatsonK, double aromaticWatsonK);
 
   /**
    * Calculate specific gravity from a normal boiling point and a Watson characterization factor.
@@ -2817,7 +3041,12 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
    * @param numberOfMoles number of moles
    * @param density specific gravity (relative density), i.e. density in g/cm3
    * @param boilingPoint normal boiling point in K
+   * @deprecated use {@link #addTBPfraction_Sg_Tb(String, double, double, double)}, whose name states which two
+   * properties are supplied. Note that the replacement defaults to the more accurate
+   * {@link neqsim.thermo.characterization.TbpClosure#RIAZI_DAUBERT_1987} closure; pass
+   * {@link neqsim.thermo.characterization.TbpClosure#TBP_MODEL} to keep the behaviour of this method.
    */
+  @Deprecated
   public void addTBPfraction3(String componentName, double numberOfMoles, double density, double boilingPoint);
 
   /**
@@ -2835,7 +3064,10 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
    * @param molarMass molar mass in kg/mol
    * @param density specific gravity (relative density), i.e. density in g/cm3
    * @param boilingPoint normal boiling point in K
+   * @deprecated use {@link #addTBPfraction_Mw_Sg_Tb(String, double, double, double, double)}, whose name states which
+   * properties are supplied.
    */
+  @Deprecated
   public void addTBPfraction4(String componentName, double numberOfMoles, double molarMass, double density,
       double boilingPoint);
 

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -20,6 +20,7 @@ import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.ThermodynamicModelSettings;
 import neqsim.thermo.characterization.Characterise;
 import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.characterization.TbpClosure;
 import neqsim.thermo.characterization.WaxCharacterise;
 import neqsim.thermo.characterization.WaxModelInterface;
 import neqsim.thermo.component.ComponentInterface;
@@ -1799,17 +1800,9 @@ public abstract class SystemThermo implements SystemInterface {
     return table;
   }
 
-  /**
-   * Riazi-Daubert (1980) coefficient a in M = a * Tb^b * SG^c, with Tb in degrees Rankine and M in g/mol.
-   */
-  private static final double RD1980_A = 4.5673e-5;
-  /** Riazi-Daubert (1980) boiling point exponent b. */
-  private static final double RD1980_B = 2.1962;
-  /** Riazi-Daubert (1980) specific gravity exponent c. */
-  private static final double RD1980_C = -1.0164;
-
   /** {@inheritDoc} */
   @Override
+  @Deprecated
   public void addTBPfraction2(String componentName, double numberOfMoles, double molarMass, double boilingPoint) {
     if (boilingPoint <= 0.0) {
       throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, "addTBPfraction2",
@@ -1844,12 +1837,12 @@ public abstract class SystemThermo implements SystemInterface {
           "calculateDensityFromBoilingPoint", "boilingPoint", "must be positive."));
     }
 
-    // Riazi-Daubert (1980) M = a*Tb^c*SG^c inverted analytically for SG. The TBP model's own
-    // calcTB cannot be used here: for the Pedersen models it carries no density dependence below
-    // 540 g/mol, so the inverse problem has no solution (see PedersenTBPModelSRK.calcTB).
+    // Riazi-Daubert (1980) is the only closure that is monotonic in specific gravity and so the
+    // only one this inverse has a unique root for; see TbpClosure. The TBP model's own calcTB
+    // cannot be used either, because for the Pedersen models it carries no density dependence
+    // below 540 g/mol (see PedersenTBPModelSRK.calcTB).
     double molarMassGmol = molarMass * 1000.0;
-    double boilingPointRankine = boilingPoint * 1.8;
-    double density = Math.pow(RD1980_A * Math.pow(boilingPointRankine, RD1980_B) / molarMassGmol, -1.0 / RD1980_C);
+    double density = TbpClosure.RIAZI_DAUBERT_1980.calcDensity(boilingPoint, molarMass, characterization.getTBPModel());
 
     if (boilingPoint < 300.0 || boilingPoint > 620.0 || molarMassGmol < 70.0 || molarMassGmol > 300.0) {
       logger.warn("calculateDensityFromBoilingPoint: molar mass {} g/mol and boiling point {} K fall outside the "
@@ -1893,6 +1886,7 @@ public abstract class SystemThermo implements SystemInterface {
    * Add TBP fraction using density and boiling point, calculating molar mass.
    */
   @Override
+  @Deprecated
   public void addTBPfraction3(String componentName, double numberOfMoles, double density, double boilingPoint) {
     if (boilingPoint <= 0.0) {
       throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, "addTBPfraction3",
@@ -1967,6 +1961,7 @@ public abstract class SystemThermo implements SystemInterface {
    * Add TBP fraction using density and boiling point, calculating molar mass.
    */
   @Override
+  @Deprecated
   public void addTBPfraction4(String componentName, double numberOfMoles, double molarMass, double density,
       double boilingPoint) {
     characterization.getTBPModel().setBoilingPoint(boilingPoint);
@@ -1977,6 +1972,229 @@ public abstract class SystemThermo implements SystemInterface {
       // every fraction added afterwards.
       characterization.getTBPModel().setBoilingPoint(0.0);
     }
+  }
+
+  /**
+   * Watson factor of a pure paraffin. The n-alkanes C5 to C16 in COMP.csv give 12.647 to 13.136, median 12.785.
+   */
+  private static final double PARAFFIN_WATSON_K = 12.8;
+  /**
+   * Watson factor of a pure naphthene. Cyclohexane is the only naphthene in COMP.csv with both a measured boiling point
+   * and a credible density; it gives 10.989.
+   */
+  private static final double NAPHTHENE_WATSON_K = 11.0;
+  /**
+   * Watson factor of a pure aromatic. Benzene, toluene and m-xylene in COMP.csv give 9.706, 10.149 and 10.430, median
+   * 10.149. The o- and p-xylene rows are excluded because their stored density is wrong.
+   */
+  private static final double AROMATIC_WATSON_K = 10.1;
+
+  /** Lower molar mass of the range the characterization correlations were fitted over, g/mol. */
+  private static final double CORRELATION_MOLAR_MASS_LOWER = 70.0;
+  /** Upper molar mass of the range the characterization correlations were fitted over, g/mol. */
+  private static final double CORRELATION_MOLAR_MASS_UPPER = 300.0;
+  /** Lower boiling point of the range the characterization correlations were fitted over, K. */
+  private static final double CORRELATION_BOILING_POINT_LOWER = 300.0;
+  /** Upper boiling point of the range the characterization correlations were fitted over, K. */
+  private static final double CORRELATION_BOILING_POINT_UPPER = 620.0;
+
+  /**
+   * Reject a non-positive argument before it reaches a correlation.
+   *
+   * @param methodName name of the calling method, used in the exception message
+   * @param inputName name of the offending argument
+   * @param value the supplied value
+   */
+  private void requirePositive(String methodName, String inputName, double value) {
+    if (value <= 0.0) {
+      throw new RuntimeException(
+          new neqsim.util.exception.InvalidInputException(this, methodName, inputName, "must be positive."));
+    }
+  }
+
+  /**
+   * Reject a specific gravity no petroleum fraction can have.
+   *
+   * <p>
+   * A value outside this range almost always means an argument was supplied in the wrong unit, so the message says so
+   * rather than letting a nonsensical fraction into the fluid.
+   * </p>
+   *
+   * @param methodName name of the calling method, used in the exception message
+   * @param density specific gravity to check
+   */
+  private void requirePhysicalSpecificGravity(String methodName, double density) {
+    if (density < 0.5 || density > 1.3) {
+      throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, methodName, "density",
+          "of " + density + " is outside the physical range 0.5 to 1.3 for a petroleum fraction. "
+              + "Check that the boiling point is in K and the molar mass in kg/mol."));
+    }
+  }
+
+  /**
+   * Warn when a fraction sits outside the range the characterization correlations were fitted over.
+   *
+   * @param methodName name of the calling method, used in the log message
+   * @param molarMass molar mass in kg/mol
+   * @param boilingPoint normal boiling point in K
+   */
+  private void warnIfOutsideCorrelationRange(String methodName, double molarMass, double boilingPoint) {
+    double molarMassGmol = molarMass * 1000.0;
+    if (molarMassGmol < CORRELATION_MOLAR_MASS_LOWER || molarMassGmol > CORRELATION_MOLAR_MASS_UPPER
+        || boilingPoint < CORRELATION_BOILING_POINT_LOWER || boilingPoint > CORRELATION_BOILING_POINT_UPPER) {
+      logger.warn(
+          "{}: molar mass {} g/mol and boiling point {} K fall outside the range the characterization "
+              + "correlations were fitted over ({}-{} g/mol, {}-{} K). The result is an extrapolation.",
+          methodName, molarMassGmol, boilingPoint, CORRELATION_MOLAR_MASS_LOWER, CORRELATION_MOLAR_MASS_UPPER,
+          CORRELATION_BOILING_POINT_LOWER, CORRELATION_BOILING_POINT_UPPER);
+    }
+  }
+
+  /**
+   * Add a fraction while the supplied boiling point overrides the TBP model correlation.
+   *
+   * <p>
+   * The pin has to be cleared in a finally block: it lives on the characterization's shared TBP model instance, so
+   * leaving it set would silently apply the same boiling point to every fraction added afterwards.
+   * </p>
+   *
+   * @param componentName name of the fraction
+   * @param numberOfMoles number of moles to be added
+   * @param molarMass molar mass in kg/mol
+   * @param density specific gravity (relative density, g/cm3)
+   * @param boilingPoint normal boiling point in K
+   */
+  private void addFractionWithPinnedBoilingPoint(String componentName, double numberOfMoles, double molarMass,
+      double density, double boilingPoint) {
+    characterization.getTBPModel().setBoilingPoint(boilingPoint);
+    try {
+      addTBPfraction(componentName, numberOfMoles, molarMass, density);
+    } finally {
+      characterization.getTBPModel().setBoilingPoint(0.0);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Mw_Sg(String componentName, double numberOfMoles, double molarMass, double density) {
+    addTBPfraction(componentName, numberOfMoles, molarMass, density);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Mw_Tb(String componentName, double numberOfMoles, double molarMass, double boilingPoint) {
+    addTBPfraction_Mw_Tb(componentName, numberOfMoles, molarMass, boilingPoint, TbpClosure.RIAZI_DAUBERT_1980);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Mw_Tb(String componentName, double numberOfMoles, double molarMass, double boilingPoint,
+      TbpClosure closure) {
+    requirePositive("addTBPfraction_Mw_Tb", "molarMass", molarMass);
+    requirePositive("addTBPfraction_Mw_Tb", "boilingPoint", boilingPoint);
+    double density = closure.calcDensity(boilingPoint, molarMass, characterization.getTBPModel());
+    warnIfOutsideCorrelationRange("addTBPfraction_Mw_Tb", molarMass, boilingPoint);
+    requirePhysicalSpecificGravity("addTBPfraction_Mw_Tb", density);
+    addFractionWithPinnedBoilingPoint(componentName, numberOfMoles, molarMass, density, boilingPoint);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Sg_Tb(String componentName, double numberOfMoles, double density, double boilingPoint) {
+    addTBPfraction_Sg_Tb(componentName, numberOfMoles, density, boilingPoint, TbpClosure.RIAZI_DAUBERT_1987);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Sg_Tb(String componentName, double numberOfMoles, double density, double boilingPoint,
+      TbpClosure closure) {
+    requirePositive("addTBPfraction_Sg_Tb", "density", density);
+    requirePositive("addTBPfraction_Sg_Tb", "boilingPoint", boilingPoint);
+    requirePhysicalSpecificGravity("addTBPfraction_Sg_Tb", density);
+    double molarMass = closure.calcMolarMass(boilingPoint, density, characterization.getTBPModel());
+    warnIfOutsideCorrelationRange("addTBPfraction_Sg_Tb", molarMass, boilingPoint);
+    addFractionWithPinnedBoilingPoint(componentName, numberOfMoles, molarMass, density, boilingPoint);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Tb_Kw(String componentName, double numberOfMoles, double boilingPoint, double watsonK) {
+    addTBPfraction_Tb_Kw(componentName, numberOfMoles, boilingPoint, watsonK, TbpClosure.RIAZI_DAUBERT_1987);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Tb_Kw(String componentName, double numberOfMoles, double boilingPoint, double watsonK,
+      TbpClosure closure) {
+    requirePositive("addTBPfraction_Tb_Kw", "boilingPoint", boilingPoint);
+    requirePositive("addTBPfraction_Tb_Kw", "watsonK", watsonK);
+    // Exact from the definition of the Watson factor, no correlation error enters here.
+    double density = calculateDensityFromBoilingPointAndWatsonK(boilingPoint, watsonK);
+    double molarMass = closure.calcMolarMass(boilingPoint, density, characterization.getTBPModel());
+    warnIfOutsideCorrelationRange("addTBPfraction_Tb_Kw", molarMass, boilingPoint);
+    addFractionWithPinnedBoilingPoint(componentName, numberOfMoles, molarMass, density, boilingPoint);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Tb_Pna(String componentName, double numberOfMoles, double boilingPoint,
+      double paraffinFraction, double naphtheneFraction, double aromaticFraction) {
+    addTBPfraction_Tb_Pna(componentName, numberOfMoles, boilingPoint, paraffinFraction, naphtheneFraction,
+        aromaticFraction, PARAFFIN_WATSON_K, NAPHTHENE_WATSON_K, AROMATIC_WATSON_K, TbpClosure.RIAZI_DAUBERT_1987);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Tb_Pna(String componentName, double numberOfMoles, double boilingPoint,
+      double paraffinFraction, double naphtheneFraction, double aromaticFraction, double paraffinWatsonK,
+      double naphtheneWatsonK, double aromaticWatsonK, TbpClosure closure) {
+    double watsonK = calculateWatsonKFromPna(paraffinFraction, naphtheneFraction, aromaticFraction, paraffinWatsonK,
+        naphtheneWatsonK, aromaticWatsonK);
+    addTBPfraction_Tb_Kw(componentName, numberOfMoles, boilingPoint, watsonK, closure);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Mw_Sg_Tb(String componentName, double numberOfMoles, double molarMass, double density,
+      double boilingPoint) {
+    requirePositive("addTBPfraction_Mw_Sg_Tb", "molarMass", molarMass);
+    requirePositive("addTBPfraction_Mw_Sg_Tb", "density", density);
+    requirePositive("addTBPfraction_Mw_Sg_Tb", "boilingPoint", boilingPoint);
+    addFractionWithPinnedBoilingPoint(componentName, numberOfMoles, molarMass, density, boilingPoint);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addTBPfraction_Mw_Sg_Crit(String componentName, double numberOfMoles, double molarMass, double density,
+      double criticalTemperature, double criticalPressure, double acentricFactor) {
+    addTBPfraction(componentName, numberOfMoles, molarMass, density, criticalTemperature, criticalPressure,
+        acentricFactor);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double calculateWatsonKFromPna(double paraffinFraction, double naphtheneFraction, double aromaticFraction) {
+    return calculateWatsonKFromPna(paraffinFraction, naphtheneFraction, aromaticFraction, PARAFFIN_WATSON_K,
+        NAPHTHENE_WATSON_K, AROMATIC_WATSON_K);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double calculateWatsonKFromPna(double paraffinFraction, double naphtheneFraction, double aromaticFraction,
+      double paraffinWatsonK, double naphtheneWatsonK, double aromaticWatsonK) {
+    if (paraffinFraction < 0.0 || naphtheneFraction < 0.0 || aromaticFraction < 0.0) {
+      throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, "calculateWatsonKFromPna",
+          "paraffinFraction", "P, N and A fractions must all be non-negative. Got P=" + paraffinFraction + ", N="
+              + naphtheneFraction + ", A=" + aromaticFraction + "."));
+    }
+    double sum = paraffinFraction + naphtheneFraction + aromaticFraction;
+    if (Math.abs(sum - 1.0) > 1.0e-6) {
+      throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, "calculateWatsonKFromPna",
+          "paraffinFraction", "P, N and A fractions must sum to 1. Got " + sum + " from P=" + paraffinFraction + ", N="
+              + naphtheneFraction + ", A=" + aromaticFraction + "."));
+    }
+    return paraffinFraction * paraffinWatsonK + naphtheneFraction * naphtheneWatsonK
+        + aromaticFraction * aromaticWatsonK;
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/thermo/characterization/TbpClosureTest.java
+++ b/src/test/java/neqsim/thermo/characterization/TbpClosureTest.java
@@ -1,0 +1,186 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the closure correlations behind the named <code>addTBPfraction_*</code> overloads.
+ *
+ * <p>
+ * The reference values are pure components taken from the shipped COMP.csv, so a failure here means either a
+ * correlation coefficient has been altered or the component data underneath it has moved. Both are worth failing for.
+ * </p>
+ *
+ * @author ESOL
+ * @version $Id: $Id
+ */
+public class TbpClosureTest {
+  /** Molar mass tolerance, kg/mol, matching the published accuracy of the correlations. */
+  private static final double MOLAR_MASS_TOLERANCE = 0.005;
+
+  @Test
+  void testRiaziDaubert1987ReproducesParaffinMolarMass() {
+    // n-heptane: Tb 371.6 K, SG 0.690, M 100.2 g/mol.
+    double molarMass = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(371.6, 0.690, null);
+    assertEquals(0.1002, molarMass, MOLAR_MASS_TOLERANCE);
+
+    // nC10: Tb 447.3 K, SG 0.734, M 142.3 g/mol.
+    assertEquals(0.1423, TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(447.3, 0.734, null), 0.006);
+  }
+
+  @Test
+  void testRiaziDaubert1980RoundTripsBetweenMolarMassAndDensity() {
+    double boilingPoint = 447.3;
+    double density = 0.734;
+    double molarMass = TbpClosure.RIAZI_DAUBERT_1980.calcMolarMass(boilingPoint, density, null);
+    double recovered = TbpClosure.RIAZI_DAUBERT_1980.calcDensity(boilingPoint, molarMass, null);
+    assertEquals(density, recovered, 1.0e-9);
+  }
+
+  @Test
+  void testSoreideInversionRecoversItsOwnForwardCorrelation() {
+    double molarMass = 0.150;
+    double density = 0.780;
+    double boilingPoint = TbpClosure.calcBoilingPointSoreide(molarMass, density);
+    double recovered = TbpClosure.SOREIDE.calcMolarMass(boilingPoint, density, null);
+    assertEquals(molarMass, recovered, 1.0e-6);
+  }
+
+  @Test
+  void testOnlyRiaziDaubert1980CanBeInvertedForDensity() {
+    assertTrue(TbpClosure.RIAZI_DAUBERT_1980.supportsDensityFromMolarMass());
+    assertFalse(TbpClosure.RIAZI_DAUBERT_1987.supportsDensityFromMolarMass());
+    assertFalse(TbpClosure.SOREIDE.supportsDensityFromMolarMass());
+    assertFalse(TbpClosure.TBP_MODEL.supportsDensityFromMolarMass());
+  }
+
+  @Test
+  void testNonInvertibleClosuresThrowRatherThanReturnAnArbitraryRoot() {
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> TbpClosure.RIAZI_DAUBERT_1987.calcDensity(450.0, 0.150, null));
+    assertTrue(thrown.getCause().getMessage().contains("RIAZI_DAUBERT_1980"),
+        "the message must name the closure that does work, got: " + thrown.getCause().getMessage());
+
+    assertThrows(RuntimeException.class, () -> TbpClosure.SOREIDE.calcDensity(450.0, 0.150, null));
+    assertThrows(RuntimeException.class, () -> TbpClosure.TBP_MODEL.calcDensity(450.0, 0.150, null));
+  }
+
+  @Test
+  void testRiaziDaubert1987IsNotMonotonicInDensity() {
+    // This is the measured reason RIAZI_DAUBERT_1987.calcDensity refuses to run. If the correlation
+    // ever becomes monotonic over this range the refusal is no longer justified.
+    double boilingPoint = 450.0;
+    boolean sawIncrease = false;
+    boolean sawDecrease = false;
+    double previous = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, 0.60, null);
+    for (int i = 1; i <= 20; i++) {
+      double density = 0.60 + 0.02 * i;
+      double current = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, density, null);
+      if (current > previous) {
+        sawIncrease = true;
+      } else if (current < previous) {
+        sawDecrease = true;
+      }
+      previous = current;
+    }
+    assertTrue(sawIncrease && sawDecrease,
+        "molar mass must turn over within 0.60-1.00 specific gravity for the refusal to be justified");
+  }
+
+  @Test
+  void testTbpModelClosureRequiresAModel() {
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> TbpClosure.TBP_MODEL.calcMolarMass(450.0, 0.75, null));
+    assertTrue(thrown.getCause().getMessage().contains("model"));
+  }
+
+  @Test
+  void testUnattainableBoilingPointReportsTheAttainableRange() {
+    // 1500 K is far above anything the Soreide correlation produces for a petroleum fraction.
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> TbpClosure.SOREIDE.calcMolarMass(1500.0, 0.75, null));
+    assertTrue(thrown.getCause().getMessage().contains("Attainable range"),
+        "the caller needs to be told what is reachable, got: " + thrown.getCause().getMessage());
+  }
+
+  @Test
+  void testRiaziDaubert1987WorksForwardEvenThoughItCannotBeInverted() {
+    // The distinction the API depends on: addTBPfraction_Tb_Kw uses this closure forward and is
+    // fine; addTBPfraction_Mw_Tb would have to invert it and is not.
+    double boilingPoint = 447.3;
+    double density = 0.734;
+    double molarMass = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, density, null);
+    assertEquals(0.1423, molarMass, 0.006);
+
+    assertThrows(RuntimeException.class,
+        () -> TbpClosure.RIAZI_DAUBERT_1987.calcDensity(boilingPoint, molarMass, null));
+  }
+
+  @Test
+  void testTwoDensitiesReproduceTheSameMolarMassUnderRiaziDaubert1987() {
+    // The concrete reason the inverse is refused: the turning point sits inside the petroleum
+    // range, so a molar mass just below the maximum is reached from both sides.
+    double boilingPoint = 447.3;
+    double turningPointDensity = 4.98308 / (7.78712 - 2.08476e-3 * boilingPoint);
+    assertTrue(turningPointDensity > 0.60 && turningPointDensity < 1.00,
+        "turning point must fall inside the petroleum range for the ambiguity to be real, got " + turningPointDensity);
+
+    double maximumMolarMass = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, turningPointDensity, null);
+    double target = 0.98 * maximumMolarMass;
+
+    Double lightRoot = findRoot(boilingPoint, target, 0.60, turningPointDensity);
+    Double heavyRoot = findRoot(boilingPoint, target, turningPointDensity, 1.00);
+    assertTrue(lightRoot != null && heavyRoot != null,
+        "expected a root on each side of the turning point, got " + lightRoot + " and " + heavyRoot);
+    assertTrue(Math.abs(heavyRoot - lightRoot) > 0.02,
+        "the two roots must be far enough apart to matter, got " + lightRoot + " and " + heavyRoot);
+  }
+
+  /**
+   * Bisect for a specific gravity reproducing a target molar mass, or null when none exists.
+   *
+   * @param boilingPoint normal boiling point in K
+   * @param targetMolarMass molar mass to reach, kg/mol
+   * @param lower lower specific gravity bound
+   * @param upper upper specific gravity bound
+   * @return the specific gravity, or null when the target is not bracketed
+   */
+  private Double findRoot(double boilingPoint, double targetMolarMass, double lower, double upper) {
+    double fLower = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, lower, null) - targetMolarMass;
+    double fUpper = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, upper, null) - targetMolarMass;
+    if (fLower * fUpper > 0.0) {
+      return null;
+    }
+    for (int i = 0; i < 200; i++) {
+      double mid = 0.5 * (lower + upper);
+      double fMid = TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, mid, null) - targetMolarMass;
+      if (fLower * fMid <= 0.0) {
+        upper = mid;
+      } else {
+        lower = mid;
+        fLower = fMid;
+      }
+    }
+    return 0.5 * (lower + upper);
+  }
+
+  @Test
+  void testAccuracyRankingHoldsForParaffins() {
+    // RD-1987 is documented as the most accurate closure for molar mass and is therefore the
+    // default. If a coefficient is mistyped this ordering is the first thing to break.
+    double referenceMolarMass = 0.1423;
+    double boilingPoint = 447.3;
+    double density = 0.734;
+
+    double errorRd1987 = Math
+        .abs(TbpClosure.RIAZI_DAUBERT_1987.calcMolarMass(boilingPoint, density, null) - referenceMolarMass);
+    double errorRd1980 = Math
+        .abs(TbpClosure.RIAZI_DAUBERT_1980.calcMolarMass(boilingPoint, density, null) - referenceMolarMass);
+
+    assertTrue(errorRd1987 < errorRd1980,
+        "RD-1987 error " + errorRd1987 + " should be below RD-1980 error " + errorRd1980);
+  }
+}

--- a/src/test/java/neqsim/thermo/system/AddTBPfractionNamedOverloadsTest.java
+++ b/src/test/java/neqsim/thermo/system/AddTBPfractionNamedOverloadsTest.java
@@ -1,0 +1,228 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.TbpClosure;
+
+/**
+ * Verifies the named <code>addTBPfraction_*</code> overloads.
+ *
+ * <p>
+ * The point of the named family is that the method name states which properties the caller supplied. These tests
+ * therefore assert that each overload actually stores what it was given and derives only what it was supposed to
+ * derive.
+ * </p>
+ *
+ * @author ESOL
+ * @version $Id: $Id
+ */
+public class AddTBPfractionNamedOverloadsTest {
+  /** Tolerance on a property that is stored verbatim rather than correlated. */
+  private static final double EXACT_TOLERANCE = 1.0e-9;
+
+  private SystemInterface newFluid() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    return fluid;
+  }
+
+  private int lastComponentIndex(SystemInterface fluid) {
+    return fluid.getPhase(0).getNumberOfComponents() - 1;
+  }
+
+  @Test
+  void testMwSgMatchesTheClassicOverload() {
+    SystemInterface named = newFluid();
+    named.addTBPfraction_Mw_Sg("C7", 1.0, 0.092, 0.73);
+
+    SystemInterface classic = newFluid();
+    classic.addTBPfraction("C7", 1.0, 0.092, 0.73);
+
+    int i = lastComponentIndex(named);
+    assertEquals(classic.getPhase(0).getComponent(i).getTC(), named.getPhase(0).getComponent(i).getTC(),
+        EXACT_TOLERANCE);
+    assertEquals(classic.getPhase(0).getComponent(i).getPC(), named.getPhase(0).getComponent(i).getPC(),
+        EXACT_TOLERANCE);
+  }
+
+  @Test
+  void testMwTbStoresTheSuppliedBoilingPointAndMolarMass() {
+    SystemInterface fluid = newFluid();
+    double molarMass = 0.100;
+    double boilingPoint = 372.0;
+    fluid.addTBPfraction_Mw_Tb("C7", 1.0, molarMass, boilingPoint);
+
+    int i = lastComponentIndex(fluid);
+    assertEquals(molarMass, fluid.getPhase(0).getComponent(i).getMolarMass(), 1.0e-6);
+    assertEquals(boilingPoint, fluid.getPhase(0).getComponent(i).getNormalBoilingPoint(), 0.5);
+  }
+
+  @Test
+  void testMwTbAgreesWithTheDeprecatedNumericOverload() {
+    SystemInterface named = newFluid();
+    named.addTBPfraction_Mw_Tb("C7", 1.0, 0.100, 372.0);
+
+    SystemInterface legacy = newFluid();
+    legacy.addTBPfraction2("C7", 1.0, 0.100, 372.0);
+
+    int i = lastComponentIndex(named);
+    assertEquals(legacy.getPhase(0).getComponent(i).getTC(), named.getPhase(0).getComponent(i).getTC(), 1.0e-6);
+    assertEquals(legacy.getPhase(0).getComponent(i).getPC(), named.getPhase(0).getComponent(i).getPC(), 1.0e-6);
+  }
+
+  @Test
+  void testMwTbRejectsAClosureThatCannotBeInvertedForDensity() {
+    SystemInterface fluid = newFluid();
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> fluid.addTBPfraction_Mw_Tb("C7", 1.0, 0.100, 372.0, TbpClosure.RIAZI_DAUBERT_1987));
+    assertTrue(thrown.getCause().getMessage().contains("RIAZI_DAUBERT_1980"));
+  }
+
+  @Test
+  void testSgTbStoresTheSuppliedDensityAndBoilingPoint() {
+    SystemInterface fluid = newFluid();
+    double density = 0.734;
+    double boilingPoint = 447.3;
+    fluid.addTBPfraction_Sg_Tb("C10", 1.0, density, boilingPoint);
+
+    int i = lastComponentIndex(fluid);
+    assertEquals(boilingPoint, fluid.getPhase(0).getComponent(i).getNormalBoilingPoint(), 0.5);
+    // The default RD-1987 closure should land close to the real nC10 molar mass of 142.3 g/mol.
+    assertEquals(0.1423, fluid.getPhase(0).getComponent(i).getMolarMass(), 0.006);
+  }
+
+  @Test
+  void testSgTbWithTbpModelClosureMatchesTheDeprecatedNumericOverload() {
+    SystemInterface named = newFluid();
+    named.addTBPfraction_Sg_Tb("C10", 1.0, 0.734, 447.3, TbpClosure.TBP_MODEL);
+
+    SystemInterface legacy = newFluid();
+    legacy.addTBPfraction3("C10", 1.0, 0.734, 447.3);
+
+    int i = lastComponentIndex(named);
+    assertEquals(legacy.getPhase(0).getComponent(i).getMolarMass(), named.getPhase(0).getComponent(i).getMolarMass(),
+        1.0e-6);
+  }
+
+  @Test
+  void testTbKwDerivesDensityExactlyFromTheWatsonDefinition() {
+    SystemInterface fluid = newFluid();
+    double boilingPoint = 447.3;
+    double watsonK = 12.0;
+    fluid.addTBPfraction_Tb_Kw("C10", 1.0, boilingPoint, watsonK);
+
+    // SG = (1.8*Tb)^(1/3) / Kw, no correlation involved.
+    double expectedDensity = Math.pow(1.8 * boilingPoint, 1.0 / 3.0) / watsonK;
+    int i = lastComponentIndex(fluid);
+    assertEquals(boilingPoint, fluid.getPhase(0).getComponent(i).getNormalBoilingPoint(), 0.5);
+    assertEquals(expectedDensity, fluid.getPhase(0).getComponent(i).getNormalLiquidDensity(), 1.0e-6);
+  }
+
+  @Test
+  void testTbPnaOfAPureParaffinMatchesTheParaffinWatsonFactor() {
+    SystemInterface viaPna = newFluid();
+    viaPna.addTBPfraction_Tb_Pna("C10", 1.0, 447.3, 1.0, 0.0, 0.0);
+
+    SystemInterface viaKw = newFluid();
+    viaKw.addTBPfraction_Tb_Kw("C10", 1.0, 447.3, viaPna.calculateWatsonKFromPna(1.0, 0.0, 0.0));
+
+    int i = lastComponentIndex(viaPna);
+    assertEquals(viaKw.getPhase(0).getComponent(i).getMolarMass(), viaPna.getPhase(0).getComponent(i).getMolarMass(),
+        EXACT_TOLERANCE);
+  }
+
+  @Test
+  void testTbPnaGivesAHeavierAndDenserFractionAsAromaticContentRises() {
+    SystemInterface paraffinic = newFluid();
+    paraffinic.addTBPfraction_Tb_Pna("cut", 1.0, 450.0, 0.90, 0.10, 0.0);
+
+    SystemInterface aromatic = newFluid();
+    aromatic.addTBPfraction_Tb_Pna("cut", 1.0, 450.0, 0.20, 0.20, 0.60);
+
+    int i = lastComponentIndex(paraffinic);
+    double paraffinicDensity = paraffinic.getPhase(0).getComponent(i).getNormalLiquidDensity();
+    double aromaticDensity = aromatic.getPhase(0).getComponent(i).getNormalLiquidDensity();
+    assertTrue(aromaticDensity > paraffinicDensity, "an aromatic cut at the same boiling point must be denser, got "
+        + aromaticDensity + " vs " + paraffinicDensity);
+  }
+
+  @Test
+  void testWatsonKFromPnaBlendsLinearlyAndValidatesTheSum() {
+    SystemInterface fluid = newFluid();
+    assertEquals(0.6 * 12.8 + 0.25 * 11.0 + 0.15 * 10.1, fluid.calculateWatsonKFromPna(0.60, 0.25, 0.15), 1.0e-9);
+    assertEquals(11.5, fluid.calculateWatsonKFromPna(0.5, 0.0, 0.5, 13.0, 11.0, 10.0), 1.0e-9);
+
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> fluid.calculateWatsonKFromPna(0.5, 0.25, 0.15));
+    assertTrue(thrown.getCause().getMessage().contains("sum to 1"));
+
+    assertThrows(RuntimeException.class, () -> fluid.calculateWatsonKFromPna(1.2, -0.2, 0.0));
+  }
+
+  @Test
+  void testMwSgTbStoresAllThreeWithoutCorrelatingAnything() {
+    SystemInterface fluid = newFluid();
+    double molarMass = 0.150;
+    double density = 0.800;
+    double boilingPoint = 500.0;
+    fluid.addTBPfraction_Mw_Sg_Tb("C11", 1.0, molarMass, density, boilingPoint);
+
+    int i = lastComponentIndex(fluid);
+    assertEquals(molarMass, fluid.getPhase(0).getComponent(i).getMolarMass(), 1.0e-6);
+    assertEquals(density, fluid.getPhase(0).getComponent(i).getNormalLiquidDensity(), 1.0e-6);
+    assertEquals(boilingPoint, fluid.getPhase(0).getComponent(i).getNormalBoilingPoint(), 0.5);
+  }
+
+  @Test
+  void testMwSgCritStoresTheSuppliedCriticalProperties() {
+    SystemInterface fluid = newFluid();
+    double criticalTemperature = 560.0;
+    double criticalPressure = 30.0;
+    double acentricFactor = 0.49;
+    fluid.addTBPfraction_Mw_Sg_Crit("C7", 1.0, 0.092, 0.73, criticalTemperature, criticalPressure, acentricFactor);
+
+    int i = lastComponentIndex(fluid);
+    assertEquals(criticalTemperature, fluid.getPhase(0).getComponent(i).getTC(), 1.0e-6);
+    assertEquals(criticalPressure, fluid.getPhase(0).getComponent(i).getPC(), 1.0e-6);
+    assertEquals(acentricFactor, fluid.getPhase(0).getComponent(i).getAcentricFactor(), 1.0e-6);
+  }
+
+  @Test
+  void testBoilingPointPinDoesNotLeakIntoTheNextFraction() {
+    // The pin lives on the shared TBP model. A missing finally block would silently give every
+    // later fraction the same boiling point.
+    SystemInterface pinned = newFluid();
+    pinned.addTBPfraction_Mw_Sg_Tb("C7", 1.0, 0.092, 0.73, 480.0);
+    pinned.addTBPfraction_Mw_Sg("C10", 1.0, 0.142, 0.78);
+
+    SystemInterface clean = newFluid();
+    clean.addTBPfraction_Mw_Sg("C10", 1.0, 0.142, 0.78);
+
+    int pinnedIndex = lastComponentIndex(pinned);
+    int cleanIndex = lastComponentIndex(clean);
+    assertEquals(clean.getPhase(0).getComponent(cleanIndex).getNormalBoilingPoint(),
+        pinned.getPhase(0).getComponent(pinnedIndex).getNormalBoilingPoint(), 1.0e-6);
+  }
+
+  @Test
+  void testNonPositiveArgumentsAreRejected() {
+    SystemInterface fluid = newFluid();
+    assertThrows(RuntimeException.class, () -> fluid.addTBPfraction_Mw_Tb("C7", 1.0, -0.1, 372.0));
+    assertThrows(RuntimeException.class, () -> fluid.addTBPfraction_Mw_Tb("C7", 1.0, 0.1, 0.0));
+    assertThrows(RuntimeException.class, () -> fluid.addTBPfraction_Sg_Tb("C7", 1.0, 0.0, 372.0));
+    assertThrows(RuntimeException.class, () -> fluid.addTBPfraction_Tb_Kw("C7", 1.0, 372.0, -1.0));
+    assertThrows(RuntimeException.class, () -> fluid.addTBPfraction_Mw_Sg_Tb("C7", 1.0, 0.1, 0.7, -1.0));
+  }
+
+  @Test
+  void testAWildlyWrongUnitIsRejectedRatherThanCharacterized() {
+    SystemInterface fluid = newFluid();
+    // Molar mass given in g/mol instead of kg/mol produces a non-physical specific gravity.
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> fluid.addTBPfraction_Mw_Tb("C7", 1.0, 100.0, 372.0));
+    assertTrue(thrown.getCause().getMessage().contains("kg/mol"),
+        "the message should point at the likely unit mistake, got: " + thrown.getCause().getMessage());
+  }
+}


### PR DESCRIPTION
## Why

`addTBPfraction2`, `addTBPfraction3` and `addTBPfraction4` give no indication of
which properties the caller is supplying, or which correlation is used to close
the one that is missing. The numbered names also hide a behavioural difference:
some overloads store the boiling point the caller supplied, others recompute it
from the fitted correlation and silently discard it.

## What

A family of named overloads whose suffix states the supplied properties, so the
closure direction is visible at the call site:

```java
fluid.addTBPfraction_Mw_Dens("C7", 1.0, 0.0961, 0.738);
fluid.addTBPfraction_Tb_Kw("C7", 1.0, 371.6, 12.0);
fluid.addTBPfraction_Mw_Tb("C7", 1.0, 0.0961, 371.6);
```

The numbered forms still work and are unchanged; they are marked
`@Deprecated`.

`TbpClosure` collects the correlations behind an enum with one constant per
closure. Each documents its own units and validity range.

| Closure | Direction |
|---|---|
| `RIAZI_DAUBERT_1980` | analytic both ways |
| `RIAZI_DAUBERT_1987` | forward only |
| `SOREIDE` | forward, inverted by bisection |
| `TBP_MODEL` | forward, inverted through the model `calcTB` |

**Units are explicit at the interface**: `Tb` in K, `M` in kg/mol, `SG`
dimensionless (60/60 °F). Nothing is converted or clamped on the caller's behalf.

## Why two different correlations

`_Tb_Kw` evaluates RD-1987 **forward**. Watson K fixes the specific gravity
exactly from its own definition, `SG = (1.8*Tb)^(1/3) / Kw`, so only the molar
mass is left to correlate.

`_Mw_Tb` has to **invert** the correlation, and RD-1987 is not invertible over
the petroleum band. Its `SG` exponent changes sign at

```
SG* = 4.98308 / (7.78712 - 2.08476e-3 * Tb)
```

which lands at SG 0.706-0.762 — inside the range of interest. Measured on the
COMP.csv reference set, n-heptane, nC10 and nC14 each admit **two** roots, and
the error amplification `|dlnSG/dlnM|` reaches **6.9x, 20.7x and 7.9x**.

RD-1980 has a constant exponent of -1.0164, so the root is unique and error
propagates 1:1. `_Mw_Tb` therefore uses RD-1980.

Closures that cannot be inverted do not return an arbitrary root — they report
the turning point for the caller's boiling point.

## Closure accuracy

AAD against COMP.csv, forward direction:

| Closure | paraffins | aromatics |
|---|---|---|
| RD-1987 | 1.7 % | 7.8 % |
| Søreide | 3.0 % | 9.1 % |
| RD-1980 | 5.4 % | 13.6 % |
| NeqSim K-form | 9.2 % | 14.3 % |

## Verification

- `TbpClosureTest` — 11 tests covering both directions and round trips
- `AddTBPfractionNamedOverloadsTest` — 15 tests, including a **negative control**
  that fails if the supplied boiling point is not preserved (it reports
  `expected: <447.735176> but was: <480.0>` when the pin is removed)
- Full suite: **13064 tests, 0 failures**

`devtools/validate_tbp_closures.py` reproduces the accuracy table above;
`analyze_rd1987_inversion.py` and `analyze_tbp_closure_invertibility.py`
reproduce the invertibility measurements.

## Release note

This API is intended to ship in **3.20.0**. Release PR #3460 is held as a draft
until this is merged.
