### PR TITLE
[AI-Assisted] docs(twofluid): publish evidence envelope

### DIFF
--- a/.github/agents/flow.assurance.agent.md
+++ b/.github/agents/flow.assurance.agent.md
@@ -109,6 +109,16 @@ response schema. Gate the result on convergence, pressure-floor, and wall-clock
 findings, then apply the steady/transient limitations in the loaded
 `neqsim-flow-assurance` skill.
 
+Before routing a mechanistic steady or transient study, read
+`docs/process/twofluidpipe-evidence-matrix.md`. Distinguish implemented,
+numerically verified, experimentally qualified, failed, and unsupported rows.
+Do not route severe-slugging loads, slug statistics, default liquid-rich
+long-horizon dynamics, named-component reverse outlet inflow without an external
+composition, or unsupported multi-stage coupled phase appearance as qualified
+NeqSim work. Use a separately qualified simulator or controlled experiment for
+those cases, while preserving NeqSim fluids and boundary conditions for a
+traceable handoff.
+
 When a pipeline hydraulics/environment study feeds an explicit current `DNV-RP-F105 2025-12`
 basis, use `DnvRpF105FreeSpanScreeningKernel` for the simply supported first-mode and dimensionless
 screen. Do not infer effective mass, axial force, hydrodynamic diameter, or trigger values silently

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-09-05"
+last_verified: "2026-09-07"
 ---
 
 # Dynamic Simulation Guidance
@@ -423,6 +423,12 @@ requires the controlled context attribute `distributedTransientModel=approved`.
 
 ## TwoFluidPipe Phase Appearance and Disappearance
 
+Read the
+[TwoFluidPipe evidence matrix](../../../docs/process/twofluidpipe-evidence-matrix.md)
+before selecting a steady or transient configuration. It is the canonical
+distinction between implemented, numerically verified, experimentally qualified,
+failed, and unsupported behavior.
+
 When `TwoFluidPipe.setIncludeMassTransfer(true)` is enabled, flash-driven transfer is phase
 resolved. Condensation must use equilibrium hydrocarbon-liquid and aqueous-liquid **mass**
 contributions; never use the current cell water cut to identify a phase that is not yet present.
@@ -444,9 +450,18 @@ oil or water seeding. Check gas, oil, water, liquid, and total closure with
 `TwoFluidMassBalanceReport`; sweep nearby temperatures, refine time step and mesh, repeat the run,
 and compare rigorous flash with `FlashTable`. The flash table must retain the oil/aqueous liquid mass
 split. Record EOS, mixing rule, composition, absolute pressure, temperature, mass-transfer
-relaxation time, and units. The current hydrodynamic state transports bulk phase inventories, not a
-full component-composition vector per cell, and does not establish equivalence with any commercial
-transient multiphase simulator.
+relaxation time, and units. With named-component transport, freeze component source compositions
+and their partial-enthalpy latent source from the same RHS-stage equilibrium state as the
+hydrodynamic phase source. A disappearing phase uses its conserved donor composition for the
+property state; a receiving phase still uses only the equilibrium flash composition. Require
+phase, total, named-component, interphase, bounded-fraction, and latent-inclusive energy closure.
+
+The conservative Lagrangian slug/film + named-component + phase-transfer + thermal combination is
+currently verified only with single-stage Euler. Reject a multi-stage selection before mutation
+until intermediate phase appearance owns stage-local component inventories. Also reject signed
+outlet backflow with named-component transport unless a physical external outlet composition is
+configured; the last interior composition is not a valid inflow boundary. None of these numerical
+contracts establishes equivalence with a commercial transient multiphase simulator.
 
 ## TwoFluidPipe Regime-Transition Continuation
 
@@ -662,8 +677,10 @@ override unless it is classified or cites an explicit repository ADR. Custom/dow
 `UNCLASSIFIED_DYNAMIC` until reviewed. `isFullyAudited()` is an inventory signal only: it does not certify numerical
 stability, conservation, benchmark parity, controls performance, or safety suitability. In particular,
 `PipeBeggsAndBrills` has distributed profile state but no conservative line-pack/storage term; do not use its capability
-label to claim severe-slugging or liquid-rich transient validity. Route those studies to the qualified `TwoFluidPipe`
-path and apply the relevant numerical and public-benchmark gates.
+label to claim severe-slugging or liquid-rich transient validity. Use `TwoFluidPipe` only when the requested
+configuration fits a numerically verified or experimentally qualified evidence-matrix row. Route failed or unsupported
+severe-slugging, slug-statistics, and boundary-composition cases to a separately qualified model or controlled
+experimental study.
 
 1. **Always run steady state first**: Call `process.run()` before `runTransient()`
 2. **Timestep size**: Start with 1.0 s, reduce if oscillating (0.1-0.5 s)

