### PR TITLE
[AI-Assisted] fix(twofluid): expose three-phase steady residuals

### DIFF
--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -496,11 +496,18 @@ See [Known limitations](../wiki/two_fluid_model#known-limitations).
 
 ```python
 pipe.run()
-if not pipe.isSteadyStateConverged():
-    if pipe.isSteadyStatePressureFloorLimited():
-        raise RuntimeError("Line cannot deliver this rate at this inlet pressure")
-    raise RuntimeError("Steady state did not converge")
+steady = pipe.getSteadyStateConvergenceReport()
+if not steady.isConverged():
+    raise RuntimeError(
+        f"Steady state stopped at {steady.getTerminationReason()}; "
+        f"liquid-split residual={steady.getLiquidSplitResidual():.3e}"
+    )
 ```
+
+The report also exposes pressure-momentum, pressure-update, total-holdup,
+thermodynamic-property, and pressure-drop residuals. Its `CONVERGED` result includes the mandatory
+final flash and holdup/oil-water resweep; an iteration-, wall-clock-, or pressure-floor-limited
+profile remains explicitly non-converged.
 
 > **Further Reading**: See [TwoFluidPipe Tutorial](../examples/TwoFluidPipe_Tutorial) for comprehensive examples including slug visualization and transient analysis.
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1329,7 +1329,9 @@ pipe.setSteadyStateMaxWallClockTime(60.0); // Allow 60 seconds
 ### Always check the steady-state outcome
 
 `run()` does not throw when the steady state fails to settle, so the outcome has to be read back.
-Three independent flags describe it, and a profile is only trustworthy when the first is true:
+The legacy flags remain available, while `getSteadyStateConvergenceReport()` gives the termination
+reason and the residual that controlled the solve. A profile is only trustworthy when the report
+is converged:
 
 | Query | Meaning when true |
 |-------|-------------------|
@@ -1337,14 +1339,22 @@ Three independent flags describe it, and a profile is only trustworthy when the 
 | `isSteadyStateWallClockLimited()` | The wall-clock guard stopped the sweep early |
 | `isSteadyStatePressureFloorLimited()` | One or more sections rest on the internal 1 bara pressure floor |
 
+The immutable report distinguishes `CONVERGED`, `ITERATION_LIMIT`, `WALL_CLOCK_LIMIT`, and
+`PRESSURE_FLOOR_LIMIT` (or `NOT_RUN` before initialization). Its dimensionless residuals cover the
+accumulated discrete pressure-momentum mismatch, maximum relative pressure update, absolute
+total-liquid-holdup and water-holdup updates, maximum thermodynamic-property update, and relative
+total-pressure-drop update. Every applicable value must be below `getTolerance()` for convergence.
+The mandatory final flash and unrelaxed holdup/oil-water resweep are included in that decision; a
+post-flash state that moves beyond tolerance is refined again instead of being returned under a
+stale convergence flag.
+
 ```java
 pipe.run();
-if (!pipe.isSteadyStateConverged()) {
-  if (pipe.isSteadyStatePressureFloorLimited()) {
-    throw new IllegalStateException(
-        "The line cannot deliver this rate at this inlet pressure");
-  }
-  throw new IllegalStateException("Steady state did not converge");
+SteadyStateConvergenceReport steady = pipe.getSteadyStateConvergenceReport();
+if (!steady.isConverged()) {
+  throw new IllegalStateException("Steady state stopped at "
+      + steady.getTerminationReason() + "; liquid-split residual="
+      + steady.getLiquidSplitResidual());
 }
 ```
 
@@ -1576,6 +1586,11 @@ Remaining limitations:
   split did not converge; `isSteadyStateConverged()` was correctly false. That 73.8 km case has
   not been rerun for the pressure-boundary and oil/water-split corrections described here. Compact
   regression coverage does not resolve this historical case or qualify its reported pressure drop.
+- The reproducible 3 km, 10-degree uphill gas/oil/water fixture converges with positive
+  oil-over-water slip and closed phase volumes and mass flow on both 30 and 60 cells. Arrival
+  pressure changes from 7.469114 bar to 7.429146 bar (0.538% relative), while mean liquid holdup
+  changes from 0.274301 to 0.271630 (0.983%). These are numerical-refinement results for a synthetic
+  regression fixture, not experimental qualification or evidence for the unavailable 73.8 km case.
 - All observations are model-internal on one line.
 
 ### Implemented regression tests

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -1046,14 +1046,31 @@ double[] pressures = pipe.getPressureProfile();
 double[] holdups = pipe.getLiquidHoldupProfile();
 ```
 
-**Checking the outcome.** Three flags describe how the sweep ended, and a profile is only
-trustworthy when the first is true:
+**Checking the outcome.** The legacy flags describe the common failure modes, while
+`getSteadyStateConvergenceReport()` exposes the termination reason and the solved residuals. A
+profile is only trustworthy when the report is converged:
 
 | Query | Meaning when true |
 |-------|-------------------|
 | `isSteadyStateConverged()` | The sweep met the 1e-4 tolerance and the profile is a solution |
 | `isSteadyStateWallClockLimited()` | The wall-clock guard (default 300 s) stopped it early |
 | `isSteadyStatePressureFloorLimited()` | One or more sections rest on the internal 1 bara pressure floor |
+
+`SteadyStateConvergenceReport` distinguishes `CONVERGED`, `ITERATION_LIMIT`,
+`WALL_CLOCK_LIMIT`, `PRESSURE_FLOOR_LIMIT`, and the pre-run `NOT_RUN` state. It reports the
+dimensionless pressure-momentum, pressure-update, total-liquid-holdup, oil/water-split,
+thermodynamic-property, and total-pressure-drop residuals against `getTolerance()`. Convergence
+includes the mandatory final flash and unrelaxed holdup/split resweep, so that pass cannot silently
+change the state after the convergence flag has been set.
+
+```java
+SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
+if (!report.isConverged()) {
+  throw new IllegalStateException("Steady state stopped at "
+      + report.getTerminationReason() + "; liquid-split residual="
+      + report.getLiquidSplitResidual());
+}
+```
 
 The marching solver clamps section pressure at 1 bara so it stays numerically alive on a line with
 no deliverability. That clamp is a fixed point of itself: the per-section change falls below
@@ -1743,6 +1760,11 @@ measured on a 73.8 km subsea gas-condensate export line at 200 bara inlet (see
   did not converge. This long case has not been rerun for the pressure-boundary and split
   corrections described here; the compact regressions do not establish that it is resolved.
   Always check `isSteadyStateConverged()` on a water-bearing line.
+- The reproducible 3 km, 10-degree uphill gas/oil/water fixture converges on 30 and 60 cells with
+  positive oil-over-water slip, closed phase volumes and closed phase mass flow. Refinement changes
+  arrival pressure from 7.469114 bar to 7.429146 bar (0.538%) and mean liquid holdup from 0.274301
+  to 0.271630 (0.983%). This is numerical evidence for the compact synthetic fixture, not
+  experimental qualification or evidence for the unavailable 73.8 km input.
 - **Pressure drop does not always respond to a temperature change.** In an earlier revision, adding
   10 MW of heating raised the arrival temperature 22 K but left the computed pressure drop
   unchanged; warmer gas at fixed mass rate is less dense and ΔP ~ G²/ρ must rise. Treat pressure

--- a/src/main/java/neqsim/process/equipment/pipeline/SteadyStateConvergenceReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/SteadyStateConvergenceReport.java
@@ -1,0 +1,121 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+
+/**
+ * Immutable diagnostics from a {@link TwoFluidPipe} steady-state initialization.
+ *
+ * <p>
+ * Every residual is dimensionless and is compared with {@link #getTolerance()}. Holdup and liquid-split residuals are
+ * absolute volume-fraction changes. Pressure-update, thermodynamic-property, pressure-drop, and pressure-momentum
+ * residuals are relative changes. A report is converged only when every applicable residual is below the tolerance and
+ * the mandatory final thermodynamic/holdup consistency pass has also settled.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class SteadyStateConvergenceReport implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  /** Reason the steady-state refinement loop stopped. */
+  public enum TerminationReason {
+    /** No steady-state solve has run. */
+    NOT_RUN,
+    /** Every applicable residual met the configured tolerance. */
+    CONVERGED,
+    /** The configured iteration budget was exhausted. */
+    ITERATION_LIMIT,
+    /** The wall-clock guard stopped the solve. */
+    WALL_CLOCK_LIMIT,
+    /** At least one section reached the numerical pressure floor. */
+    PRESSURE_FLOOR_LIMIT
+  }
+
+  private final TerminationReason terminationReason;
+  private final int iterations;
+  private final double tolerance;
+  private final double pressureMomentumResidual;
+  private final double pressureUpdateResidual;
+  private final double liquidHoldupResidual;
+  private final double liquidSplitResidual;
+  private final double thermodynamicResidual;
+  private final double pressureDropResidual;
+
+  /**
+   * Create a steady-state convergence report.
+   *
+   * @param terminationReason reason the solver stopped
+   * @param iterations number of refinement sweeps performed
+   * @param tolerance dimensionless convergence tolerance
+   * @param pressureMomentumResidual accumulated pressure-march residual normalized by pressure drop
+   * @param pressureUpdateResidual maximum relative pressure correction
+   * @param liquidHoldupResidual maximum absolute total-liquid-holdup correction
+   * @param liquidSplitResidual maximum absolute water-holdup correction
+   * @param thermodynamicResidual maximum relative thermodynamic-property correction
+   * @param pressureDropResidual relative total-pressure-drop correction between sweeps
+   */
+  public SteadyStateConvergenceReport(TerminationReason terminationReason, int iterations, double tolerance,
+      double pressureMomentumResidual, double pressureUpdateResidual, double liquidHoldupResidual,
+      double liquidSplitResidual, double thermodynamicResidual, double pressureDropResidual) {
+    this.terminationReason = terminationReason;
+    this.iterations = iterations;
+    this.tolerance = tolerance;
+    this.pressureMomentumResidual = pressureMomentumResidual;
+    this.pressureUpdateResidual = pressureUpdateResidual;
+    this.liquidHoldupResidual = liquidHoldupResidual;
+    this.liquidSplitResidual = liquidSplitResidual;
+    this.thermodynamicResidual = thermodynamicResidual;
+    this.pressureDropResidual = pressureDropResidual;
+  }
+
+  /** @return reason the steady-state refinement stopped */
+  public TerminationReason getTerminationReason() {
+    return terminationReason;
+  }
+
+  /** @return number of refinement sweeps performed */
+  public int getIterations() {
+    return iterations;
+  }
+
+  /** @return dimensionless convergence tolerance */
+  public double getTolerance() {
+    return tolerance;
+  }
+
+  /** @return accumulated pressure-march residual normalized by total pressure drop */
+  public double getPressureMomentumResidual() {
+    return pressureMomentumResidual;
+  }
+
+  /** @return maximum relative pressure correction */
+  public double getPressureUpdateResidual() {
+    return pressureUpdateResidual;
+  }
+
+  /** @return maximum absolute total-liquid-holdup correction */
+  public double getLiquidHoldupResidual() {
+    return liquidHoldupResidual;
+  }
+
+  /** @return maximum absolute water-holdup correction */
+  public double getLiquidSplitResidual() {
+    return liquidSplitResidual;
+  }
+
+  /** @return maximum relative thermodynamic-property correction */
+  public double getThermodynamicResidual() {
+    return thermodynamicResidual;
+  }
+
+  /** @return relative total-pressure-drop correction between refinement sweeps */
+  public double getPressureDropResidual() {
+    return pressureDropResidual;
+  }
+
+  /** @return true only when the solver stopped because every residual met the tolerance */
+  public boolean isConverged() {
+    return terminationReason == TerminationReason.CONVERGED;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -806,6 +806,12 @@ public class TwoFluidPipe extends Pipeline {
   /** True when the last steady-state refinement loop met its tolerance. */
   private boolean ssConverged = false;
 
+  /** Detailed outcome of the most recent steady-state initialization. */
+  private SteadyStateConvergenceReport steadyStateConvergenceReport = new SteadyStateConvergenceReport(
+      SteadyStateConvergenceReport.TerminationReason.NOT_RUN, 0, 1.0e-4, Double.POSITIVE_INFINITY,
+      Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+      Double.POSITIVE_INFINITY);
+
   /** Current step count. */
   private int currentStep = 0;
 
@@ -1355,6 +1361,10 @@ public class TwoFluidPipe extends Pipeline {
     ssConverged = false;
     ssPressureFloorLimited = false;
     ssIterationsUsed = 0;
+    steadyStateConvergenceReport = new SteadyStateConvergenceReport(
+        SteadyStateConvergenceReport.TerminationReason.NOT_RUN, 0, tolerance, Double.POSITIVE_INFINITY,
+        Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+        Double.POSITIVE_INFINITY);
     transientOutletBackflowClamped = false;
     equations.clearOutletBackflowClamped();
 
@@ -1449,8 +1459,14 @@ public class TwoFluidPipe extends Pipeline {
     // accumulated profile is still far from the solution. The total pressure drop is tracked
     // as well, which is mesh-independent and is the quantity the caller actually reads.
     double previousTotalDrop = Double.NaN;
+    double pressureMomentumResidual = Double.POSITIVE_INFINITY;
+    double pressureUpdateResidual = Double.POSITIVE_INFINITY;
+    double liquidHoldupResidual = Double.POSITIVE_INFINITY;
+    double liquidSplitResidual = Double.POSITIVE_INFINITY;
+    double thermodynamicResidual = Double.POSITIVE_INFINITY;
+    double pressureDropResidual = Double.POSITIVE_INFINITY;
     for (int iter = 0; iter < maxIter; iter++) {
-      ssIterationsUsed = iter;
+      ssIterationsUsed = iter + 1;
       // Wall-clock time guard
       long elapsed = System.currentTimeMillis() - startWallClock;
       if (elapsed > (long) (ssMaxWallClockTime * 1000)) {
@@ -1459,7 +1475,9 @@ public class TwoFluidPipe extends Pipeline {
         break;
       }
 
-      double maxChange = 0;
+      pressureUpdateResidual = 0.0;
+      liquidHoldupResidual = 0.0;
+      liquidSplitResidual = 0.0;
       double pressureResidualSum = 0.0;
 
       // Under-relaxation: ramp from 0.3 up to ssUnderRelaxation across first 20 iterations
@@ -1476,6 +1494,8 @@ public class TwoFluidPipe extends Pipeline {
         TwoFluidSection inletSec = sections[0];
         double localMDotG = localMDotGas[0];
         double localMDotL = localMDotLiq[0];
+        double inletLiquidHoldupBefore = inletSec.getLiquidHoldup();
+        double inletWaterHoldupBefore = inletSec.getWaterHoldup();
 
         // Calculate inlet holdup using momentum balance (pass null for prev to indicate inlet)
         double[] inletHoldups = calculateLocalHoldup(inletSec, null, localMDotG, localMDotL, area);
@@ -1484,6 +1504,7 @@ public class TwoFluidPipe extends Pipeline {
 
         inletSec.setLiquidHoldup(alphaL_inlet);
         inletSec.setGasHoldup(alphaG_inlet);
+        liquidHoldupResidual = Math.max(liquidHoldupResidual, Math.abs(alphaL_inlet - inletLiquidHoldupBefore));
 
         // Update inlet velocities
         inletSec.setGasVelocity(
@@ -1494,6 +1515,8 @@ public class TwoFluidPipe extends Pipeline {
         // Update water/oil holdups for inlet if three-phase
         if (inletSec.getWaterDensity() > 0 && inletSec.getOilDensity() > 0 && alphaL_inlet > 0.0) {
           updateLiquidPhaseSplit(inletSec, null, alphaL_inlet, area);
+          liquidSplitResidual = Math.max(liquidSplitResidual,
+              Math.abs(inletSec.getWaterHoldup() - inletWaterHoldupBefore));
         }
 
         inletSec.updateDerivedQuantities();
@@ -1512,7 +1535,7 @@ public class TwoFluidPipe extends Pipeline {
         // Under-relaxed pressure update
         double P_new = sec.getPressure() + omega * (P_calc - sec.getPressure());
         double change = Math.abs(P_new - sec.getPressure()) / Math.max(sec.getPressure(), 1e5);
-        maxChange = Math.max(maxChange, change);
+        pressureUpdateResidual = Math.max(pressureUpdateResidual, change);
 
         sec.setPressure(P_new);
 
@@ -1530,7 +1553,7 @@ public class TwoFluidPipe extends Pipeline {
 
         // Track holdup change for convergence
         double holdupChange = Math.abs(alphaL_new - sec.getLiquidHoldup());
-        maxChange = Math.max(maxChange, holdupChange);
+        liquidHoldupResidual = Math.max(liquidHoldupResidual, holdupChange);
 
         // Apply new holdups
         sec.setLiquidHoldup(alphaL_new);
@@ -1557,7 +1580,7 @@ public class TwoFluidPipe extends Pipeline {
 
           // The liquid split is a solved variable. Leaving it out of the residual lets the solver
           // report convergence while oil and water are still redistributing.
-          maxChange = Math.max(maxChange, Math.abs(sec.getWaterHoldup() - waterHoldupBefore));
+          liquidSplitResidual = Math.max(liquidSplitResidual, Math.abs(sec.getWaterHoldup() - waterHoldupBefore));
         }
 
         // Update derived quantities
@@ -1569,7 +1592,7 @@ public class TwoFluidPipe extends Pipeline {
       // explicit pressure boundary inside the iteration, before both the thermal sweep and flash;
       // translating the finished profile would leave its properties at a different pressure.
       if (explicitPressureBoundary) {
-        maxChange = Math.max(maxChange, applySteadyStatePressureBoundary());
+        pressureUpdateResidual = Math.max(pressureUpdateResidual, applySteadyStatePressureBoundary());
         P_inlet = sections[0].getPressure();
       }
 
@@ -1586,6 +1609,7 @@ public class TwoFluidPipe extends Pipeline {
       // because properties change slowly with small pressure changes between iterations.
       boolean thermodynamicsRefreshed = false;
       boolean thermodynamicsEvaluated = referenceFluid == null;
+      double iterationThermodynamicResidual = referenceFluid == null ? 0.0 : Double.POSITIVE_INFINITY;
       if (referenceFluid != null && (iter % ssFlashInterval == 0)) {
         thermodynamicsEvaluated = true;
         double[][] propertiesBefore = new double[numberOfSections][7];
@@ -1622,6 +1646,8 @@ public class TwoFluidPipe extends Pipeline {
           maxPropertyChange = Math.max(maxPropertyChange,
               Math.abs(localMDotGas[i] - propertiesBefore[i][4]) / Math.max(Math.abs(massFlow), 1.0e-12));
         }
+        iterationThermodynamicResidual = maxPropertyChange;
+        thermodynamicResidual = maxPropertyChange;
         thermodynamicsRefreshed = maxPropertyChange > tolerance;
       }
 
@@ -1651,9 +1677,10 @@ public class TwoFluidPipe extends Pipeline {
       for (TwoFluidSection section : sections) {
         liquidSplitCouplingMatters |= section.getOilHoldup() > 0.0 && section.getWaterHoldup() > 0.0;
       }
-      double dropChange = Double.isNaN(previousTotalDrop) ? Double.POSITIVE_INFINITY
+      pressureDropResidual = Double.isNaN(previousTotalDrop) ? Double.POSITIVE_INFINITY
           : Math.abs(totalDrop - previousTotalDrop) / Math.max(Math.abs(totalDrop), 1.0e3);
       previousTotalDrop = totalDrop;
+      pressureMomentumResidual = pressureResidualSum / Math.max(Math.abs(totalDrop), 1.0e3);
 
       // The flash runs only every ssFlashInterval sweeps, and thermodynamicsRefreshed starts false, so on a
       // non-flash sweep it reports "the flash moved nothing" when in truth no flash was performed. Convergence
@@ -1661,17 +1688,19 @@ public class TwoFluidPipe extends Pipeline {
       // iteration 1 that returned a pressure drop several per cent away from the settled value. Require a sweep
       // in which the thermodynamics was actually evaluated and found stationary.
       boolean profileSettled = !densityCouplingMatters
-          || (dropChange < tolerance && thermodynamicsEvaluated && !thermodynamicsRefreshed);
+          || (pressureDropResidual < tolerance && thermodynamicsEvaluated && !thermodynamicsRefreshed);
       if (explicitPressureBoundary || liquidSplitCouplingMatters) {
-        profileSettled &= thermodynamicsEvaluated && !thermodynamicsRefreshed && dropChange < tolerance;
+        profileSettled &= thermodynamicsEvaluated && !thermodynamicsRefreshed && pressureDropResidual < tolerance;
       }
       if (explicitPressureBoundary) {
         // A small relaxed update relative to absolute pressure can still accumulate a significant
         // error over many cells. Require the unrelaxed momentum residual of the whole pressure
         // profile to be small relative to its calculated drop, independently of the initial guess.
-        profileSettled &= pressureResidualSum / Math.max(Math.abs(totalDrop), 1.0e3) < tolerance;
+        profileSettled &= pressureMomentumResidual < tolerance;
       }
-      if (maxChange < tolerance && profileSettled) {
+      boolean iterationSettled = pressureUpdateResidual < tolerance && liquidHoldupResidual < tolerance
+          && liquidSplitResidual < tolerance && iterationThermodynamicResidual < tolerance && profileSettled;
+      if (iterationSettled) {
         // A section resting on the pressure floor is a fixed point of the clamp, not of the
         // momentum balance: marchPressure keeps returning the floor, the under-relaxed update
         // stops moving, and the loop would otherwise report success on a profile the line
@@ -1683,10 +1712,25 @@ public class TwoFluidPipe extends Pipeline {
               + "inlet pressure, or increase the diameter.", MIN_SECTION_PRESSURE_PA / 1.0e5, iter);
           break;
         }
-        ssConverged = true;
-        logger.info("Steady-state converged after {} iterations ({}ms wall-clock)", iter,
-            System.currentTimeMillis() - startWallClock);
-        break;
+
+        // A sparse flash is followed by a mandatory unrelaxed holdup/split resweep. That resweep
+        // is part of the solved state, not post-processing: if it moves a variable beyond the
+        // tolerance, use the reconciled state as the next iterate instead of returning a false
+        // positive and handing a different state to the transient solver.
+        double[] finalConsistencyResiduals = reconcileSteadyThermodynamicsAndHoldup(massFlow, localMDotGas,
+            localMDotLiq, area);
+        thermodynamicResidual = finalConsistencyResiduals[0];
+        liquidHoldupResidual = Math.max(liquidHoldupResidual, finalConsistencyResiduals[1]);
+        liquidSplitResidual = Math.max(liquidSplitResidual, finalConsistencyResiduals[2]);
+        pressureMomentumResidual = calculateSteadyPressureMomentumResidual();
+        boolean finalConsistencySettled = thermodynamicResidual < tolerance && liquidHoldupResidual < tolerance
+            && liquidSplitResidual < tolerance && pressureMomentumResidual < tolerance;
+        if (finalConsistencySettled) {
+          ssConverged = true;
+          logger.info("Steady-state converged after {} iterations ({}ms wall-clock)", ssIterationsUsed,
+              System.currentTimeMillis() - startWallClock);
+          break;
+        }
       }
     }
 
@@ -1701,31 +1745,30 @@ public class TwoFluidPipe extends Pipeline {
           + "or reduce setSteadyStateUnderRelaxation(...).", maxIter, numberOfSections);
     }
 
-    // ===== Final consistency pass: flash + holdup recalculation =====
-    // With sparse flash during iteration, the final state may not be fully consistent.
-    // Do one mandatory flash + holdup sweep to ensure thermodynamic consistency.
-    if (referenceFluid != null) {
-      updateThermodynamicsWithCondensation(massFlow, localMDotGas, localMDotLiq);
-
-      // Re-sweep holdups using updated properties (densities changed by flash)
-      for (int i = 0; i < numberOfSections; i++) {
-        TwoFluidSection sec = sections[i];
-        TwoFluidSection prev = i > 0 ? sections[i - 1] : null;
-        double localMDotG = localMDotGas[i];
-        double localMDotL = localMDotLiq[i];
-
-        double[] hi = calculateLocalHoldup(sec, prev, localMDotG, localMDotL, area);
-        sec.setLiquidHoldup(hi[0]);
-        sec.setGasHoldup(hi[1]);
-        sec.setGasVelocity(calculateFinitePhaseVelocity(localMDotG, hi[1], sec.getGasDensity(), area, 100.0));
-        sec.setLiquidVelocity(calculateFinitePhaseVelocity(localMDotL, hi[0], sec.getLiquidDensity(), area, 50.0));
-        if (sec.getWaterDensity() > 0 && sec.getOilDensity() > 0 && hi[0] > 0.0) {
-          updateLiquidPhaseSplit(sec, prev, hi[0], area);
-        }
-        sec.updateDerivedQuantities();
-        sec.updateStratifiedGeometry();
-      }
+    // Preserve a thermodynamically and hydraulically reconciled last iterate even on a limited
+    // solve, but keep its residuals visible and never promote it to convergence after the loop.
+    if (!ssConverged) {
+      double[] finalConsistencyResiduals = reconcileSteadyThermodynamicsAndHoldup(massFlow, localMDotGas, localMDotLiq,
+          area);
+      thermodynamicResidual = finalConsistencyResiduals[0];
+      liquidHoldupResidual = Math.max(liquidHoldupResidual, finalConsistencyResiduals[1]);
+      liquidSplitResidual = Math.max(liquidSplitResidual, finalConsistencyResiduals[2]);
+      pressureMomentumResidual = calculateSteadyPressureMomentumResidual();
     }
+
+    SteadyStateConvergenceReport.TerminationReason terminationReason;
+    if (ssConverged) {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.CONVERGED;
+    } else if (ssPressureFloorLimited) {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.PRESSURE_FLOOR_LIMIT;
+    } else if (ssWallClockLimited) {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.WALL_CLOCK_LIMIT;
+    } else {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.ITERATION_LIMIT;
+    }
+    steadyStateConvergenceReport = new SteadyStateConvergenceReport(terminationReason, ssIterationsUsed, tolerance,
+        pressureMomentumResidual, pressureUpdateResidual, liquidHoldupResidual, liquidSplitResidual,
+        thermodynamicResidual, pressureDropResidual);
 
     // Final accumulation zone identification after convergence
     if (enableTerrainTracking && accumulationTracker != null) {
@@ -1757,6 +1800,100 @@ public class TwoFluidPipe extends Pipeline {
 
     // Store initial profiles
     updateResultArrays();
+  }
+
+  /**
+   * Reconcile the steady primitive profile with a mandatory thermodynamic update.
+   *
+   * @param massFlow total pipe mass flow in kg/s
+   * @param localMDotGas local gas mass-flow profile in kg/s
+   * @param localMDotLiq local liquid mass-flow profile in kg/s
+   * @param area internal pipe area in m2
+   * @return thermodynamic, total-liquid-holdup, and water-holdup residuals
+   */
+  private double[] reconcileSteadyThermodynamicsAndHoldup(double massFlow, double[] localMDotGas, double[] localMDotLiq,
+      double area) {
+    double thermodynamicResidual = 0.0;
+    if (referenceFluid != null) {
+      double[][] propertiesBefore = snapshotSteadyThermodynamicProperties(localMDotGas);
+      updateThermodynamicsWithCondensation(massFlow, localMDotGas, localMDotLiq);
+      thermodynamicResidual = calculateSteadyThermodynamicResidual(propertiesBefore, localMDotGas, massFlow);
+    }
+
+    double liquidHoldupResidual = 0.0;
+    double liquidSplitResidual = 0.0;
+    for (int i = 0; i < numberOfSections; i++) {
+      TwoFluidSection sec = sections[i];
+      TwoFluidSection prev = i > 0 ? sections[i - 1] : null;
+      double liquidHoldupBefore = sec.getLiquidHoldup();
+      double waterHoldupBefore = sec.getWaterHoldup();
+      double[] holdups = calculateLocalHoldup(sec, prev, localMDotGas[i], localMDotLiq[i], area);
+      sec.setLiquidHoldup(holdups[0]);
+      sec.setGasHoldup(holdups[1]);
+      sec.setGasVelocity(calculateFinitePhaseVelocity(localMDotGas[i], holdups[1], sec.getGasDensity(), area, 100.0));
+      sec.setLiquidVelocity(
+          calculateFinitePhaseVelocity(localMDotLiq[i], holdups[0], sec.getLiquidDensity(), area, 50.0));
+      if (sec.getWaterDensity() > 0 && sec.getOilDensity() > 0 && holdups[0] > 0.0) {
+        updateLiquidPhaseSplit(sec, prev, holdups[0], area);
+      }
+      sec.updateDerivedQuantities();
+      sec.updateStratifiedGeometry();
+      liquidHoldupResidual = Math.max(liquidHoldupResidual, Math.abs(sec.getLiquidHoldup() - liquidHoldupBefore));
+      liquidSplitResidual = Math.max(liquidSplitResidual, Math.abs(sec.getWaterHoldup() - waterHoldupBefore));
+    }
+    return new double[] { thermodynamicResidual, liquidHoldupResidual, liquidSplitResidual };
+  }
+
+  /** Snapshot the properties that close the steady hydraulic equations. */
+  private double[][] snapshotSteadyThermodynamicProperties(double[] localMDotGas) {
+    double[][] properties = new double[numberOfSections][7];
+    for (int i = 0; i < numberOfSections; i++) {
+      properties[i][0] = sections[i].getGasDensity();
+      properties[i][1] = sections[i].getOilDensity();
+      properties[i][2] = sections[i].getWaterDensity();
+      properties[i][3] = sections[i].getInputWaterVolumeFraction();
+      properties[i][4] = localMDotGas[i];
+      properties[i][5] = sections[i].getLiquidViscosity();
+      properties[i][6] = sections[i].getSurfaceTension();
+    }
+    return properties;
+  }
+
+  /** Calculate the maximum normalized change in properties that close the steady equations. */
+  private double calculateSteadyThermodynamicResidual(double[][] propertiesBefore, double[] localMDotGas,
+      double massFlow) {
+    double maximumResidual = 0.0;
+    for (int i = 0; i < numberOfSections; i++) {
+      double[] densities = { sections[i].getGasDensity(), sections[i].getOilDensity(), sections[i].getWaterDensity() };
+      for (int phase = 0; phase < densities.length; phase++) {
+        if (densities[phase] > 0.0) {
+          maximumResidual = Math.max(maximumResidual,
+              Math.abs(densities[phase] - propertiesBefore[i][phase]) / densities[phase]);
+        }
+      }
+      double[] closureProperties = { sections[i].getLiquidViscosity(), sections[i].getSurfaceTension() };
+      for (int property = 0; property < closureProperties.length; property++) {
+        if (closureProperties[property] > 0.0) {
+          maximumResidual = Math.max(maximumResidual,
+              Math.abs(closureProperties[property] - propertiesBefore[i][5 + property]) / closureProperties[property]);
+        }
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(sections[i].getInputWaterVolumeFraction() - propertiesBefore[i][3]));
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(localMDotGas[i] - propertiesBefore[i][4]) / Math.max(Math.abs(massFlow), 1.0e-12));
+    }
+    return maximumResidual;
+  }
+
+  /** Calculate the accumulated discrete momentum residual of the returned pressure profile. */
+  private double calculateSteadyPressureMomentumResidual() {
+    double pressureResidualSum = 0.0;
+    for (int i = 1; i < numberOfSections; i++) {
+      pressureResidualSum += Math.abs(marchPressure(sections[i - 1]) - sections[i].getPressure());
+    }
+    double totalDrop = sections[0].getPressure() - sections[numberOfSections - 1].getPressure();
+    return pressureResidualSum / Math.max(Math.abs(totalDrop), 1.0e3);
   }
 
   /**
@@ -8635,6 +8772,20 @@ public class TwoFluidPipe extends Pipeline {
    */
   public boolean isSteadyStateConverged() {
     return ssConverged;
+  }
+
+  /**
+   * Get residuals and the termination reason from the latest steady-state initialization.
+   *
+   * <p>
+   * Unlike {@link #isSteadyStateConverged()}, this report identifies the variable that prevented convergence and
+   * distinguishes iteration, wall-clock, and pressure-floor limits. The returned value is immutable.
+   * </p>
+   *
+   * @return detailed steady-state convergence report, or a {@code NOT_RUN} report before the first solve
+   */
+  public SteadyStateConvergenceReport getSteadyStateConvergenceReport() {
+    return steadyStateConvergenceReport;
   }
 
   // ============ Minimum Slip Methods ============

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipePressureFloorTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipePressureFloorTest.java
@@ -1,8 +1,10 @@
 package neqsim.process.equipment.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.SteadyStateConvergenceReport.TerminationReason;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -92,5 +94,6 @@ public class TwoFluidPipePressureFloorTest {
     assertTrue(pipe.isSteadyStatePressureFloorLimited(), "A profile resting on the pressure floor must be flagged");
     assertFalse(pipe.isSteadyStateConverged(),
         "A profile resting on the pressure floor must not be reported as converged");
+    assertEquals(TerminationReason.PRESSURE_FLOOR_LIMIT, pipe.getSteadyStateConvergenceReport().getTerminationReason());
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeSteadyStateConvergenceTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeSteadyStateConvergenceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.SteadyStateConvergenceReport.TerminationReason;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -86,6 +87,18 @@ public class TwoFluidPipeSteadyStateConvergenceTest {
     pipe.run();
 
     assertTrue(pipe.getSteadyStateIterationsUsed() <= 2, "The solver must respect the user-specified iteration limit");
+    SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
+    assertFalse(report.isConverged(), "Two refinement sweeps must not be promoted to convergence");
+    assertEquals(TerminationReason.ITERATION_LIMIT, report.getTerminationReason());
+    assertEquals(pipe.getSteadyStateIterationsUsed(), report.getIterations());
+    assertTrue(
+        report.getPressureMomentumResidual() >= report.getTolerance()
+            || report.getPressureUpdateResidual() >= report.getTolerance()
+            || report.getLiquidHoldupResidual() >= report.getTolerance()
+            || report.getLiquidSplitResidual() >= report.getTolerance()
+            || report.getThermodynamicResidual() >= report.getTolerance()
+            || report.getPressureDropResidual() >= report.getTolerance(),
+        "An iteration-limited solve must expose at least one residual above tolerance");
   }
 
   /** A horizontal line must reproduce a Darcy-Weisbach order-of-magnitude pressure drop. */

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeThreePhaseConvergenceReportTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeThreePhaseConvergenceReportTest.java
@@ -1,0 +1,127 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.SteadyStateConvergenceReport.TerminationReason;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Physical and mesh-refinement contracts for three-phase steady-state convergence diagnostics. */
+class TwoFluidPipeThreePhaseConvergenceReportTest {
+
+  /** Results needed for an independent mesh comparison. */
+  private static final class ThreePhaseResult {
+    private final double arrivalPressurePa;
+    private final double meanLiquidHoldup;
+
+    private ThreePhaseResult(double arrivalPressurePa, double meanLiquidHoldup) {
+      this.arrivalPressurePa = arrivalPressurePa;
+      this.meanLiquidHoldup = meanLiquidHoldup;
+    }
+  }
+
+  /** Build the public 3 km uphill gas/oil/water regression fixture. */
+  private TwoFluidPipe makeThreePhaseUphillPipe(int sections) {
+    SystemInterface fluid = new SystemSrkEos(290.15, 30.0);
+    fluid.addComponent("methane", 0.40);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addComponent("propane", 0.03);
+    fluid.addComponent("n-pentane", 0.15);
+    fluid.addComponent("n-heptane", 0.17);
+    fluid.addComponent("water", 0.20);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream("three-phase-inlet-" + sections, fluid);
+    inlet.setFlowRate(8.0, "kg/sec");
+    inlet.setTemperature(20.0, "C");
+    inlet.setPressure(30.0, "bara");
+    inlet.run();
+
+    double pipeLength = 3000.0;
+    double totalRise = pipeLength * Math.sin(Math.toRadians(10.0));
+    double[] elevations = new double[sections];
+    for (int section = 0; section < sections; section++) {
+      elevations[section] = totalRise * section / (sections - 1.0);
+    }
+
+    TwoFluidPipe pipe = new TwoFluidPipe("three-phase-uphill-" + sections, inlet);
+    pipe.setLength(pipeLength);
+    pipe.setDiameter(0.15);
+    pipe.setNumberOfSections(sections);
+    pipe.setRoughness(4.5e-5);
+    pipe.setElevationProfile(elevations);
+    pipe.setEnableWaterOilSlip(true);
+    return pipe;
+  }
+
+  /** Solve and check the residual, phase-volume, phase-flow, and slip contracts. */
+  private ThreePhaseResult solveAndCheck(int sections) {
+    TwoFluidPipe pipe = makeThreePhaseUphillPipe(sections);
+    pipe.run();
+
+    SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
+    assertTrue(report.isConverged(),
+        "three-phase solve stopped with " + report.getTerminationReason() + ", pressure-momentum="
+            + report.getPressureMomentumResidual() + ", pressure-update=" + report.getPressureUpdateResidual()
+            + ", total-holdup=" + report.getLiquidHoldupResidual() + ", liquid-split=" + report.getLiquidSplitResidual()
+            + ", thermodynamics=" + report.getThermodynamicResidual() + ", pressure-drop="
+            + report.getPressureDropResidual());
+    assertEquals(TerminationReason.CONVERGED, report.getTerminationReason());
+    assertFalse(pipe.isSteadyStatePressureFloorLimited());
+    assertFalse(pipe.isSteadyStateWallClockLimited());
+    assertTrue(report.getPressureMomentumResidual() < report.getTolerance());
+    assertTrue(report.getPressureUpdateResidual() < report.getTolerance());
+    assertTrue(report.getLiquidHoldupResidual() < report.getTolerance());
+    assertTrue(report.getLiquidSplitResidual() < report.getTolerance());
+    assertTrue(report.getThermodynamicResidual() < report.getTolerance());
+    assertTrue(report.getPressureDropResidual() < report.getTolerance());
+
+    double[] pressure = pipe.getPressureProfile();
+    double[] liquidHoldup = pipe.getLiquidHoldupProfile();
+    double[] oilHoldup = pipe.getOilHoldupProfile();
+    double[] waterHoldup = pipe.getWaterHoldupProfile();
+    double[] oilVelocity = pipe.getOilVelocityProfile();
+    double[] waterVelocity = pipe.getWaterVelocityProfile();
+    double[] gasMassFlow = pipe.getGasMassFlowProfile();
+    double[] oilMassFlow = pipe.getOilMassFlowProfile();
+    double[] waterMassFlow = pipe.getWaterMassFlowProfile();
+    double meanLiquidHoldup = 0.0;
+    double meanOilOverWaterSlip = 0.0;
+    for (int section = 0; section < sections; section++) {
+      assertTrue(pressure[section] > 1.0e5, "pressure floor at section " + section);
+      assertTrue(oilHoldup[section] > 0.0 && waterHoldup[section] > 0.0,
+          "oil and water must remain present at section " + section);
+      assertEquals(liquidHoldup[section], oilHoldup[section] + waterHoldup[section], 1.0e-12,
+          "phase volumes must close at section " + section);
+      assertEquals(8.0, gasMassFlow[section] + oilMassFlow[section] + waterMassFlow[section], 8.0e-8,
+          "phase mass flows must close at section " + section);
+      meanLiquidHoldup += liquidHoldup[section];
+      meanOilOverWaterSlip += oilVelocity[section] - waterVelocity[section];
+    }
+    meanLiquidHoldup /= sections;
+    meanOilOverWaterSlip /= sections;
+    assertTrue(meanOilOverWaterSlip > 1.0e-3,
+        "uphill gravity must retard water relative to oil, slip=" + meanOilOverWaterSlip);
+    return new ThreePhaseResult(pressure[sections - 1], meanLiquidHoldup);
+  }
+
+  /** The three-phase solution and all solved residuals must be stable under one mesh refinement. */
+  @Test
+  void testThreePhaseConvergenceAndMeshRefinement() {
+    ThreePhaseResult coarse = solveAndCheck(30);
+    ThreePhaseResult fine = solveAndCheck(60);
+
+    double pressureSensitivity = Math.abs(fine.arrivalPressurePa - coarse.arrivalPressurePa)
+        / Math.max(Math.abs(fine.arrivalPressurePa), 1.0e5);
+    double holdupSensitivity = Math.abs(fine.meanLiquidHoldup - coarse.meanLiquidHoldup)
+        / Math.max(Math.abs(fine.meanLiquidHoldup), 1.0e-12);
+    assertTrue(pressureSensitivity < 0.02,
+        "30/60-cell arrival-pressure sensitivity must be below 2%, got " + pressureSensitivity);
+    assertTrue(holdupSensitivity < 0.02,
+        "30/60-cell mean-holdup sensitivity must be below 2%, got " + holdupSensitivity);
+  }
+}


### PR DESCRIPTION
## Summary

Stage 3 of the ordered five-PR TwoFluidPipe campaign in #3298.

- makes the mandatory final thermodynamic/holdup resweep part of the steady-state convergence decision instead of mutating an already-declared converged state;
- tracks the inlet and all downstream total-liquid and water/oil-split corrections;
- adds an immutable `SteadyStateConvergenceReport` with an explicit termination reason and pressure-momentum, pressure-update, total-holdup, liquid-split, thermodynamic-property, and pressure-drop residuals;
- distinguishes iteration, wall-clock, and pressure-floor limits without weakening the existing `1e-4` convergence tolerance;
- adds a 30/60-cell gas/oil/water refinement and conservation contract plus explicit iteration- and pressure-floor-limited regressions.

Capability contract: https://github.com/equinor/neqsim/issues/3298#issuecomment-5571208331  
Base update: https://github.com/equinor/neqsim/issues/3298#issuecomment-5571468849

## Exact scope

- Exact base: `9f2a0e7ad81f0a384f2d444c856fc7d5d9a01a59`
- Exact head: `834c42ced0fd4d0458f0b2b5b59c77add0eb4ecd`
- Branch: `codex/twofluid-three-phase-convergence-20260907`
- Eight files, one commit
- Stage 1 is merged as #3514; stage 2 remains the independent draft #3541 and is not part of this diff.

No default closure, oil/water-slip parameter, pressure floor, wall-clock budget, benchmark target, experimental datum, or tolerance changes.

## Diagnosis and repair

The historical 73.8 km / 15 m3/hr free-water input fixture is unavailable, so its reported 4,078-iteration / 1,200 s run cannot be reconstructed honestly. The maintained 3 km uphill gas/oil/water fixture does converge after #3514, showing that the older blanket three-phase-stall description is stale.

The remaining reusable defect was in the convergence contract: the loop could set `ssConverged=true`, then the mandatory flash plus unrelaxed total-holdup/oil-water resweep changed the returned state without rechecking the solved residuals. The inlet holdup and split corrections were also omitted from the aggregate update residual. This change reconciles the final state before accepting convergence; a material final-pass correction becomes the next iterate within the same iteration/time budgets.

## Physical and numerical evidence

The 3 km, 10-degree uphill gas/oil/water fixture:

- converges on both 30 and 60 cells with every reported residual below `1e-4`;
- preserves positive oil-over-water velocity slip;
- keeps gas, oil, and water present;
- closes oil + water holdup to total liquid holdup within `1e-12`;
- closes summed phase mass flow to 8 kg/s within `8e-8 kg/s`;
- gives arrival pressures 7.469114 bar (30 cells) and 7.429146 bar (60 cells): 0.538% relative sensitivity;
- gives mean liquid holdups 0.274301 and 0.271630: 0.983% relative sensitivity.

A two-iteration case reports `ITERATION_LIMIT` with at least one residual above tolerance. The deliberately undeliverable line reports `PRESSURE_FLOOR_LIMIT`, never convergence.

This is numerical and conservation evidence for the public synthetic fixture, not experimental qualification. The unavailable historical 73.8 km case remains unqualified.

## Validation

Maven was prepared with the NeqSim helper before each Maven/Spotless invocation.

Passed locally:

- `./mvnw -q -DskipTests compile`
- focused/report/three-phase/steady-boundary suite: 15 tests, 0 failures, 0 errors, 0 skipped
- broader gas-density/terrain/minimum-slip/lean-gas/phase-degeneracy suite: 20 tests, 0 failures, 0 errors, 0 skipped
- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 690 Markdown and one standalone HTML page audited

The task-specific `pre-commit` install could not reach the package index through this runtime's proxy; the repository's direct pre-commit-equivalent Spotless and documentation-search gates both pass. Local `javadoc:javadoc` could not run because this runtime contains a JRE without the `javadoc` executable. Exact-head hosted pre-commit, Javadocs, Java 8/21, slow shards, CodeQL, and other required checks are authoritative and pending.

## Documentation impact

Updated both TwoFluidPipe references and the pipeline cookbook with:

- the report API and termination reasons;
- definitions and normalization of every residual;
- the final-pass convergence rule;
- the exact 30/60-cell sensitivity evidence;
- the unchanged historical free-water qualification limitation.

## Portfolio and stop boundary

Four positively identified autonomous implementation drafts were open before this branch; including this draft, occupancy is 5/10. No other open PR owns this report/final-consistency scope.

Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or weaken checks. Stage 4 is separate coupled transient capability validation and is not included here.

Generated with AI assistance.