### PR TITLE
[AI-Assisted] feat(pitzer): enforce independent grouped validation

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -711,6 +711,22 @@ laboratory-grouped validation split. The reserved Al Ghafri/NIST ThermoML
 pressure series must not be supplied as calibration input when it is retained
 as the campaign hold-out.
 
+### Independent source-group holdout validation
+
+`PitzerBinaryVolumetricGroupedValidation` fits only an explicit calibration
+list and evaluates a separate untouched holdout list. It rejects any
+source-lineage identifier present in both lists, reports holdout chi-square,
+weighted RMS and maximum standardized residual, and returns deterministic
+per-lineage diagnostics. The class deliberately defines no universal pass
+threshold.
+
+The string identifiers are an auditable software boundary, not proof of
+scientific independence. The caller must map each row to its real laboratory,
+apparatus, publication lineage and reuse history before assigning groups. A
+validation result is admissible only when those lineages are genuinely
+independent, all rows and uncertainties have qualified provenance, and the
+acceptance limits were fixed before the holdout was evaluated.
+
 ### Qualification boundary
 
 - The caller owns coefficient provenance and must keep calibration and
@@ -989,6 +1005,7 @@ component.setCostaldCharacteristicVolume(newValue);  // cm³/mol
 | `calculateIonicStrength(...)` | Return the binary salt's stoichiometric ionic strength |
 | `PitzerBinaryVolumetricRegression.fit(...)` | Fit caller-supplied one-state observations with SVD rank checks |
 | `FitResult.getGroupStatistics()` | Inspect residuals by laboratory or source lineage |
