### PR TITLE
[AI-Assisted] Add refinery kinematic-viscosity blend screening

### DIFF
--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -175,6 +175,47 @@ temperature/pressure effects, excess volume or contraction, viscosity, cloud/pou
 asphaltene stability, phase equilibrium, TBP/pseudo-component compatibility, product
 specifications, or blend optimization.
 
+### Kinematic-viscosity blend screening
+
+`RefineryViscosityBlend` supplies a separate empirical Refutas screen for source viscosities
+already resolved at one common temperature. It transforms kinematic viscosity `nu` in cSt to a
+dimensionless viscosity blending number, mixes that number by normalized mass fraction, and
+applies the analytical inverse:
+
+$VBN_i=14.534\ln(\ln(\nu_i+0.8))+10.975$
+
+$VBN_{blend}=\sum_i x_iVBN_i$
+
+$\nu_{blend}=\exp\left(\exp\left(\frac{VBN_{blend}-10.975}{14.534}\right)\right)-0.8$
+
+The double logarithm requires every positive-mass source viscosity to be finite and greater than
+0.2 cSt. A zero-mass source is ignored and may leave its viscosity unresolved. The temperature is
+stored with the immutable result but is not used to extrapolate viscosity.
+
+```java
+RefineryViscosityBlend viscosityBlend = RefineryViscosityBlend.fromMassBasis(
+    new double[] {5000.0, 12000.0},
+    new double[] {550.0, 375.0},
+    50.0);
+
+double blendViscosityCSt = viscosityBlend.getKinematicViscosityCSt();
+double blendNumber = viscosityBlend.getViscosityBlendingNumber();
+double temperatureCelsius = viscosityBlend.getTemperatureCelsius();
+double[] massFractions = viscosityBlend.getMassFractions();
+double[] sourceBlendNumbers = viscosityBlend.getSourceViscosityBlendingNumbers();
+double directBlendNumber =
+    RefineryViscosityBlend.calculateViscosityBlendingNumber(550.0);
+double directViscosityCSt =
+    RefineryViscosityBlend.calculateKinematicViscosityCSt(directBlendNumber);
+```
+
+The equations and mass-weighting basis follow Centeno et al.,
+[DOI 10.1016/j.fuel.2011.02.028](https://doi.org/10.1016/j.fuel.2011.02.028).
+The fixed binary example above is an independently recomputed arithmetic reference, not measured
+blend evidence. This API does not claim physical prediction accuracy, uncertainty, ASTM
+compliance, dynamic-viscosity conversion, viscosity-temperature extrapolation, non-Newtonian
+behavior, pressure correction, phase behavior, compatibility, or optimization.
+
 ## Per-cut UOP/Watson characterization factor
 
 `AssayCut.getWatsonCharacterizationFactor()` calculates the dimensionless UOP/Watson factor from the same authoritative density and representative-boiling-point inputs used by the assay workflow:

--- a/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
@@ -7,10 +7,9 @@ import java.util.Arrays;
  * Immutable mass-basis kinematic-viscosity screening result for a refinery blend.
  *
  * <p>
- * The empirical Refutas relation transforms each source kinematic viscosity to a viscosity
- * blending number, mixes those numbers by normalized mass fraction, and applies the analytical
- * inverse. Every contributing viscosity must be resolved at the same caller-supplied temperature.
- * This class does not mutate an assay or thermodynamic system.
+ * The empirical Refutas relation transforms each source kinematic viscosity to a viscosity blending number, mixes those
+ * numbers by normalized mass fraction, and applies the analytical inverse. Every contributing viscosity must be
+ * resolved at the same caller-supplied temperature. This class does not mutate an assay or thermodynamic system.
  * </p>
  */
 public final class RefineryViscosityBlend implements Serializable {
@@ -58,8 +57,7 @@ public final class RefineryViscosityBlend implements Serializable {
         continue;
       }
 
-      double sourceBlendNumber =
-          calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[i]);
+      double sourceBlendNumber = calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[i]);
       resolvedSourceBlendingNumbers[i] = sourceBlendNumber;
       resolvedBlendNumber += massFraction * sourceBlendNumber;
       minimumSourceBlendNumber = Math.min(minimumSourceBlendNumber, sourceBlendNumber);
@@ -71,8 +69,7 @@ public final class RefineryViscosityBlend implements Serializable {
       throw new IllegalArgumentException("Blend viscosity number must be finite and bounded");
     }
 
