### PR TITLE
[AI-Assisted] fix(twofluid): couple slug and thermodynamic ledgers

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -199,6 +199,39 @@ every component, cell-wise equal/opposite phase transfer, phase mass, boundednes
 history, and the latent-inclusive thermal residual. Engineering applications should repeat mesh and
 time-step refinement at their own length, velocity, phase split, and event duration.
 
+#### Coupled slug/component/phase/thermal contract
+
+The conservative Lagrangian slug/film flux can be combined with named-component transport,
+flash-driven phase transfer, and the thermal equation. Component source compositions and their
+partial-enthalpy latent source are frozen at the same Runge-Kutta stage as the hydrodynamic phase
+source. This matters when a moving slug/film interface advects composition between the source
+evaluation and the accepted update: a second post-advection flash may no longer contain a phase
+whose appearance or disappearance has already been accepted. For a disappearing phase, its donor
+composition is evaluated as a forced single-phase thermodynamic state at the same cell pressure and
+temperature; receiving-phase composition still comes only from the equilibrium source-stage flash.
+
+`TwoFluidPipeCoupledCapabilityTest` seeds a deterministic in-domain marker in a closed four-cell
+wet-gas pipe just above its calculated water dew point, selects conservative film coupling, and
+cools the wall. Over 0.05 s, the 0.05 and 0.025 s outer-step partitions both close phase/total mass,
+every named-component ledger, cellwise interphase transfer, and the wall/latent thermal residual.
+Both transfer `1.5855002575e-9 kg` of water to the aqueous phase, release `0.0034892651 J` of
+composition-resolved latent heat, and cool the mean fluid by `0.0305006304 K`; the recorded
+outer-step sensitivities are zero because both partitions resolve to the same internal CFL steps.
+The tracked slug ages by exactly 0.05 s and its geometry is identical on both partitions. This is a
+coupling and conservation regression around a seeded marker, not evidence for spontaneous slug
+initiation, sustained severe-slug cycles, or experimental slug-load accuracy.
+
+This four-way coupling is currently validated only with the single-stage Euler integrator.
+Conservative slug/film transport plus named-component phase transfer rejects multi-stage methods
+before state mutation because a phase that appears within an intermediate stage requires a
+stage-local component inventory. Other named-component advection cases retain their documented
+Euler, Runge-Kutta, and IMEX stage-weighted paths.
+
+Signed outlet backflow and named-component transport are mutually rejected during configuration,
+in either setter order, before steady or transient state can change. Reverse outlet inflow requires
+an independently supplied external composition; no such boundary API exists, so the implementation
+does not infer composition from the last interior cell.
+
 ### Momentum Conservation
 Separate momentum equations for each phase:
 

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -912,6 +912,27 @@ approximation. The sustained regression covers 120 s of gas, gas/oil and gas/oil
 heat and EOS updates active, plus heating/cooling transfer signs and conservative component
 ledgers. Positive-flow boundaries and a fixed named-component slate remain required.
 
