### PR TITLE
[AI-Assisted] feat(diagram): publish PFD/P&ID companion exchanges

### DIFF
--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -32,13 +32,28 @@ incomplete or the canonical source-graph fingerprints differ.
 
 Each sub-delivery contains controlled document JSON, native SVG sheet(s), a
 native PDF drawing set, native DEXPI 2.0 Process XML, and a delivery manifest.
-The bundle manifest labels the PFD exchange as `DEXPI_2_0_PROCESS`. For the
-P&ID proposal, the same exchange is labelled
-`PROCESS_PFD_BFD_COMPANION_ONLY`: it is not a DEXPI Plant or Proteus P&ID
-exchange.
+The bundle manifest labels the PFD exchange as `DEXPI_2_0_PROCESS`. The P&ID
+child-delivery exchange remains labelled `PROCESS_PFD_BFD_COMPANION_ONLY`.
+When an executed operating case and explicit balance-boundary declarations are
+supplied, the coordinated bundle additionally publishes:
+
+- `stream-table.json`, containing governed temperature, pressure, mass-flow,
+  and specific-enthalpy values with units, bases, provenance, and diagnostics;
+- `balance-table.json`, containing declared inlet/outlet assignments and
+  calculated mass/energy closure evidence;
+- `pid/dexpi-plant-2.0.xml` plus its native Plant-profile assessment; and
+- `pid/proteus-4.1.xml`, explicitly labelled as a compatibility proposal.
+
+Boundary declarations resolve exact canonical source labels and fail closed for
+missing, duplicate, or invalid operating evidence. The compatibility writer's
+volatile export date/time is normalized to the documented
+`1970-01-01T00:00:00` reproducibility sentinel; it is not an engineering
+revision timestamp. The controlled revision remains in the manifests.
 
 The facade is intentionally opt-in. Existing Graphviz, native DEXPI Process and
-Plant, Proteus, simulation, and document APIs are unchanged.
+Plant, Proteus, simulation, and document APIs are unchanged. Supplying an
+operating-case identity opts into the companion package and therefore requires
+at least one explicit balance boundary.
 
 ## Requirement and evidence matrix
 
@@ -48,8 +63,8 @@ Plant, Proteus, simulation, and document APIs are unchanged.
 | Reviewable vector and PDF sheets | Existing native SVG/PDF renderer, A3 default, fixed-port orthogonal routing | Existing renderer tests plus bundle artifact checks | Full-sheet and detail inspection of every new reference sheet |
 | Stable regeneration | Deterministic child and bundle manifests | Fresh-model repeated-delivery test | Normalized reference baselines for the full model |
 | Native PFD exchange | Native DEXPI 2.0 Process artifact | Existing delivery assessment and bundle labels | Full-model topology/loss evidence |
-| P&ID exchange identity | Fail-closed companion-only label | Manifest assertion | Add and qualify a separately labelled Plant/Proteus proposal artifact |
-| Stream and H&MB companions | Existing governed stream and balance models | Existing focused tests | Publish full-model companions and boundary assignments |
+| P&ID exchange identity | Companion-only child label plus separate native DEXPI 2.0 Plant and Proteus 4.1 proposal artifacts | Plant assessment, profile labels, artifact and deterministic-regeneration assertions | Qualify the full-model proposal and external interoperability |
+| Stream and H&MB companions | Opt-in governed stream/balance artifacts with exact boundary resolution | Valid, missing-case, unknown-boundary, and repeated-delivery tests | Publish and qualify full-model operating values and boundary assignments |
 | Piping and instrumentation content | Existing governed proposal, Proteus writer, and detailed DEXPI paths | Existing DEXPI/P&ID tests | Bind explicit line/nozzle/valve/reducer/instrument/control/interface registers to this model |
 | Manual layout and routing | Existing evidence-bearing layout register | Existing layout and renderer tests | Declare full-model sheets, pins, protected routes, and stale-reference regeneration |
 | Standards alignment | Explicit scope and no-conformance boundary | Manifest flags and documentation checks | Licensed clause mapping and accountable review |

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
@@ -8,21 +8,34 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister;
 import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
 import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.dexpi.Dexpi20ConformanceAssessment;