-    double resolvedKinematicViscosity =
-        calculateKinematicViscosityCSt(resolvedBlendNumber);
+    double resolvedKinematicViscosity = calculateKinematicViscosityCSt(resolvedBlendNumber);
     massFractions = resolvedMassFractions;
     sourceViscosityBlendingNumbers = resolvedSourceBlendingNumbers;
     this.temperatureCelsius = temperatureCelsius;
@@ -84,17 +81,14 @@ public final class RefineryViscosityBlend implements Serializable {
    * Create an empirical mass-basis viscosity blend at one explicit common temperature.
    *
    * @param sourceMasses non-negative source masses in any common mass unit
-   * @param sourceKinematicViscositiesCSt source kinematic viscosities in cSt at the common
-   *        temperature
+   * @param sourceKinematicViscositiesCSt source kinematic viscosities in cSt at the common temperature
    * @param temperatureCelsius common source-viscosity temperature in degrees Celsius
    * @return immutable viscosity blend result
-   * @throws IllegalArgumentException for invalid arrays, masses, temperature, or contributing
-   *         viscosities
+   * @throws IllegalArgumentException for invalid arrays, masses, temperature, or contributing viscosities
    */
-  public static RefineryViscosityBlend fromMassBasis(double[] sourceMasses,
-      double[] sourceKinematicViscositiesCSt, double temperatureCelsius) {
-    return new RefineryViscosityBlend(sourceMasses, sourceKinematicViscositiesCSt,
-        temperatureCelsius);
+  public static RefineryViscosityBlend fromMassBasis(double[] sourceMasses, double[] sourceKinematicViscositiesCSt,
+      double temperatureCelsius) {
+    return new RefineryViscosityBlend(sourceMasses, sourceKinematicViscositiesCSt, temperatureCelsius);
   }
 
   /**
@@ -105,13 +99,10 @@ public final class RefineryViscosityBlend implements Serializable {
    * @throws IllegalArgumentException if the viscosity is outside the mathematical domain
    */
   public static double calculateViscosityBlendingNumber(double kinematicViscosityCSt) {
-    if (!Double.isFinite(kinematicViscosityCSt)
-        || !(kinematicViscosityCSt > MINIMUM_KINEMATIC_VISCOSITY_CST)) {
-      throw new IllegalArgumentException(
-          "Kinematic viscosity must be finite and greater than 0.2 cSt");
+    if (!Double.isFinite(kinematicViscosityCSt) || !(kinematicViscosityCSt > MINIMUM_KINEMATIC_VISCOSITY_CST)) {
+      throw new IllegalArgumentException("Kinematic viscosity must be finite and greater than 0.2 cSt");
     }
-    double blendingNumber = REFUTAS_SCALE
-        * Math.log(Math.log(kinematicViscosityCSt + REFUTAS_VISCOSITY_OFFSET_CST))
+    double blendingNumber = REFUTAS_SCALE * Math.log(Math.log(kinematicViscosityCSt + REFUTAS_VISCOSITY_OFFSET_CST))
         + REFUTAS_OFFSET;
     if (!Double.isFinite(blendingNumber)) {
       throw new IllegalArgumentException("Viscosity blending number must be finite");
@@ -130,13 +121,10 @@ public final class RefineryViscosityBlend implements Serializable {
     if (!Double.isFinite(viscosityBlendingNumber)) {
       throw new IllegalArgumentException("Viscosity blending number must be finite");
     }
-    double kinematicViscosity = Math
-        .exp(Math.exp((viscosityBlendingNumber - REFUTAS_OFFSET) / REFUTAS_SCALE))
+    double kinematicViscosity = Math.exp(Math.exp((viscosityBlendingNumber - REFUTAS_OFFSET) / REFUTAS_SCALE))
         - REFUTAS_VISCOSITY_OFFSET_CST;
-    if (!Double.isFinite(kinematicViscosity)
-        || !(kinematicViscosity > MINIMUM_KINEMATIC_VISCOSITY_CST)) {
-      throw new IllegalArgumentException(
-          "Calculated kinematic viscosity must be finite and greater than 0.2 cSt");
+    if (!Double.isFinite(kinematicViscosity) || !(kinematicViscosity > MINIMUM_KINEMATIC_VISCOSITY_CST)) {
+      throw new IllegalArgumentException("Calculated kinematic viscosity must be finite and greater than 0.2 cSt");
     }
     return kinematicViscosity;
   }
@@ -150,15 +138,13 @@ public final class RefineryViscosityBlend implements Serializable {
    * Return source viscosity blending numbers in source order.
    *
    * <p>
-   * A zero-mass source is represented by {@link Double#NaN} because its viscosity is deliberately
-   * not resolved.
+   * A zero-mass source is represented by {@link Double#NaN} because its viscosity is deliberately not resolved.
    * </p>
    *
    * @return defensive copy of source viscosity blending numbers
    */
   public double[] getSourceViscosityBlendingNumbers() {
-    return Arrays.copyOf(sourceViscosityBlendingNumbers,
-        sourceViscosityBlendingNumbers.length);
+    return Arrays.copyOf(sourceViscosityBlendingNumbers, sourceViscosityBlendingNumbers.length);
   }
 
   /** @return common source-viscosity temperature in degrees Celsius */
@@ -176,10 +162,9 @@ public final class RefineryViscosityBlend implements Serializable {
     return kinematicViscosityCSt;
   }
 
-  private static void validateInputs(double[] sourceMasses,
-      double[] sourceKinematicViscositiesCSt, double temperatureCelsius) {
-    if (sourceMasses == null || sourceKinematicViscositiesCSt == null
-        || sourceMasses.length == 0
+  private static void validateInputs(double[] sourceMasses, double[] sourceKinematicViscositiesCSt,
+      double temperatureCelsius) {
+    if (sourceMasses == null || sourceKinematicViscositiesCSt == null || sourceMasses.length == 0
         || sourceMasses.length != sourceKinematicViscositiesCSt.length) {
       throw new IllegalArgumentException(
           "Source mass and kinematic-viscosity arrays must be non-empty and equal length");

--- a/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
@@ -1,0 +1,191 @@
+package neqsim.thermo.characterization;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable mass-basis kinematic-viscosity screening result for a refinery blend.
+ *
+ * <p>
+ * The empirical Refutas relation transforms each source kinematic viscosity to a viscosity
+ * blending number, mixes those numbers by normalized mass fraction, and applies the analytical
+ * inverse. Every contributing viscosity must be resolved at the same caller-supplied temperature.
+ * This class does not mutate an assay or thermodynamic system.
+ * </p>
+ */
+public final class RefineryViscosityBlend implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double MINIMUM_KINEMATIC_VISCOSITY_CST = 0.2;
+  private static final double REFUTAS_SCALE = 14.534;
+  private static final double REFUTAS_OFFSET = 10.975;
+  private static final double REFUTAS_VISCOSITY_OFFSET_CST = 0.8;
+
+  private final double[] massFractions;
+  private final double[] sourceViscosityBlendingNumbers;
+  private final double temperatureCelsius;
+  private final double viscosityBlendingNumber;
+  private final double kinematicViscosityCSt;
+
+  private RefineryViscosityBlend(double[] sourceMasses, double[] sourceKinematicViscositiesCSt,
+      double temperatureCelsius) {
+    validateInputs(sourceMasses, sourceKinematicViscositiesCSt, temperatureCelsius);
+
+    double totalMass = 0.0;
+    for (double sourceMass : sourceMasses) {
+      if (!Double.isFinite(sourceMass) || sourceMass < 0.0) {
+        throw new IllegalArgumentException("Source masses must be finite and non-negative");
+      }
+      totalMass += sourceMass;
+      if (!Double.isFinite(totalMass)) {
+        throw new IllegalArgumentException("Total source mass must be finite");
+      }
+    }
+    if (!(totalMass > 0.0)) {
+      throw new IllegalArgumentException("Blend must contain positive source mass");
+    }
+
+    double[] resolvedMassFractions = new double[sourceMasses.length];
+    double[] resolvedSourceBlendingNumbers = new double[sourceMasses.length];
+    Arrays.fill(resolvedSourceBlendingNumbers, Double.NaN);
+    double resolvedBlendNumber = 0.0;
+    double minimumSourceBlendNumber = Double.POSITIVE_INFINITY;
+    double maximumSourceBlendNumber = Double.NEGATIVE_INFINITY;
+
+    for (int i = 0; i < sourceMasses.length; i++) {
+      double massFraction = sourceMasses[i] / totalMass;
+      resolvedMassFractions[i] = massFraction;
+      if (!(massFraction > 0.0)) {
+        continue;
+      }
+
+      double sourceBlendNumber =
+          calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[i]);
+      resolvedSourceBlendingNumbers[i] = sourceBlendNumber;
+      resolvedBlendNumber += massFraction * sourceBlendNumber;
+      minimumSourceBlendNumber = Math.min(minimumSourceBlendNumber, sourceBlendNumber);
+      maximumSourceBlendNumber = Math.max(maximumSourceBlendNumber, sourceBlendNumber);
+    }
+
+    if (!Double.isFinite(resolvedBlendNumber) || resolvedBlendNumber < minimumSourceBlendNumber
+        || resolvedBlendNumber > maximumSourceBlendNumber) {
+      throw new IllegalArgumentException("Blend viscosity number must be finite and bounded");
+    }
+
+    double resolvedKinematicViscosity =
+        calculateKinematicViscosityCSt(resolvedBlendNumber);
+    massFractions = resolvedMassFractions;
+    sourceViscosityBlendingNumbers = resolvedSourceBlendingNumbers;
+    this.temperatureCelsius = temperatureCelsius;
+    viscosityBlendingNumber = resolvedBlendNumber;
+    kinematicViscosityCSt = resolvedKinematicViscosity;
+  }
+
+  /**
+   * Create an empirical mass-basis viscosity blend at one explicit common temperature.
+   *
+   * @param sourceMasses non-negative source masses in any common mass unit
+   * @param sourceKinematicViscositiesCSt source kinematic viscosities in cSt at the common
+   *        temperature
+   * @param temperatureCelsius common source-viscosity temperature in degrees Celsius
+   * @return immutable viscosity blend result
+   * @throws IllegalArgumentException for invalid arrays, masses, temperature, or contributing
+   *         viscosities
+   */
+  public static RefineryViscosityBlend fromMassBasis(double[] sourceMasses,
+      double[] sourceKinematicViscositiesCSt, double temperatureCelsius) {
+    return new RefineryViscosityBlend(sourceMasses, sourceKinematicViscositiesCSt,
+        temperatureCelsius);
+  }
+
+  /**
+   * Transform kinematic viscosity to the published Refutas viscosity blending number.
+   *
+   * @param kinematicViscosityCSt finite kinematic viscosity greater than 0.2 cSt
+   * @return dimensionless viscosity blending number
+   * @throws IllegalArgumentException if the viscosity is outside the mathematical domain
+   */
+  public static double calculateViscosityBlendingNumber(double kinematicViscosityCSt) {
+    if (!Double.isFinite(kinematicViscosityCSt)
+        || !(kinematicViscosityCSt > MINIMUM_KINEMATIC_VISCOSITY_CST)) {
+      throw new IllegalArgumentException(
+          "Kinematic viscosity must be finite and greater than 0.2 cSt");
+    }
+    double blendingNumber = REFUTAS_SCALE
+        * Math.log(Math.log(kinematicViscosityCSt + REFUTAS_VISCOSITY_OFFSET_CST))
+        + REFUTAS_OFFSET;
+    if (!Double.isFinite(blendingNumber)) {
+      throw new IllegalArgumentException("Viscosity blending number must be finite");
+    }
+    return blendingNumber;
+  }
+
+  /**
+   * Apply the analytical inverse Refutas relation.
+   *
+   * @param viscosityBlendingNumber finite dimensionless viscosity blending number
+   * @return kinematic viscosity in cSt
+   * @throws IllegalArgumentException if the input or calculated viscosity is non-finite
+   */
+  public static double calculateKinematicViscosityCSt(double viscosityBlendingNumber) {
+    if (!Double.isFinite(viscosityBlendingNumber)) {
+      throw new IllegalArgumentException("Viscosity blending number must be finite");
+    }
+    double kinematicViscosity = Math
+        .exp(Math.exp((viscosityBlendingNumber - REFUTAS_OFFSET) / REFUTAS_SCALE))
+        - REFUTAS_VISCOSITY_OFFSET_CST;
+    if (!Double.isFinite(kinematicViscosity)
+        || !(kinematicViscosity > MINIMUM_KINEMATIC_VISCOSITY_CST)) {
+      throw new IllegalArgumentException(
+          "Calculated kinematic viscosity must be finite and greater than 0.2 cSt");
+    }
+    return kinematicViscosity;
+  }
+
+  /** @return defensive copy of normalized source mass fractions */
+  public double[] getMassFractions() {
+    return Arrays.copyOf(massFractions, massFractions.length);
+  }
+
+  /**
+   * Return source viscosity blending numbers in source order.
+   *
+   * <p>
+   * A zero-mass source is represented by {@link Double#NaN} because its viscosity is deliberately
+   * not resolved.
+   * </p>
+   *
+   * @return defensive copy of source viscosity blending numbers
+   */
+  public double[] getSourceViscosityBlendingNumbers() {
+    return Arrays.copyOf(sourceViscosityBlendingNumbers,
+        sourceViscosityBlendingNumbers.length);
+  }
+
+  /** @return common source-viscosity temperature in degrees Celsius */
+  public double getTemperatureCelsius() {
+    return temperatureCelsius;
+  }
+
+  /** @return mass-weighted dimensionless viscosity blending number */
+  public double getViscosityBlendingNumber() {
+    return viscosityBlendingNumber;
+  }
+
+  /** @return estimated blend kinematic viscosity in cSt at the common temperature */
+  public double getKinematicViscosityCSt() {
+    return kinematicViscosityCSt;
+  }
+
+  private static void validateInputs(double[] sourceMasses,
+      double[] sourceKinematicViscositiesCSt, double temperatureCelsius) {
+    if (sourceMasses == null || sourceKinematicViscositiesCSt == null
+        || sourceMasses.length == 0
+        || sourceMasses.length != sourceKinematicViscositiesCSt.length) {
+      throw new IllegalArgumentException(
+          "Source mass and kinematic-viscosity arrays must be non-empty and equal length");
+    }
+    if (!Double.isFinite(temperatureCelsius)) {
+      throw new IllegalArgumentException("Common viscosity temperature must be finite");
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
@@ -17,7 +17,7 @@ public class RefineryViscosityBlendTest {
     assertArrayEquals(new double[] { 5.0 / 17.0, 12.0 / 17.0 },
         blend.getMassFractions(), 1.0e-15);
     assertEquals(50.0, blend.getTemperatureCelsius(), 0.0);
-    assertEquals(37.11160290060912, blend.getViscosityBlendingNumber(), 1.0e-13);
+    assertEquals(37.110677920222024, blend.getViscosityBlendingNumber(), 1.0e-13);
     assertEquals(418.68738293612904, blend.getKinematicViscosityCSt(), 1.0e-12);
 
     double[] sourceBlendNumbers = blend.getSourceViscosityBlendingNumbers();

--- a/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
@@ -11,43 +11,35 @@ import org.junit.jupiter.api.Test;
 public class RefineryViscosityBlendTest {
   @Test
   public void fixedBinaryArithmeticReferenceIsReproducible() {
-    RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(
-        new double[] { 5000.0, 12000.0 }, new double[] { 550.0, 375.0 }, 50.0);
+    RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(new double[] { 5000.0, 12000.0 },
+        new double[] { 550.0, 375.0 }, 50.0);
 
-    assertArrayEquals(new double[] { 5.0 / 17.0, 12.0 / 17.0 },
-        blend.getMassFractions(), 1.0e-15);
+    assertArrayEquals(new double[] { 5.0 / 17.0, 12.0 / 17.0 }, blend.getMassFractions(), 1.0e-15);
     assertEquals(50.0, blend.getTemperatureCelsius(), 0.0);
     assertEquals(37.110677920222024, blend.getViscosityBlendingNumber(), 1.0e-13);
     assertEquals(418.68738293612904, blend.getKinematicViscosityCSt(), 1.0e-12);
 
     double[] sourceBlendNumbers = blend.getSourceViscosityBlendingNumbers();
-    assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(550.0),
-        sourceBlendNumbers[0], 0.0);
-    assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(375.0),
-        sourceBlendNumbers[1], 0.0);
+    assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(550.0), sourceBlendNumbers[0], 0.0);
+    assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(375.0), sourceBlendNumbers[1], 0.0);
     assertEquals(blend.getKinematicViscosityCSt(),
-        RefineryViscosityBlend.calculateKinematicViscosityCSt(
-            blend.getViscosityBlendingNumber()),
-        0.0);
+        RefineryViscosityBlend.calculateKinematicViscosityCSt(blend.getViscosityBlendingNumber()), 0.0);
   }
 
   @Test
   public void resultIsScaleOrderPureSourceAndDefensiveCopyInvariant() {
-    RefineryViscosityBlend base = RefineryViscosityBlend.fromMassBasis(
-        new double[] { 2.0, 3.0 }, new double[] { 10.0, 100.0 }, 40.0);
-    RefineryViscosityBlend scaled = RefineryViscosityBlend.fromMassBasis(
-        new double[] { 20.0, 30.0 }, new double[] { 10.0, 100.0 }, 40.0);
-    RefineryViscosityBlend reversed = RefineryViscosityBlend.fromMassBasis(
-        new double[] { 3.0, 2.0 }, new double[] { 100.0, 10.0 }, 40.0);
-    RefineryViscosityBlend pure = RefineryViscosityBlend.fromMassBasis(
-        new double[] { 7.0 }, new double[] { 42.0 }, 40.0);
+    RefineryViscosityBlend base = RefineryViscosityBlend.fromMassBasis(new double[] { 2.0, 3.0 },
+        new double[] { 10.0, 100.0 }, 40.0);
+    RefineryViscosityBlend scaled = RefineryViscosityBlend.fromMassBasis(new double[] { 20.0, 30.0 },
+        new double[] { 10.0, 100.0 }, 40.0);
+    RefineryViscosityBlend reversed = RefineryViscosityBlend.fromMassBasis(new double[] { 3.0, 2.0 },
+        new double[] { 100.0, 10.0 }, 40.0);
+    RefineryViscosityBlend pure = RefineryViscosityBlend.fromMassBasis(new double[] { 7.0 }, new double[] { 42.0 },
+        40.0);
 
-    assertEquals(base.getViscosityBlendingNumber(), scaled.getViscosityBlendingNumber(),
-        0.0);
-    assertEquals(base.getKinematicViscosityCSt(), scaled.getKinematicViscosityCSt(),
-        0.0);
-    assertEquals(base.getKinematicViscosityCSt(), reversed.getKinematicViscosityCSt(),
-        1.0e-13);
+    assertEquals(base.getViscosityBlendingNumber(), scaled.getViscosityBlendingNumber(), 0.0);
+    assertEquals(base.getKinematicViscosityCSt(), scaled.getKinematicViscosityCSt(), 0.0);
+    assertEquals(base.getKinematicViscosityCSt(), reversed.getKinematicViscosityCSt(), 1.0e-13);
     assertEquals(42.0, pure.getKinematicViscosityCSt(), 1.0e-13);
     assertTrue(base.getKinematicViscosityCSt() > 10.0);
     assertTrue(base.getKinematicViscosityCSt() < 100.0);
@@ -62,8 +54,8 @@ public class RefineryViscosityBlendTest {
 
   @Test
   public void zeroMassSourceDoesNotRequireFabricatedViscosity() {
-    RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(
-        new double[] { 1.0, 0.0 }, new double[] { 25.0, Double.NaN }, 37.7);
+    RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(new double[] { 1.0, 0.0 },
+        new double[] { 25.0, Double.NaN }, 37.7);
 
     assertArrayEquals(new double[] { 1.0, 0.0 }, blend.getMassFractions(), 0.0);
     assertEquals(25.0, blend.getKinematicViscosityCSt(), 1.0e-13);
@@ -74,12 +66,9 @@ public class RefineryViscosityBlendTest {
   public void publishedTransformAndInverseRoundTripAcrossDomain() {
     double[] viscositiesCSt = { 0.200001, 1.0, 10.0, 100.0, 10000.0 };
     for (double viscosityCSt : viscositiesCSt) {
-      double blendNumber =
-          RefineryViscosityBlend.calculateViscosityBlendingNumber(viscosityCSt);
-      double roundTrip =
-          RefineryViscosityBlend.calculateKinematicViscosityCSt(blendNumber);
-      assertEquals(viscosityCSt, roundTrip,
-          Math.max(1.0e-12, viscosityCSt * 1.0e-12));
+      double blendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(viscosityCSt);
+      double roundTrip = RefineryViscosityBlend.calculateKinematicViscosityCSt(blendNumber);
+      assertEquals(viscosityCSt, roundTrip, Math.max(1.0e-12, viscosityCSt * 1.0e-12));
     }
   }
 
@@ -88,35 +77,25 @@ public class RefineryViscosityBlendTest {
     assertThrows(IllegalArgumentException.class,
         () -> RefineryViscosityBlend.fromMassBasis(null, new double[] { 10.0 }, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] {},
-            new double[] {}, 40.0));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] {}, new double[] {}, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
-            new double[] { 10.0, 20.0 }, 40.0));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 }, new double[] { 10.0, 20.0 }, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { -1.0 },
-            new double[] { 10.0 }, 40.0));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { -1.0 }, new double[] { 10.0 }, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { Double.NaN },
-            new double[] { 10.0 }, 40.0));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { Double.NaN }, new double[] { 10.0 }, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 0.0 },
-            new double[] { 10.0 }, 40.0));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 0.0 }, new double[] { 10.0 }, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
-            new double[] { 0.2 }, 40.0));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 }, new double[] { 0.2 }, 40.0));
+    assertThrows(IllegalArgumentException.class, () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
+        new double[] { Double.POSITIVE_INFINITY }, 40.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
-            new double[] { Double.POSITIVE_INFINITY }, 40.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
-            new double[] { 10.0 }, Double.NaN));
-    assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.calculateViscosityBlendingNumber(0.2));
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 }, new double[] { 10.0 }, Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> RefineryViscosityBlend.calculateViscosityBlendingNumber(0.2));
     assertThrows(IllegalArgumentException.class,
         () -> RefineryViscosityBlend.calculateKinematicViscosityCSt(Double.NaN));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryViscosityBlend.calculateKinematicViscosityCSt(
-            Double.MAX_VALUE));
+        () -> RefineryViscosityBlend.calculateKinematicViscosityCSt(Double.MAX_VALUE));
   }
 }