+For the supported conservative-slug coupling, phase and component source allocations plus their
+partial-enthalpy latent source are frozen at the same integration stage. A moving slug/film
+interface can otherwise advect composition before a post-step flash and make an already accepted
+phase appearance impossible to reconstruct. A disappearing phase uses its conserved donor
+composition in a forced single-phase property state; receiving composition still comes from the
+equilibrium flash. The closed wet-gas coupling regression exercises conservative slug/film
+tracking, water condensation, wall cooling, bounded named-component transport, and phase/total/
+component/thermal closure on two outer-step partitions. It gives identical internal-CFL-resolved
+results: `1.5855002575e-9 kg` aqueous-water transfer, `0.0034892651 J` latent heat, and
+`-0.0305006304 K` mean temperature change over 0.05 s. The seeded marker is numerical coupling
+evidence, not spontaneous or experimentally qualified severe slugging.
+
+The four-way conservative slug/film combination is validated with the single-stage Euler
+integrator. It rejects multi-stage integration before state mutation until intermediate phase
+appearance has a stage-local component inventory; this limitation does not change the existing
+stage-weighted paths for other named-component transport cases.
+
+Signed outlet backflow cannot be combined with named-component transport because no external
+outlet composition is configured. Either setter order now fails before state mutation instead of
+waiting for reverse inflow during an accepted transient step.
+
 
 
 ### Flash Calculations

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4313,6 +4313,12 @@ public class TwoFluidPipe extends Pipeline {
     if (!Double.isFinite(dt) || dt <= 0.0) {
       throw new IllegalArgumentException("Transient time step must be positive and finite");
     }
+    if (componentTransportEnabled && includeMassTransfer && slugTrackingMode == SlugTrackingMode.CONSERVATIVE_LAGRANGIAN
+        && getTimeIntegrationStageWeights().length > 1) {
+      throw new IllegalStateException("Conservative slug/film transport with named-component phase transfer "
+          + "currently requires a single-stage time integrator; multi-stage phase appearance needs "
+          + "stage-local component inventories");
+    }
     if (sections == null || sections.length == 0) {
       throw new IllegalStateException("Call run() to initialize the pipe before runTransient()");
     }
@@ -4453,6 +4459,12 @@ public class TwoFluidPipe extends Pipeline {
           : new double[0][0];
       final double[][] weightedPhaseMassSources = captureComponentStageFluxes ? new double[numberOfSections][3]
           : new double[0][0];
+      final double[][][] weightedComponentSources = captureComponentStageFluxes && includeMassTransfer
+          ? new double[numberOfSections][3][componentTransport.getComponentNames().length]
+          : null;
+      final double[] weightedLatentHeatSources = captureComponentStageFluxes && includeMassTransfer
+          ? new double[numberOfSections]
+          : null;
       final int[] phaseStageIndex = { 0 };
 
       TimeIntegrator.RHSFunction rhs = (state, t) -> {
@@ -4484,6 +4496,23 @@ public class TwoFluidPipe extends Pipeline {
           equations.accumulateLastPhaseMassFaceFluxes(weightedPhaseMassFaceFluxes, phaseStageWeights[stage]);
           if (captureComponentStageFluxes) {
             equations.accumulateLastPhaseMassSourcesPerLength(weightedPhaseMassSources, phaseStageWeights[stage]);
+            if (includeMassTransfer) {
+              double[][] phaseSources = new double[numberOfSections][3];
+              equations.accumulateLastPhaseMassSourcesPerLength(phaseSources, 1.0);
+              double[][][] componentSources = componentTransport.createComponentSourceRates(phaseSources,
+                  localEquilibriumStates, componentConservationTolerance);
+              double[] latentHeatSources = componentTransport.createLatentHeatSourceRates(componentSources,
+                  localEquilibriumStates);
+              for (int cell = 0; cell < numberOfSections; cell++) {
+                weightedLatentHeatSources[cell] += phaseStageWeights[stage] * latentHeatSources[cell];
+                for (int phase = 0; phase < 3; phase++) {
+                  for (int component = 0; component < weightedComponentSources[cell][phase].length; component++) {
+                    weightedComponentSources[cell][phase][component] += phaseStageWeights[stage]
+                        * componentSources[cell][phase][component];
+                  }
+                }
+              }
+            }
           }
         }
         return derivative;
@@ -4730,8 +4759,8 @@ public class TwoFluidPipe extends Pipeline {
       double[] latentHeatEnergyByCellJ = new double[numberOfSections];
       if (captureComponentStageFluxes) {
         latentHeatEnergyByCellJ = componentTransport.advance(dtActual, weightedPhaseMassFaceFluxes,
-            weightedPhaseMassSources, sections, getInletStream().getFluid(), referenceFluid,
-            componentConservationTolerance);
+            weightedPhaseMassSources, weightedComponentSources, weightedLatentHeatSources, sections,
+            getInletStream().getFluid(), referenceFluid, componentConservationTolerance);
       }
       // Compensated accepted-time summation prevents repeated subtraction from leaving
       // a spurious, unrepresentable tail after hundreds of CFL-limited steps.
@@ -6148,6 +6177,9 @@ public class TwoFluidPipe extends Pipeline {
    * @param enabled true to track named components conservatively
    */
   public void setComponentTransportEnabled(boolean enabled) {
+    if (enabled && equations.isOutletPhaseBackflowAllowed()) {
+      throw new IllegalStateException(componentOutletBackflowUnsupportedMessage());
+    }
     componentTransportEnabled = enabled;
     if (!enabled) {
       componentTransport = null;
@@ -8104,7 +8136,15 @@ public class TwoFluidPipe extends Pipeline {
    * @param allow true to carry signed phase mass and energy through the outlet
    */
   public void setAllowOutletPhaseBackflow(boolean allow) {
+    if (allow && componentTransportEnabled) {
+      throw new IllegalStateException(componentOutletBackflowUnsupportedMessage());
+    }
     equations.setAllowOutletPhaseBackflow(allow);
+  }
+
+  private static String componentOutletBackflowUnsupportedMessage() {
+    return "Named-component transport cannot be combined with signed outlet backflow: "
+        + "reverse outlet inflow requires an external outlet composition, which is not configured";
   }
 
   /** @return true when signed outlet phase flow is enabled */

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidComponentTransport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidComponentTransport.java
@@ -19,6 +19,7 @@ public final class TwoFluidComponentTransport implements Serializable {
   private static final int WATER = 2;
   private static final int PHASE_COUNT = 3;
   private static final double MASS_FLOOR_KG = 1.0e-12;
+  private static final double MASS_SYNCHRONIZATION_ABSOLUTE_TOLERANCE_KG = 1.0e-10;
   private static final double FLOW_DIRECTION_TOLERANCE_KG_S = 1.0e-12;
 
   private final String[] componentNames;
@@ -97,6 +98,30 @@ public final class TwoFluidComponentTransport implements Serializable {
   public double[] advance(double timeStepSeconds, double[][] phaseMassFaceFluxKgS,
       double[][] phaseMassSourceKgPerMetreSecond, TwoFluidSection[] sections, SystemInterface inletFluid,
       SystemInterface fluidTemplate, double tolerance) {
+    return advance(timeStepSeconds, phaseMassFaceFluxKgS, phaseMassSourceKgPerMetreSecond, null, null, sections,
+        inletFluid, fluidTemplate, tolerance);
+  }
+
+  /**
+   * Advance components using component source rates frozen at the same Runge-Kutta stages as the hydrodynamic phase
+   * sources.
+   *
+   * @param timeStepSeconds accepted substep duration
+   * @param phaseMassFaceFluxKgS stage-weighted gas/oil/water face mass flows
+   * @param phaseMassSourceKgPerMetreSecond stage-weighted cell phase sources
+   * @param componentSourceKgPerMetreSecond stage-weighted cell/phase/component sources, or {@code null} to allocate
+   * from the accepted post-advection state
+   * @param latentHeatSourceWPerMetre stage-weighted cell latent-heat sources, or {@code null} with legacy allocation
+   * @param sections accepted hydrodynamic cell states
+   * @param inletFluid current inlet boundary fluid
+   * @param fluidTemplate thermodynamic template used for cell flashes
+   * @param tolerance relative conservation/synchronization tolerance
+   * @return composition-dependent latent heat added in each cell over the accepted step, in joules
+   */
+  public double[] advance(double timeStepSeconds, double[][] phaseMassFaceFluxKgS,
+      double[][] phaseMassSourceKgPerMetreSecond, double[][][] componentSourceKgPerMetreSecond,
+      double[] latentHeatSourceWPerMetre, TwoFluidSection[] sections, SystemInterface inletFluid,
+      SystemInterface fluidTemplate, double tolerance) {
     validateAdvanceArguments(timeStepSeconds, phaseMassFaceFluxKgS, phaseMassSourceKgPerMetreSecond, sections,
         tolerance);
     if (fluidTemplate == null) {
@@ -132,9 +157,23 @@ public final class TwoFluidComponentTransport implements Serializable {
       if (Math.abs(sum(phaseTransferKg)) > tolerance * transferScale) {
         throw new IllegalStateException("Hydrodynamic interphase sources do not sum to zero in cell " + cell);
       }
-      double[][] componentTransfer = allocateComponentTransfer(cell, phaseTransferKg, updated, sections, fluidTemplate);
-      latentHeatEnergyByCellJ[cell] = calculateLatentHeatEnergyJ(cell, componentTransfer, updated, sections,
-          fluidTemplate);
+      double[][] componentTransfer;
+      if (componentSourceKgPerMetreSecond == null) {
+        componentTransfer = allocateComponentTransfer(cell, phaseTransferKg, updated, sections, fluidTemplate);
+      } else {
+        componentTransfer = componentTransferFromSourceRates(cell, timeStepSeconds, sections[cell].getLength(),
+            phaseTransferKg, componentSourceKgPerMetreSecond, tolerance);
+      }
+      if (componentSourceKgPerMetreSecond == null) {
+        latentHeatEnergyByCellJ[cell] = calculateLatentHeatEnergyJ(cell, componentTransfer, updated, sections,
+            fluidTemplate);
+      } else {
+        if (latentHeatSourceWPerMetre == null || latentHeatSourceWPerMetre.length != cellCount
+            || !Double.isFinite(latentHeatSourceWPerMetre[cell])) {
+          throw new IllegalArgumentException("Stage-frozen component sources require finite cell latent-heat sources");
+        }
+        latentHeatEnergyByCellJ[cell] = latentHeatSourceWPerMetre[cell] * sections[cell].getLength() * timeStepSeconds;
+      }
       intervalLatentHeatEnergyJ += latentHeatEnergyByCellJ[cell];
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
         for (int component = 0; component < componentNames.length; component++) {
@@ -150,10 +189,224 @@ public final class TwoFluidComponentTransport implements Serializable {
     return latentHeatEnergyByCellJ;
   }
 
+  /**
+   * Resolve phase-mass sources into named-component sources at one hydrodynamic RHS stage.
+   *
+   * <p>
+   * Condensation uses the receiving-phase composition from the exact local equilibrium state that generated the
+   * hydrodynamic source. Evaporation uses the conserved donor-phase composition. Freezing these allocations at the RHS
+   * stage prevents a later slug/advection split from asking a different post-transport flash to reconstruct the
+   * already-accepted phase appearance.
+   * </p>
+   *
+   * @param phaseMassSourceKgPerMetreSecond cell gas/oil/water source rates
+   * @param localEquilibriumStates local flashed states used to calculate those source rates
+   * @param tolerance relative source-closure tolerance
+   * @return cell/phase/component source rates in kg/(m s)
+   */
+  public double[][][] createComponentSourceRates(double[][] phaseMassSourceKgPerMetreSecond,
+      SystemInterface[] localEquilibriumStates, double tolerance) {
+    if (phaseMassSourceKgPerMetreSecond == null || phaseMassSourceKgPerMetreSecond.length != cellCount
+        || localEquilibriumStates == null || localEquilibriumStates.length != cellCount || !Double.isFinite(tolerance)
+        || tolerance <= 0.0) {
+      throw new IllegalArgumentException("Component source arrays must match the grid and tolerance must be positive");
+    }
+    double[][][] source = new double[cellCount][PHASE_COUNT][componentNames.length];
+    double[][][] donorFractions = currentMassFractions();
+    for (int cell = 0; cell < cellCount; cell++) {
+      double[] phaseSource = phaseMassSourceKgPerMetreSecond[cell];
+      if (phaseSource == null || phaseSource.length != PHASE_COUNT) {
+        throw new IllegalArgumentException("Every component cell must contain gas, oil, and water source rates");
+      }
+      double scale = Math.max(MASS_FLOOR_KG,
+          Math.max(Math.abs(phaseSource[GAS]), Math.max(Math.abs(phaseSource[OIL]), Math.abs(phaseSource[WATER]))));
+      if (Math.abs(sum(phaseSource)) > tolerance * scale) {
+        throw new IllegalStateException("Hydrodynamic interphase sources do not sum to zero in cell " + cell);
+      }
+      if ((phaseSource[OIL] > MASS_FLOOR_KG && phaseSource[WATER] < -MASS_FLOOR_KG)
+          || (phaseSource[OIL] < -MASS_FLOOR_KG && phaseSource[WATER] > MASS_FLOOR_KG)) {
+        throw new IllegalStateException("Direct oil-water component transfer is outside the validated closure");
+      }
+      double gasSource = phaseSource[GAS];
+      if (gasSource > MASS_FLOOR_KG) {
+        for (int donorPhase : new int[] { OIL, WATER }) {
+          double withdrawalRate = Math.max(0.0, -phaseSource[donorPhase]);
+          if (withdrawalRate <= 0.0) {
+            continue;
+          }
+          if (sum(donorFractions[cell][donorPhase]) <= 0.0) {
+            throw new IllegalStateException(
+                "Unsupported evaporation from empty " + phaseName(donorPhase) + " component inventory in cell " + cell);
+          }
+          for (int component = 0; component < componentNames.length; component++) {
+            double componentRate = withdrawalRate * donorFractions[cell][donorPhase][component];
+            source[cell][donorPhase][component] -= componentRate;
+            source[cell][GAS][component] += componentRate;
+          }
+        }
+      } else if (gasSource < -MASS_FLOOR_KG) {
+        if (localEquilibriumStates[cell] == null) {
+          throw new IllegalArgumentException("Missing local equilibrium state for condensation in cell " + cell);
+        }
+        double[][] equilibriumFractions = phaseMassFractions(localEquilibriumStates[cell]);
+        for (int receivingPhase : new int[] { OIL, WATER }) {
+          double additionRate = Math.max(0.0, phaseSource[receivingPhase]);
+          if (additionRate <= 0.0) {
+            continue;
+          }
+          if (sum(equilibriumFractions[receivingPhase]) <= 0.0) {
+            throw new IllegalStateException("Unsupported phase appearance: source-stage flash provides no "
+                + phaseName(receivingPhase) + " composition in cell " + cell);
+          }
+          for (int component = 0; component < componentNames.length; component++) {
+            double componentRate = additionRate * equilibriumFractions[receivingPhase][component];
+            source[cell][receivingPhase][component] += componentRate;
+            source[cell][GAS][component] -= componentRate;
+          }
+        }
+      } else if (Math.abs(phaseSource[OIL]) > MASS_FLOOR_KG || Math.abs(phaseSource[WATER]) > MASS_FLOOR_KG) {
+        throw new IllegalStateException("Direct oil-water component transfer is outside the validated closure");
+      }
+    }
+    return source;
+  }
+
+  /**
+   * Calculate composition-resolved latent-heat source rates at the same local equilibrium states as the component
+   * source allocation.
+   *
+   * @param componentSourceKgPerMetreSecond cell/phase/component source rates in kg/(m s)
+   * @param localEquilibriumStates source-stage local equilibrium states
+   * @return heat released to sensible energy in each cell, in W/m
+   */
+  public double[] createLatentHeatSourceRates(double[][][] componentSourceKgPerMetreSecond,
+      SystemInterface[] localEquilibriumStates) {
+    if (componentSourceKgPerMetreSecond == null || componentSourceKgPerMetreSecond.length != cellCount
+        || localEquilibriumStates == null || localEquilibriumStates.length != cellCount) {
+      throw new IllegalArgumentException("Latent-heat source arrays must match the component grid");
+    }
+    double[] sourceWPerMetre = new double[cellCount];
+    double[][][] donorFractions = currentMassFractions();
+    for (int cell = 0; cell < cellCount; cell++) {
+      if (localEquilibriumStates[cell] == null) {
+        throw new IllegalArgumentException("Missing local equilibrium state for latent heat in cell " + cell);
+      }
+      double[][] enthalpyJkg = componentSpecificEnthalpies(localEquilibriumStates[cell]);
+      double[][] forcedDonorEnthalpyJkg = new double[PHASE_COUNT][];
+      double phaseFormationWPerMetre = 0.0;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        if (componentSourceKgPerMetreSecond[cell][phase] == null
+            || componentSourceKgPerMetreSecond[cell][phase].length != componentNames.length) {
+          throw new IllegalArgumentException("Every latent-heat source phase must contain the component slate");
+        }
+        for (int component = 0; component < componentNames.length; component++) {
+          double massSource = componentSourceKgPerMetreSecond[cell][phase][component];
+          if (Math.abs(massSource) <= MASS_FLOOR_KG) {
+            continue;
+          }
+          double specificEnthalpyJkg = enthalpyJkg[phase][component];
+          if (!Double.isFinite(specificEnthalpyJkg) && massSource < 0.0 && sum(donorFractions[cell][phase]) > 0.0) {
+            if (forcedDonorEnthalpyJkg[phase] == null) {
+              forcedDonorEnthalpyJkg[phase] = forcedPhaseSpecificEnthalpies(localEquilibriumStates[cell],
+                  donorFractions[cell][phase], phase, cell);
+            }
+            specificEnthalpyJkg = forcedDonorEnthalpyJkg[phase][component];
+          }
+          if (!Double.isFinite(specificEnthalpyJkg)) {
+            throw new IllegalStateException("Unsupported source-stage latent-enthalpy closure: component '"
+                + componentNames[component] + "' has no partial enthalpy in thermodynamic " + phaseName(phase)
+                + " phase while mass transfers in cell " + cell);
+          }
+          phaseFormationWPerMetre += massSource * specificEnthalpyJkg;
+        }
+      }
+      sourceWPerMetre[cell] = -phaseFormationWPerMetre;
+    }
+    return sourceWPerMetre;
+  }
+
+  private double[] forcedPhaseSpecificEnthalpies(SystemInterface template, double[] massFractions, int phase,
+      int cell) {
+    double[] componentMoles = new double[componentNames.length];
+    double totalMoles = 0.0;
+    for (int component = 0; component < componentNames.length; component++) {
+      componentMoles[component] = massFractions[component] / componentMolarMassKgMol[component];
+      totalMoles += componentMoles[component];
+    }
+    if (!(totalMoles > 0.0) || !Double.isFinite(totalMoles)) {
+      throw new IllegalStateException("Cannot construct disappearing " + phaseName(phase)
+          + " enthalpy state from an empty component inventory in cell " + cell);
+    }
+    SystemInterface forced = template.clone();
+    double[] templateComposition = new double[forced.getNumberOfComponents()];
+    for (int templateIndex = 0; templateIndex < forced.getNumberOfComponents(); templateIndex++) {
+      String name = forced.getPhase(0).getComponent(templateIndex).getComponentName();
+      templateComposition[templateIndex] = componentMoles[componentIndex(name)] / totalMoles;
+    }
+    try {
+      forced.setMolarComposition(templateComposition);
+      forced.setNumberOfPhases(1);
+      forced.setMaxNumberOfPhases(1);
+      forced.setForcePhaseTypes(true);
+      forced.init(0);
+      forced.setPhaseType(0, forcedPhaseType(phase));
+      forced.init(3);
+      return componentSpecificEnthalpies(forced)[phase];
+    } catch (Exception exception) {
+      throw new IllegalStateException("Cannot evaluate disappearing " + phaseName(phase)
+          + " partial enthalpies in cell " + cell + ": " + exception.getMessage(), exception);
+    }
+  }
+
+  private static PhaseType forcedPhaseType(int phase) {
+    switch (phase) {
+    case GAS:
+      return PhaseType.GAS;
+    case OIL:
+      return PhaseType.LIQUID;
+    case WATER:
+      return PhaseType.AQUEOUS;
+    default:
+      throw new IllegalArgumentException("Unsupported phase index " + phase);
+    }
+  }
+
+  private double[][] componentTransferFromSourceRates(int cell, double timeStepSeconds, double cellLengthMetres,
+      double[] phaseTransferKg, double[][][] componentSourceKgPerMetreSecond, double tolerance) {
+    if (componentSourceKgPerMetreSecond.length != cellCount || componentSourceKgPerMetreSecond[cell] == null
+        || componentSourceKgPerMetreSecond[cell].length != PHASE_COUNT) {
+      throw new IllegalArgumentException("Component source arrays must match the hydrodynamic grid");
+    }
+    double[][] transfer = new double[PHASE_COUNT][componentNames.length];
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      double componentSumKg = 0.0;
+      if (componentSourceKgPerMetreSecond[cell][phase] == null
+          || componentSourceKgPerMetreSecond[cell][phase].length != componentNames.length) {
+        throw new IllegalArgumentException("Every component source phase must contain the tracked component slate");
+      }
+      for (int component = 0; component < componentNames.length; component++) {
+        double value = componentSourceKgPerMetreSecond[cell][phase][component] * cellLengthMetres * timeStepSeconds;
+        if (!Double.isFinite(value)) {
+          throw new IllegalStateException("Non-finite component source in cell " + cell);
+        }
+        transfer[phase][component] = value;
+        componentSumKg += value;
+      }
+      double scale = Math.max(MASS_FLOOR_KG, Math.max(Math.abs(phaseTransferKg[phase]), Math.abs(componentSumKg)));
+      if (Math.abs(componentSumKg - phaseTransferKg[phase]) > Math.max(MASS_SYNCHRONIZATION_ABSOLUTE_TOLERANCE_KG,
+          tolerance * scale)) {
+        throw new IllegalStateException(
+            "Component sources do not reproduce the " + phaseName(phase) + " hydrodynamic source in cell " + cell
+                + ": component transfer=" + componentSumKg + " kg, phase transfer=" + phaseTransferKg[phase] + " kg");
+      }
+    }
+    return transfer;
+  }
+
   private void advectPositiveFace(double timeStepSeconds, int face, int phase, double phaseFlowKgS,
       double[][] inletPhaseFractions, double[][][] oldFractions, double[][][] updated) {
     double[] donorFractions = face == 0 ? inletPhaseFractions[phase] : oldFractions[face - 1][phase];
-    validateDonorComposition(donorFractions, phaseFlowKgS, face, phase);
+    validateDonorComposition(donorFractions, timeStepSeconds * phaseFlowKgS, face, phase);
     for (int component = 0; component < componentNames.length; component++) {
       double transportedMassKg = timeStepSeconds * phaseFlowKgS * donorFractions[component];
       if (face > 0) {
@@ -180,7 +433,7 @@ public final class TwoFluidComponentTransport implements Serializable {
           + ": provide a validated outlet composition before enabling reverse boundary flow");
     }
     double[] donorFractions = oldFractions[face][phase];
-    validateDonorComposition(donorFractions, phaseFlowKgS, face, phase);
+    validateDonorComposition(donorFractions, timeStepSeconds * phaseFlowKgS, face, phase);
     for (int component = 0; component < componentNames.length; component++) {
       double transportedMassKg = timeStepSeconds * phaseFlowKgS * donorFractions[component];
       updated[face][phase][component] -= transportedMassKg;
@@ -190,8 +443,8 @@ public final class TwoFluidComponentTransport implements Serializable {
     }
   }
 
-  private void validateDonorComposition(double[] donorFractions, double phaseFlowKgS, int face, int phase) {
-    if (phaseFlowKgS > FLOW_DIRECTION_TOLERANCE_KG_S && sum(donorFractions) <= 0.0) {
+  private void validateDonorComposition(double[] donorFractions, double transportedMassKg, int face, int phase) {
+    if (transportedMassKg > MASS_SYNCHRONIZATION_ABSOLUTE_TOLERANCE_KG && sum(donorFractions) <= 0.0) {
       throw new IllegalStateException(
           "Boundary/face flow has no " + phaseName(phase) + " component composition at face " + face);
     }
@@ -441,19 +694,20 @@ public final class TwoFluidComponentTransport implements Serializable {
         double errorKg = componentMassKg - targetMassKg;
         maximumPhaseMassSynchronizationErrorKg = Math.max(maximumPhaseMassSynchronizationErrorKg, Math.abs(errorKg));
         double scale = Math.max(MASS_FLOOR_KG, Math.max(Math.abs(componentMassKg), Math.abs(targetMassKg)));
-        if (Math.abs(errorKg) > tolerance * scale) {
+        double synchronizationToleranceKg = Math.max(MASS_SYNCHRONIZATION_ABSOLUTE_TOLERANCE_KG, tolerance * scale);
+        if (Math.abs(errorKg) > synchronizationToleranceKg) {
           throw new IllegalStateException("Component sum and hydrodynamic " + phaseName(phase) + " mass differ in cell "
               + cell + " by " + errorKg + " kg");
         }
         for (int component = 0; component < componentNames.length; component++) {
-          if (updated[cell][phase][component] < -tolerance * scale) {
+          if (updated[cell][phase][component] < -synchronizationToleranceKg) {
             throw new IllegalStateException("Negative component inventory for '" + componentNames[component] + "' in "
                 + phaseName(phase) + " cell " + cell);
           }
           updated[cell][phase][component] = Math.max(0.0, updated[cell][phase][component]);
         }
         componentMassKg = phaseInventory(updated[cell][phase]);
-        if (targetMassKg <= MASS_FLOOR_KG) {
+        if (targetMassKg <= MASS_SYNCHRONIZATION_ABSOLUTE_TOLERANCE_KG) {
           Arrays.fill(updated[cell][phase], 0.0);
         } else if (componentMassKg > 0.0) {
           double correction = targetMassKg / componentMassKg;

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeCoupledCapabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeCoupledCapabilityTest.java
@@ -1,0 +1,251 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.pipeline.TwoFluidComponentConservationReport.Phase;
+import neqsim.process.equipment.pipeline.twophasepipe.LagrangianSlugTracker.SlugBubbleUnit;
+import neqsim.process.equipment.pipeline.twophasepipe.LiquidAccumulationTracker.SlugCharacteristics;
+import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidSection;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Coupled transient contracts for supported TwoFluidPipe capabilities. */
+class TwoFluidPipeCoupledCapabilityTest {
+  private static final Logger logger = LogManager.getLogger(TwoFluidPipeCoupledCapabilityTest.class);
+  private static final UUID TRANSIENT_ID = UUID.fromString("00000000-0000-0000-0000-000000002904");
+
+  @Test
+  void componentTransportAndSignedOutletBackflowFailBeforeMutationInEitherSetterOrder() {
+    TwoFluidPipe componentsFirst = uninitializedPipe("components-first");
+    componentsFirst.setComponentTransportEnabled(true);
+    IllegalStateException backflowException = assertThrows(IllegalStateException.class,
+        () -> componentsFirst.setAllowOutletPhaseBackflow(true));
+    assertTrue(backflowException.getMessage().contains("external outlet composition"));
+    assertFalse(componentsFirst.isOutletPhaseBackflowAllowed());
+    assertTrue(componentsFirst.isComponentTransportEnabled());
+    assertEquals(0.0, componentsFirst.getSimulationTime(), 0.0);
+
+    TwoFluidPipe backflowFirst = uninitializedPipe("backflow-first");
+    backflowFirst.setAllowOutletPhaseBackflow(true);
+    IllegalStateException componentException = assertThrows(IllegalStateException.class,
+        () -> backflowFirst.setComponentTransportEnabled(true));
+    assertTrue(componentException.getMessage().contains("external outlet composition"));
+    assertTrue(backflowFirst.isOutletPhaseBackflowAllowed());
+    assertFalse(backflowFirst.isComponentTransportEnabled());
+    assertEquals(0.0, backflowFirst.getSimulationTime(), 0.0);
+  }
+
+  @Test
+  void multistageConservativeSlugPhaseTransferFailsBeforeStateMutation() {
+    TwoFluidPipe pipe = uninitializedPipe("multistage-source");
+    pipe.setComponentTransportEnabled(true);
+    pipe.setIncludeMassTransfer(true);
+    pipe.setTimeIntegrationMethod(TimeIntegrator.Method.RK2);
+    pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.CONSERVATIVE_LAGRANGIAN);
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> pipe.runTransient(0.01, TRANSIENT_ID));
+    assertTrue(exception.getMessage().contains("stage-local component inventories"));
+    assertEquals(0.0, pipe.getSimulationTime(), 0.0);
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(value = 5, unit = TimeUnit.MINUTES)
+  void slugComponentPhaseChangeAndThermalCouplingClosesAndRefines() throws Exception {
+    CoupledResult coarse = runCoupledCase(0.05);
+    CoupledResult refined = runCoupledCase(0.025);
+
+    assertTrue(coarse.waterTransferKg > 0.0 && refined.waterTransferKg > 0.0,
+        "Cooling below the water dew point must create aqueous water on both time grids");
+    assertTrue(Math.abs(coarse.latentHeatJ) > 0.0 && Math.abs(refined.latentHeatJ) > 0.0,
+        "The same component transfer must produce compositional latent heat");
+    assertTrue(coarse.meanTemperatureChangeK < 0.0 && refined.meanTemperatureChangeK < 0.0,
+        "A colder wall must cool the closed fluid");
+    assertEquals(0.05, coarse.slugAgeSeconds, 1.0e-12);
+    assertEquals(0.05, refined.slugAgeSeconds, 1.0e-12);
+    assertTrue(coarse.slugLengthMetres > 0.0 && refined.slugLengthMetres > 0.0);
+
+    double waterSensitivity = relativeDifference(coarse.waterTransferKg, refined.waterTransferKg);
+    double latentSensitivity = relativeDifference(coarse.latentHeatJ, refined.latentHeatJ);
+    double temperatureSensitivity = relativeDifference(coarse.meanTemperatureChangeK, refined.meanTemperatureChangeK);
+    logger.info("Coupled outer-step sensitivity: water transfer={}, latent heat={}, temperature response={}",
+        waterSensitivity, latentSensitivity, temperatureSensitivity);
+    assertTrue(waterSensitivity < 0.10, "Aqueous-water transfer outer-step sensitivity was " + waterSensitivity);
+    assertTrue(latentSensitivity < 0.10, "Latent-heat outer-step sensitivity was " + latentSensitivity);
+    assertTrue(temperatureSensitivity < 0.10,
+        "Mean-temperature-response outer-step sensitivity was " + temperatureSensitivity);
+    assertEquals(coarse.slugFrontMetres, refined.slugFrontMetres, 1.0e-12,
+        "Outer-step partitioning must not change accepted slug travel over the same physical duration");
+    assertEquals(coarse.slugLengthMetres, refined.slugLengthMetres, 1.0e-12,
+        "Outer-step partitioning must not change tracked slug length over the same physical duration");
+  }
+
+  private static CoupledResult runCoupledCase(double outerStepSeconds) throws Exception {
+    SystemInterface wetGas = wetGasNearWaterDewPoint();
+    double initialTemperatureK = wetGas.getTemperature("K");
+    Stream inlet = new Stream("coupled-inlet-" + outerStepSeconds, wetGas);
+    inlet.setFlowRate(6.0, "kg/sec");
+    inlet.setPressure(70.0, "bara");
+    inlet.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("coupled-pipe-" + outerStepSeconds, inlet);
+    pipe.setLength(20.0);
+    pipe.setDiameter(0.20);
+    pipe.setRoughness(1.0e-5);
+    pipe.setNumberOfSections(4);
+    pipe.setTimeIntegrationMethod(TimeIntegrator.Method.EULER);
+    pipe.setEnableAdaptiveTimestepping(false);
+    pipe.setEnableSlugTracking(true);
+    pipe.setIncludeMassTransfer(true);
+    pipe.setMassTransferRelaxationTime(30.0);
+    pipe.setThermodynamicUpdateInterval(1);
+    pipe.setSteadyStateMaxWallClockTime(Double.POSITIVE_INFINITY);
+    pipe.setComponentTransportEnabled(true);
+    pipe.run();
+    pipe.closeInlet();
+    pipe.closeOutlet();
+    pipe.setEnableJouleThomson(false);
+    pipe.setWallProperties(0.005, 1000.0, 100.0);
+    pipe.setHeatTransferCoefficient(5000.0);
+    pipe.setSurfaceTemperature(initialTemperatureK - 10.0, "K");
+    pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.CONSERVATIVE_LAGRANGIAN);
+    pipe.getLagrangianSlugTracker().setEnableInletSlugGeneration(false);
+    pipe.getLagrangianSlugTracker().setEnableWakeEffects(false);
+    SlugBubbleUnit slug = seedSlug(pipe);
+
+    double cumulativeWaterTransferKg = 0.0;
+    double cumulativeLatentHeatJ = 0.0;
+    int steps = (int) Math.round(0.05 / outerStepSeconds);
+    for (int step = 0; step < steps; step++) {
+      pipe.runTransient(outerStepSeconds, TRANSIENT_ID);
+      TwoFluidComponentConservationReport componentReport = pipe.getLastComponentConservationReport();
+      TwoFluidMassBalanceReport phaseReport = pipe.getLastMassBalanceReport();
+      TwoFluidThermalEnergyBalanceReport energyReport = pipe.getLastThermalEnergyBalanceReport();
+
+      assertTrue(componentReport.isConverged(), componentReport.getMessage());
+      assertTrue(componentReport.getMaximumRelativeInventoryResidual() <= 1.0e-8, componentReport.getMessage());
+      assertTrue(componentReport.getMaximumInterphaseTransferResidualKg() <= 1.0e-10, componentReport.getMessage());
+      assertTrue(componentReport.getMinimumMassFraction() >= -1.0e-12, componentReport.getMessage());
+      assertTrue(componentReport.getMaximumMassFraction() <= 1.0 + 1.0e-12, componentReport.getMessage());
+      assertTrue(componentReport.getMaximumMassFractionSumError() <= 1.0e-12, componentReport.getMessage());
+      for (TwoFluidMassBalanceReport.Phase phase : TwoFluidMassBalanceReport.Phase.values()) {
+        assertTrue(phaseReport.isWithinTolerance(phase, 1.0e-7, 1.0e-10),
+            phase + " mass residual was " + phaseReport.getResidualKg(phase) + " kg");
+      }
+      assertTrue(energyReport.isWithinTolerance(1.0e-5, 1.0e-10),
+          "Thermal residual was " + energyReport.getResidualJ() + " J");
+      assertTrue(pipe.isCoupledPressureMomentumConverged());
+      assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected());
+      assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
+      assertEquals(componentReport.getInterphaseLatentHeatEnergyJ(), energyReport.getLatentHeatEnergyJ(), 1.0e-8);
+      for (String component : componentReport.getComponentNames()) {
+        assertEquals(0.0,
+            componentReport.getInterphaseTransferKg(Phase.GAS, component)
+                + componentReport.getInterphaseTransferKg(Phase.OIL, component)
+                + componentReport.getInterphaseTransferKg(Phase.WATER, component),
+            1.0e-12, component);
+      }
+      cumulativeWaterTransferKg += componentReport.getInterphaseTransferKg(Phase.WATER, "water");
+      cumulativeLatentHeatJ += componentReport.getInterphaseLatentHeatEnergyJ();
+    }
+
+    assertTrue(pipe.getLagrangianSlugTracker().isConservativeFilmCouplingEnabled());
+    assertFalse(pipe.isTransientOutletBackflowClamped());
+    double finalMeanTemperatureK = mean(pipe.getTemperatureProfile());
+    return new CoupledResult(cumulativeWaterTransferKg, cumulativeLatentHeatJ,
+        finalMeanTemperatureK - initialTemperatureK, slug.age, slug.frontPosition, slug.slugLength);
+  }
+
+  private static SlugBubbleUnit seedSlug(TwoFluidPipe pipe) throws Exception {
+    SlugCharacteristics marker = new SlugCharacteristics();
+    marker.tailPosition = 2.0;
+    marker.frontPosition = 12.0;
+    marker.length = 10.0;
+    marker.holdup = 0.9;
+    marker.volume = marker.length * sections(pipe)[0].getArea() * marker.holdup;
+    return pipe.getLagrangianSlugTracker().initializeTerrainSlug(marker, sections(pipe));
+  }
+
+  private static SystemInterface wetGasNearWaterDewPoint() throws Exception {
+    double waterMoleFraction = 22.0e-6;
+    SystemInterface fluid = new SystemSrkCPAstatoil(260.15, 70.0);
+    fluid.addComponent("CO2", 0.02);
+    fluid.addComponent("nitrogen", 0.01);
+    fluid.addComponent("methane", 0.9 - waterMoleFraction);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addComponent("propane", 0.01);
+    fluid.addComponent("i-butane", 0.005);
+    fluid.addComponent("n-butane", 0.005);
+    fluid.addComponent("water", waterMoleFraction);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    SystemInterface dewPointFluid = fluid.clone();
+    new ThermodynamicOperations(dewPointFluid).waterDewPointTemperatureMultiphaseFlash();
+    fluid.setTemperature(dewPointFluid.getTemperature("K") + 0.02, "K");
+    return fluid;
+  }
+
+  private static TwoFluidPipe uninitializedPipe(String name) {
+    SystemInterface fluid = new SystemSrkEos(288.15, 70.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("nitrogen", 0.05);
+    fluid.setMixingRule("classic");
+    Stream inlet = new Stream(name + "-inlet", fluid);
+    inlet.setFlowRate(5.0, "kg/sec");
+    inlet.run();
+    return new TwoFluidPipe(name, inlet);
+  }
+
+  private static TwoFluidSection[] sections(TwoFluidPipe pipe) throws Exception {
+    Field field = TwoFluidPipe.class.getDeclaredField("sections");
+    field.setAccessible(true);
+    return (TwoFluidSection[]) field.get(pipe);
+  }
+
+  private static double mean(double[] values) {
+    double sum = 0.0;
+    for (double value : values) {
+      sum += value;
+    }
+    return sum / values.length;
+  }
+
+  private static double relativeDifference(double first, double second) {
+    return Math.abs(first - second) / Math.max(1.0e-30, Math.max(Math.abs(first), Math.abs(second)));
+  }
+
+  private static final class CoupledResult {
+    private final double waterTransferKg;
+    private final double latentHeatJ;
+    private final double meanTemperatureChangeK;
+    private final double slugAgeSeconds;
+    private final double slugFrontMetres;
+    private final double slugLengthMetres;
+
+    private CoupledResult(double waterTransferKg, double latentHeatJ, double meanTemperatureChangeK,
+        double slugAgeSeconds, double slugFrontMetres, double slugLengthMetres) {
+      this.waterTransferKg = waterTransferKg;
+      this.latentHeatJ = latentHeatJ;
+      this.meanTemperatureChangeK = meanTemperatureChangeK;
+      this.slugAgeSeconds = slugAgeSeconds;
+      this.slugFrontMetres = slugFrontMetres;
+      this.slugLengthMetres = slugLengthMetres;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stage 4 of `twofluid-five-pr-20260906` couples conservative slug/film motion, named-component transport, phase transfer, and thermal/energy ledgers for the supported single-stage transient path.

- accumulate component-transfer and latent-heat sources from the same source-stage equilibrium state used by the phase equations;
- advance named-component inventories with those frozen accepted-stage sources, avoiding a second post-advection flash;
- retain donor composition when a phase disappears and reject material transport from an empty donor;
- fail before state mutation for reverse outlet component inflow without an external composition;
- fail before state mutation for multi-stage conservative slug + component + phase-transfer integration until stage-local component inventories exist;
- add a coupled wet-gas/dewpoint cooling regression and document the bounded capability envelope.

Capability contract: https://github.com/equinor/neqsim/issues/3298#issuecomment-5571655924  
Base/scope update: https://github.com/equinor/neqsim/issues/3298#issuecomment-5572337042  
Related: #3298, #2907

## Immutable scope

- Current target `master` at publication: `9ca9ea2c546fa9d5b7cf47118da6404266027bfc`
- Implementation parent: `fe573aa6063a570574e83cc826759c141143a8e1`
- Head: `de2b0d977ac83c7bcd39d009656fcea3f6a95a5d`
- The two intervening master commits do not touch any of this PR's five paths; GitHub reports the PR mergeable with exactly five changed files.
- One commit: two production classes, one focused test class, and both TwoFluidPipe references.
- No default model, benchmark datum, or acceptance tolerance is changed.

## Evidence

The closed, four-cell wet-gas case crosses the water dewpoint while a deterministic in-domain liquid marker is advected in conservative Lagrangian mode. Two outer-step partitions (0.05 s and 0.025 s over 0.05 s) give:

- water transferred: `1.5855002575381513e-9 kg`;
- latent heat: `0.0034892651355490707 J`;
- mean temperature change: `-0.030500630367015447 K`;
- zero reported partition sensitivity for transfer, latent heat, temperature, and marker geometry under the common adaptive internal CFL steps;
- phase/total mass and named-component closure, bounded normalized fractions, thermal residual closure, positive state, no rejected substeps, and no outlet clamp;
- marker age `0.05 s` in both runs.

Local focused validation:

```
./mvnw -q -DskipTests compile
./mvnw -q -DexcludedTestGroups= -Dtest=TwoFluidPipeCoupledCapabilityTest,TwoFluidPipeComponentTransportTest,TwoFluidPipeClosedPhaseTransitionTest,TwoFluidPipeClosedThermalTest,TwoFluidPipeConservativeSlugTest,TwoFluidPipeSustainedThermodynamicRegressionTest test
```

Result: **41 tests, 0 failures, 0 errors, 0 skipped**.

Also passed: Spotless apply/check (after the NeqSim Maven preparation helper), documentation link/search validation over 690 Markdown files plus one standalone HTML file, and `git diff --check`.

Local limitations: the checkout does not contain `pomJava8.xml`, the available JRE 17 lacks `javadoc`, and the pre-commit executable is unavailable; hosted CI remains authoritative for those gates.

## Qualification boundary

This is numerical coupling/conservation evidence for a seeded in-domain marker, not qualification of spontaneous severe slugging, sustained slug cycles, or experimental slug loads. Stage 1's 65.163 kPa severe-slugging amplitude remains below the 68.6 kPa lower limit, and the public benchmark limitations recorded in Stage 2 remain. Multi-stage integration for the conservative slug/component/phase-transfer combination and reverse outlet named-component inflow without an external composition are intentionally unsupported and fail clearly.

Automation occupancy after publication is 7/10. This draft is the only new PR for this invocation.