--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-flow-assurance
 description: "Flow assurance analysis patterns for NeqSim. USE WHEN: predicting hydrate formation, wax appearance, asphaltene stability, CO2/H2S corrosion (NORSOK M-506, de Waard-Milliams, FeCO3 film), mineral scale (saturation index, scale kinetics, brine mixing / seawater incompatibility), scale/solids valve plugging & Cv/opening drift (ValveScaleDrift), scale/deposit remediation & dissolver/solvent/wash selection for cleaning fouled equipment (ScaleRemediationAdvisor), elemental sulfur (S8) deposition from oxygen ingress / H2S oxidation at pressure or temperature letdown (compressor inlets, valves, dry-gas seals, letdown stations), per-segment pipeline corrosion+scale profiles, inspected metal-loss screening, pipeline hydraulics, DNV-RP-F109 on-bottom stability screening, DNV-RP-F105 free-span screening, DNV-RP-F104 CO2-envelope screening, DNV-RP-F110 global-buckling response screening, DNV-RP-F114 pipe-soil screening, water/liquid hammer screening, slug flow, thermal analysis, or chemical inhibitor dosing. Covers all flow assurance threats with NeqSim code patterns and industry standards."
-last_verified: "2026-09-05"
+last_verified: "2026-09-07"
 ---
 
 # Flow Assurance Analysis with NeqSim
