### PR TITLE
[AI-Assisted] Plan binary refinery viscosity blends to target

### DIFF
--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -207,14 +207,31 @@ double directBlendNumber =
     RefineryViscosityBlend.calculateViscosityBlendingNumber(550.0);
 double directViscosityCSt =
     RefineryViscosityBlend.calculateKinematicViscosityCSt(directBlendNumber);
+
+RefineryViscosityBlend plannedBlend =
+    RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(
+        550.0, 375.0, 418.68738293612904, 50.0);
+double[] plannedMassFractions = plannedBlend.getMassFractions();
 ```
+
+For two distinct source viscosities, the target factory solves the unique mass fractions in VBN
+space:
+
+$x_1=\frac{VBN_{target}-VBN_2}{VBN_1-VBN_2}$
+
+$x_2=1-x_1$
+
+The target must lie inside the closed interval formed by the two source viscosities. Exact endpoint
+targets return a pure-source result. Equal-viscosity sources fail closed because their mass ratio is
+not uniquely determined.
 
 The equations and mass-weighting basis follow Centeno et al.,
 [DOI 10.1016/j.fuel.2011.02.028](https://doi.org/10.1016/j.fuel.2011.02.028).
 The fixed binary example above is an independently recomputed arithmetic reference, not measured
 blend evidence. This API does not claim physical prediction accuracy, uncertainty, ASTM
 compliance, dynamic-viscosity conversion, viscosity-temperature extrapolation, non-Newtonian
-behavior, pressure correction, phase behavior, compatibility, or optimization.
+behavior, pressure correction, phase behavior, compatibility, multi-source or multi-property
+optimization, economics, or control.
 
 ## Per-cut UOP/Watson characterization factor
 

--- a/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
@@ -92,6 +92,53 @@ public final class RefineryViscosityBlend implements Serializable {
   }
 
   /**
+   * Plan the unique mass-basis binary blend that reaches a target kinematic viscosity.
+   *
+   * <p>
+   * The two source viscosities and target must be resolved at the supplied common temperature. The target must lie
+   * inside the closed interval formed by the source viscosities. Equal-viscosity sources are rejected because their
+   * mass ratio is not uniquely determined.
+   * </p>
+   *
+   * @param firstSourceKinematicViscosityCSt first source kinematic viscosity in cSt
+   * @param secondSourceKinematicViscosityCSt second source kinematic viscosity in cSt
+   * @param targetKinematicViscosityCSt target blend kinematic viscosity in cSt
+   * @param temperatureCelsius common source and target viscosity temperature in degrees Celsius
+   * @return immutable binary blend result with source-order mass fractions
+   * @throws IllegalArgumentException for invalid viscosities, temperature, target interval, or non-unique sources
+   */
+  public static RefineryViscosityBlend fromBinaryTargetKinematicViscosity(double firstSourceKinematicViscosityCSt,
+      double secondSourceKinematicViscosityCSt, double targetKinematicViscosityCSt, double temperatureCelsius) {
+    if (!Double.isFinite(temperatureCelsius)) {
+      throw new IllegalArgumentException("Common viscosity temperature must be finite");
+    }
+
+    double firstBlendNumber = calculateViscosityBlendingNumber(firstSourceKinematicViscosityCSt);
+    double secondBlendNumber = calculateViscosityBlendingNumber(secondSourceKinematicViscosityCSt);
+    double targetBlendNumber = calculateViscosityBlendingNumber(targetKinematicViscosityCSt);
+    if (firstBlendNumber == secondBlendNumber) {
+      throw new IllegalArgumentException("Distinct source viscosities are required for a unique binary blend ratio");
+    }
+
+    double minimumSourceBlendNumber = Math.min(firstBlendNumber, secondBlendNumber);
+    double maximumSourceBlendNumber = Math.max(firstBlendNumber, secondBlendNumber);
+    if (targetBlendNumber < minimumSourceBlendNumber || targetBlendNumber > maximumSourceBlendNumber) {
+      throw new IllegalArgumentException("Target viscosity must be bounded by the two source viscosities");
+    }
+
+    double firstMassFraction =
+        (targetBlendNumber - secondBlendNumber) / (firstBlendNumber - secondBlendNumber);
+    if (!Double.isFinite(firstMassFraction) || firstMassFraction < 0.0 || firstMassFraction > 1.0) {
+      throw new IllegalArgumentException("Calculated binary blend mass fraction must be finite and bounded");
+    }
+    firstMassFraction = Math.max(0.0, Math.min(1.0, firstMassFraction));
+    double secondMassFraction = 1.0 - firstMassFraction;
+
+    return fromMassBasis(new double[] {firstMassFraction, secondMassFraction},
+        new double[] {firstSourceKinematicViscosityCSt, secondSourceKinematicViscosityCSt}, temperatureCelsius);
+  }
+
+  /**
    * Transform kinematic viscosity to the published Refutas viscosity blending number.
    *
    * @param kinematicViscosityCSt finite kinematic viscosity greater than 0.2 cSt

--- a/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
@@ -126,16 +126,15 @@ public final class RefineryViscosityBlend implements Serializable {
       throw new IllegalArgumentException("Target viscosity must be bounded by the two source viscosities");
     }
 
-    double firstMassFraction =
-        (targetBlendNumber - secondBlendNumber) / (firstBlendNumber - secondBlendNumber);
+    double firstMassFraction = (targetBlendNumber - secondBlendNumber) / (firstBlendNumber - secondBlendNumber);
     if (!Double.isFinite(firstMassFraction) || firstMassFraction < 0.0 || firstMassFraction > 1.0) {
       throw new IllegalArgumentException("Calculated binary blend mass fraction must be finite and bounded");
     }
     firstMassFraction = Math.max(0.0, Math.min(1.0, firstMassFraction));
     double secondMassFraction = 1.0 - firstMassFraction;
 
-    return fromMassBasis(new double[] {firstMassFraction, secondMassFraction},
-        new double[] {firstSourceKinematicViscosityCSt, secondSourceKinematicViscosityCSt}, temperatureCelsius);
+    return fromMassBasis(new double[] { firstMassFraction, secondMassFraction },
+        new double[] { firstSourceKinematicViscosityCSt, secondSourceKinematicViscosityCSt }, temperatureCelsius);
   }
 
   /**

--- a/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
@@ -80,26 +80,24 @@ public class RefineryViscosityBlendTest {
     RefineryViscosityBlend reversed = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(375.0, 550.0,
         targetViscosityCSt, 50.0);
 
-    assertArrayEquals(new double[] {5.0 / 17.0, 12.0 / 17.0}, planned.getMassFractions(), 1.0e-14);
-    assertArrayEquals(new double[] {12.0 / 17.0, 5.0 / 17.0}, reversed.getMassFractions(), 1.0e-14);
+    assertArrayEquals(new double[] { 5.0 / 17.0, 12.0 / 17.0 }, planned.getMassFractions(), 1.0e-14);
+    assertArrayEquals(new double[] { 12.0 / 17.0, 5.0 / 17.0 }, reversed.getMassFractions(), 1.0e-14);
     assertEquals(targetViscosityCSt, planned.getKinematicViscosityCSt(), 1.0e-12);
     assertEquals(targetViscosityCSt, reversed.getKinematicViscosityCSt(), 1.0e-12);
     assertEquals(50.0, planned.getTemperatureCelsius(), 0.0);
 
     RefineryViscosityBlend reconstructed = RefineryViscosityBlend.fromMassBasis(planned.getMassFractions(),
-        new double[] {550.0, 375.0}, planned.getTemperatureCelsius());
+        new double[] { 550.0, 375.0 }, planned.getTemperatureCelsius());
     assertEquals(targetViscosityCSt, reconstructed.getKinematicViscosityCSt(), 1.0e-12);
   }
 
   @Test
   public void binaryTargetPlannerAcceptsExactEndpoints() {
-    RefineryViscosityBlend first = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 10.0,
-        40.0);
-    RefineryViscosityBlend second = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 100.0,
-        40.0);
+    RefineryViscosityBlend first = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 10.0, 40.0);
+    RefineryViscosityBlend second = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 100.0, 40.0);
 
-    assertArrayEquals(new double[] {1.0, 0.0}, first.getMassFractions(), 0.0);
-    assertArrayEquals(new double[] {0.0, 1.0}, second.getMassFractions(), 0.0);
+    assertArrayEquals(new double[] { 1.0, 0.0 }, first.getMassFractions(), 0.0);
+    assertArrayEquals(new double[] { 0.0, 1.0 }, second.getMassFractions(), 0.0);
     assertEquals(10.0, first.getKinematicViscosityCSt(), 1.0e-13);
     assertEquals(100.0, second.getKinematicViscosityCSt(), 1.0e-12);
   }

--- a/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
@@ -73,6 +73,54 @@ public class RefineryViscosityBlendTest {
   }
 
   @Test
+  public void binaryTargetPlannerRecoversMassFractionsAndTarget() {
+    double targetViscosityCSt = 418.68738293612904;
+    RefineryViscosityBlend planned = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(550.0, 375.0,
+        targetViscosityCSt, 50.0);
+    RefineryViscosityBlend reversed = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(375.0, 550.0,
+        targetViscosityCSt, 50.0);
+
+    assertArrayEquals(new double[] {5.0 / 17.0, 12.0 / 17.0}, planned.getMassFractions(), 1.0e-14);
+    assertArrayEquals(new double[] {12.0 / 17.0, 5.0 / 17.0}, reversed.getMassFractions(), 1.0e-14);
+    assertEquals(targetViscosityCSt, planned.getKinematicViscosityCSt(), 1.0e-12);
+    assertEquals(targetViscosityCSt, reversed.getKinematicViscosityCSt(), 1.0e-12);
+    assertEquals(50.0, planned.getTemperatureCelsius(), 0.0);
+
+    RefineryViscosityBlend reconstructed = RefineryViscosityBlend.fromMassBasis(planned.getMassFractions(),
+        new double[] {550.0, 375.0}, planned.getTemperatureCelsius());
+    assertEquals(targetViscosityCSt, reconstructed.getKinematicViscosityCSt(), 1.0e-12);
+  }
+
+  @Test
+  public void binaryTargetPlannerAcceptsExactEndpoints() {
+    RefineryViscosityBlend first = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 10.0,
+        40.0);
+    RefineryViscosityBlend second = RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 100.0,
+        40.0);
+
+    assertArrayEquals(new double[] {1.0, 0.0}, first.getMassFractions(), 0.0);
+    assertArrayEquals(new double[] {0.0, 1.0}, second.getMassFractions(), 0.0);
+    assertEquals(10.0, first.getKinematicViscosityCSt(), 1.0e-13);
+    assertEquals(100.0, second.getKinematicViscosityCSt(), 1.0e-12);
+  }
+
+  @Test
+  public void binaryTargetPlannerFailsClosedForUnsupportedInputs() {
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 10.0, 10.0, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 5.0, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 200.0, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(Double.NaN, 100.0, 50.0, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 0.2, 40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(10.0, 100.0, 50.0, Double.NaN));
+  }
+
+  @Test
   public void invalidOrIncompleteInputsFailClosed() {
     assertThrows(IllegalArgumentException.class,
         () -> RefineryViscosityBlend.fromMassBasis(null, new double[] { 10.0 }, 40.0));


### PR DESCRIPTION
## Summary

Advances #3305 with a bounded binary target-viscosity planner built on the qualified Refutas forward screen.

- Adds `RefineryViscosityBlend.fromBinaryTargetKinematicViscosity(...)`.
- Solves the unique two-source mass fractions analytically in viscosity-blending-number space.
- Preserves source order and the explicit common-temperature basis in the existing immutable result.
- Accepts exact endpoint targets as pure-source blends.
- Fails closed for non-unique equal-viscosity sources, targets outside the source interval, invalid source/target viscosities, and invalid temperature.

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5573859019

## Exact-head contract

- Exact base: `5bb230e1c2e2227074ce4d20ec19d6be91b53ec7`
- Exact head: `02c5d152347d94c74cbbc617abf6d76122421349`
- Branch: `codex/3305-binary-target-viscosity-blend`
- Five ordered commits, exactly three intended files, zero commits behind the exact base. The final two commits apply the exact hosted Spotless artifact without engineering changes.

## Provenance and licensing

The Refutas VBN relation and mass-weighting basis remain from Centeno et al., “Testing various mixing rules for calculation of viscosity of petroleum blends,” *Fuel* 90 (2011) 3561–3570, DOI [10.1016/j.fuel.2011.02.028](https://doi.org/10.1016/j.fuel.2011.02.028).

The binary ratio is transparent algebra derived from the two-source linear VBN balance. This PR reproduces no experimental dataset, paywalled prose, table, or ASTM procedure text.

## Engineering acceptance

Acceptance requires:

- recovery of the fixed 550/375 cSt case's original 5/17 and 12/17 mass fractions;
- forward reconstruction of the 418.68738293612904 cSt target;
- source-order reversal invariance;
- exact endpoint behavior;
- preservation of the caller's common-temperature metadata;
- fail-closed equal-source, out-of-interval, non-finite, and out-of-domain cases;
- no change to existing forward-screen behavior.

## Scientific boundary

This is a two-source algebraic planning helper under the existing empirical common-temperature Refutas assumption. It is not measured-blend validation, an accuracy or uncertainty claim, ASTM compliance, viscosity-temperature extrapolation, dynamic-viscosity conversion, a phase/compatibility model, a multi-source or multi-property optimizer, economic optimization, assay mutation, or process/control authority. No thermodynamic model, solver, coefficient, dataset, or existing API behavior changes.

## Validation

**READY TO MERGE**

All exact-head GitHub Actions pass: Java 8 and Java 21 tests on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, agent-skill checks, Spotless, pre-commit, documentation search, CodeQL, and PaperLab. The fixed binary recovery, target reconstruction, source-order reversal, endpoint, and fail-closed cases pass within the frozen acceptance boundary.

The initial head passed PaperLab and documentation search; pre-commit failed only on the two Java files' Spotless layout. The exact hosted `spotless-format-patch` artifact (artifact `10028091788`, SHA-256 `38a835558475926118be24cd985bfecbe002d889b957599fd598663c19d9b0e3`) was applied verbatim as one mechanical repair operation, producing two ordered contents-API commits. Behavior, tests, APIs, provenance, documentation meaning, and acceptance limits are unchanged.

## Portfolio and stop boundary

Including this draft, autonomous implementation occupancy is **6/10**. This is the sole active #3305 implementation PR.

Keep this PR draft-only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, force-push, close, replace, restart, or abandon it. Do not broaden the scientific claim or weaken the acceptance boundary.

Generated with AI assistance.