+import neqsim.process.processmodel.dexpi.Dexpi20XmlWriter;
+import neqsim.process.processmodel.dexpi.DexpiXmlWriter;
 
 /**
  * Publishes coordinated PFD and review-required P&amp;ID proposal deliveries from one canonical {@link ProcessSystem}.
  *
  * <p>
  * Both views are generated from the same process object and must retain the same canonical source-graph fingerprint.
- * The P&amp;ID view is not a complete control, piping, or safety design. Its accompanying native DEXPI 2.0 Process file
- * is a PFD/BFD information-model companion only; it is not represented as a DEXPI Plant or Proteus P&amp;ID exchange.
+ * The P&amp;ID view is not a complete control, piping, or safety design. Its child-delivery DEXPI 2.0 Process file
+ * remains a PFD/BFD information-model companion. An opt-in companion package additionally publishes separately
+ * labelled native DEXPI 2.0 Plant and Proteus 4.1 compatibility exchanges for review.
  * </p>
  *
  * <p>
@@ -33,8 +46,65 @@ import neqsim.process.processmodel.ProcessSystem;
 public final class EngineeringDiagramDualProfileDelivery {
   private static final String SCHEMA_VERSION = "neqsim_engineering_diagram_dual_profile_delivery.v1";
   private static final String MANIFEST_FILE = "dual-profile-manifest.json";
+  private static final String STREAM_TABLE_FILE = "stream-table.json";
+  private static final String BALANCE_TABLE_FILE = "balance-table.json";
+  private static final String PID_DEXPI_PLANT_FILE = "pid/dexpi-plant-2.0.xml";
+  private static final String PID_DEXPI_PLANT_ASSESSMENT_FILE = "pid/dexpi-plant-assessment.json";
+  private static final String PID_PROTEUS_FILE = "pid/proteus-4.1.xml";
 
   private EngineeringDiagramDualProfileDelivery() {
+  }
+
+  /** One controlled balance-boundary declaration resolved against canonical stream evidence. */
+  public static final class BalanceBoundary {
+    private final String balanceId;
+    private final String streamSourceLabel;
+    private final Direction direction;
+    private final String sourceReference;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates one proposed or reviewed balance-boundary declaration.
+     *
+     * @param balanceId controlled balance identity
+     * @param streamSourceLabel exact source-model stream label
+     * @param direction stream direction relative to the balance boundary
+     * @param sourceReference engineering-register source reference
+     * @param evidenceState review state of the declaration
+     */
+    public BalanceBoundary(String balanceId, String streamSourceLabel, Direction direction, String sourceReference,
+        EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.streamSourceLabel = requireText(streamSourceLabel, "streamSourceLabel");
+      this.direction = requireNonNull(direction, "direction");
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      this.evidenceState = requireNonNull(evidenceState, "evidenceState");
+    }
+
+    /** @return controlled balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return exact source-model stream label */
+    public String getStreamSourceLabel() {
+      return streamSourceLabel;
+    }
+
+    /** @return boundary direction */
+    public Direction getDirection() {
+      return direction;
+    }
+
+    /** @return engineering-register source reference */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return declaration review state */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
   }
 
   /** Immutable coordinated delivery request. */