--- a/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
@@ -1,0 +1,122 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests the fail-closed empirical refinery viscosity blend screen. */
+public class RefineryViscosityBlendTest {
+  @Test
+  public void fixedBinaryArithmeticReferenceIsReproducible() {
+    RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(
+        new double[] { 5000.0, 12000.0 }, new double[] { 550.0, 375.0 }, 50.0);
+
+    assertArrayEquals(new double[] { 5.0 / 17.0, 12.0 / 17.0 },
+        blend.getMassFractions(), 1.0e-15);
+    assertEquals(50.0, blend.getTemperatureCelsius(), 0.0);
+    assertEquals(37.11160290060912, blend.getViscosityBlendingNumber(), 1.0e-13);
+    assertEquals(418.68738293612904, blend.getKinematicViscosityCSt(), 1.0e-12);
+
+    double[] sourceBlendNumbers = blend.getSourceViscosityBlendingNumbers();
+    assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(550.0),
+        sourceBlendNumbers[0], 0.0);
+    assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(375.0),
+        sourceBlendNumbers[1], 0.0);
+    assertEquals(blend.getKinematicViscosityCSt(),
+        RefineryViscosityBlend.calculateKinematicViscosityCSt(
+            blend.getViscosityBlendingNumber()),
+        0.0);
+  }
+
+  @Test
+  public void resultIsScaleOrderPureSourceAndDefensiveCopyInvariant() {
+    RefineryViscosityBlend base = RefineryViscosityBlend.fromMassBasis(
+        new double[] { 2.0, 3.0 }, new double[] { 10.0, 100.0 }, 40.0);
+    RefineryViscosityBlend scaled = RefineryViscosityBlend.fromMassBasis(
+        new double[] { 20.0, 30.0 }, new double[] { 10.0, 100.0 }, 40.0);
+    RefineryViscosityBlend reversed = RefineryViscosityBlend.fromMassBasis(
+        new double[] { 3.0, 2.0 }, new double[] { 100.0, 10.0 }, 40.0);
+    RefineryViscosityBlend pure = RefineryViscosityBlend.fromMassBasis(
+        new double[] { 7.0 }, new double[] { 42.0 }, 40.0);
+
+    assertEquals(base.getViscosityBlendingNumber(), scaled.getViscosityBlendingNumber(),
+        0.0);
+    assertEquals(base.getKinematicViscosityCSt(), scaled.getKinematicViscosityCSt(),
+        0.0);
+    assertEquals(base.getKinematicViscosityCSt(), reversed.getKinematicViscosityCSt(),
+        1.0e-13);
+    assertEquals(42.0, pure.getKinematicViscosityCSt(), 1.0e-13);
+    assertTrue(base.getKinematicViscosityCSt() > 10.0);
+    assertTrue(base.getKinematicViscosityCSt() < 100.0);
+
+    double[] fractions = base.getMassFractions();
+    double[] sourceBlendNumbers = base.getSourceViscosityBlendingNumbers();
+    fractions[0] = 1.0;
+    sourceBlendNumbers[0] = Double.NaN;
+    assertArrayEquals(new double[] { 0.4, 0.6 }, base.getMassFractions(), 1.0e-15);
+    assertTrue(Double.isFinite(base.getSourceViscosityBlendingNumbers()[0]));
+  }
+
+  @Test
+  public void zeroMassSourceDoesNotRequireFabricatedViscosity() {
+    RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(
+        new double[] { 1.0, 0.0 }, new double[] { 25.0, Double.NaN }, 37.7);
+
+    assertArrayEquals(new double[] { 1.0, 0.0 }, blend.getMassFractions(), 0.0);
+    assertEquals(25.0, blend.getKinematicViscosityCSt(), 1.0e-13);
+    assertTrue(Double.isNaN(blend.getSourceViscosityBlendingNumbers()[1]));
+  }
+
+  @Test
+  public void publishedTransformAndInverseRoundTripAcrossDomain() {
+    double[] viscositiesCSt = { 0.200001, 1.0, 10.0, 100.0, 10000.0 };
+    for (double viscosityCSt : viscositiesCSt) {
+      double blendNumber =
+          RefineryViscosityBlend.calculateViscosityBlendingNumber(viscosityCSt);
+      double roundTrip =
+          RefineryViscosityBlend.calculateKinematicViscosityCSt(blendNumber);
+      assertEquals(viscosityCSt, roundTrip,
+          Math.max(1.0e-12, viscosityCSt * 1.0e-12));
+    }
+  }
+
+  @Test
+  public void invalidOrIncompleteInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(null, new double[] { 10.0 }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] {},
+            new double[] {}, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
+            new double[] { 10.0, 20.0 }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { -1.0 },
+            new double[] { 10.0 }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { Double.NaN },
+            new double[] { 10.0 }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 0.0 },
+            new double[] { 10.0 }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
+            new double[] { 0.2 }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
+            new double[] { Double.POSITIVE_INFINITY }, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromMassBasis(new double[] { 1.0 },
+            new double[] { 10.0 }, Double.NaN));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.calculateViscosityBlendingNumber(0.2));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.calculateKinematicViscosityCSt(Double.NaN));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.calculateKinematicViscosityCSt(
+            Double.MAX_VALUE));
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3305 with a bounded, fail-closed refinery kinematic-viscosity blend screen.