+| `PitzerBinaryVolumetricGroupedValidation.validate(...)` | Fit one lineage set and evaluate a disjoint untouched holdout |
 
 These methods do not install a parameter dataset or alter a phase. A caller
 must explicitly supply a provenance-qualified `StateParameters` instance.

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
@@ -1,0 +1,242 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Independent source-group holdout validation for binary volumetric Pitzer regression.
+ *
+ * <p>
+ * Calibration and validation observations are supplied separately. Their source-lineage identifiers must be disjoint,
+ * preventing observations from the same declared laboratory lineage from appearing on both sides of the validation
+ * boundary. The caller remains responsible for assigning identifiers that represent genuine experimental independence.
+ * </p>
+ *
+ * <p>
+ * This class fits no validation observation and installs no fitted parameter in a phase. It reports standardized
+ * residual diagnostics for the untouched holdout and does not define an acceptance threshold.
+ * </p>
+ */
+public final class PitzerBinaryVolumetricGroupedValidation implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final PitzerBinaryVolumetricModel model;
+  private final PitzerBinaryVolumetricRegression regression;
+
+  /**
+   * Construct grouped holdout validation for one binary electrolyte.
+   *
+   * @param model parameter-neutral binary volumetric Pitzer model
+   */
+  public PitzerBinaryVolumetricGroupedValidation(PitzerBinaryVolumetricModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException("Binary volumetric Pitzer model must not be null");
+    }
+    this.model = model;
+    regression = new PitzerBinaryVolumetricRegression(model);
+  }
+
+  /**
+   * Fit calibration observations and evaluate an untouched, lineage-disjoint holdout.
+   *
+   * @param calibrationObservations observations used by the weighted regression
+   * @param validationObservations observations used only after the fit is complete
+   * @param temperatureK common temperature in K
+   * @param pressurePa common absolute pressure in Pa
+   * @param debyeHuckelVolumeSlope caller-supplied Debye-Huckel volume slope in SI units
+   * @return immutable calibration fit and held-out residual diagnostics
+   */
+  public ValidationResult validate(List<PitzerBinaryVolumetricRegression.Observation> calibrationObservations,
+      List<PitzerBinaryVolumetricRegression.Observation> validationObservations, double temperatureK, double pressurePa,
+      double debyeHuckelVolumeSlope) {
+    if (calibrationObservations == null) {
+      throw new IllegalArgumentException("Calibration observations must not be null");
+    }
+    if (validationObservations == null || validationObservations.isEmpty()) {
+      throw new IllegalArgumentException("Validation observations must not be null or empty");
+    }
+
+    Set<String> calibrationGroups = sourceGroups(calibrationObservations, "Calibration");
+    Set<String> validationGroups = sourceGroups(validationObservations, "Validation");
+    Set<String> overlappingGroups = new HashSet<String>(calibrationGroups);
+    overlappingGroups.retainAll(validationGroups);
+    if (!overlappingGroups.isEmpty()) {
+      List<String> sortedOverlap = new ArrayList<String>(overlappingGroups);
+      Collections.sort(sortedOverlap);
+      throw new IllegalArgumentException("Calibration and validation source lineages overlap: " + sortedOverlap);
+    }
+
+    PitzerBinaryVolumetricRegression.FitResult calibrationFit = regression.fit(calibrationObservations, temperatureK,
+        pressurePa, debyeHuckelVolumeSlope);
+    double limitingVolume = calibrationFit.getLimitingApparentMolarVolume();
+    PitzerBinaryVolumetricModel.StateParameters parameters = calibrationFit.getStateParameters();
+
+    double chiSquare = 0.0;
+    double maximumAbsoluteStandardizedResidual = 0.0;
+    Map<String, MutableGroupStatistics> mutableGroups = new TreeMap<String, MutableGroupStatistics>();
+    for (PitzerBinaryVolumetricRegression.Observation observation : validationObservations) {
+      double predictedVolume = model.calculateApparentMolarVolume(observation.getMolality(), limitingVolume,
+          parameters);
+      double residual = observation.getApparentMolarVolume() - predictedVolume;
+      double standardizedResidual = residual / observation.getStandardUncertainty();
+      if (!Double.isFinite(standardizedResidual)) {
+        throw new IllegalArgumentException("Holdout evaluation produced a non-finite standardized residual");
+      }
+      chiSquare += standardizedResidual * standardizedResidual;
+      maximumAbsoluteStandardizedResidual = Math.max(maximumAbsoluteStandardizedResidual,
+          Math.abs(standardizedResidual));
+
+      MutableGroupStatistics group = mutableGroups.get(observation.getSourceGroup());
+      if (group == null) {
+        group = new MutableGroupStatistics(observation.getSourceGroup());
+        mutableGroups.put(observation.getSourceGroup(), group);
+      }
+      group.add(residual, standardizedResidual);
+    }
+
+    List<GroupStatistics> groups = new ArrayList<GroupStatistics>();
+    for (MutableGroupStatistics group : mutableGroups.values()) {
+      groups.add(group.toImmutable());
+    }
+    return new ValidationResult(calibrationFit, validationObservations.size(), chiSquare,
+        maximumAbsoluteStandardizedResidual, groups);
+  }
+
+  private static Set<String> sourceGroups(List<PitzerBinaryVolumetricRegression.Observation> observations,
+      String role) {
+    Set<String> groups = new HashSet<String>();
+    for (PitzerBinaryVolumetricRegression.Observation observation : observations) {
+      if (observation == null) {
+        throw new IllegalArgumentException(role + " observations must not contain null");
+      }
+      groups.add(observation.getSourceGroup());
+    }
+    return groups;
+  }
+
+  /** Immutable calibration fit and untouched-holdout diagnostics. */
+  public static final class ValidationResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final PitzerBinaryVolumetricRegression.FitResult calibrationFit;
+    private final int observationCount;
+    private final double chiSquare;
+    private final double maximumAbsoluteStandardizedResidual;
+    private final List<GroupStatistics> groupStatistics;
+
+    private ValidationResult(PitzerBinaryVolumetricRegression.FitResult calibrationFit, int observationCount,
+        double chiSquare, double maximumAbsoluteStandardizedResidual, List<GroupStatistics> groupStatistics) {
+      this.calibrationFit = calibrationFit;
+      this.observationCount = observationCount;
+      this.chiSquare = chiSquare;
+      this.maximumAbsoluteStandardizedResidual = maximumAbsoluteStandardizedResidual;
+      this.groupStatistics = Collections.unmodifiableList(new ArrayList<GroupStatistics>(groupStatistics));
+    }
+
+    /** @return weighted fit obtained from calibration observations only */
+    public PitzerBinaryVolumetricRegression.FitResult getCalibrationFit() {
+      return calibrationFit;
+    }
+
+    /** @return number of untouched validation observations */
+    public int getObservationCount() {
+      return observationCount;
+    }
+
+    /** @return sum of squared standardized holdout residuals */
+    public double getChiSquare() {
+      return chiSquare;
+    }
+
+    /** @return root-mean-square standardized holdout residual */
+    public double getWeightedRootMeanSquareResidual() {
+      return Math.sqrt(chiSquare / observationCount);
+    }
+
+    /** @return maximum absolute standardized holdout residual */
+    public double getMaximumAbsoluteStandardizedResidual() {
+      return maximumAbsoluteStandardizedResidual;
+    }
+
+    /** @return immutable holdout diagnostics sorted by source-lineage identifier */
+    public List<GroupStatistics> getGroupStatistics() {
+      return groupStatistics;
+    }
+  }
+
+  /** Immutable held-out residual diagnostics for one source lineage. */
+  public static final class GroupStatistics implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String sourceGroup;
+    private final int count;
+    private final double meanResidual;
+    private final double weightedRootMeanSquareResidual;
+    private final double maximumAbsoluteStandardizedResidual;
+
+    private GroupStatistics(String sourceGroup, int count, double meanResidual, double weightedRootMeanSquareResidual,
+        double maximumAbsoluteStandardizedResidual) {
+      this.sourceGroup = sourceGroup;
+      this.count = count;
+      this.meanResidual = meanResidual;
+      this.weightedRootMeanSquareResidual = weightedRootMeanSquareResidual;
+      this.maximumAbsoluteStandardizedResidual = maximumAbsoluteStandardizedResidual;
+    }
+
+    /** @return laboratory or source-lineage identifier */
+    public String getSourceGroup() {
+      return sourceGroup;
+    }
+
+    /** @return number of held-out observations in this source group */
+    public int getCount() {
+      return count;
+    }
+
+    /** @return arithmetic mean held-out volume residual in m3/mol */
+    public double getMeanResidual() {
+      return meanResidual;
+    }
+
+    /** @return root-mean-square standardized holdout residual for this source group */
+    public double getWeightedRootMeanSquareResidual() {
+      return weightedRootMeanSquareResidual;
+    }
+
+    /** @return maximum absolute standardized holdout residual for this source group */
+    public double getMaximumAbsoluteStandardizedResidual() {
+      return maximumAbsoluteStandardizedResidual;
+    }
+  }
+
+  private static final class MutableGroupStatistics {
+    private final String sourceGroup;
+    private int count;
+    private double residualSum;
+    private double standardizedResidualSquareSum;
+    private double maximumAbsoluteStandardizedResidual;
+
+    private MutableGroupStatistics(String sourceGroup) {
+      this.sourceGroup = sourceGroup;
+    }
+
+    private void add(double residual, double standardizedResidual) {
+      count++;
+      residualSum += residual;
+      standardizedResidualSquareSum += standardizedResidual * standardizedResidual;
+      maximumAbsoluteStandardizedResidual = Math.max(maximumAbsoluteStandardizedResidual,
+          Math.abs(standardizedResidual));
+    }
+
+    private GroupStatistics toImmutable() {
+      return new GroupStatistics(sourceGroup, count, residualSum / count,
+          Math.sqrt(standardizedResidualSquareSum / count), maximumAbsoluteStandardizedResidual);
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidationTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidationTest.java
@@ -1,0 +1,123 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests independent source-group holdout evaluation for volumetric Pitzer regression. */
+class PitzerBinaryVolumetricGroupedValidationTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 323.15;
+  private static final double PRESSURE_PA = 20.0e6;
+  private static final double DEBYE_HUCKEL_VOLUME_SLOPE = 1.2e-6;
+  private static final double LIMITING_VOLUME = 17.6e-6;
+  private static final double BETA0_DERIVATIVE = 2.0e-10;
+  private static final double BETA1_DERIVATIVE = -0.7e-10;
+  private static final double CPHI_DERIVATIVE = 1.1e-11;
+  private static final double STANDARD_UNCERTAINTY = 2.0e-8;
+  private static final double[] CALIBRATION_MOLALITIES = { 0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0 };
+
+  @Test
+  void fitsCalibrationOnlyAndReportsUntouchedHoldoutResiduals() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricGroupedValidation validation = new PitzerBinaryVolumetricGroupedValidation(model);
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(model, CALIBRATION_MOLALITIES,
+        new double[CALIBRATION_MOLALITIES.length], "calibration-laboratory");
+    List<PitzerBinaryVolumetricRegression.Observation> holdout = observations(model, new double[] { 0.1, 1.5, 4.0 },
+        new double[] { 1.0, -2.0, 0.5 }, "validation-laboratory");
+
+    PitzerBinaryVolumetricGroupedValidation.ValidationResult result = validation.validate(calibration, holdout,
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE);
+
+    assertEquals(LIMITING_VOLUME, result.getCalibrationFit().getLimitingApparentMolarVolume(), 1.0e-17);
+    assertEquals(3, result.getObservationCount());
+    assertEquals(5.25, result.getChiSquare(), 1.0e-8);
+    assertEquals(Math.sqrt(1.75), result.getWeightedRootMeanSquareResidual(), 1.0e-8);
+    assertEquals(2.0, result.getMaximumAbsoluteStandardizedResidual(), 1.0e-8);
+    assertEquals(1, result.getGroupStatistics().size());
+    assertEquals("validation-laboratory", result.getGroupStatistics().get(0).getSourceGroup());
+    assertEquals(3, result.getGroupStatistics().get(0).getCount());
+    assertEquals(-STANDARD_UNCERTAINTY / 6.0, result.getGroupStatistics().get(0).getMeanResidual(), 1.0e-17);
+  }
+
+  @Test
+  void keepsGroupedHoldoutDiagnosticsSortedAndOrderInvariant() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricGroupedValidation validation = new PitzerBinaryVolumetricGroupedValidation(model);
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(model, CALIBRATION_MOLALITIES,
+        new double[CALIBRATION_MOLALITIES.length], "calibration");
+    List<PitzerBinaryVolumetricRegression.Observation> holdout = new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    holdout.addAll(observations(model, new double[] { 0.3, 2.5 }, new double[] { 0.4, -0.2 }, "laboratory-b"));
+    holdout.addAll(observations(model, new double[] { 0.6, 4.5 }, new double[] { -0.5, 0.1 }, "laboratory-a"));
+
+    PitzerBinaryVolumetricGroupedValidation.ValidationResult forward = validation.validate(calibration, holdout,
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE);
+    Collections.reverse(holdout);
+    PitzerBinaryVolumetricGroupedValidation.ValidationResult reversed = validation.validate(calibration, holdout,
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE);
+
+    assertEquals(forward.getChiSquare(), reversed.getChiSquare(), 1.0e-12);
+    assertEquals(forward.getWeightedRootMeanSquareResidual(), reversed.getWeightedRootMeanSquareResidual(), 1.0e-12);
+    assertEquals(2, forward.getGroupStatistics().size());
+    assertEquals("laboratory-a", forward.getGroupStatistics().get(0).getSourceGroup());
+    assertEquals("laboratory-b", forward.getGroupStatistics().get(1).getSourceGroup());
+    for (PitzerBinaryVolumetricGroupedValidation.GroupStatistics group : forward.getGroupStatistics()) {
+      assertEquals(2, group.getCount());
+      assertTrue(Double.isFinite(group.getMeanResidual()));
+      assertTrue(group.getWeightedRootMeanSquareResidual() > 0.0);
+      assertTrue(group.getMaximumAbsoluteStandardizedResidual() > 0.0);
+    }
+  }
+
+  @Test
+  void rejectsSourceLineageLeakage() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    PitzerBinaryVolumetricGroupedValidation validation = new PitzerBinaryVolumetricGroupedValidation(model);
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(model, CALIBRATION_MOLALITIES,
+        new double[CALIBRATION_MOLALITIES.length], "shared-lineage");
+    List<PitzerBinaryVolumetricRegression.Observation> holdout = observations(model, new double[] { 0.1 },
+        new double[] { 0.0 }, "shared-lineage");
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> validation.validate(calibration, holdout, TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+    assertTrue(exception.getMessage().contains("shared-lineage"));
+  }
+
+  @Test
+  void rejectsInvalidInputsBeforeEvaluation() {
+    assertThrows(IllegalArgumentException.class, () -> new PitzerBinaryVolumetricGroupedValidation(null));
+    PitzerBinaryVolumetricGroupedValidation validation = new PitzerBinaryVolumetricGroupedValidation(
+        calciumChlorideModel());
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    List<PitzerBinaryVolumetricRegression.Observation> holdout = new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> validation.validate(null, holdout, TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+    assertThrows(IllegalArgumentException.class,
+        () -> validation.validate(calibration, holdout, TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+    holdout.add(null);
+    assertThrows(IllegalArgumentException.class,
+        () -> validation.validate(calibration, holdout, TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE));
+  }
+
+  private static List<PitzerBinaryVolumetricRegression.Observation> observations(PitzerBinaryVolumetricModel model,
+      double[] molalities, double[] noiseInSigma, String sourceGroup) {
+    PitzerBinaryVolumetricModel.StateParameters parameters = new PitzerBinaryVolumetricModel.StateParameters(
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE, BETA0_DERIVATIVE, BETA1_DERIVATIVE, CPHI_DERIVATIVE);
+    List<PitzerBinaryVolumetricRegression.Observation> observations = new ArrayList<PitzerBinaryVolumetricRegression.Observation>();
+    for (int index = 0; index < molalities.length; index++) {
+      double volume = model.calculateApparentMolarVolume(molalities[index], LIMITING_VOLUME, parameters)
+          + noiseInSigma[index] * STANDARD_UNCERTAINTY;
+      observations.add(new PitzerBinaryVolumetricRegression.Observation(molalities[index], volume, STANDARD_UNCERTAINTY,
+          sourceGroup));
+    }
+    return observations;
+  }
+
+  private static PitzerBinaryVolumetricModel calciumChlorideModel() {
+    return new PitzerBinaryVolumetricModel(1, 2, 2, -1);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3144 with a parameter- and dataset-neutral independent source-group validation boundary for the merged volumetric-Pitzer regression.

- Fits only an explicit calibration observation list.
- Evaluates an untouched holdout only after fitting is complete.
- Rejects any declared laboratory/source-lineage identifier present in both lists.
- Reports holdout χ², weighted RMS standardized residual, maximum standardized residual, and deterministic per-lineage diagnostics.
- Defines no universal acceptance threshold and installs no fitted parameter.

Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5573803438

## Exact continuity and scope

- Exact base: `5bb230e1c2e2227074ce4d20ec19d6be91b53ec7`
- Exact head: `8891fa00db6531f6fa4beed42b0560119530bb88`
- Branch: `ai/3144-volumetric-pitzer-grouped-validation`
- Three ordered commits; three intended files
- Branch is 3 commits ahead and 0 behind its exact base
- No active #3144 PR existed before publication
- Open autonomous PRs #3544, #3546, #3548, and #3550 do not overlap this package or documentation scope

## Scientific contract

The evaluator treats source-lineage IDs as an auditable software boundary. It cannot prove experimental independence: callers must map every row to its actual laboratory, apparatus, publication lineage, and reuse history. Calibration and validation groups must be genuinely independent, uncertainties must be qualified absolute 1σ values, and acceptance limits must be fixed before the holdout is evaluated.

The 197-point Al Ghafri/NIST ThermoML series is not bundled, read, or fitted and remains reserved as independent validation evidence.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local validation on the qualified Pitzer tree, whose relevant upstream blobs match the exact base:

- `PitzerBinaryVolumetricModelTest`: **6/6 passed**
- `PitzerBinaryVolumetricRegressionTest`: **4/4 passed**
- `PitzerBinaryVolumetricGroupedValidationTest`: **4/4 passed**
- `python3 devtools/run_spotless.py apply`: passed
- `python3 devtools/run_spotless.py check`: passed
- `python3 devtools/check_documentation_search.py`: passed (691 Markdown and one standalone HTML page)
- `git diff --check`: passed
- pre-commit executable: unavailable; no local pre-commit result is claimed

The frozen synthetic holdout reproduces χ² **5.25**, weighted RMS **sqrt(1.75)**, and maximum absolute standardized residual **2.0**. Reversing holdout order preserves aggregate results and deterministic group ordering. Declared lineage overlap fails closed.

Hosted Java 8/21, Windows/Ubuntu, slow shards, Javadocs, Spotless, documentation, CodeQL, PaperLab, and repository-policy checks remain authoritative.

## Documentation impact

`docs/physical_properties/density_models.md` now documents the separate calibration/holdout lists, fail-closed declared-lineage check, returned diagnostics, pre-registered threshold requirement, and distinction between string labels and real scientific independence.

## Stop boundary

This PR adds no experimental row, salt coefficient, acceptance threshold, default-model connection, or phase installation. It changes no Ksp, `Vdelta`, activity coefficient, reaction/speciation behavior, phase selection, solver tolerance, or MCP payload. Quantitative high-pressure aqueous density and calcium-sulfate prediction remain fail-closed pending redistribution-qualified calibration evidence and independent laboratory-grouped validation.

Portfolio occupancy becomes **5/10**. Keep the PR draft-only: do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity.

Generated with AI assistance.