@@ -45,6 +115,7 @@ public final class EngineeringDiagramDualProfileDelivery {
     private final String pidDrawingNumber;
     private final String title;
     private final String operatingCaseId;
+    private final List<BalanceBoundary> balanceBoundaries;
     private final NativeEngineeringDiagramRenderer.SheetFormat sheetFormat;
     private final NativeEngineeringDiagramRenderer.RoutingMode routingMode;
     private final EngineeringDiagramDesignationRegister designationRegister;
@@ -58,6 +129,8 @@ public final class EngineeringDiagramDualProfileDelivery {
       pidDrawingNumber = requireText(builder.pidDrawingNumber, "pidDrawingNumber");
       title = requireText(builder.title, "title");
       operatingCaseId = optionalText(builder.operatingCaseId);
+      balanceBoundaries =
+          Collections.unmodifiableList(new ArrayList<BalanceBoundary>(builder.balanceBoundaries));
       sheetFormat = requireNonNull(builder.sheetFormat, "sheetFormat");
       routingMode = requireNonNull(builder.routingMode, "routingMode");
       designationRegister = requireNonNull(builder.designationRegister, "designationRegister");
@@ -65,6 +138,12 @@ public final class EngineeringDiagramDualProfileDelivery {
       conventionRegister = requireNonNull(builder.conventionRegister, "conventionRegister");
       if (pfdDrawingNumber.equals(pidDrawingNumber)) {
         throw new IllegalArgumentException("PFD and P&ID drawing numbers must be distinct");
+      }
+      if (operatingCaseId.isEmpty() && !balanceBoundaries.isEmpty()) {
+        throw new IllegalArgumentException("balance boundaries require an operating case");
+      }
+      if (!operatingCaseId.isEmpty() && balanceBoundaries.isEmpty()) {
+        throw new IllegalArgumentException("an operating case requires at least one balance boundary");
       }
     }
 
@@ -91,6 +170,7 @@ public final class EngineeringDiagramDualProfileDelivery {
       private final String pidDrawingNumber;
       private final String title;
       private String operatingCaseId;
+      private List<BalanceBoundary> balanceBoundaries = Collections.emptyList();
       private NativeEngineeringDiagramRenderer.SheetFormat sheetFormat = NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE;
       private NativeEngineeringDiagramRenderer.RoutingMode routingMode = NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL;
       private EngineeringDiagramDesignationRegister designationRegister = new EngineeringDiagramDesignationRegister();
@@ -108,6 +188,15 @@ public final class EngineeringDiagramDualProfileDelivery {
       /** @param value successfully-run operating-case identity @return this builder */
       public Builder operatingCaseId(String value) {
         operatingCaseId = requireText(value, "operatingCaseId");
+        return this;
+      }
+
+      /** @param value controlled balance-boundary declarations @return this builder */
+      public Builder balanceBoundaries(List<BalanceBoundary> value) {
+        if (value == null || value.contains(null)) {
+          throw new IllegalArgumentException("balanceBoundaries must not be null or contain null");
+        }
+        balanceBoundaries = new ArrayList<BalanceBoundary>(value);
         return this;
       }
 
@@ -153,12 +242,24 @@ public final class EngineeringDiagramDualProfileDelivery {
     private final Path directory;
     private final EngineeringDiagramDelivery.Report pfd;
     private final EngineeringDiagramDelivery.Report pid;
+    private final String operatingCaseId;
+    private final String balanceBoundaryEvidenceState;
+    private final EngineeringDiagramStreamTable streamTable;
+    private final EngineeringDiagramBalanceTable balanceTable;
+    private final Dexpi20ConformanceAssessment.Report pidPlantAssessment;
     private final String fingerprint;
 
-    private Report(Path directory, EngineeringDiagramDelivery.Report pfd, EngineeringDiagramDelivery.Report pid) {
+    private Report(Path directory, EngineeringDiagramDelivery.Report pfd, EngineeringDiagramDelivery.Report pid,
+        Request request, EngineeringDiagramStreamTable streamTable, EngineeringDiagramBalanceTable balanceTable,
+        Dexpi20ConformanceAssessment.Report pidPlantAssessment) {
       this.directory = directory;
       this.pfd = pfd;
       this.pid = pid;
+      operatingCaseId = request.operatingCaseId;
+      balanceBoundaryEvidenceState = evidenceState(request.balanceBoundaries);
+      this.streamTable = streamTable;
+      this.balanceTable = balanceTable;
+      this.pidPlantAssessment = pidPlantAssessment;
       fingerprint = sha256(new GsonBuilder().create().toJson(toMapWithoutFingerprint()));
     }
 
@@ -184,7 +285,13 @@ public final class EngineeringDiagramDualProfileDelivery {
 
     /** @return whether both deliveries passed and retained one canonical source graph */
     public boolean isComplete() {
-      return pfd.isComplete() && pid.isComplete()
+      boolean companionEvidenceComplete =
+          operatingCaseId.isEmpty() ? streamTable == null && balanceTable == null
+              : streamTable != null && streamTable.isValid() && balanceTable != null && balanceTable.isValid()
+                  && streamTable.getSourceGraphFingerprint()
+                      .equals(pfd.getDocumentSet().getSourceGraphFingerprint());
+      return pfd.isComplete() && pid.isComplete() && pidPlantAssessment != null
+          && pidPlantAssessment.isSchemaAndProfileConformant() && companionEvidenceComplete
           && pfd.getDocumentSet().getSourceGraphFingerprint().equals(pid.getDocumentSet().getSourceGraphFingerprint());
     }
 
@@ -210,6 +317,22 @@ public final class EngineeringDiagramDualProfileDelivery {
       result.put("pidContentProfile", ContentProfile.PID.name());
       result.put("pfdDexpiInformationModel", "DEXPI_2_0_PROCESS");
       result.put("pidDexpiInformationModel", "PROCESS_PFD_BFD_COMPANION_ONLY");
+      result.put("pidNativeDexpiInformationModel", "DEXPI_2_0_PLANT_P_ID");
+      result.put("pidProteusCompatibilityProfile", "PROTEUS_4_1");
+      result.put("operatingCaseId", operatingCaseId);
+      result.put("balanceBoundaryEvidenceState", balanceBoundaryEvidenceState);
+      result.put("streamTableFile", operatingCaseId.isEmpty() ? "" : STREAM_TABLE_FILE);
+      result.put("balanceTableFile", operatingCaseId.isEmpty() ? "" : BALANCE_TABLE_FILE);
+      result.put("pidNativeDexpiFile", PID_DEXPI_PLANT_FILE);
+      result.put("pidNativeDexpiAssessmentFile", PID_DEXPI_PLANT_ASSESSMENT_FILE);
+      result.put("pidProteusFile", PID_PROTEUS_FILE);
+      result.put("pidNativeDexpiAssessment", pidPlantAssessment.toMap());
+      if (streamTable != null) {
+        result.put("streamTable", streamTable.toMap());
+      }
+      if (balanceTable != null) {
+        result.put("balanceTable", balanceTable.toMap());
+      }
       result.put("pidApprovalStatus", "REVIEW_REQUIRED");
       result.put("fitnessForConstruction", Boolean.FALSE);
       result.put("iso10628ConformanceClaimed", Boolean.FALSE);
@@ -243,7 +366,35 @@ public final class EngineeringDiagramDualProfileDelivery {
           deliveryRequest(request, ContentProfile.PFD, request.pfdDrawingNumber));
       EngineeringDiagramDelivery.Report pid = EngineeringDiagramDelivery.deliver(processSystem, target.resolve("pid"),
           deliveryRequest(request, ContentProfile.PID, request.pidDrawingNumber));
-      Report report = new Report(target, pfd, pid);
+      Path nativePidPath = target.resolve(PID_DEXPI_PLANT_FILE);
+      Dexpi20ConformanceAssessment.Report pidPlantAssessment =
+          Dexpi20XmlWriter.writeAndAssess(processSystem, nativePidPath.toFile());
+      if (!pidPlantAssessment.isSchemaAndProfileConformant()) {
+        throw new IOException("native DEXPI 2.0 Plant P&ID assessment failed");
+      }
+      Files.write(target.resolve(PID_DEXPI_PLANT_ASSESSMENT_FILE),
+          pidPlantAssessment.toJson().getBytes(StandardCharsets.UTF_8));
+      Path proteusPath = target.resolve(PID_PROTEUS_FILE);
+      DexpiXmlWriter.write(processSystem, proteusPath.toFile());
+      normalizeProteusTimestamp(proteusPath);
+
+      EngineeringDiagramStreamTable streamTable = null;
+      EngineeringDiagramBalanceTable balanceTable = null;
+      if (!request.operatingCaseId.isEmpty()) {
+        streamTable = EngineeringDiagramStreamTable.fromDocumentSet(pfd.getDocumentSet(), request.operatingCaseId);
+        if (!streamTable.isValid()) {
+          throw new IOException("operating-case stream-table evidence is invalid");
+        }
+        balanceTable = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+            resolveBoundaries(streamTable, request.balanceBoundaries));
+        if (!balanceTable.isValid()) {
+          throw new IOException("operating-case balance-table evidence is invalid");
+        }
+        Files.write(target.resolve(STREAM_TABLE_FILE), streamTable.toJson().getBytes(StandardCharsets.UTF_8));
+        Files.write(target.resolve(BALANCE_TABLE_FILE), balanceTable.toJson().getBytes(StandardCharsets.UTF_8));
+      }
+
+      Report report = new Report(target, pfd, pid, request, streamTable, balanceTable, pidPlantAssessment);
       if (!report.isComplete()) {
         throw new IOException("PFD and P&ID deliveries do not retain one complete canonical plant");
       }
@@ -256,6 +407,50 @@ public final class EngineeringDiagramDualProfileDelivery {
       deleteRecursively(target);
       throw ex;
     }
+  }
+
+  private static List<Boundary> resolveBoundaries(EngineeringDiagramStreamTable streamTable,
+      List<BalanceBoundary> declarations) throws IOException {
+    List<Boundary> result = new ArrayList<Boundary>();
+    for (BalanceBoundary declaration : declarations) {
+      Row match = null;
+      for (Row row : streamTable.getRows()) {
+        if (declaration.getStreamSourceLabel().equals(row.getSourceLabel())) {
+          if (match != null) {
+            throw new IOException("ambiguous balance-boundary stream label: "
+                + declaration.getStreamSourceLabel());
+          }
+          match = row;
+        }
+      }
+      if (match == null) {
+        throw new IOException("unknown balance-boundary stream label: "
+            + declaration.getStreamSourceLabel());
+      }
+      result.add(new Boundary(declaration.getBalanceId(), match.getSemanticObjectId(),
+          declaration.getDirection(), declaration.getSourceReference(), declaration.getEvidenceState()));
+    }
+    return result;
+  }
+
+  private static String evidenceState(List<BalanceBoundary> boundaries) {
+    if (boundaries.isEmpty()) {
+      return "NOT_SUPPLIED";
+    }
+    EvidenceState state = boundaries.get(0).getEvidenceState();
+    for (BalanceBoundary boundary : boundaries) {
+      if (boundary.getEvidenceState() != state) {
+        return "MIXED";
+      }
+    }
+    return state.name();
+  }
+
+  private static void normalizeProteusTimestamp(Path file) throws IOException {
+    String xml = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    xml = xml.replaceAll("Date=\"[^\"]*\"", "Date=\"1970-01-01\"");
+    xml = xml.replaceAll("Time=\"[^\"]*\"", "Time=\"00:00:00\"");
+    Files.write(file, xml.getBytes(StandardCharsets.UTF_8));
   }
 
   private static EngineeringDiagramDelivery.Request deliveryRequest(Request request, ContentProfile profile,

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
@@ -34,8 +34,8 @@ import neqsim.process.processmodel.dexpi.DexpiXmlWriter;
  * <p>
  * Both views are generated from the same process object and must retain the same canonical source-graph fingerprint.
  * The P&amp;ID view is not a complete control, piping, or safety design. Its child-delivery DEXPI 2.0 Process file
- * remains a PFD/BFD information-model companion. An opt-in companion package additionally publishes separately
- * labelled native DEXPI 2.0 Plant and Proteus 4.1 compatibility exchanges for review.
+ * remains a PFD/BFD information-model companion. An opt-in companion package additionally publishes separately labelled
+ * native DEXPI 2.0 Plant and Proteus 4.1 compatibility exchanges for review.
  * </p>
  *
  * <p>
@@ -129,8 +129,7 @@ public final class EngineeringDiagramDualProfileDelivery {
       pidDrawingNumber = requireText(builder.pidDrawingNumber, "pidDrawingNumber");
       title = requireText(builder.title, "title");
       operatingCaseId = optionalText(builder.operatingCaseId);
-      balanceBoundaries =
-          Collections.unmodifiableList(new ArrayList<BalanceBoundary>(builder.balanceBoundaries));
+      balanceBoundaries = Collections.unmodifiableList(new ArrayList<BalanceBoundary>(builder.balanceBoundaries));
       sheetFormat = requireNonNull(builder.sheetFormat, "sheetFormat");
       routingMode = requireNonNull(builder.routingMode, "routingMode");
       designationRegister = requireNonNull(builder.designationRegister, "designationRegister");
@@ -285,11 +284,9 @@ public final class EngineeringDiagramDualProfileDelivery {
 
     /** @return whether both deliveries passed and retained one canonical source graph */
     public boolean isComplete() {
-      boolean companionEvidenceComplete =
-          operatingCaseId.isEmpty() ? streamTable == null && balanceTable == null
-              : streamTable != null && streamTable.isValid() && balanceTable != null && balanceTable.isValid()
-                  && streamTable.getSourceGraphFingerprint()
-                      .equals(pfd.getDocumentSet().getSourceGraphFingerprint());
+      boolean companionEvidenceComplete = operatingCaseId.isEmpty() ? streamTable == null && balanceTable == null
+          : streamTable != null && streamTable.isValid() && balanceTable != null && balanceTable.isValid()
+              && streamTable.getSourceGraphFingerprint().equals(pfd.getDocumentSet().getSourceGraphFingerprint());
       return pfd.isComplete() && pid.isComplete() && pidPlantAssessment != null
           && pidPlantAssessment.isSchemaAndProfileConformant() && companionEvidenceComplete
           && pfd.getDocumentSet().getSourceGraphFingerprint().equals(pid.getDocumentSet().getSourceGraphFingerprint());
@@ -367,8 +364,8 @@ public final class EngineeringDiagramDualProfileDelivery {
       EngineeringDiagramDelivery.Report pid = EngineeringDiagramDelivery.deliver(processSystem, target.resolve("pid"),
           deliveryRequest(request, ContentProfile.PID, request.pidDrawingNumber));
       Path nativePidPath = target.resolve(PID_DEXPI_PLANT_FILE);
-      Dexpi20ConformanceAssessment.Report pidPlantAssessment =
-          Dexpi20XmlWriter.writeAndAssess(processSystem, nativePidPath.toFile());
+      Dexpi20ConformanceAssessment.Report pidPlantAssessment = Dexpi20XmlWriter.writeAndAssess(processSystem,
+          nativePidPath.toFile());
       if (!pidPlantAssessment.isSchemaAndProfileConformant()) {
         throw new IOException("native DEXPI 2.0 Plant P&ID assessment failed");
       }
@@ -417,18 +414,16 @@ public final class EngineeringDiagramDualProfileDelivery {
       for (Row row : streamTable.getRows()) {
         if (declaration.getStreamSourceLabel().equals(row.getSourceLabel())) {
           if (match != null) {
-            throw new IOException("ambiguous balance-boundary stream label: "
-                + declaration.getStreamSourceLabel());
+            throw new IOException("ambiguous balance-boundary stream label: " + declaration.getStreamSourceLabel());
           }
           match = row;
         }
       }
       if (match == null) {
-        throw new IOException("unknown balance-boundary stream label: "
-            + declaration.getStreamSourceLabel());
+        throw new IOException("unknown balance-boundary stream label: " + declaration.getStreamSourceLabel());
       }
-      result.add(new Boundary(declaration.getBalanceId(), match.getSemanticObjectId(),
-          declaration.getDirection(), declaration.getSourceReference(), declaration.getEvidenceState()));
+      result.add(new Boundary(declaration.getBalanceId(), match.getSemanticObjectId(), declaration.getDirection(),
+          declaration.getSourceReference(), declaration.getEvidenceState()));
     }
     return result;
   }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
@@ -15,12 +15,15 @@ import java.util.Arrays;
 import java.util.List;
 import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
 import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
-import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class EngineeringDiagramDualProfileCompanionDeliveryTest {
+  private static final String GAS_PRODUCT_LABEL = "10-GAS-PRODUCT";
+  private static final String LIQUID_PRODUCT_LABEL = "10-LIQUID-PRODUCT";
+
   @TempDir
   Path temporaryDirectory;
 
@@ -108,6 +111,8 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
 
   private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
     EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    reference.getProcessSystem().add(new Stream(GAS_PRODUCT_LABEL, reference.getProducts().get(0)));
+    reference.getProcessSystem().add(new Stream(LIQUID_PRODUCT_LABEL, reference.getProducts().get(1)));
     reference.getProcessSystem().run();
     return reference;
   }
@@ -117,10 +122,10 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
     List<EngineeringDiagramDualProfileDelivery.BalanceBoundary> boundaries = new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>();
     boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
         reference.getFeed().getName(), Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
-    for (StreamInterface product : reference.getProducts()) {
-      boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10", product.getName(),
-          Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
-    }
+    boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10", GAS_PRODUCT_LABEL,
+        Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10", LIQUID_PRODUCT_LABEL,
+        Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
     return EngineeringDiagramDualProfileDelivery.Request
         .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").operatingCaseId("NORMAL-01")
         .balanceBoundaries(boundaries).build();

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
@@ -53,10 +53,10 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
     EngineeringDiagramReferenceFixtures.SystemCase firstReference = completeBoundaryCase();
     EngineeringDiagramReferenceFixtures.SystemCase secondReference = completeBoundaryCase();
 
-    EngineeringDiagramDualProfileDelivery.Report first = EngineeringDiagramDualProfileDelivery.deliver(
-        firstReference.getProcessSystem(), temporaryDirectory.resolve("first"), request(firstReference));
-    EngineeringDiagramDualProfileDelivery.Report second = EngineeringDiagramDualProfileDelivery.deliver(
-        secondReference.getProcessSystem(), temporaryDirectory.resolve("second"), request(secondReference));
+    EngineeringDiagramDualProfileDelivery.Report first = EngineeringDiagramDualProfileDelivery
+        .deliver(firstReference.getProcessSystem(), temporaryDirectory.resolve("first"), request(firstReference));
+    EngineeringDiagramDualProfileDelivery.Report second = EngineeringDiagramDualProfileDelivery
+        .deliver(secondReference.getProcessSystem(), temporaryDirectory.resolve("second"), request(secondReference));
 
     assertEquals(first.toJson(), second.toJson());
     assertArrayEquals(Files.readAllBytes(first.getDirectory().resolve("stream-table.json")),
@@ -73,26 +73,23 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
   void failsClosedForMissingOperatingEvidenceOrUnknownBoundary() {
     EngineeringDiagramReferenceFixtures.SystemCase unexecuted = EngineeringDiagramReferenceFixtures.simpleTrain();
     EngineeringDiagramDualProfileDelivery.Request missingCase = EngineeringDiagramDualProfileDelivery.Request
-        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
-        .operatingCaseId("NORMAL-01")
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").operatingCaseId("NORMAL-01")
         .balanceBoundaries(Arrays.asList(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
-            unexecuted.getFeed().getName(), Direction.INLET, "project-balance-register:test",
-            EvidenceState.PROPOSED)))
+            unexecuted.getFeed().getName(), Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED)))
         .build();
 
-    assertThrows(IOException.class, () -> EngineeringDiagramDualProfileDelivery.deliver(
-        unexecuted.getProcessSystem(), temporaryDirectory.resolve("missing-case"), missingCase));
+    assertThrows(IOException.class, () -> EngineeringDiagramDualProfileDelivery.deliver(unexecuted.getProcessSystem(),
+        temporaryDirectory.resolve("missing-case"), missingCase));
     assertFalse(Files.exists(temporaryDirectory.resolve("missing-case")));
 
     EngineeringDiagramReferenceFixtures.SystemCase executed = completeBoundaryCase();
     EngineeringDiagramDualProfileDelivery.Request unknownBoundary = EngineeringDiagramDualProfileDelivery.Request
-        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
-        .operatingCaseId("NORMAL-01")
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").operatingCaseId("NORMAL-01")
         .balanceBoundaries(Arrays.asList(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
             "ABSENT-STREAM", Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED)))
         .build();
-    assertThrows(IOException.class, () -> EngineeringDiagramDualProfileDelivery.deliver(
-        executed.getProcessSystem(), temporaryDirectory.resolve("unknown-boundary"), unknownBoundary));
+    assertThrows(IOException.class, () -> EngineeringDiagramDualProfileDelivery.deliver(executed.getProcessSystem(),
+        temporaryDirectory.resolve("unknown-boundary"), unknownBoundary));
     assertFalse(Files.exists(temporaryDirectory.resolve("unknown-boundary")));
   }
 
@@ -104,11 +101,9 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
             .balanceBoundaries(Arrays.asList(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
                 "10-FEED-001", Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED)))
             .build());
-    assertThrows(IllegalArgumentException.class,
-        () -> EngineeringDiagramDualProfileDelivery.Request
-            .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
-            .operatingCaseId("NORMAL-01").balanceBoundaries(new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>())
-            .build());
+    assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").operatingCaseId("NORMAL-01")
+        .balanceBoundaries(new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>()).build());
   }
 
   private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
@@ -122,8 +117,7 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
 
   private static EngineeringDiagramDualProfileDelivery.Request request(
       EngineeringDiagramReferenceFixtures.SystemCase reference) {
-    List<EngineeringDiagramDualProfileDelivery.BalanceBoundary> boundaries =
-        new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>();
+    List<EngineeringDiagramDualProfileDelivery.BalanceBoundary> boundaries = new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>();
     boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
         reference.getFeed().getName(), Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
     for (StreamInterface product : reference.getProducts()) {
@@ -131,7 +125,7 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
           Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
     }
     return EngineeringDiagramDualProfileDelivery.Request
-        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
-        .operatingCaseId("NORMAL-01").balanceBoundaries(boundaries).build();
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression").operatingCaseId("NORMAL-01")
+        .balanceBoundaries(boundaries).build();
   }
 }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
@@ -108,9 +108,6 @@ class EngineeringDiagramDualProfileCompanionDeliveryTest {
 
   private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
     EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
-    for (StreamInterface product : reference.getProducts()) {
-      reference.getProcessSystem().add(product);
-    }
     reference.getProcessSystem().run();
     return reference;
   }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileCompanionDeliveryTest.java
@@ -1,0 +1,137 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessSystem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EngineeringDiagramDualProfileCompanionDeliveryTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void publishesOperatingCaseCompanionsAndDistinctPidExchanges() throws IOException {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = completeBoundaryCase();
+    ProcessSystem process = reference.getProcessSystem();
+    String classicDot = process.toDOT();
+
+    EngineeringDiagramDualProfileDelivery.Report report = EngineeringDiagramDualProfileDelivery.deliver(process,
+        temporaryDirectory.resolve("complete"), request(reference));
+
+    assertTrue(report.isComplete(), report.toJson());
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("stream-table.json")));
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("balance-table.json")));
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("pid/dexpi-plant-2.0.xml")));
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("pid/dexpi-plant-assessment.json")));
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("pid/proteus-4.1.xml")));
+    assertTrue(report.toJson().contains("\"pidNativeDexpiInformationModel\": \"DEXPI_2_0_PLANT_P_ID\""));
+    assertTrue(report.toJson().contains("\"pidProteusCompatibilityProfile\": \"PROTEUS_4_1\""));
+    assertTrue(report.toJson().contains("\"operatingCaseId\": \"NORMAL-01\""));
+    assertTrue(report.toJson().contains("\"balanceBoundaryEvidenceState\": \"PROPOSED\""));
+    assertTrue(report.toJson().contains("\"pidApprovalStatus\": \"REVIEW_REQUIRED\""));
+    assertFalse(report.toJson().contains("\"fitnessForConstruction\": true"));
+    assertEquals(classicDot, process.toDOT());
+  }
+
+  @Test
+  void isDeterministicAcrossFreshExecutedPlants() throws IOException {
+    EngineeringDiagramReferenceFixtures.SystemCase firstReference = completeBoundaryCase();
+    EngineeringDiagramReferenceFixtures.SystemCase secondReference = completeBoundaryCase();
+
+    EngineeringDiagramDualProfileDelivery.Report first = EngineeringDiagramDualProfileDelivery.deliver(
+        firstReference.getProcessSystem(), temporaryDirectory.resolve("first"), request(firstReference));
+    EngineeringDiagramDualProfileDelivery.Report second = EngineeringDiagramDualProfileDelivery.deliver(
+        secondReference.getProcessSystem(), temporaryDirectory.resolve("second"), request(secondReference));
+
+    assertEquals(first.toJson(), second.toJson());
+    assertArrayEquals(Files.readAllBytes(first.getDirectory().resolve("stream-table.json")),
+        Files.readAllBytes(second.getDirectory().resolve("stream-table.json")));
+    assertArrayEquals(Files.readAllBytes(first.getDirectory().resolve("balance-table.json")),
+        Files.readAllBytes(second.getDirectory().resolve("balance-table.json")));
+    assertArrayEquals(Files.readAllBytes(first.getDirectory().resolve("pid/dexpi-plant-2.0.xml")),
+        Files.readAllBytes(second.getDirectory().resolve("pid/dexpi-plant-2.0.xml")));
+    assertArrayEquals(Files.readAllBytes(first.getDirectory().resolve("pid/proteus-4.1.xml")),
+        Files.readAllBytes(second.getDirectory().resolve("pid/proteus-4.1.xml")));
+  }
+
+  @Test
+  void failsClosedForMissingOperatingEvidenceOrUnknownBoundary() {
+    EngineeringDiagramReferenceFixtures.SystemCase unexecuted = EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramDualProfileDelivery.Request missingCase = EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
+        .operatingCaseId("NORMAL-01")
+        .balanceBoundaries(Arrays.asList(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
+            unexecuted.getFeed().getName(), Direction.INLET, "project-balance-register:test",
+            EvidenceState.PROPOSED)))
+        .build();
+
+    assertThrows(IOException.class, () -> EngineeringDiagramDualProfileDelivery.deliver(
+        unexecuted.getProcessSystem(), temporaryDirectory.resolve("missing-case"), missingCase));
+    assertFalse(Files.exists(temporaryDirectory.resolve("missing-case")));
+
+    EngineeringDiagramReferenceFixtures.SystemCase executed = completeBoundaryCase();
+    EngineeringDiagramDualProfileDelivery.Request unknownBoundary = EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
+        .operatingCaseId("NORMAL-01")
+        .balanceBoundaries(Arrays.asList(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
+            "ABSENT-STREAM", Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED)))
+        .build();
+    assertThrows(IOException.class, () -> EngineeringDiagramDualProfileDelivery.deliver(
+        executed.getProcessSystem(), temporaryDirectory.resolve("unknown-boundary"), unknownBoundary));
+    assertFalse(Files.exists(temporaryDirectory.resolve("unknown-boundary")));
+  }
+
+  @Test
+  void companionRequestRequiresAnOperatingCaseAndBoundaries() {
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDualProfileDelivery.Request
+            .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
+            .balanceBoundaries(Arrays.asList(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
+                "10-FEED-001", Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED)))
+            .build());
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDualProfileDelivery.Request
+            .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
+            .operatingCaseId("NORMAL-01").balanceBoundaries(new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>())
+            .build());
+  }
+
+  private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    for (StreamInterface product : reference.getProducts()) {
+      reference.getProcessSystem().add(product);
+    }
+    reference.getProcessSystem().run();
+    return reference;
+  }
+
+  private static EngineeringDiagramDualProfileDelivery.Request request(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    List<EngineeringDiagramDualProfileDelivery.BalanceBoundary> boundaries =
+        new ArrayList<EngineeringDiagramDualProfileDelivery.BalanceBoundary>();
+    boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10",
+        reference.getFeed().getName(), Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    for (StreamInterface product : reference.getProducts()) {
+      boundaries.add(new EngineeringDiagramDualProfileDelivery.BalanceBoundary("BAL-PLANT-10", product.getName(),
+          Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    }
+    return EngineeringDiagramDualProfileDelivery.Request
+        .builder("PLANT-10", "A", "PFD-10-001", "PID-10-001", "Separation and compression")
+        .operatingCaseId("NORMAL-01").balanceBoundaries(boundaries).build();
+  }
+}


### PR DESCRIPTION
## Summary

Advances the user-prioritized `comparesimulations2.ipynb` PFD/P&ID milestone with a coherent companion-exchange prerequisite.

- publishes governed operating-case stream and balance tables from the same canonical PFD/P&ID source graph
- resolves explicit balance-boundary declarations by exact canonical stream label and fails closed on missing, ambiguous, or invalid evidence
- publishes a separately labelled native DEXPI 2.0 Plant P&ID proposal with its conformance assessment
- publishes a separately labelled Proteus 4.1 compatibility proposal with deterministic timestamp normalization
- preserves the child P&ID DEXPI Process artifact's companion-only identity
- preserves legacy requests, topology, simulation state, existing exporters, and Java 8 compatibility

## Engineering boundary

This does not deliver or qualify the final full-sheet notebook reference. It does not add the illustrated `24-VB-01`, which is absent from the runnable `getprocess()` model. The P&ID remains review-required, non-construction teaching output. No ISO/ISA conformance, DEXPI interoperability certification, safety credit, or engineering approval is claimed.

## Tests first

`EngineeringDiagramDualProfileCompanionDeliveryTest` covers:

- complete artifact and profile labels
- deterministic regeneration from fresh executed plants
- unchanged simulation DOT topology
- missing operating evidence
- unknown boundary labels and cleanup
- invalid operating-case/boundary contracts

## Validation

Hosted exact-head formatting, Java 8/21, documentation, static-analysis, performance, and reference workflows are pending on this draft.

Roadmaps: #1332, #2899.