@@ -444,17 +444,14 @@ for (double qgMSm3d : gasRates) {
 > deviation against one is recorded here. Validate against experimental,
 > laboratory or field data, or against an analytic/first-principles check.
 
-> **`TwoFluidPipe` steady-state usage.** The refinement loop needs a few hundred
-> sweeps to settle the pressure profile against the updated section densities
-> (74 km at 160 sections ≈ 25 s, at 320 sections ≈ 60 s). Always
-> `assert pipe.isSteadyStateConverged()` **and** check
-> `pipe.getSteadyStateIterationsUsed() > 1` — a result reported after one sweep
-> still carries the densities the sections were initialised with and understates
-> the pressure drop of a gas line by roughly ten per cent. Around 160 sections
-> (≈450 m) is the sweet spot on a long transmission line: it converges reliably
-> and is grid-converged to 0.4% against 320 sections. Raise
-> `setSteadyStateMaxWallClockTime(...)` (default 300 s) before blaming the model
-> if `isSteadyStateWallClockLimited()` is true.
+> **`TwoFluidPipe` steady-state usage.** Gate every result on the complete
+> immutable `SteadyStateConvergenceReport`, not a stationary pressure trace or
+> iteration count. Require `isConverged()`, inspect the explicit termination
+> reason, and retain pressure-momentum, pressure-update, total-liquid-holdup,
+> water/oil-split, thermodynamic-property, and total-pressure-drop residuals
+> against the report's unchanged tolerance. Pressure-floor and wall-clock
+> termination are non-converged. Repeat mesh sensitivity for the actual
+> geometry; no fixed cell length is universally qualified.
 
 > **MCP `runPipeline` solver and response handoff.** Omit `solver` (or use
 > `beggsBrill`) for the established correlation path. Use `solver: "twoFluid"`
@@ -500,13 +497,14 @@ for (double qgMSm3d : gasRates) {
 > energy equation feeds the momentum balance. Grid-converged (160 vs 320 sections
 > within 0.4%). Terrain response is solved, not tuned: the annular film balance
 > carries `tau_i = tau_wL + rhoL*g*sin(theta)*delta`, so holdup responds to
-> inclination and scales with `sin(theta)`. Still open: **the three-phase
-> free-water case does not converge** — 15 m3/hr of free water on the same line is
-> wall-clock limited after 4078 iterations at a 1200 s budget. ΔP is identical
-> between a 300 s and a 1200 s budget, so the profile is stationary and the
-> criterion is stalling on the three-phase liquid split — but
-> `isSteadyStateConverged()` is false, so the number must not be quoted. ALWAYS
-> check it on a water-bearing line.
+> inclination and scales with `sin(theta)`. The compact public 3 km,
+> 10-degree uphill gas/oil/water fixture now converges on 30 and 60 cells, with
+> 0.538% arrival-pressure and 0.983% mean-liquid-holdup sensitivity and every
+> final report residual below `1e-4`. This is numerical verification, not
+> experimental qualification. The historical 73.8 km / 15 m3/hr free-water
+> input is unavailable, so the earlier 4,078-iteration / 1,200 s report cannot
+> be reproduced or claimed fixed. Never generalize the compact result to that
+> unavailable case.
 
 > **`TwoFluidPipe` also fails silently when a line has no deliverability.** The
 > marching solver clamps section pressure at a 1 bara floor; that clamp is a
@@ -557,10 +555,12 @@ for (double qgMSm3d : gasRates) {
 > stratified flow because its perimeters come from a circular-segment layer; annular flow,
 > whose film wets the whole perimeter, is not that geometry.
 
-> **Measured accuracy on the 73.8 km reference line**, across a threefold rate range:
-> ΔP +1.4 / +1.6 / +0.1 / −2.7 % and maximum holdup −2.4 / −7.1 / −6.6 / +3.5 % at
-> 4 / 7 / 10 / 12 MSm3/d, all converged and grid-converged. The earlier defaults gave
-> ΔP +5.7 / +5.6 / +1.4 / −0.0 % and holdup −25.5 / −18.6 / −6.2 / +3.3 %.
+> **The historical 73.8 km comparison is not a public qualification basis.**
+> Its complete input and measurement package is unavailable in the repository,
+> so earlier reported pressure-drop and holdup deviations are retained only as
+> repair history. Do not route or certify a study from those values. Use the
+> reproducible public evidence and explicit failed/unsupported rows in the
+> TwoFluidPipe evidence matrix.
 
 > **Direct electrical heating (DEH)** is available on both models with the same
 > convention — the power set is what reaches the fluid, so cable and coating
@@ -581,6 +581,17 @@ for (double qgMSm3d : gasRates) {
 > trajectory from either a small residual or a completed time loop alone. Use the
 > analytical `SevereSluggingBenchmarkHarnessTest` screen and the public Tengesdal
 > evidence until the dynamic qualification gates below pass.
+>
+> **Coupled component/phase/thermal slug transport has a narrower envelope.**
+> For the conservative Lagrangian slug/film path, named-component phase sources
+> and their partial-enthalpy latent source must be frozen from the same
+> hydrodynamic RHS-stage equilibrium state. The Stage 4 closed wet-gas regression
+> verifies phase, total, component, interphase, and thermal ledgers around a
+> seeded in-domain marker. It is single-stage Euler evidence only. Multi-stage
+> phase appearance needs stage-local component inventories and fails before
+> mutation; named-component transport with signed outlet backflow likewise fails
+> unless a physical external outlet composition is supplied. Never infer that
+> composition from the last interior cell.
 >
 > **The coupled route is an opt-in four-part configuration.** For a pressure
 > outlet that physically permits phase fallback, use
@@ -949,28 +960,29 @@ dominates the heat capacity — do not assume a large drop.
 
 ### Choosing the multiphase model for a transport check
 
-Verified on a 6" water-continuous line (17 bara, 83 mol% water) against
-OLGA 2025.1.0 on an identical fluid, geometry and mass flow:
+Start with the
+[TwoFluidPipe evidence matrix](../../../docs/process/twofluidpipe-evidence-matrix.md).
+It separates implemented, numerically verified, experimentally qualified, failed,
+and unsupported configurations. Do not route from a finite profile or a private
+commercial-simulator comparison.
 
-| model | H_L | u_L [m/s] | slip |
-|---|---|---|---|
-| `PipeBeggsAndBrills` | 0.325 | 1.141 | 2.28 |
-| `TwoFluidPipe` | 0.407 | 0.913 | 3.24 |
-| OLGA 2025.1.0 | 0.407 | 0.916 | 3.32 |
-
-- `TwoFluidPipe` reproduced OLGA to **0.2% on both hold-up and liquid velocity**.
-- **Beggs & Brill is non-conservative for sand transport**: it under-predicts
-  hold-up ~20%, so it over-predicts the sand-carrying `u_L` ~25% and inflates the
-  margin. Prefer `TwoFluidPipe` (or OLGA) for water-continuous transport checks;
-  use B&B for a quick pressure-drop screen only.
-- **Gate on convergence.** `TwoFluidPipe` converged in 6 iterations at the above
-  duty but failed (399 iterations) at a slower, more liquid-loaded slug condition.
-  Always assert `isSteadyStateConverged()` and exclude the result if it is False —
-  never quote an unconverged two-fluid number.
-- Do not over-constrain `setOutletPressure` with a measured dP the modelled
-  geometry cannot produce; that alone can break convergence. If the measured drop
-  is much larger than the predicted pipe friction, the difference is manifold
-  valves and fittings, not the line.
+- Use `PipeBeggsAndBrills` for a correlation-based steady or quasi-steady
+  pressure-drop screen. It has no conservative distributed line-pack inventory,
+  so it is not evidence for transient liquid accumulation or severe slugging.
+- Use `TwoFluidPipe` when section-resolved phase momentum, holdup, inventory,
+  thermal, or transient diagnostics are required **and** the requested
+  configuration fits a verified matrix row.
+- The public Mohmmed air/water slug comparison currently fails qualification:
+  the baseline passes 3/9 fixed gates with MARE 1.0402, and the 40/80-cell plus
+  0.05/0.025 s sweep is non-monotone. Do not replace that evidence with a looser
+  physical bound or a proprietary trace.
+- Gate every steady result on the complete convergence report and every transient
+  on requested elapsed time, conservation, positivity, refinement, and all
+  applicable sticky solver/boundary diagnostics. Exclude a failed or unsupported
+  row instead of quoting it.
+- Do not over-constrain `setOutletPressure` with a measured pressure drop the
+  modelled geometry cannot produce. Investigate valves, fittings, elevations, and
+  boundary consistency separately.
 
 ### Mineral Scale (thermodynamics + kinetics + brine mixing)
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -7,10 +7,16 @@ description: The NeqSim `TwoFluidPipe` model implements a transient multiphase-f
 
 ## Release scope and current validation
 
-The phase-consistency repairs in PR #3514 correct steady/transient thermodynamic
-updates, conservative accumulation observation, integrated closure forces, and
-three-phase hydraulic viscosity consistency. They do not establish general
-experimental accuracy for multiphase transients.
+The canonical status vocabulary, row-by-row evidence, executable example, and
+supported-use boundary are maintained in the
+[TwoFluidPipe Evidence Matrix and Supported Envelope](twofluidpipe-evidence-matrix).
+Use that matrix before selecting a configuration; implementation, numerical
+verification, and public experimental qualification are different claims.
+
+The evidence chain in merged PRs #3514, #3541, #3543, and #3547 covers
+steady/transient consistency, public benchmark reporting, three-phase steady
+convergence, and coupled component/phase/thermal ledgers. It does not establish
+general experimental accuracy for multiphase transients.
 
 | Configuration | Current evidence | Release interpretation |
 |---|---|---|
@@ -31,14 +37,16 @@ the unchanged 68.6 kPa lower bound; the unchanged liquid-trough detector finds n
 completed cycle intervals, and pressure limits still activate. Do not use these
 results as qualification of slug loads or extreme pressure transients.
 
-Implementation evidence at commit `bfd3bb0`: 153 selected tests passed, two existing
-tests skipped, and no failures. These local checks do not replace the full CI
-matrix on the final release candidate. Release inclusion requires successful
-required checks and review; an open draft PR is not an available released feature.
+The public Mohmmed slug-kinematics sweep remains experimentally unqualified:
+its baseline passes 3/9 fixed gates and its mesh/time-step refinement is
+non-monotone. The compact uphill gas/oil/water case is numerically verified on
+30 and 60 cells, but the historical 73.8 km free-water input is unavailable and
+is not covered. The coupled component/phase/thermal case is a closed, seeded
+marker conservation test; it does not qualify spontaneous or sustained slugging.
 
 Later sections preserve earlier measurements to explain the repair history.
 Read those results with their stated configuration and revision; they are not
-additional claims about the current defaults.
+additional claims about the current defaults or released experimental accuracy.
 
 ## Overview
 

--- a/docs/process/twofluidpipe-evidence-matrix.md
+++ b/docs/process/twofluidpipe-evidence-matrix.md
@@ -1,0 +1,120 @@
+---
+title: TwoFluidPipe Evidence Matrix and Supported Envelope
+description: Evidence levels, supported operating envelope, executable examples, and explicit limitations for steady and transient TwoFluidPipe use.
+---
+
+# TwoFluidPipe Evidence Matrix and Supported Envelope
+
+This page is the qualification boundary for **TwoFluidPipe**. It separates available code from
+numerical verification and public experimental qualification. A completed calculation, finite
+profile, small pressure change, or stationary pressure trace is not by itself evidence that the
+model converged or represents the requested physics.
+
+## Evidence labels
+
+| Label | Meaning |
+|---|---|
+| **Implemented** | The public configuration and runtime path exist. This says nothing about convergence or accuracy. |
+| **Numerically verified** | An executable test checks relevant conservation, convergence, boundedness, sensitivity, or refinement contracts. |
+| **Experimentally qualified** | A reproducible public measured-data comparison passes its declared error gates, with source provenance and uncertainty or acceptance definitions. |
+| **Not qualified** | A required numerical or experimental gate fails, is unavailable, or has not been run. The result must not be promoted by loosening the gate. |
+| **Unsupported** | The configuration is rejected because the governing boundary or state information is missing. |
+
+## Current evidence matrix
+
+| Capability and configuration | Implemented | Numerically verified | Experimentally qualified | Evidence and use boundary |
+|---|---:|---:|---:|---|
+| Positive-flow steady gas/liquid pressure, holdup, thermal and terrain profiles | Yes | Yes | No general claim | Require the complete steady convergence report to be converged, every residual below its recorded tolerance, and no pressure-floor or wall-clock termination. Repeat mesh sensitivity for the actual geometry. |
+| Steady gas/oil/water on the compact 3 km, 10-degree uphill fixture | Yes | Yes | No | The 30/60-cell results differ by 0.538% in arrival pressure and 0.983% in mean liquid holdup. All three phases remain present and the final thermodynamic/holdup reconciliation is inside the unchanged 1e-4 tolerance. The unavailable historical 73.8 km case is not covered. |
+| Liquid-rich unchanged-boundary transient with shared slug force balance, interfacial pressure, and coupled pressure/momentum | Opt-in | Yes | Not applicable | Over 1,800 s, inventory drift is 1.323% at 40 cells and 1.358% at 80 cells, below the declared 2% fixture gate, with total-mass closure. This does not qualify slug loads or another operating envelope. |
+| Default liquid-rich unchanged-boundary transient | Yes | No | No | The recorded 1,800 s inventory drift is 5.757%, above the unchanged 5% gate. Do not infer default-mode qualification from the opt-in shared-force result. |
+| Mohmmed et al. public horizontal air/water slug kinematics | Harness and data implemented | Conservation only | **Failed** | At 40 cells and 0.05 s outer steps, 3/9 comparisons pass, MARE is 1.0402, and maximum absolute relative error is 3.2147. The 40/80-cell and 0.05/0.025 s sweep is non-monotone; steady starts are unconverged and pressure-floor limited and transients clamp outlet backflow. The fixed 20% speed and 30% length/frequency gates remain unchanged. |
+| Conservative severe-slugging characterization against the public Tengesdal envelope | Opt-in | Partial characterization | **Failed** | The 600 s run completes, but its 65.163 kPa pressure amplitude is below the 68.6 kPa lower gate, no required repeated settled cycle is detected, and pressure limiting remains active. It is not a slug-load or extreme-pressure design basis. |
+| Flash-driven phase appearance/disappearance with phase and energy ledgers | Yes | Yes | No | Check gas/oil/water and total mass, transfer closure, temperature sensitivity, and latent-inclusive energy balance. Record EOS, mixing rule, composition, pressure, temperature, relaxation time, mesh, and time step. |
+| Named-component advection for supported positive-flow boundaries | Yes | Yes | No | Require every named-component ledger, bounded normalized phase fractions, phase/component synchronization, and component-sum closure. |
+| Conservative slug/film + named components + phase transfer + thermal balance | Yes | Yes | No | Merged in #3547. A closed four-cell wet-gas cooling case transfers 1.5855002575e-9 kg of water, records 0.0034892651 J latent heat and -0.0305006304 K mean temperature change on both outer-step partitions, while a seeded marker preserves accepted-time geometry. This is coupled-ledger evidence, not spontaneous slug initiation. |
+| Reverse outlet inflow with named-component transport and no external composition | **Unsupported** | Fail-closed | No | Configuration is rejected in either setter order. The last interior composition is not a physical external boundary condition. |
+| Multi-stage conservative slug + component + phase-transfer coupling | **Unsupported** | Fail-closed | No | Phase appearance inside an intermediate stage needs stage-local component inventories. The coupled four-way path is currently restricted to single-stage Euler. |
+
+The Mohmmed source provenance, exact spreadsheet cells, point selection, missing-data policy, and
+error definitions are maintained in
+[TwoFluidPipe Reporting and Validation](../wiki/two_fluid_reporting_and_validation). Those fixed
+engineering gates are not claimed as measurement confidence intervals; the paper does not publish
+pointwise uncertainty intervals for the selected observations.
+
+## Supported-use envelope
+
+Use **TwoFluidPipe** only when the case fits a row above and its runtime evidence is retained:
+
+1. Run steady initialization and inspect the complete immutable convergence report. A stationary
+   pressure profile is insufficient if liquid split, holdup, thermodynamics, or total pressure drop
+   remains outside tolerance.
+2. For transient work, require requested elapsed time, phase and total mass balances, positivity,
+   and all sticky pressure/momentum, pressure-limiter, rejected-substep, outlet-backflow, component,
+   and energy diagnostics applicable to the selected configuration.
+3. Repeat mesh and time-step sensitivity at the actual length, diameter, inclination, composition,
+   phase split, thermal boundary, rates, and event duration. Evidence from one fixture does not
+   define a universal operating envelope.
+4. Treat seeded slug markers as transport/coupling probes. They do not demonstrate spontaneous
+   slug initiation, sustained cycles, arrival statistics, or load distributions.
+5. Use **PipeBeggsAndBrills** for a correlation-based steady or quasi-steady screen, not for
+   conservative distributed line-pack dynamics. Use a separately qualified transient model or a
+   controlled experimental study when the requested TwoFluidPipe row is failed or unsupported.
+
+## Executable steady and transient example
+
+The executable **TwoFluidPipeEvidenceExampleTest** in
+src/test/java/neqsim/process/equipment/pipeline runs a 5 km,
+0.30 m liquid-rich gas-condensate line at 50 kg/s, 60 bara and 50 degrees Celsius. It enables the
+opt-in shared slug force balance, interfacial pressure, and coupled pressure/momentum before steady
+initialization. The same object then advances ten one-second outer steps with unchanged boundaries.
+
+The example fails unless:
+
+- the complete steady report is converged without pressure-floor or wall-clock termination;
+- the transient accepts exactly 10 s;
+- maximum relative total-mass residual is at most 1e-10;
+- inventory and outlet-pressure drift are each at most 2%;
+- no outlet clamp, nonlinear failure, pressure-correction limiter, or rejected substep occurs.
+
+Execute it from the repository root:
+
+~~~bash
+./mvnw -q -Dtest=TwoFluidPipeEvidenceExampleTest test
+~~~
+
+The exact Stage 5 execution values and source/head commit are recorded in the Stage 5 pull request
+and the issue #3298 series ledger. These values are reproducibility evidence for the example, not
+experimental qualification.
+
+The prepared local execution on master
+`5bb230e1c2e2227074ce4d20ec19d6be91b53ec7` produced:
+
+| Quantity | Result |
+|---|---:|
+| Steady termination / iterations / tolerance | CONVERGED / 16 / 1e-4 |
+| Steady outlet pressure | 57.62005697 bara |
+| Initial mean liquid holdup | 0.269435835 |
+| Initial total inventory | 72,424.765816 kg |
+| Accepted transient duration | 10.0 s |
+| Maximum total-mass residual | 1.92344e-11 kg |
+| Maximum relative total-mass residual | 2.65574e-16 |
+| Inventory drift | 0.00977583% |
+| Outlet-pressure drift | 0.0% |
+| Final mean liquid holdup | 0.269473910 |
+
+The Stage 5 pull request and issue ledger bind these values to the final evidence-only head.
+
+## Decision record
+
+The five-stage evidence chain is recorded in issue
+[#3298](https://github.com/equinor/neqsim/issues/3298):
+
+- #3514: steady-to-transient consistency and the opt-in liquid-rich drift result;
+- #3541: public Mohmmed benchmark reporting and failed qualification;
+- #3543: honest three-phase steady convergence residuals and compact refinement evidence;
+- #3547: merged coupled slug/component/phase/thermal ledgers and fail-closed unsupported combinations;
+- the Stage 5 PR: this evidence matrix, executable example, and agent/skill routing.
+
+Open or draft work is not a released capability. Confirm the target release contains the referenced
+implementation before using its row.

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -7,10 +7,16 @@ description: "This document describes the two-fluid model implementation in NeqS
 
 ## Release scope and current validation
 
-The phase-consistency repairs in PR #3514 correct steady/transient thermodynamic
-updates, conservative accumulation observation, integrated closure forces, and
-three-phase hydraulic viscosity consistency. They do not establish general
-experimental accuracy for multiphase transients.
+The canonical status vocabulary, row-by-row evidence, executable example, and
+supported-use boundary are maintained in the
+[TwoFluidPipe Evidence Matrix and Supported Envelope](../process/twofluidpipe-evidence-matrix).
+Use that matrix before selecting a configuration; implementation, numerical
+verification, and public experimental qualification are different claims.
+
+The evidence chain in merged PRs #3514, #3541, #3543, and #3547 covers
+steady/transient consistency, public benchmark reporting, three-phase steady
+convergence, and coupled component/phase/thermal ledgers. It does not establish
+general experimental accuracy for multiphase transients.
 
 | Configuration | Current evidence | Release interpretation |
 |---|---|---|
@@ -31,14 +37,16 @@ the unchanged 68.6 kPa lower bound; the unchanged liquid-trough detector finds n
 completed cycle intervals, and pressure limits still activate. Do not use these
 results as qualification of slug loads or extreme pressure transients.
 
-Implementation evidence at commit `bfd3bb0`: 153 selected tests passed, two existing
-tests skipped, and no failures. These local checks do not replace the full CI
-matrix on the final release candidate. Release inclusion requires successful
-required checks and review; an open draft PR is not an available released feature.
+The public Mohmmed slug-kinematics sweep remains experimentally unqualified:
+its baseline passes 3/9 fixed gates and its mesh/time-step refinement is
+non-monotone. The compact uphill gas/oil/water case is numerically verified on
+30 and 60 cells, but the historical 73.8 km free-water input is unavailable and
+is not covered. The coupled component/phase/thermal case is a closed, seeded
+marker conservation test; it does not qualify spontaneous or sustained slugging.
 
 Later sections preserve earlier measurements to explain the repair history.
 Read those results with their stated configuration and revision; they are not
-additional claims about the current defaults.
+additional claims about the current defaults or released experimental accuracy.
 
 This document describes the two-fluid model implementation in NeqSim for transient multiphase pipeline simulation.
 

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeEvidenceExampleTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeEvidenceExampleTest.java
@@ -1,0 +1,131 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Executable steady-to-transient TwoFluidPipe evidence example with explicit numerical gates.
+ *
+ * <p>
+ * The example is a deterministic liquid-rich gas-condensate line. It reports the complete steady convergence decision,
+ * advances ten seconds with unchanged boundaries, and rejects a transient that violates total-mass conservation, the
+ * validated two-percent inventory-drift screen, or the coupled-solver diagnostics. It is numerical evidence for this
+ * configured case, not experimental qualification of general liquid-rich or severe-slugging flow.
+ * </p>
+ */
+class TwoFluidPipeEvidenceExampleTest {
+  private static final Logger logger = LogManager.getLogger(TwoFluidPipeEvidenceExampleTest.class);
+  private static final double TRANSIENT_DURATION_SECONDS = 10.0;
+  private static final double OUTER_STEP_SECONDS = 1.0;
+
+  @Test
+  @Timeout(value = 3, unit = TimeUnit.MINUTES)
+  void runSteadyAndUnchangedBoundaryTransientEvidenceChain() {
+    TwoFluidPipe pipe = createPipe();
+    pipe.run();
+
+    SteadyStateConvergenceReport steady = pipe.getSteadyStateConvergenceReport();
+    assertTrue(steady.isConverged(), "Steady solve stopped with " + steady.getTerminationReason());
+    assertFalse(pipe.isSteadyStatePressureFloorLimited());
+    assertFalse(pipe.isSteadyStateWallClockLimited());
+
+    double initialInventoryKg = pipe.getTotalMassInventory();
+    double initialOutletPressurePa = last(pipe.getPressureProfile());
+    double initialMeanLiquidHoldup = mean(pipe.getLiquidHoldupProfile());
+
+    double maximumTotalMassResidualKg = 0.0;
+    double maximumTotalMassRelativeResidual = 0.0;
+    int numberOfSteps = (int) Math.round(TRANSIENT_DURATION_SECONDS / OUTER_STEP_SECONDS);
+    for (int step = 0; step < numberOfSteps; step++) {
+      pipe.runTransient(OUTER_STEP_SECONDS, UUID.randomUUID());
+      TwoFluidMassBalanceReport massBalance = pipe.getLastMassBalanceReport();
+      maximumTotalMassResidualKg = Math.max(maximumTotalMassResidualKg,
+          Math.abs(massBalance.getResidualKg(Phase.TOTAL)));
+      maximumTotalMassRelativeResidual = Math.max(maximumTotalMassRelativeResidual,
+          massBalance.getRelativeResidual(Phase.TOTAL));
+    }
+
+    double finalInventoryKg = pipe.getTotalMassInventory();
+    double finalOutletPressurePa = last(pipe.getPressureProfile());
+    double finalMeanLiquidHoldup = mean(pipe.getLiquidHoldupProfile());
+    double inventoryDrift = Math.abs(finalInventoryKg - initialInventoryKg) / initialInventoryKg;
+    double outletPressureDrift = Math.abs(finalOutletPressurePa - initialOutletPressurePa) / initialOutletPressurePa;
+
+    assertEquals(TRANSIENT_DURATION_SECONDS, pipe.getSimulationTime(), 1.0e-10);
+    assertTrue(maximumTotalMassRelativeResidual <= 1.0e-10,
+        "Total-mass relative residual was " + maximumTotalMassRelativeResidual);
+    assertTrue(inventoryDrift <= 0.02, "Inventory drift was " + inventoryDrift);
+    assertTrue(outletPressureDrift <= 0.02, "Outlet-pressure drift was " + outletPressureDrift);
+    assertFalse(pipe.isTransientOutletBackflowClamped());
+    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected());
+    assertFalse(pipe.isTransientCoupledPressureMomentumCorrectionLimited());
+    assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
+
+    logger.info(
+        "Steady evidence: termination={}, iterations={}, tolerance={}, outletPressureBar={}, "
+            + "meanLiquidHoldup={}, inventoryKg={}",
+        steady.getTerminationReason(), steady.getIterations(), steady.getTolerance(), initialOutletPressurePa / 1.0e5,
+        initialMeanLiquidHoldup, initialInventoryKg);
+    logger.info(
+        "Transient evidence: durationSeconds={}, maximumTotalMassResidualKg={}, "
+            + "maximumTotalMassRelativeResidual={}, inventoryDriftPercent={}, "
+            + "outletPressureDriftPercent={}, finalMeanLiquidHoldup={}",
+        pipe.getSimulationTime(), maximumTotalMassResidualKg, maximumTotalMassRelativeResidual, 100.0 * inventoryDrift,
+        100.0 * outletPressureDrift, finalMeanLiquidHoldup);
+  }
+
+  private static TwoFluidPipe createPipe() {
+    SystemInterface fluid = new SystemSrkEos(323.15, 60.0);
+    fluid.addComponent("methane", 60.0);
+    fluid.addComponent("ethane", 5.0);
+    fluid.addComponent("propane", 3.0);
+    fluid.addComponent("n-heptane", 20.0);
+    fluid.addComponent("nC10", 12.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream feed = new Stream("evidence feed", fluid);
+    feed.setFlowRate(50.0, "kg/sec");
+    feed.setTemperature(50.0, "C");
+    feed.setPressure(60.0, "bara");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("evidence pipe", feed);
+    pipe.setLength(5000.0);
+    pipe.setDiameter(0.30);
+    pipe.setNumberOfSections(20);
+    pipe.setCflNumber(0.5);
+    pipe.setElevationProfile(new double[20]);
+    pipe.setHeatTransferCoefficient(5.0);
+    pipe.setSurfaceTemperature(4.0, "C");
+    pipe.setSteadyStateMaxWallClockTime(120.0);
+    pipe.setSharedSlugForceBalanceEnabled(true);
+    pipe.setEnableInterfacialPressure(true);
+    pipe.setEnableCoupledPressureMomentum(true);
+    return pipe;
+  }
+
+  private static double last(double[] values) {
+    return values[values.length - 1];
+  }
+
+  private static double mean(double[] values) {
+    double sum = 0.0;
+    for (double value : values) {
+      sum += value;
+    }
+    return sum / values.length;
+  }
+}


### PR DESCRIPTION
## Summary

Completes Stage 5/5 of the bounded TwoFluidPipe steady/dynamic improvement series tracked in #3298.

- publishes one evidence matrix with explicit `implemented`, `numerically verified`, `experimentally qualified`, `failed`, and `unsupported` labels;
- reconciles both TwoFluidPipe references with the merged Stage 1–4 evidence and their limits;
- updates the dynamic-simulation and flow-assurance skills plus flow-assurance routing so failed or unsupported cases are not presented as qualified;
- adds a CI-executed steady-to-dynamic example with unchanged boundaries, mass closure, inventory drift, pressure drift, positivity, and convergence assertions.

No production equation, default, tolerance, proprietary trace, or benchmark datum changes.

## Capability boundary

The documentation deliberately preserves these negative results:

- the public Mohmmed et al. holdup benchmark is **not experimentally qualified**: baseline 40-cell/0.05 s MARE 1.0402, 3/9 points within declared uncertainty, maximum absolute relative error 3.2147;
- the default liquid-rich 1,800 s case remains **failed** at 5.757% inventory drift; the opt-in shared closure achieved 1.323% (40 cells) and 1.358% (80 cells);
- the active severe-slugging amplitude remains **failed/unqualified** at 65.163 kPa versus the 68.6 kPa lower bound;
- the compact gas/oil/water uphill case is numerically verified, while the historical 73.8 km case is not qualified;
- four-way slug/component/phase/thermal coupling is verified only for the merged seeded, closed, Euler case;
- named-component transport with reverse outlet inflow and multistage four-way coupling remain unsupported and fail before state mutation.

## Executable evidence example

`TwoFluidPipeEvidenceExampleTest` uses a 5 km, 0.30 m gas-condensate pipe with 20 sections and then advances ten one-second unchanged-boundary transient steps.

Exact base execution produced:

- steady termination: `CONVERGED`, 16 iterations, tolerance `1e-4`;
- initial outlet pressure: 57.6200569682 bara;
- initial mean liquid holdup: 0.2694358346;
- initial inventory: 72,424.765816 kg;
- maximum total-mass residual: 1.92344e-11 kg;
- maximum relative residual: 2.65574e-16;
- ten-second inventory drift: 0.0097758%;
- outlet-pressure drift: 0.0%;
- no outlet-backflow clamp, coupled-pressure failure, correction-limit hit, or rejected substep.

## Validation

Base: `5bb230e1c2e2227074ce4d20ec19d6be91b53ec7`  
Head: `99c1bef1960b9c23929dae39658be64ba3e4c985`

Maven was prepared with the repository helper from the `work-with-neqsim` skill.

```text
python devtools/run_spotless.py apply
python devtools/run_spotless.py check
./mvnw -q -DskipTests compile
./mvnw -q -Dtest=TwoFluidPipeEvidenceExampleTest,TwoFluidPipeSteadyStateConvergenceTest,TwoFluidPipeThreePhaseConvergenceReportTest,TwoFluidPipeThreePhaseConservationTest test
python devtools/check_documentation_search.py
git diff --check -- <seven intended paths>
```

Results: compile passed; 14 tests passed with 0 failures, errors, or skips; Spotless passed; documentation search audited 691 Markdown pages and one standalone HTML page; intended-path whitespace check passed.

The local image does not provide `pre-commit` or `pomJava8.xml`; hosted exact-head CI remains authoritative for those gates. An attempted pre-existing standalone-documentation compilation check exposed the current-master `FlowRegimeDetectionExample.java` logging mismatch; this PR neither changes that example nor weakens its test.

## Documentation impact

Updated. This PR centralizes the supported envelope and routes users to a separately qualified model or controlled experiment when the requested behavior is failed or unsupported.

Series predecessors: #3514, #3541, #3543, #3547. Existing #3493 remains outside this five-PR series.