- Adds an immutable Java/JPype-friendly `RefineryViscosityBlend`.
- Implements the published Refutas viscosity-blending-number transform, mass weighting, and analytical inverse.
- Requires all positive-mass source viscosities in cSt to share one explicit finite temperature in °C.
- Preserves zero-mass sources without inventing missing viscosity.
- Exposes defensive mass-fraction and source-VBN arrays plus the blend VBN and kinematic viscosity.

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5571928894

## Exact-head contract

- Exact base: `0324b26541c3dcf482cd935bb74d3b18e1354c44`
- Exact head: `d2590a52dc4b1eb81337e9861455dc45af6773f0`
- Branch: `codex/3305-refutas-viscosity-blend`
- Three intended files and six commits; zero commits behind the exact base. The final two commits apply the exact hosted Spotless patch without engineering changes.

## Provenance and licensing

The equations and mass-weighting basis follow Centeno et al., “Testing various mixing rules for calculation of viscosity of petroleum blends,” *Fuel* 90 (2011) 3561–3570, DOI [10.1016/j.fuel.2011.02.028](https://doi.org/10.1016/j.fuel.2011.02.028).

This PR cites public bibliographic metadata and reproduces only the mathematical relation, units, and weighting basis. It copies no paywalled prose, tables, ASTM procedure text, or experimental dataset.

## Engineering acceptance

Acceptance requires:

- exact forward and inverse equations with strict `nu > 0.2 cSt` mathematical domain;
- finite common-temperature metadata;
- fixed high-precision binary arithmetic, forward/inverse round trips, and scale/order/pure-source invariance;
- blend results bounded by contributing endpoints;
- zero-mass source handling without fabricated property values;
- defensive arrays;
- fail-closed null, empty, mismatched, negative/non-finite mass, zero-total, invalid contributing viscosity, invalid temperature, and non-finite inverse cases.

The fixed 550/375 cSt binary case is independently recomputed arithmetic evidence, not a measured blend validation result.

## Frozen scientific boundary

This is empirical screening only. It does not claim physical prediction accuracy or uncertainty and does not implement ASTM compliance, viscosity-temperature extrapolation, dynamic-viscosity conversion, non-Newtonian behavior, pressure effects, phase behavior, asphaltene compatibility, assay mutation, pseudo-component creation, product optimization, or control tuning. No existing API, thermodynamic model, solver, assay, acceptance threshold, or source dataset changes.

## Validation

**VALIDATION PENDING EXACT-HEAD CI**

The exact hosted Spotless artifact was applied as the campaign's single formatting-only repair. Behavior, tests, documentation meaning, provenance, and acceptance limits are unchanged.

Hosted exact-head workflows are authoritative. Required gates include Spotless, Java 8/21 on Ubuntu and Windows, slow-test shards, full tests and Javadocs, documentation, pre-commit, CodeQL, PaperLab, and agent-skill checks.

## Documentation impact

The existing refinery-assay guide now documents the equations, mass basis, common-temperature contract, Java API, mathematical domain, source, and scientific limitations. The focused JUnit class calls every documented method.

## Portfolio and overlap

Open autonomous implementation drafts #3538, #3539, #3541, and #3543 touch no frozen refinery path. Including this draft, occupancy is **5/10**. This is the sole active #3305 PR.

## Stop boundary

Keep this PR draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it as part of the campaign.

Generated with AI assistance.