### PR TITLE
[AI-Assisted] feat(optimization): qualify shared total-power evidence

### DIFF
--- a/devtools/validate_plant_capacity_jpype.py
+++ b/devtools/validate_plant_capacity_jpype.py
@@ -28,8 +28,10 @@ def main():
         Coverage = JClass("neqsim.process.util.optimizer.UtilizationCoverageReport")
         Registry = JClass("neqsim.process.util.optimizer.PlantConstraintRegistry")
         Definition = JClass("neqsim.process.util.optimizer.PlantConstraintDefinition")
+        Participant = JClass("neqsim.process.util.optimizer.PlantConstraintParticipant")
         Scope = JClass("neqsim.process.util.optimizer.PlantConstraintScope")
         Sample = JClass("neqsim.process.util.optimizer.PlantConstraintSample")
+        SharedEvidence = JClass("neqsim.process.util.optimizer.PlantSharedResourceEvidence")
         Snapshot = JClass("neqsim.process.util.optimizer.PlantUtilizationSnapshot")
 
         fluid = Fluid(298.15, 50.0)
@@ -102,12 +104,48 @@ def main():
         assert all(row["currentValue"] is None for row in missing_json["rows"])
         assert not (Snapshot.builder(registry, calculation_id).expectedCoverage(missing)
                     .convergenceComplete(True).sample(sample).build()).isFeasible()
+        shaft_power_kw = model.getPower("kW")
+        shared_definition = (Definition.builder(
+            "total-shaft-power",
+            Scope.sharedResource("Plant", "compression shaft power"),
+        ).aggregationPolicy(Definition.AggregationPolicy.SHARED_BUDGET)
+         .limitDirection(Definition.LimitDirection.MAXIMUM)
+         .unit("kW").basis("compressor and pump shaft power")
+         .provenance("synthetic shared power budget")
+         .participant(Participant.direct(
+             "Compression",
+             "kW",
+             "compressor and pump shaft power",
+         )).build())
+        shared_evidence = SharedEvidence.fromProcessModelShaftPower(
+            shared_definition,
+            calculation_id,
+            shaft_power_kw * 1.1,
+            model,
+            True,
+            "completed JPype ProcessModel",
+        )
+        shared_document = json.loads(str(shared_evidence.toJson()))
+        assert shared_evidence.isComplete(), str(shared_evidence.getDiagnostics())
+        assert shared_evidence.isFeasible()
+        assert shared_document["basis"] == "compressor and pump shaft power"
+        assert shared_document["participants"][0]["sourceId"] == "Compression"
+        assert abs(shared_document["aggregateValue"] - shaft_power_kw) < 1.0e-9
+        shared_registry = Registry()
+        shared_registry.register(shared_definition)
+        shared_snapshot = (Snapshot.builder(shared_registry, calculation_id)
+                           .convergenceComplete(True)
+                           .sample(shared_evidence.toPlantConstraintSample()).build())
+        assert shared_snapshot.isFeasible()
         print(json.dumps({"status": "PASS", "jpype": jpype.__version__,
                           "java": str(JClass("java.lang.System").getProperty("java.version")),
                           "shaftPowerKW": compressor.getPower("kW"),
                           "powerUtilization": utilization, "coverageRows": len(document["rows"]),
                           "snapshotSchema": str(snapshot.getSchemaVersion()),
-                          "missingEvidenceRejected": True}, indent=2))
+                          "missingEvidenceRejected": True,
+                          "sharedPowerSchema": str(shared_evidence.getSchemaVersion()),
+                          "sharedPowerParticipantCount": len(shared_document["participants"]),
+                          "sharedPowerUtilization": shared_evidence.getNormalizedUtilization()}, indent=2))
     finally:
         jpype.shutdownJVM()
 

--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -138,6 +138,47 @@ does not claim automatic rollback. Successful multi-area, Pareto and scenario wo
 their established path. A snapshot explicitly declaring failed convergence is incomplete even
 when its registry is empty or every constraint is disabled.
 
+### Qualify a shared total-power budget
+
+After the complete isolated candidate has converged, use `PlantSharedResourceEvidence` to collect
+exact participant coverage and create the common snapshot sample. Choose the physical basis first:
+
+- `fromProcessModelShaftPower(...)` and `fromProcessSystemShaftPower(...)` report compressor and
+  pump **shaft power** from the existing process APIs.
+- `fromSolvedEnergyBusRequestedDemand(...)` reports **requested electrical load**, including unmet
+  demand, from a current solved electrical `EnergyBus`.
+
+These bases are deliberately not interchangeable. NeqSim does not infer driver or motor efficiency.
+Declare any unit conversion explicitly in each `PlantConstraintParticipant`.
+
+```java
+PlantConstraintDefinition totalPower = PlantConstraintDefinition
+    .builder("total-power",
+        PlantConstraintScope.sharedResource("Plant", "compression shaft power"))
+    .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET)
+    .limitDirection(PlantConstraintDefinition.LimitDirection.MAXIMUM)
+    .unit("kW")
+    .basis("compressor and pump shaft power")
+    .provenance("approved power budget")
+    .participant(PlantConstraintParticipant.direct(
+        "Compression", "kW", "compressor and pump shaft power"))
+    .build();
+
+PlantSharedResourceEvidence evidence =
+    PlantSharedResourceEvidence.fromProcessModelShaftPower(
+        totalPower, calculationId, 12000.0, model, fullModelConverged,
+        "completed isolated ProcessModel");
+if (!evidence.isComplete()) {
+  throw new IllegalStateException(evidence.getDiagnostics().toString());
+}
+```
+
+Java getters, `toJson()`, and JPype expose the same frozen calculation ID, participants, source and
+converted values, conversion metadata, total cross-check, units, basis, provenance, utilization,
+physical margin, required relief, and diagnostics. Missing observations remain unavailable rather
+than becoming zero utilization. Rebuild evidence after any process, availability, bus, or limit
+change; never reuse it for a different candidate.
+
 ---
 
 ## Overview

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -57,7 +57,7 @@ PlantConstraintDefinition totalPower = PlantConstraintDefinition
     .participant(PlantConstraintParticipant.direct(
         "compression/K-101", "MW", "instantaneous electrical load"))
     .participant(PlantConstraintParticipant.converted(
-        "compression/K-102", "kW", "shaft power", 0.001, 0.0))
+        "compression/K-102", "kW", "instantaneous electrical load", 0.001, 0.0))
     .build();
 registry.register(totalPower);
 ```
@@ -102,11 +102,56 @@ boundary evidence. These adapters validate identity, direction, physical unit, a
 they do not retain live suppliers or evaluator callbacks. A sample's registered basis is copied from
 the matching plant definition, so an adapter cannot invent a rate- or reference-basis conversion.
 
-This layer is deliberately not operating authority. It does not calculate total power, common-shaft
-driver or torque balance, compressor maps, separator capacity, piping hydraulics, product quality,
-emissions, utility allocation, rollback, caching, dirty scheduling, or solver acceptance. Those
-increments must supply qualified samples after complete convergence, and external optimizer
-proposals must still be replayed and accepted by the full NeqSim model.
+### Shared total-power evidence
+
+`PlantSharedResourceEvidence` is the immutable post-solve adapter for a maximum
+`SHARED_BUDGET`. It requires one observation for every registered participant and an independently
+calculated total in the same target unit and basis. Missing, unexpected, stale, non-finite,
+out-of-validity, metadata-mismatched, exception, or unconverged evidence is incomplete; unavailable
+values are Java `NaN` and JSON `null`, never zero load.
+
+Use `fromProcessSystemShaftPower(...)` when participant IDs are top-level compressor or pump names,
+or `fromProcessModelShaftPower(...)` when participant IDs are `ProcessModel` area names. Both
+adapters cross-check the participant sum against the existing `getPower(unit)` total and retain the
+explicit **compressor and pump shaft-power** basis. They do not infer motor efficiency or convert
+shaft power to electrical demand.
+
+```java
+PlantConstraintDefinition shaftBudget = PlantConstraintDefinition
+    .builder("total-shaft-power",
+        PlantConstraintScope.sharedResource("NorthPlant", "compression shaft power"))
+    .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET)
+    .limitDirection(PlantConstraintDefinition.LimitDirection.MAXIMUM)
+    .unit("MW")
+    .basis("compressor and pump shaft power")
+    .provenance("approved rotating-equipment study")
+    .participant(PlantConstraintParticipant.converted(
+        "Compression", "kW", "compressor and pump shaft power", 0.001, 0.0))
+    .build();
+
+PlantSharedResourceEvidence powerEvidence =
+    PlantSharedResourceEvidence.fromProcessModelShaftPower(
+        shaftBudget, calculationId, 12.0, model, model.isModelConverged(),
+        "completed isolated ProcessModel");
+PlantUtilizationSnapshot snapshot = PlantUtilizationSnapshot.builder(
+        new PlantConstraintRegistry().register(shaftBudget), calculationId)
+    .convergenceComplete(model.isModelConverged())
+    .sample(powerEvidence.toPlantConstraintSample())
+    .build();
+```
+
+For an electrical `EnergyBus`, `fromSolvedEnergyBusRequestedDemand(...)` uses the current solved
+report's requested input demand, including unmet demand. It ignores producer output rows and rejects
+unregistered inputs, external demand, bidirectional loads, and stale reports. An out-of-service
+shaft participant is accepted only when explicitly named and observed at finite zero power.
+Changing a limit or line-up requires new evidence with a new calculation identity; collection is
+read-only and does not restore process mutations.
+
+This layer is deliberately not operating authority. It does not coordinate a common-shaft driver or
+torque balance, infer electrical efficiency, compute compressor maps, separator capacity, piping
+hydraulics, product quality, emissions, utility allocation, rollback, caching, dirty scheduling, or
+solver acceptance. External optimizer proposals must still be replayed and accepted by the full
+NeqSim model.
 
 ## Expected equipment coverage before qualification
 

--- a/docs/process/optimization/industrial-process-optimization-baseline.md
+++ b/docs/process/optimization/industrial-process-optimization-baseline.md
@@ -236,19 +236,32 @@ It exposes deterministic complete coverage and bottleneck ladders without retain
 mutable process state. Existing installed-equipment and boundary evidence are adapted rather than
 recalculated or duplicated.
 
-This snapshot layer does not aggregate total power, coordinate a common shaft, compute separator or
-piping physics, alter process solving, or accept an optimizer proposal. Those operations remain later
-increments and must provide qualified samples after a complete full-model solve.
+`PlantSharedResourceEvidence` now supplies participant-complete maximum-budget evidence for
+`ProcessSystem`/`ProcessModel` compressor-and-pump shaft power and solved `EnergyBus` requested
+electrical demand. Its aggregate is cross-checked against the existing authoritative total; units,
+basis and conversions remain explicit. Missing, extra, stale, non-finite, unconverged, or ambiguous
+load evidence fails closed. It produces the common snapshot sample without retaining live process
+state.
+
+The maintained 27-unit M fixture qualifies a controlled transition from equipment-local compressor
+power at a 120% total budget to the shared total-shaft-power constraint at a 95% budget, then verifies
+the restored line-up reproduces the cold total power. The same tests exercise an ordered 180-
+participant/six-area evidence ledger with 2 s capture, 64 MB used-heap growth, 500 kB Java
+serialization, and 1 MB JSON budgets. This is evidence-path scale qualification, not the still-open
+full L process-model acceptance fixture or a generic execution speedup claim.
+
+This layer does not coordinate a common shaft, compute separator or piping physics, alter process
+solving, or accept an optimizer proposal. Those operations remain later increments and must provide
+qualified samples after a complete full-model solve.
 
 ## Next dependency-ready increments
 
-1. Add first-class total-power/shared-utility evidence, using the complete immutable utilization
-   snapshot without adding execution-layer scheduling or caching.
-2. Add a common-shaft compressor-train
+1. Add a common-shaft compressor-train
    resource constraint.
-3. Complete separator and piping evidence adapters before adding fail-closed scalable evaluation
+2. Complete separator and piping evidence adapters before adding fail-closed scalable evaluation
    and solver orchestration.
-4. Expose the stable result through Java JSON and Python/JPype, then execute M, L, C, B, and R as
+3. Execute the full L fixture, then expose the stable evaluator result through current Java and
+   Python workflows and execute C, B, and R as
    maintained workflows.
 
 Until those increments are merged and measured, this page is the authoritative baseline contract,

--- a/docs/process/optimization/industrial-sm-benchmark.md
+++ b/docs/process/optimization/industrial-sm-benchmark.md
@@ -208,8 +208,17 @@ equipment-local compressor to shared total-power bottleneck transition. On the f
 from master `ac79c56945b0cdf45a1bcb42e3417dff99e7acbf`, total shaft power was
 `918.164876805159 kW`: the 120% budget left the equipment row limiting, while the 95% budget made
 the shared row limiting with `45.90824384025791 kW` required relief. Restoration differed from the
-cold total by `2.7199348551221192e-8 kW` (relative `2.9623599462728176e-11`) against the `1e-7`
-gate, and evidence capture did not mutate the process.
+cold total by `2.7199348551221192e-8 kW` (relative `2.9623599462728176e-11`), and evidence capture
+did not mutate the process.
+
+The maintained cold/restored power gate is `1e-6 * max(1 kW, cold shaft power)`, or one part per
+million above 1 kW. This matches the relative recalculation thresholds in `Stream`, `Compressor`,
+and `Separator`; the earlier `1e-7` replay assertion demanded finer repeatability than those
+equipment paths provide. Java 21 CI observed a valid `0.0003080296899 kW` difference on
+`918.1651848674367 kW` (relative `3.35e-7`). The JSON restoration record includes both absolute and
+relative tolerances alongside the measured differences. The participant-sum/source-total check
+within a single solved state retains its separate `1e-10` tolerance, and the existing convergence,
+mass-balance and bottleneck-transition gates still apply.
 
 That result qualifies the total-power evidence path only. The full ordered piping, compressor,
 separator and export-quality sequence, full L process fixture, and common-shaft case remain open.

--- a/docs/process/optimization/industrial-sm-benchmark.md
+++ b/docs/process/optimization/industrial-sm-benchmark.md
@@ -157,8 +157,9 @@ both sources. Candidate solve-time medians are higher in these sequential host o
 the measurements do not isolate the cause or establish a performance improvement. No speedup
 claim is made. The five-fork wall-time totals were 128.385 s before and 116.614 s after; different
 compilation work contributes to those totals. Timing distributions and per-mode execution counts
-remain available in the preserved reports. Large-plant qualification and the shared-power and
-common-shaft transitions remain open roadmap acceptance work.
+remain available in the preserved reports. A later additive evidence-path qualification executes
+the M case's total-shaft-power transition; it does not change or reinterpret these preserved timing
+records. Full large-process qualification and the common-shaft transition remain open roadmap work.
 
 The exact aggregates are stored as deterministic gzip files with an empty filename and `mtime=0`.
 Decompression reproduces the original aggregate bytes, including every fork's raw report and its
@@ -200,7 +201,16 @@ The record marks these metrics unavailable rather than zero:
 - ProcessSystem has no whole-system energy-balance residual API comparable to its mass-balance API.
 
 Execution counts, dirty/dependency scheduling, cache attribution, allocation, and end-to-end
-performance remain coordinated with [#2939](https://github.com/equinor/neqsim/issues/2939). The
-ordered M transition from piping through compressor to separator or total power remains incomplete;
-it depends on the next #3154 stable plant constraint/resource identity increment. No missing metric
-or transition is represented as a passed gate.
+performance remain coordinated with [#2939](https://github.com/equinor/neqsim/issues/2939).
+
+The maintained M test now records exact three-compressor shaft-power coverage and a controlled
+equipment-local compressor to shared total-power bottleneck transition. On the first qualifying run
+from master `ac79c56945b0cdf45a1bcb42e3417dff99e7acbf`, total shaft power was
+`918.164876805159 kW`: the 120% budget left the equipment row limiting, while the 95% budget made
+the shared row limiting with `45.90824384025791 kW` required relief. Restoration differed from the
+cold total by `2.7199348551221192e-8 kW` (relative `2.9623599462728176e-11`) against the `1e-7`
+gate, and evidence capture did not mutate the process.
+
+That result qualifies the total-power evidence path only. The full ordered piping, compressor,
+separator and export-quality sequence, full L process fixture, and common-shaft case remain open.
+No missing metric or transition is represented as a passed gate.

--- a/src/main/java/neqsim/process/util/optimizer/PlantSharedResourceEvidence.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantSharedResourceEvidence.java
@@ -1,0 +1,711 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.stream.EnergyAllocation;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.util.unit.PowerUnit;
+
+/**
+ * Immutable participant-complete evidence for one maximum shared-resource budget.
+ *
+ * <p>
+ * This evidence is captured only from caller-owned completed state. It retains no process, bus, equipment, callback, or
+ * supplier reference. Missing, unexpected, stale, non-finite, metadata-inconsistent, or unconverged observations fail
+ * closed. Aggregation uses only the explicit participant conversions registered in the matching
+ * {@link PlantConstraintDefinition}; unlike units or bases are never inferred.
+ * </p>
+ */
+public final class PlantSharedResourceEvidence implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final String SCHEMA_VERSION = "1.0";
+  private static final double TOTAL_TOLERANCE = 1.0e-10;
+
+  /** Overall evidence status. */
+  public enum Status {
+    /** Every enabled participant and aggregate check is complete. */
+    AVAILABLE,
+    /** The registered shared-resource constraint is disabled. */
+    DISABLED,
+    /** One or more fail-closed diagnostics prevent use as feasible evidence. */
+    INCOMPLETE
+  }
+
+  private final PlantConstraintDefinition definition;
+  private final String calculationId;
+  private final double applicableLimit;
+  private final boolean convergenceComplete;
+  private final List<PlantSharedResourceParticipantSample> participants;
+  private final List<String> diagnostics;
+  private final Status status;
+  private final double aggregateValue;
+  private final double normalizedUtilization;
+  private final double normalizedResidual;
+  private final double physicalMargin;
+  private final double requiredRelief;
+  private final double sourceTotal;
+  private final String sourceTotalUnit;
+  private final String sourceTotalBasis;
+  private final String sourceTotalProvenance;
+
+  private PlantSharedResourceEvidence(Builder builder) {
+    definition = validateDefinition(builder.definition);
+    calculationId = PlantConstraintScope.requireText(builder.calculationId, "Calculation id");
+    applicableLimit = builder.applicableLimit;
+    convergenceComplete = builder.convergenceComplete;
+    sourceTotal = builder.sourceTotalSet ? builder.sourceTotal : Double.NaN;
+    sourceTotalUnit = builder.sourceTotalUnit;
+    sourceTotalBasis = builder.sourceTotalBasis;
+    sourceTotalProvenance = builder.sourceTotalProvenance;
+
+    List<String> findings = new ArrayList<String>(builder.diagnostics);
+    if (!convergenceComplete) {
+      findings.add("INCOMPLETE_CONVERGENCE");
+    }
+    if (definition.getRegistrationStatus() == PlantConstraintDefinition.RegistrationStatus.INCOMPLETE_BASIS
+        || definition
+            .getRegistrationStatus() == PlantConstraintDefinition.RegistrationStatus.DISABLED_INCOMPLETE_BASIS) {
+      findings.add("INCOMPLETE_REGISTRATION_BASIS");
+    }
+    if (!Double.isFinite(applicableLimit) || applicableLimit <= 0.0) {
+      findings.add("INVALID_APPLICABLE_LIMIT");
+    }
+
+    Map<String, PlantSharedResourceParticipantSample> supplied = new TreeMap<String, PlantSharedResourceParticipantSample>(
+        builder.samples);
+    List<PlantSharedResourceParticipantSample> captured = new ArrayList<PlantSharedResourceParticipantSample>();
+    double total = 0.0;
+    boolean totalAvailable = true;
+    for (PlantConstraintParticipant expected : definition.getParticipants()) {
+      PlantSharedResourceParticipantSample sample = supplied.remove(expected.getSourceId());
+      if (sample == null) {
+        sample = missingSample(expected);
+      }
+      captured.add(sample);
+      String problem = validateParticipant(expected, sample);
+      if (!problem.isEmpty()) {
+        findings.add(expected.getSourceId() + "=" + problem);
+        totalAvailable = false;
+      } else {
+        try {
+          total += expected.convertToTarget(sample.getValue());
+        } catch (RuntimeException ex) {
+          findings.add(expected.getSourceId() + "=CONVERSION_FAILED:" + safeMessage(ex));
+          totalAvailable = false;
+        }
+      }
+    }
+    for (PlantSharedResourceParticipantSample unexpected : supplied.values()) {
+      captured.add(unexpected);
+      findings.add(unexpected.getSourceId() + "=UNEXPECTED_PARTICIPANT");
+      totalAvailable = false;
+    }
+    Collections.sort(captured);
+    participants = Collections.unmodifiableList(captured);
+
+    if (totalAvailable && builder.sourceTotalSet) {
+      if (!Double.isFinite(builder.sourceTotal) || !definition.getUnit().equals(builder.sourceTotalUnit)
+          || !definition.getBasis().equals(builder.sourceTotalBasis) || builder.sourceTotalProvenance.isEmpty()) {
+        findings.add("SOURCE_TOTAL_METADATA_MISMATCH");
+        totalAvailable = false;
+      } else if (!approximatelyEqual(total, builder.sourceTotal)) {
+        findings.add("SOURCE_TOTAL_MISMATCH expected=" + builder.sourceTotal + " aggregated=" + total);
+        totalAvailable = false;
+      }
+    }
+    if (!builder.sourceTotalSet) {
+      findings.add("SOURCE_TOTAL_NOT_CROSS_CHECKED");
+      totalAvailable = false;
+    }
+
+    diagnostics = Collections.unmodifiableList(new ArrayList<String>(findings));
+    if (!definition.isEnabled()) {
+      status = Status.DISABLED;
+    } else if (findings.isEmpty() && totalAvailable) {
+      status = Status.AVAILABLE;
+    } else {
+      status = Status.INCOMPLETE;
+    }
+
+    if (status == Status.AVAILABLE) {
+      aggregateValue = total;
+      normalizedUtilization = total / applicableLimit;
+      normalizedResidual = normalizedUtilization - 1.0;
+      physicalMargin = applicableLimit - total;
+      requiredRelief = Math.max(0.0, total - applicableLimit);
+    } else {
+      aggregateValue = Double.NaN;
+      normalizedUtilization = Double.NaN;
+      normalizedResidual = Double.NaN;
+      physicalMargin = Double.NaN;
+      requiredRelief = Double.NaN;
+    }
+  }
+
+  /** Starts an evidence builder for a registered shared budget and one exact calculation. */
+  public static Builder builder(PlantConstraintDefinition definition, String calculationId, double applicableLimit) {
+    return new Builder(definition, calculationId, applicableLimit);
+  }
+
+  /**
+   * Captures exact top-level compressor and pump shaft-power participants from a solved process system.
+   *
+   * @param definition shared-budget registration whose participants are equipment names
+   * @param calculationId exact completed calculation identity
+   * @param applicableLimit finite positive shared limit in the definition unit and basis
+   * @param process solved isolated process system
+   * @param convergenceComplete caller's full-candidate convergence decision
+   * @param provenance runtime evidence provenance
+   * @return immutable callback-free evidence
+   */
+  public static PlantSharedResourceEvidence fromProcessSystemShaftPower(PlantConstraintDefinition definition,
+      String calculationId, double applicableLimit, ProcessSystem process, boolean convergenceComplete,
+      String provenance) {
+    return fromProcessSystemShaftPower(definition, calculationId, applicableLimit, process, convergenceComplete,
+        provenance, Collections.<String>emptyList());
+  }
+
+  /**
+   * Captures shaft-power evidence with explicit out-of-service equipment identities.
+   *
+   * <p>
+   * An out-of-service declaration is accepted only when the solved equipment power is numerically zero. It never
+   * converts a missing or non-zero observation to zero.
+   * </p>
+   *
+   * @param definition shared-budget registration whose participants are equipment names
+   * @param calculationId exact completed calculation identity
+   * @param applicableLimit finite positive shared limit
+   * @param process solved isolated process system
+   * @param convergenceComplete caller's full-candidate convergence decision
+   * @param provenance runtime evidence provenance
+   * @param outOfServiceParticipantIds equipment names explicitly unavailable in this line-up
+   * @return immutable callback-free evidence
+   */
+  public static PlantSharedResourceEvidence fromProcessSystemShaftPower(PlantConstraintDefinition definition,
+      String calculationId, double applicableLimit, ProcessSystem process, boolean convergenceComplete,
+      String provenance, Collection<String> outOfServiceParticipantIds) {
+    if (process == null) {
+      throw new IllegalArgumentException("Process system is required");
+    }
+    Builder result = builder(definition, calculationId, applicableLimit);
+    String safeProvenance = PlantConstraintScope.safeText(provenance);
+    Map<String, PlantConstraintParticipant> expected = participantMap(definition);
+    Collection<String> unavailable = outOfServiceParticipantIds == null ? Collections.<String>emptyList()
+        : outOfServiceParticipantIds;
+    for (ProcessEquipmentInterface equipment : process.getUnitOperations()) {
+      double power;
+      if (equipment instanceof Compressor) {
+        power = ((Compressor) equipment).getPower(sourceUnit(expected.get(equipment.getName()), definition));
+      } else if (equipment instanceof Pump) {
+        power = ((Pump) equipment).getPower(sourceUnit(expected.get(equipment.getName()), definition));
+      } else {
+        continue;
+      }
+      PlantConstraintParticipant participant = expected.get(equipment.getName());
+      String unit = sourceUnit(participant, definition);
+      String basis = sourceBasis(participant, definition);
+      PlantSharedResourceParticipantSample.Status sampleStatus = sampleStatus(power);
+      String diagnostic = "";
+      if (unavailable.contains(equipment.getName())) {
+        if (Double.isFinite(power) && power == 0.0) {
+          sampleStatus = PlantSharedResourceParticipantSample.Status.OUT_OF_SERVICE;
+        } else {
+          sampleStatus = PlantSharedResourceParticipantSample.Status.METADATA_MISMATCH;
+          diagnostic = "Out-of-service equipment retained non-zero or unavailable shaft power";
+        }
+      }
+      result.participant(
+          PlantSharedResourceParticipantSample.builder(equipment.getName(), calculationId).status(sampleStatus)
+              .value(power).unit(unit).basis(basis).provenance(safeProvenance).diagnostic(diagnostic).build());
+    }
+    boolean solved = convergenceComplete && process.solved() && process.getRunStatus().isSuccess();
+    result.convergenceComplete(solved);
+    try {
+      result.sourceTotal(process.getPower(definition.getUnit()), definition.getUnit(), definition.getBasis(),
+          safeProvenance);
+    } catch (RuntimeException ex) {
+      result.diagnostic("PROCESS_TOTAL_FAILED:" + safeMessage(ex));
+    }
+    return result.build();
+  }
+
+  /**
+   * Captures area-complete compressor and pump shaft-power evidence from a solved process model.
+   *
+   * @param definition shared-budget registration whose participants are process-area names
+   * @param calculationId exact completed calculation identity
+   * @param applicableLimit finite positive shared limit
+   * @param model solved isolated process model
+   * @param convergenceComplete caller's full-candidate convergence decision
+   * @param provenance runtime evidence provenance
+   * @return immutable callback-free evidence
+   */
+  public static PlantSharedResourceEvidence fromProcessModelShaftPower(PlantConstraintDefinition definition,
+      String calculationId, double applicableLimit, ProcessModel model, boolean convergenceComplete,
+      String provenance) {
+    if (model == null) {
+      throw new IllegalArgumentException("Process model is required");
+    }
+    Builder result = builder(definition, calculationId, applicableLimit);
+    String safeProvenance = PlantConstraintScope.safeText(provenance);
+    Map<String, PlantConstraintParticipant> expected = participantMap(definition);
+    for (String areaName : model.getProcessSystemNames()) {
+      PlantConstraintParticipant participant = expected.get(areaName);
+      String unit = sourceUnit(participant, definition);
+      String basis = sourceBasis(participant, definition);
+      double power;
+      try {
+        power = model.get(areaName).getPower(unit);
+      } catch (RuntimeException ex) {
+        result.participant(PlantSharedResourceParticipantSample.builder(areaName, calculationId)
+            .status(PlantSharedResourceParticipantSample.Status.EXCEPTION).unit(unit).basis(basis)
+            .provenance(safeProvenance).diagnostic(safeMessage(ex)).build());
+        continue;
+      }
+      result.participant(PlantSharedResourceParticipantSample.builder(areaName, calculationId)
+          .status(sampleStatus(power)).value(power).unit(unit).basis(basis).provenance(safeProvenance).build());
+    }
+    result.convergenceComplete(convergenceComplete && model.isModelConverged() && model.isFinished());
+    try {
+      result.sourceTotal(model.getPower(definition.getUnit()), definition.getUnit(), definition.getBasis(),
+          safeProvenance);
+    } catch (RuntimeException ex) {
+      result.diagnostic("MODEL_TOTAL_FAILED:" + safeMessage(ex));
+    }
+    return result.build();
+  }
+
+  /**
+   * Captures requested electrical demand from a current solved energy-bus report.
+   *
+   * <p>
+   * The aggregate is requested demand, not served demand, so unmet load remains visible. Every input port must be
+   * registered as a constraint participant. External bus demand and bidirectional demand fail closed because neither
+   * has an unambiguous participant contract.
+   * </p>
+   *
+   * @param definition electrical shared-budget registration using stable energy-port participant IDs
+   * @param calculationId exact completed calculation identity
+   * @param applicableLimit finite positive electrical limit
+   * @param bus solved isolated electrical energy bus
+   * @param provenance runtime evidence provenance
+   * @return immutable callback-free evidence
+   */
+  public static PlantSharedResourceEvidence fromSolvedEnergyBusRequestedDemand(PlantConstraintDefinition definition,
+      String calculationId, double applicableLimit, EnergyBus bus, String provenance) {
+    if (bus == null) {
+      throw new IllegalArgumentException("Energy bus is required");
+    }
+    Builder result = builder(definition, calculationId, applicableLimit);
+    String safeProvenance = PlantConstraintScope.safeText(provenance);
+    if (bus.getEnergyType() != EnergyType.ELECTRICAL) {
+      result.diagnostic("ENERGY_BUS_IS_NOT_ELECTRICAL");
+    }
+    EnergyNetworkReport report = bus.getLastReport();
+    if (!bus.hasSolution() || report == null) {
+      result.convergenceComplete(false).diagnostic("ENERGY_BUS_SOLUTION_STALE_OR_MISSING");
+      return result.build();
+    }
+    Map<String, PlantConstraintParticipant> expected = participantMap(definition);
+    for (EnergyAllocation allocation : report.getAllocations()) {
+      if (allocation.getDirection() == EnergyPortDirection.OUTPUT) {
+        continue;
+      }
+      PlantConstraintParticipant participant = expected.get(allocation.getParticipantId());
+      String unit = sourceUnit(participant, definition);
+      String basis = sourceBasis(participant, definition);
+      double value = new PowerUnit(allocation.getRequestedPower(), "W").getValue(unit);
+      PlantSharedResourceParticipantSample.Status sampleStatus = sampleStatus(value);
+      String diagnostic = "";
+      if (allocation.getDirection() == EnergyPortDirection.BIDIRECTIONAL) {
+        sampleStatus = PlantSharedResourceParticipantSample.Status.METADATA_MISMATCH;
+        diagnostic = "Bidirectional requested demand has no unambiguous load direction";
+      }
+      result.participant(PlantSharedResourceParticipantSample.builder(allocation.getParticipantId(), calculationId)
+          .status(sampleStatus).value(value).unit(unit).basis(basis).provenance(safeProvenance).diagnostic(diagnostic)
+          .build());
+    }
+    result.convergenceComplete(true);
+    result.sourceTotal(new PowerUnit(report.getRequestedDemand(), "W").getValue(definition.getUnit()),
+        definition.getUnit(), definition.getBasis(), safeProvenance);
+    return result.build();
+  }
+
+  private static PlantConstraintDefinition validateDefinition(PlantConstraintDefinition value) {
+    if (value == null) {
+      throw new IllegalArgumentException("Shared-resource definition is required");
+    }
+    if (value.getScope().getType() != PlantConstraintScope.Type.SHARED_RESOURCE) {
+      throw new IllegalArgumentException("Shared-resource evidence requires SHARED_RESOURCE scope");
+    }
+    if (value.getAggregationPolicy() != PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET
+        || value.getLimitDirection() != PlantConstraintDefinition.LimitDirection.MAXIMUM) {
+      throw new IllegalArgumentException("This evidence supports maximum SHARED_BUDGET constraints only");
+    }
+    return value;
+  }
+
+  private PlantSharedResourceParticipantSample missingSample(PlantConstraintParticipant participant) {
+    return PlantSharedResourceParticipantSample.builder(participant.getSourceId(), calculationId)
+        .status(PlantSharedResourceParticipantSample.Status.MISSING).unit(participant.getUnit())
+        .basis(participant.getBasis()).diagnostic("Expected participant observation is missing").build();
+  }
+
+  private String validateParticipant(PlantConstraintParticipant expected, PlantSharedResourceParticipantSample sample) {
+    if (!calculationId.equals(sample.getCalculationId())) {
+      return "CALCULATION_ID_MISMATCH";
+    }
+    if (!sample.isUsable()) {
+      return sample.getStatus().name() + diagnosticSuffix(sample.getDiagnostic());
+    }
+    if (!expected.getUnit().equals(sample.getUnit()) || !expected.getBasis().equals(sample.getBasis())) {
+      return "METADATA_MISMATCH";
+    }
+    if (sample.getProvenance().isEmpty()) {
+      return "MISSING_PROVENANCE";
+    }
+    return "";
+  }
+
+  private static String diagnosticSuffix(String diagnostic) {
+    return diagnostic == null || diagnostic.isEmpty() ? "" : ":" + diagnostic;
+  }
+
+  private static Map<String, PlantConstraintParticipant> participantMap(PlantConstraintDefinition definition) {
+    Map<String, PlantConstraintParticipant> result = new LinkedHashMap<String, PlantConstraintParticipant>();
+    for (PlantConstraintParticipant participant : definition.getParticipants()) {
+      result.put(participant.getSourceId(), participant);
+    }
+    return result;
+  }
+
+  private static String sourceUnit(PlantConstraintParticipant participant, PlantConstraintDefinition definition) {
+    return participant == null ? definition.getUnit() : participant.getUnit();
+  }
+
+  private static String sourceBasis(PlantConstraintParticipant participant, PlantConstraintDefinition definition) {
+    return participant == null ? definition.getBasis() : participant.getBasis();
+  }
+
+  private static PlantSharedResourceParticipantSample.Status sampleStatus(double value) {
+    return Double.isFinite(value) ? PlantSharedResourceParticipantSample.Status.AVAILABLE
+        : PlantSharedResourceParticipantSample.Status.NON_FINITE_VALUE;
+  }
+
+  private static boolean approximatelyEqual(double first, double second) {
+    double scale = Math.max(1.0, Math.max(Math.abs(first), Math.abs(second)));
+    return Math.abs(first - second) <= TOTAL_TOLERANCE * scale;
+  }
+
+  private static String safeMessage(RuntimeException ex) {
+    String message = ex.getMessage();
+    return message == null ? ex.getClass().getSimpleName() : message;
+  }
+
+  /** @return evidence schema version */
+  public String getSchemaVersion() {
+    return SCHEMA_VERSION;
+  }
+
+  /** @return exact registered shared-resource definition */
+  public PlantConstraintDefinition getDefinition() {
+    return definition;
+  }
+
+  /** @return exact calculation identity */
+  public String getCalculationId() {
+    return calculationId;
+  }
+
+  /** @return applicable maximum limit in the registered unit and basis */
+  public double getApplicableLimit() {
+    return applicableLimit;
+  }
+
+  /** @return whether the full candidate calculation was declared converged */
+  public boolean isConvergenceComplete() {
+    return convergenceComplete;
+  }
+
+  /** @return deterministic immutable participant observations */
+  public List<PlantSharedResourceParticipantSample> getParticipants() {
+    return Collections.unmodifiableList(new ArrayList<PlantSharedResourceParticipantSample>(participants));
+  }
+
+  /** @return overall evidence status */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** @return true when every enabled participant and aggregate check is usable */
+  public boolean isComplete() {
+    return status == Status.AVAILABLE || status == Status.DISABLED;
+  }
+
+  /** @return true when complete enabled evidence does not exceed its limit */
+  public boolean isFeasible() {
+    return status == Status.AVAILABLE && normalizedResidual <= 0.0;
+  }
+
+  /** @return aggregate shared-resource value, or NaN when incomplete */
+  public double getAggregateValue() {
+    return aggregateValue;
+  }
+
+  /** @return dimensionless utilization, or NaN when incomplete */
+  public double getNormalizedUtilization() {
+    return normalizedUtilization;
+  }
+
+  /** @return dimensionless residual {@code utilization - 1}, or NaN */
+  public double getNormalizedResidual() {
+    return normalizedResidual;
+  }
+
+  /** @return signed physical headroom, or NaN when incomplete */
+  public double getPhysicalMargin() {
+    return physicalMargin;
+  }
+
+  /** @return non-negative physical relief required, or NaN when incomplete */
+  public double getRequiredRelief() {
+    return requiredRelief;
+  }
+
+  /** @return independently calculated target-basis total, or NaN when not supplied */
+  public double getSourceTotal() {
+    return sourceTotal;
+  }
+
+  /** @return unit of the independent total */
+  public String getSourceTotalUnit() {
+    return sourceTotalUnit;
+  }
+
+  /** @return basis of the independent total */
+  public String getSourceTotalBasis() {
+    return sourceTotalBasis;
+  }
+
+  /** @return provenance of the independent total */
+  public String getSourceTotalProvenance() {
+    return sourceTotalProvenance;
+  }
+
+  /** @return immutable fail-closed diagnostics */
+  public List<String> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<String>(diagnostics));
+  }
+
+  /** Converts this immutable evidence to the common plant utilization sample contract. */
+  public PlantConstraintSample toPlantConstraintSample() {
+    PlantConstraintSample.SampleStatus sampleStatus;
+    if (status == Status.AVAILABLE) {
+      sampleStatus = PlantConstraintSample.SampleStatus.AVAILABLE;
+    } else if (!convergenceComplete) {
+      sampleStatus = PlantConstraintSample.SampleStatus.INCOMPLETE_CONVERGENCE;
+    } else if (containsDiagnostic("NON_FINITE")) {
+      sampleStatus = PlantConstraintSample.SampleStatus.NON_FINITE_VALUE;
+    } else if (containsDiagnostic("STALE")) {
+      sampleStatus = PlantConstraintSample.SampleStatus.STALE;
+    } else if (containsDiagnostic("OUTSIDE_VALIDITY")) {
+      sampleStatus = PlantConstraintSample.SampleStatus.OUTSIDE_VALIDITY;
+    } else if (containsDiagnostic("EXCEPTION")) {
+      sampleStatus = PlantConstraintSample.SampleStatus.EXCEPTION;
+    } else if (containsDiagnostic("METADATA") || containsDiagnostic("MISMATCH") || containsDiagnostic("UNEXPECTED")) {
+      sampleStatus = PlantConstraintSample.SampleStatus.METADATA_MISMATCH;
+    } else if (containsDiagnostic("MISSING")) {
+      sampleStatus = PlantConstraintSample.SampleStatus.MISSING_VALUE;
+    } else {
+      sampleStatus = PlantConstraintSample.SampleStatus.NOT_CALCULABLE;
+    }
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId).status(sampleStatus)
+        .values(aggregateValue, applicableLimit).normalized(normalizedUtilization, normalizedResidual)
+        .physical(physicalMargin, requiredRelief).unit(definition.getUnit()).basis(definition.getBasis())
+        .provenance(definition.getProvenance()).diagnostic(joinDiagnostics()).build();
+  }
+
+  private boolean containsDiagnostic(String token) {
+    for (String diagnostic : diagnostics) {
+      if (diagnostic.contains(token)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private String joinDiagnostics() {
+    StringBuilder result = new StringBuilder();
+    for (String diagnostic : diagnostics) {
+      if (result.length() > 0) {
+        result.append(';');
+      }
+      result.append(diagnostic);
+    }
+    return result.toString();
+  }
+
+  /** @return JSON using null rather than zero or non-standard NaN for unavailable numbers */
+  public String toJson() {
+    JsonObject root = new JsonObject();
+    root.addProperty("schemaVersion", SCHEMA_VERSION);
+    root.addProperty("qualifiedConstraintId", definition.getQualifiedId());
+    root.addProperty("calculationId", calculationId);
+    root.addProperty("status", status.name());
+    root.addProperty("unit", definition.getUnit());
+    root.addProperty("basis", definition.getBasis());
+    root.addProperty("provenance", definition.getProvenance());
+    root.addProperty("convergenceComplete", convergenceComplete);
+    addNumber(root, "applicableLimit", applicableLimit);
+    addNumber(root, "aggregateValue", aggregateValue);
+    addNumber(root, "normalizedUtilization", normalizedUtilization);
+    addNumber(root, "normalizedResidual", normalizedResidual);
+    addNumber(root, "physicalMargin", physicalMargin);
+    addNumber(root, "requiredRelief", requiredRelief);
+    addNumber(root, "sourceTotal", sourceTotal);
+    root.addProperty("sourceTotalUnit", sourceTotalUnit);
+    root.addProperty("sourceTotalBasis", sourceTotalBasis);
+    root.addProperty("sourceTotalProvenance", sourceTotalProvenance);
+    JsonArray participantRows = new JsonArray();
+    Map<String, PlantConstraintParticipant> expected = participantMap(definition);
+    for (PlantSharedResourceParticipantSample sample : participants) {
+      JsonObject row = new JsonObject();
+      row.addProperty("sourceId", sample.getSourceId());
+      row.addProperty("status", sample.getStatus().name());
+      row.addProperty("unit", sample.getUnit());
+      row.addProperty("basis", sample.getBasis());
+      row.addProperty("provenance", sample.getProvenance());
+      row.addProperty("diagnostic", sample.getDiagnostic());
+      addNumber(row, "value", sample.getValue());
+      addNumber(row, "confidence", sample.getConfidence());
+      addNumber(row, "validityMinimum", sample.getValidityMinimum());
+      addNumber(row, "validityMaximum", sample.getValidityMaximum());
+      PlantConstraintParticipant participant = expected.get(sample.getSourceId());
+      double converted = Double.NaN;
+      if (participant != null && sample.isUsable()) {
+        row.addProperty("conversionExplicit", participant.isConversionExplicit());
+        row.addProperty("conversionFactor", participant.getConversionFactor());
+        row.addProperty("conversionOffset", participant.getConversionOffset());
+        try {
+          converted = participant.convertToTarget(sample.getValue());
+        } catch (RuntimeException ex) {
+          converted = Double.NaN;
+        }
+      } else if (participant != null) {
+        row.addProperty("conversionExplicit", participant.isConversionExplicit());
+        row.addProperty("conversionFactor", participant.getConversionFactor());
+        row.addProperty("conversionOffset", participant.getConversionOffset());
+      } else {
+        row.add("conversionExplicit", JsonNull.INSTANCE);
+        row.add("conversionFactor", JsonNull.INSTANCE);
+        row.add("conversionOffset", JsonNull.INSTANCE);
+      }
+      addNumber(row, "convertedValue", converted);
+      participantRows.add(row);
+    }
+    root.add("participants", participantRows);
+    JsonArray diagnosticRows = new JsonArray();
+    for (String diagnostic : diagnostics) {
+      diagnosticRows.add(diagnostic);
+    }
+    root.add("diagnostics", diagnosticRows);
+    return root.toString();
+  }
+
+  private static void addNumber(JsonObject target, String name, double value) {
+    if (Double.isFinite(value)) {
+      target.addProperty(name, value);
+    } else {
+      target.add(name, JsonNull.INSTANCE);
+    }
+  }
+
+  /** Callback-free shared-resource evidence builder. */
+  public static final class Builder {
+    private final PlantConstraintDefinition definition;
+    private final String calculationId;
+    private final double applicableLimit;
+    private final Map<String, PlantSharedResourceParticipantSample> samples = new LinkedHashMap<String, PlantSharedResourceParticipantSample>();
+    private final List<String> diagnostics = new ArrayList<String>();
+    private boolean convergenceComplete;
+    private boolean sourceTotalSet;
+    private double sourceTotal = Double.NaN;
+    private String sourceTotalUnit = "";
+    private String sourceTotalBasis = "";
+    private String sourceTotalProvenance = "";
+
+    private Builder(PlantConstraintDefinition definition, String calculationId, double applicableLimit) {
+      this.definition = validateDefinition(definition);
+      this.calculationId = calculationId;
+      this.applicableLimit = applicableLimit;
+    }
+
+    /** Adds one exact participant observation. */
+    public Builder participant(PlantSharedResourceParticipantSample sample) {
+      if (sample == null) {
+        throw new IllegalArgumentException("Shared-resource participant sample is required");
+      }
+      if (samples.containsKey(sample.getSourceId())) {
+        throw new IllegalArgumentException("Duplicate participant sample " + sample.getSourceId());
+      }
+      samples.put(sample.getSourceId(), sample);
+      return this;
+    }
+
+    /** Declares whether the complete process calculation converged. */
+    public Builder convergenceComplete(boolean value) {
+      convergenceComplete = value;
+      return this;
+    }
+
+    /**
+     * Adds an independently calculated total in the registered target unit and basis.
+     *
+     * @param value independently calculated total
+     * @param unit target unit
+     * @param basis target basis
+     * @param provenance total source provenance
+     * @return this builder
+     */
+    public Builder sourceTotal(double value, String unit, String basis, String provenance) {
+      sourceTotal = value;
+      sourceTotalUnit = PlantConstraintScope.safeText(unit);
+      sourceTotalBasis = PlantConstraintScope.safeText(basis);
+      sourceTotalProvenance = PlantConstraintScope.safeText(provenance);
+      sourceTotalSet = true;
+      return this;
+    }
+
+    /** Adds a fail-closed adapter diagnostic. */
+    public Builder diagnostic(String value) {
+      String safeValue = PlantConstraintScope.safeText(value);
+      if (!safeValue.isEmpty()) {
+        diagnostics.add(safeValue);
+      }
+      return this;
+    }
+
+    /** @return immutable participant-complete evidence */
+    public PlantSharedResourceEvidence build() {
+      return new PlantSharedResourceEvidence(this);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/PlantSharedResourceParticipantSample.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantSharedResourceParticipantSample.java
@@ -1,0 +1,263 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+
+/**
+ * Immutable observation for one participant in a shared plant-resource constraint.
+ *
+ * <p>
+ * Values retain the participant's declared source unit and basis. Conversion to the shared target is performed only by
+ * {@link PlantSharedResourceEvidence} using the conversion registered in {@link PlantConstraintParticipant}. Missing
+ * observations are represented by status and {@link Double#NaN}; they are never converted to zero. An explicit zero is
+ * accepted only as a finite {@link Status#AVAILABLE} observation or as {@link Status#OUT_OF_SERVICE} evidence.
+ * </p>
+ */
+public final class PlantSharedResourceParticipantSample
+    implements Serializable, Comparable<PlantSharedResourceParticipantSample> {
+  private static final long serialVersionUID = 1L;
+
+  /** Participant observation status. */
+  public enum Status {
+    /** A finite observation is available. */
+    AVAILABLE,
+    /** The participant is explicitly unavailable and contributes verified zero load. */
+    OUT_OF_SERVICE,
+    /** The expected participant or its observation is missing. */
+    MISSING,
+    /** The observation belongs to an older process state. */
+    STALE,
+    /** The observed value is non-finite. */
+    NON_FINITE_VALUE,
+    /** The observation is outside its declared validity range. */
+    OUTSIDE_VALIDITY,
+    /** The underlying process calculation did not converge. */
+    INCOMPLETE_CONVERGENCE,
+    /** Participant identity, unit, basis, availability, or provenance is inconsistent. */
+    METADATA_MISMATCH,
+    /** Observation failed with an exception. */
+    EXCEPTION
+  }
+
+  private final String sourceId;
+  private final String calculationId;
+  private final Status status;
+  private final double value;
+  private final String unit;
+  private final String basis;
+  private final String provenance;
+  private final String diagnostic;
+  private final boolean confidenceSet;
+  private final double confidence;
+  private final boolean validityRangeSet;
+  private final double validityMinimum;
+  private final double validityMaximum;
+
+  private PlantSharedResourceParticipantSample(Builder builder) {
+    sourceId = PlantConstraintScope.requireText(builder.sourceId, "Shared-resource participant identity");
+    calculationId = PlantConstraintScope.requireText(builder.calculationId, "Calculation id");
+    value = builder.value;
+    unit = PlantConstraintScope.safeText(builder.unit);
+    basis = PlantConstraintScope.safeText(builder.basis);
+    provenance = PlantConstraintScope.safeText(builder.provenance);
+    diagnostic = PlantConstraintScope.safeText(builder.diagnostic);
+    confidenceSet = builder.confidenceSet;
+    confidence = validateConfidence(builder.confidenceSet, builder.confidence);
+    validityRangeSet = builder.validityRangeSet;
+    validityMinimum = builder.validityMinimum;
+    validityMaximum = builder.validityMaximum;
+    validateValidityRange();
+    status = resolveStatus(builder.status);
+  }
+
+  /** Starts a callback-free builder suitable for Java and JPype callers. */
+  public static Builder builder(String sourceId, String calculationId) {
+    return new Builder(sourceId, calculationId);
+  }
+
+  private static double validateConfidence(boolean set, double value) {
+    if (!set) {
+      return Double.NaN;
+    }
+    if (!Double.isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException("Participant confidence must be finite and in [0, 1]");
+    }
+    return value;
+  }
+
+  private void validateValidityRange() {
+    if (validityRangeSet && (!Double.isFinite(validityMinimum) || !Double.isFinite(validityMaximum)
+        || validityMinimum > validityMaximum)) {
+      throw new IllegalArgumentException("Participant validity range must be finite and ordered");
+    }
+  }
+
+  private Status resolveStatus(Status requested) {
+    Status resolved = requested == null ? Status.MISSING : requested;
+    if (resolved == Status.AVAILABLE || resolved == Status.OUT_OF_SERVICE) {
+      if (!Double.isFinite(value)) {
+        return Status.NON_FINITE_VALUE;
+      }
+      if (resolved == Status.OUT_OF_SERVICE && value != 0.0) {
+        return Status.METADATA_MISMATCH;
+      }
+      if (validityRangeSet && (value < validityMinimum || value > validityMaximum)) {
+        return Status.OUTSIDE_VALIDITY;
+      }
+    }
+    return resolved;
+  }
+
+  /** @return stable caller-owned participant identity */
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  /** @return exact process calculation identity */
+  public String getCalculationId() {
+    return calculationId;
+  }
+
+  /** @return observation status */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** @return observed source value, or NaN when unavailable */
+  public double getValue() {
+    return value;
+  }
+
+  /** @return source engineering unit */
+  public String getUnit() {
+    return unit;
+  }
+
+  /** @return source measurement or reference basis */
+  public String getBasis() {
+    return basis;
+  }
+
+  /** @return runtime evidence provenance */
+  public String getProvenance() {
+    return provenance;
+  }
+
+  /** @return explanatory diagnostic, or empty */
+  public String getDiagnostic() {
+    return diagnostic;
+  }
+
+  /** @return whether confidence was explicitly supplied */
+  public boolean hasConfidence() {
+    return confidenceSet;
+  }
+
+  /** @return confidence in [0, 1], or NaN when not supplied */
+  public double getConfidence() {
+    return confidence;
+  }
+
+  /** @return whether a source-value validity range was supplied */
+  public boolean hasValidityRange() {
+    return validityRangeSet;
+  }
+
+  /** @return inclusive source-value validity minimum, or NaN */
+  public double getValidityMinimum() {
+    return validityRangeSet ? validityMinimum : Double.NaN;
+  }
+
+  /** @return inclusive source-value validity maximum, or NaN */
+  public double getValidityMaximum() {
+    return validityRangeSet ? validityMaximum : Double.NaN;
+  }
+
+  /** @return true for a finite available or verified out-of-service observation */
+  public boolean isUsable() {
+    return status == Status.AVAILABLE || status == Status.OUT_OF_SERVICE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compareTo(PlantSharedResourceParticipantSample other) {
+    return sourceId.compareTo(other.sourceId);
+  }
+
+  /** Callback-free participant builder. */
+  public static final class Builder {
+    private final String sourceId;
+    private final String calculationId;
+    private Status status = Status.AVAILABLE;
+    private double value = Double.NaN;
+    private String unit = "";
+    private String basis = "";
+    private String provenance = "";
+    private String diagnostic = "";
+    private boolean confidenceSet;
+    private double confidence = Double.NaN;
+    private boolean validityRangeSet;
+    private double validityMinimum = Double.NaN;
+    private double validityMaximum = Double.NaN;
+
+    private Builder(String sourceId, String calculationId) {
+      this.sourceId = sourceId;
+      this.calculationId = calculationId;
+    }
+
+    /** Sets participant status. */
+    public Builder status(Status value) {
+      status = value;
+      return this;
+    }
+
+    /** Sets the observed value in the declared source unit and basis. */
+    public Builder value(double observedValue) {
+      value = observedValue;
+      return this;
+    }
+
+    /** Sets the source engineering unit. */
+    public Builder unit(String value) {
+      unit = value;
+      return this;
+    }
+
+    /** Sets the source measurement or reference basis. */
+    public Builder basis(String value) {
+      basis = value;
+      return this;
+    }
+
+    /** Sets runtime evidence provenance. */
+    public Builder provenance(String value) {
+      provenance = value;
+      return this;
+    }
+
+    /** Sets an explanatory diagnostic. */
+    public Builder diagnostic(String value) {
+      diagnostic = value;
+      return this;
+    }
+
+    /** Sets evidence confidence in [0, 1]. */
+    public Builder confidence(double value) {
+      confidence = value;
+      confidenceSet = true;
+      return this;
+    }
+
+    /** Sets an inclusive source-value validity range. */
+    public Builder validityRange(double minimum, double maximum) {
+      validityMinimum = minimum;
+      validityMaximum = maximum;
+      validityRangeSet = true;
+      return this;
+    }
+
+    /** @return validated immutable participant observation */
+    public PlantSharedResourceParticipantSample build() {
+      return new PlantSharedResourceParticipantSample(this);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/IndustrialPlantOptimizationBaselineTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/IndustrialPlantOptimizationBaselineTest.java
@@ -60,6 +60,9 @@ import neqsim.thermo.system.SystemSrkEos;
 class IndustrialPlantOptimizationBaselineTest {
   private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
   private static final String SCHEMA_VERSION = "1.0";
+  // Independent process replays include the 1e-6 relative recalculation thresholds in Stream,
+  // Compressor and Separator. Their power repeatability budget must allow that numerical floor.
+  private static final double SHAFT_POWER_REPEATABILITY_RELATIVE_TOLERANCE = 1.0e-6;
 
   /** Holds the mutable decision point and installed constraint for case S. */
   private static final class SmallFixture {
@@ -222,10 +225,13 @@ class IndustrialPlantOptimizationBaselineTest {
     double restoredTotalPower = restoredPower.get("aggregateShaftPowerKw").getAsDouble();
     double restoredPowerDifference = Math.abs(coldTotalPower - restoredTotalPower);
     double restoredPowerRelativeDifference = restoredPowerDifference / Math.max(1.0, coldTotalPower);
-    assertEquals(coldTotalPower, restoredTotalPower, Math.max(1.0, coldTotalPower) * 1.0e-7,
-        "restored line-up must reproduce shared shaft-power evidence");
+    double restoredPowerTolerance = Math.max(1.0, coldTotalPower) * SHAFT_POWER_REPEATABILITY_RELATIVE_TOLERANCE;
+    assertEquals(coldTotalPower, restoredTotalPower, restoredPowerTolerance,
+        "restored line-up must reproduce shared shaft power within the process recalculation tolerance");
     restored.addProperty("totalPowerAbsoluteDifferenceKw", restoredPowerDifference);
     restored.addProperty("totalPowerRelativeDifference", restoredPowerRelativeDifference);
+    restored.addProperty("totalPowerAbsoluteToleranceKw", restoredPowerTolerance);
+    restored.addProperty("totalPowerRelativeTolerance", SHAFT_POWER_REPEATABILITY_RELATIVE_TOLERANCE);
     restored.add("totalPowerEvidence", restoredPower);
     modes.add(restored);
 

--- a/src/test/java/neqsim/process/util/optimizer/IndustrialPlantOptimizationBaselineTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/IndustrialPlantOptimizationBaselineTest.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
@@ -181,6 +183,9 @@ class IndustrialPlantOptimizationBaselineTest {
     modes.add(cold);
     double coldProduct = cold.get("productMassRateKgPerHr").getAsDouble();
     String coldBottleneck = bottleneckIdentity(cold);
+    JsonObject totalPowerTransition = totalPowerTransition(fixture.process, "M-cold-total-power");
+    double coldTotalPower = totalPowerTransition.get("aggregateShaftPowerKw").getAsDouble();
+    result.add("totalPowerTransition", totalPowerTransition);
 
     for (int repetition = 1; repetition <= 5; repetition++) {
       modes.add(runAndRecord(fixture.process, "unchanged", repetition, fixture.feed, coldProduct));
@@ -213,6 +218,15 @@ class IndustrialPlantOptimizationBaselineTest {
     restored.addProperty("restoration", "FULL_REPLAY_COMPLETED");
     assertTrue(restored.get("repeatabilityAbsoluteDifferenceKgPerHr").getAsDouble() <= 0.1,
         "restored product boundary must return within 0.1 kg/hr of the cold state");
+    JsonObject restoredPower = totalPowerTransition(fixture.process, "M-restored-total-power");
+    double restoredTotalPower = restoredPower.get("aggregateShaftPowerKw").getAsDouble();
+    double restoredPowerDifference = Math.abs(coldTotalPower - restoredTotalPower);
+    double restoredPowerRelativeDifference = restoredPowerDifference / Math.max(1.0, coldTotalPower);
+    assertEquals(coldTotalPower, restoredTotalPower, Math.max(1.0, coldTotalPower) * 1.0e-7,
+        "restored line-up must reproduce shared shaft-power evidence");
+    restored.addProperty("totalPowerAbsoluteDifferenceKw", restoredPowerDifference);
+    restored.addProperty("totalPowerRelativeDifference", restoredPowerRelativeDifference);
+    restored.add("totalPowerEvidence", restoredPower);
     modes.add(restored);
 
     JsonObject transition = new JsonObject();
@@ -225,6 +239,84 @@ class IndustrialPlantOptimizationBaselineTest {
         "#3154 next increment; execution counters and cache attribution coordinate with #2939");
     result.add("bottleneckTransition", transition);
     result.add("modes", modes);
+    return result;
+  }
+
+  /** Builds compressor-local and shared-power snapshots without mutating the solved process. */
+  private JsonObject totalPowerTransition(ProcessSystem process, String calculationId) {
+    List<Compressor> compressors = new ArrayList<Compressor>();
+    PlantConstraintDefinition.Builder sharedBuilder = PlantConstraintDefinition
+        .builder("total-shaft-power", PlantConstraintScope.sharedResource("M", "compression shaft power"))
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET)
+        .limitDirection(PlantConstraintDefinition.LimitDirection.MAXIMUM)
+        .category(PlantConstraintDefinition.Category.DESIGN).severity(ConstraintSeverity.HARD).unit("kW")
+        .basis("compressor and pump shaft power").provenance("synthetic case-M power budget");
+    for (ProcessEquipmentInterface equipment : process.getUnitOperations()) {
+      if (equipment instanceof Compressor) {
+        Compressor compressor = (Compressor) equipment;
+        compressors.add(compressor);
+        sharedBuilder.participant(
+            PlantConstraintParticipant.direct(compressor.getName(), "kW", "compressor and pump shaft power"));
+      }
+    }
+    assertEquals(3, compressors.size(), "case M must retain three compressor power participants");
+    PlantConstraintDefinition shared = sharedBuilder.build();
+    double totalPower = process.getPower("kW");
+    PlantSharedResourceEvidence initialShared = PlantSharedResourceEvidence.fromProcessSystemShaftPower(shared,
+        calculationId, totalPower * 1.20, process, true, "completed case-M calculation");
+    PlantSharedResourceEvidence tightenedShared = PlantSharedResourceEvidence.fromProcessSystemShaftPower(shared,
+        calculationId, totalPower * 0.95, process, true, "completed case-M calculation");
+    assertTrue(initialShared.isComplete(), initialShared.getDiagnostics().toString());
+    assertTrue(tightenedShared.isComplete(), tightenedShared.getDiagnostics().toString());
+
+    PlantConstraintRegistry registry = new PlantConstraintRegistry();
+    List<PlantConstraintDefinition> compressorDefinitions = new ArrayList<PlantConstraintDefinition>();
+    for (Compressor compressor : compressors) {
+      PlantConstraintDefinition definition = PlantConstraintDefinition
+          .builder("shaft-power", PlantConstraintScope.equipment("M", "Compression", compressor.getName()))
+          .limitDirection(PlantConstraintDefinition.LimitDirection.MAXIMUM)
+          .category(PlantConstraintDefinition.Category.DESIGN).severity(ConstraintSeverity.HARD).unit("kW")
+          .basis("compressor shaft power").provenance("synthetic casing rating").build();
+      compressorDefinitions.add(definition);
+      registry.register(definition);
+    }
+    registry.register(shared);
+
+    PlantUtilizationSnapshot.Builder initialSnapshot = PlantUtilizationSnapshot.builder(registry, calculationId)
+        .convergenceComplete(true).sample(initialShared.toPlantConstraintSample());
+    PlantUtilizationSnapshot.Builder tightenedSnapshot = PlantUtilizationSnapshot.builder(registry, calculationId)
+        .convergenceComplete(true).sample(tightenedShared.toPlantConstraintSample());
+    for (int index = 0; index < compressors.size(); index++) {
+      Compressor compressor = compressors.get(index);
+      PlantConstraintDefinition definition = compressorDefinitions.get(index);
+      double power = compressor.getPower("kW");
+      double limit = power * 1.05;
+      PlantConstraintSample sample = PlantConstraintSample.builder(definition.getQualifiedId(), calculationId)
+          .values(power, limit).normalized(power / limit, power / limit - 1.0)
+          .physical(limit - power, Math.max(0.0, power - limit)).unit("kW").basis("compressor shaft power")
+          .provenance("completed case-M calculation").build();
+      initialSnapshot.sample(sample);
+      tightenedSnapshot.sample(sample);
+    }
+    PlantUtilizationSnapshot initial = initialSnapshot.build();
+    PlantUtilizationSnapshot tightened = tightenedSnapshot.build();
+    assertTrue(initial.isFeasible());
+    assertFalse(tightened.isFeasible());
+    assertTrue(initial.getBottleneck().getQualifiedConstraintId().startsWith("equipment:"));
+    assertEquals(shared.getQualifiedId(), tightened.getBottleneck().getQualifiedConstraintId());
+
+    JsonObject result = new JsonObject();
+    result.addProperty("status", "QUALIFIED");
+    result.addProperty("basis", "compressor and pump shaft power; no electrical conversion inferred");
+    result.addProperty("participantCount", initialShared.getParticipants().size());
+    result.addProperty("aggregateShaftPowerKw", totalPower);
+    result.addProperty("initialLimitKw", initialShared.getApplicableLimit());
+    result.addProperty("tightenedLimitKw", tightenedShared.getApplicableLimit());
+    result.addProperty("initialBottleneck", initial.getBottleneck().getQualifiedConstraintId());
+    result.addProperty("tightenedBottleneck", tightened.getBottleneck().getQualifiedConstraintId());
+    result.addProperty("tightenedRequiredReliefKw", tightenedShared.getRequiredRelief());
+    result.addProperty("participantCoverageComplete", initialShared.isComplete());
+    result.addProperty("collectionMutatesProcess", false);
     return result;
   }
 

--- a/src/test/java/neqsim/process/util/optimizer/PlantSharedResourceEvidenceTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PlantSharedResourceEvidenceTest.java
@@ -1,0 +1,302 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression and engineering acceptance tests for participant-complete shared-power evidence. */
+class PlantSharedResourceEvidenceTest {
+
+  @Test
+  void explicitConversionsProducePhysicalMarginAndSnapshotEvidence() {
+    PlantConstraintDefinition definition = powerDefinition("total-power", "MW", "compressor shaft power",
+        participant("train-a", "kW", "compressor shaft power", 0.001),
+        participant("train-b", "kW", "compressor shaft power", 0.001));
+    PlantSharedResourceEvidence evidence = PlantSharedResourceEvidence.builder(definition, "calc-1", 2.0)
+        .participant(sample("train-b", "calc-1", 800.0, "kW", "compressor shaft power"))
+        .participant(sample("train-a", "calc-1", 900.0, "kW", "compressor shaft power"))
+        .sourceTotal(1.7, "MW", "compressor shaft power", "solved process total").convergenceComplete(true).build();
+
+    assertTrue(evidence.isComplete());
+    assertTrue(evidence.isFeasible());
+    assertEquals(1.7, evidence.getAggregateValue(), 1.0e-12);
+    assertEquals(0.85, evidence.getNormalizedUtilization(), 1.0e-12);
+    assertEquals(0.3, evidence.getPhysicalMargin(), 1.0e-12);
+    assertEquals(0.0, evidence.getRequiredRelief(), 0.0);
+    assertEquals(1.7, evidence.getSourceTotal(), 0.0);
+    assertEquals("solved process total", evidence.getSourceTotalProvenance());
+    assertEquals("train-a", evidence.getParticipants().get(0).getSourceId());
+
+    PlantConstraintRegistry registry = new PlantConstraintRegistry().register(definition);
+    PlantUtilizationSnapshot snapshot = PlantUtilizationSnapshot.builder(registry, "calc-1")
+        .sample(evidence.toPlantConstraintSample()).convergenceComplete(true).build();
+    assertTrue(snapshot.isFeasible());
+    assertEquals(0.85, snapshot.getBottleneck().getNormalizedUtilization(), 1.0e-12);
+  }
+
+  @Test
+  void missingStaleNonFiniteAndUnexpectedParticipantsFailClosedWithoutZeroes() {
+    PlantConstraintDefinition definition = powerDefinition("total-power", "kW", "electrical demand",
+        directParticipant("load-a", "kW", "electrical demand"), directParticipant("load-b", "kW", "electrical demand"));
+
+    PlantSharedResourceEvidence missing = PlantSharedResourceEvidence.builder(definition, "calc-2", 1000.0)
+        .participant(sample("load-a", "calc-2", 400.0, "kW", "electrical demand"))
+        .sourceTotal(400.0, "kW", "electrical demand", "meter").convergenceComplete(true).build();
+    assertFalse(missing.isComplete());
+    assertTrue(Double.isNaN(missing.getAggregateValue()));
+    assertTrue(missing.getDiagnostics().contains("load-b=MISSING:Expected participant observation is missing"));
+    JsonObject missingJson = JsonParser.parseString(missing.toJson()).getAsJsonObject();
+    assertTrue(missingJson.get("aggregateValue").isJsonNull());
+    assertTrue(missingJson.getAsJsonArray("participants").get(1).getAsJsonObject().get("value").isJsonNull());
+
+    PlantSharedResourceParticipantSample stale = PlantSharedResourceParticipantSample.builder("load-a", "calc-2")
+        .status(PlantSharedResourceParticipantSample.Status.STALE).unit("kW").basis("electrical demand")
+        .provenance("old meter sample").build();
+    PlantSharedResourceParticipantSample nonFinite = PlantSharedResourceParticipantSample.builder("load-b", "calc-2")
+        .value(Double.POSITIVE_INFINITY).unit("kW").basis("electrical demand").provenance("meter").build();
+    PlantSharedResourceEvidence invalid = PlantSharedResourceEvidence.builder(definition, "calc-2", 1000.0)
+        .participant(stale).participant(nonFinite)
+        .participant(sample("load-c", "calc-2", 1.0, "kW", "electrical demand"))
+        .sourceTotal(401.0, "kW", "electrical demand", "meter").convergenceComplete(true).build();
+    assertFalse(invalid.isComplete());
+    assertEquals(PlantSharedResourceParticipantSample.Status.NON_FINITE_VALUE,
+        invalid.getParticipants().get(1).getStatus());
+    assertEquals(PlantConstraintSample.SampleStatus.NON_FINITE_VALUE, invalid.toPlantConstraintSample().getStatus());
+    assertTrue(invalid.getDiagnostics().contains("load-c=UNEXPECTED_PARTICIPANT"));
+  }
+
+  @Test
+  void processModelShaftPowerUsesEveryAreaAndDoesNotInferElectricalLoad() {
+    ProcessModel model = new ProcessModel();
+    model.add("Compression A", compressorArea("A", 5000.0, 90.0));
+    model.add("Compression B", compressorArea("B", 3500.0, 105.0));
+    assertTrue(model.runUntilConverged(50, 5.0e-3));
+
+    PlantConstraintDefinition definition = powerDefinition("shaft-power", "kW", "compressor and pump shaft power",
+        directParticipant("Compression A", "kW", "compressor and pump shaft power"),
+        directParticipant("Compression B", "kW", "compressor and pump shaft power"));
+    double total = model.getPower("kW");
+    PlantSharedResourceEvidence evidence = PlantSharedResourceEvidence.fromProcessModelShaftPower(definition,
+        "model-calc", total * 1.1, model, true, "completed isolated ProcessModel");
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertTrue(evidence.isFeasible());
+    assertEquals(total, evidence.getAggregateValue(), Math.max(1.0, total) * 1.0e-10);
+    assertEquals(2, evidence.getParticipants().size());
+    assertEquals("compressor and pump shaft power", evidence.getDefinition().getBasis());
+    assertFalse(evidence.toJson().contains("electrical"));
+
+    PlantConstraintDefinition incompleteDefinition = powerDefinition("shaft-power", "kW",
+        "compressor and pump shaft power", directParticipant("Compression A", "kW", "compressor and pump shaft power"));
+    PlantSharedResourceEvidence incomplete = PlantSharedResourceEvidence.fromProcessModelShaftPower(
+        incompleteDefinition, "model-calc", total * 1.1, model, true, "completed isolated ProcessModel");
+    assertFalse(incomplete.isComplete());
+    assertTrue(incomplete.getDiagnostics().contains("Compression B=UNEXPECTED_PARTICIPANT"));
+  }
+
+  @Test
+  void solvedElectricalBusUsesRequestedDemandAndRejectsMissingParticipantsAndStaleState() {
+    EnergyBus bus = new EnergyBus("main electrical bus", EnergyType.ELECTRICAL);
+    EnergyPort generator = port("generator", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    generator.setDuty(1.2, "MW");
+    EnergyPort essential = port("essential", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    essential.setRequestedPower(1.0, "MW");
+    EnergyPort flexible = port("flexible", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    flexible.setRequestedPower(0.5, "MW");
+    assertEquals(0.3e6, bus.solveBalance().getUnmetDemand(), 1.0e-6);
+
+    PlantConstraintDefinition definition = powerDefinition("electrical-demand", "MW", "requested electrical load",
+        participant(essential.getParticipantId(), "W", "requested electrical load", 1.0e-6),
+        participant(flexible.getParticipantId(), "W", "requested electrical load", 1.0e-6));
+    PlantSharedResourceEvidence evidence = PlantSharedResourceEvidence.fromSolvedEnergyBusRequestedDemand(definition,
+        "bus-calc", 1.4, bus, "solved EnergyBus report");
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertFalse(evidence.isFeasible());
+    assertEquals(1.5, evidence.getAggregateValue(), 1.0e-12);
+    assertEquals(0.1, evidence.getRequiredRelief(), 1.0e-12);
+
+    PlantConstraintDefinition missingParticipant = powerDefinition("electrical-demand", "MW",
+        "requested electrical load",
+        participant(essential.getParticipantId(), "W", "requested electrical load", 1.0e-6));
+    PlantSharedResourceEvidence incomplete = PlantSharedResourceEvidence
+        .fromSolvedEnergyBusRequestedDemand(missingParticipant, "bus-calc", 1.4, bus, "solved EnergyBus report");
+    assertFalse(incomplete.isComplete());
+    assertTrue(incomplete.getDiagnostics().contains(flexible.getParticipantId() + "=UNEXPECTED_PARTICIPANT"));
+
+    bus.setDuty(-0.1, "MW");
+    PlantSharedResourceEvidence stale = PlantSharedResourceEvidence.fromSolvedEnergyBusRequestedDemand(definition,
+        "bus-stale", 1.4, bus, "stale EnergyBus report");
+    assertFalse(stale.isComplete());
+    assertTrue(stale.getDiagnostics().contains("ENERGY_BUS_SOLUTION_STALE_OR_MISSING"));
+  }
+
+  @Test
+  void changedLimitAndExplicitAvailabilityRemainImmutableAndRestorable() throws Exception {
+    PlantConstraintDefinition definition = powerDefinition("total-power", "kW", "shaft power",
+        directParticipant("train-a", "kW", "shaft power"), directParticipant("train-b", "kW", "shaft power"));
+    PlantSharedResourceEvidence baseline = evidence(definition, "baseline", 200.0,
+        sample("train-a", "baseline", 90.0, "kW", "shaft power"),
+        sample("train-b", "baseline", 80.0, "kW", "shaft power"));
+    PlantSharedResourceParticipantSample unavailable = PlantSharedResourceParticipantSample
+        .builder("train-b", "candidate").status(PlantSharedResourceParticipantSample.Status.OUT_OF_SERVICE).value(0.0)
+        .unit("kW").basis("shaft power").provenance("approved line-up").build();
+    PlantSharedResourceEvidence candidate = PlantSharedResourceEvidence.builder(definition, "candidate", 85.0)
+        .participant(sample("train-a", "candidate", 90.0, "kW", "shaft power")).participant(unavailable)
+        .sourceTotal(90.0, "kW", "shaft power", "candidate replay").convergenceComplete(true).build();
+
+    assertTrue(baseline.isFeasible());
+    assertFalse(candidate.isFeasible());
+    assertEquals(170.0, baseline.getAggregateValue(), 0.0);
+    assertEquals(90.0, candidate.getAggregateValue(), 0.0);
+    assertEquals(5.0, candidate.getRequiredRelief(), 0.0);
+    PlantSharedResourceEvidence restored = roundTrip(baseline);
+    assertEquals(baseline.toJson(), restored.toJson());
+    assertEquals(PlantSharedResourceParticipantSample.Status.AVAILABLE, restored.getParticipants().get(1).getStatus());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getParticipants().clear());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getDiagnostics().clear());
+
+    PlantSharedResourceParticipantSample invalidUnavailable = PlantSharedResourceParticipantSample
+        .builder("train-b", "candidate").status(PlantSharedResourceParticipantSample.Status.OUT_OF_SERVICE).value(1.0)
+        .unit("kW").basis("shaft power").provenance("line-up").build();
+    assertEquals(PlantSharedResourceParticipantSample.Status.METADATA_MISMATCH, invalidUnavailable.getStatus());
+  }
+
+  @Test
+  void sixAreaParticipantLedgerIsDeterministicAndBounded() throws Exception {
+    Runtime runtime = Runtime.getRuntime();
+    long memoryBefore = runtime.totalMemory() - runtime.freeMemory();
+    long started = System.nanoTime();
+    List<PlantConstraintParticipant> definitions = new ArrayList<PlantConstraintParticipant>();
+    for (int area = 1; area <= 6; area++) {
+      for (int load = 1; load <= 30; load++) {
+        definitions.add(directParticipant(String.format("area-%d/load-%03d", area, load), "kW", "electrical load"));
+      }
+    }
+    PlantConstraintDefinition definition = powerDefinition("large-ledger", "kW", "electrical load",
+        definitions.toArray(new PlantConstraintParticipant[definitions.size()]));
+    PlantSharedResourceEvidence.Builder builder = PlantSharedResourceEvidence.builder(definition, "large-calc", 200.0)
+        .sourceTotal(180.0, "kW", "electrical load", "synthetic acceptance ledger").convergenceComplete(true);
+    for (int index = definitions.size() - 1; index >= 0; index--) {
+      builder.participant(sample(definitions.get(index).getSourceId(), "large-calc", 1.0, "kW", "electrical load"));
+    }
+    PlantSharedResourceEvidence evidence = builder.build();
+    byte[] serialized = serialize(evidence);
+    byte[] json = evidence.toJson().getBytes("UTF-8");
+    long elapsedMillis = (System.nanoTime() - started) / 1000000L;
+    long memoryDelta = Math.max(0L, runtime.totalMemory() - runtime.freeMemory() - memoryBefore);
+
+    assertTrue(evidence.isComplete());
+    assertEquals(180, evidence.getParticipants().size());
+    assertEquals("area-1/load-001", evidence.getParticipants().get(0).getSourceId());
+    assertEquals("area-6/load-030", evidence.getParticipants().get(179).getSourceId());
+    assertTrue(serialized.length < 500000, "shared-resource evidence must stay below 500 kB");
+    assertTrue(json.length < 1000000, "shared-resource JSON must stay below 1 MB");
+    assertTrue(elapsedMillis < 2000L, "180-participant capture must complete within two seconds");
+    assertTrue(memoryDelta < 64L * 1024L * 1024L, "180-participant capture must not grow used heap by 64 MB");
+    assertEquals(evidence.toJson(), roundTrip(evidence).toJson());
+  }
+
+  private static PlantSharedResourceEvidence evidence(PlantConstraintDefinition definition, String calculationId,
+      double limit, PlantSharedResourceParticipantSample... samples) {
+    double total = 0.0;
+    PlantSharedResourceEvidence.Builder builder = PlantSharedResourceEvidence.builder(definition, calculationId, limit)
+        .convergenceComplete(true);
+    for (PlantSharedResourceParticipantSample sample : samples) {
+      builder.participant(sample);
+      total += sample.getValue();
+    }
+    return builder.sourceTotal(total, definition.getUnit(), definition.getBasis(), "independent total").build();
+  }
+
+  private static PlantConstraintDefinition powerDefinition(String id, String unit, String basis,
+      PlantConstraintParticipant... participants) {
+    PlantConstraintDefinition.Builder builder = PlantConstraintDefinition
+        .builder(id, PlantConstraintScope.sharedResource("Plant", id))
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET)
+        .limitDirection(PlantConstraintDefinition.LimitDirection.MAXIMUM)
+        .category(PlantConstraintDefinition.Category.DESIGN).severity(ConstraintSeverity.HARD).unit(unit).basis(basis)
+        .provenance("synthetic engineering power budget").owner("electrical and rotating equipment");
+    for (PlantConstraintParticipant participant : participants) {
+      builder.participant(participant);
+    }
+    return builder.build();
+  }
+
+  private static PlantConstraintParticipant directParticipant(String id, String unit, String basis) {
+    return PlantConstraintParticipant.direct(id, unit, basis);
+  }
+
+  private static PlantConstraintParticipant participant(String id, String unit, String basis, double factor) {
+    return PlantConstraintParticipant.converted(id, unit, basis, factor, 0.0);
+  }
+
+  private static PlantSharedResourceParticipantSample sample(String id, String calculationId, double value, String unit,
+      String basis) {
+    return PlantSharedResourceParticipantSample.builder(id, calculationId).value(value).unit(unit).basis(basis)
+        .provenance("completed synthetic calculation").build();
+  }
+
+  private static ProcessSystem compressorArea(String suffix, double flowKgPerHr, double outletPressureBara) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.10);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed " + suffix, fluid);
+    feed.setFlowRate(flowKgPerHr, "kg/hr");
+    Compressor compressor = new Compressor("compressor " + suffix, feed);
+    compressor.setOutletPressure(outletPressureBara, "bara");
+    compressor.setIsentropicEfficiency(0.78);
+    ProcessSystem process = new ProcessSystem("area " + suffix);
+    process.add(feed);
+    process.add(compressor);
+    return process;
+  }
+
+  private static EnergyPort port(String owner, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", EnergyType.ELECTRICAL, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+
+  private static byte[] serialize(PlantSharedResourceEvidence evidence) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(evidence);
+    output.close();
+    return bytes.toByteArray();
+  }
+
+  private static PlantSharedResourceEvidence roundTrip(PlantSharedResourceEvidence evidence) throws Exception {
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialize(evidence)));
+    PlantSharedResourceEvidence restored = (PlantSharedResourceEvidence) input.readObject();
+    input.close();
+    assertNotNull(restored);
+    return restored;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the next #3154 increment on top of merged #3527: immutable, participant-complete shared total-power evidence that feeds the common plant utilization snapshot.

- captures compressor/pump shaft power from solved `ProcessSystem` and area-qualified `ProcessModel`
- captures requested electrical demand, including unmet demand, from a current solved `EnergyBus`
- preserves explicit unit, basis, conversion, provenance, validity, availability, and calculation identity
- rejects missing, unexpected, stale, non-finite, metadata-inconsistent, unconverged, ambiguous, or non-restored evidence
- qualifies a compressor-to-total-power bottleneck transition on the maintained 27-unit M case
- adds Java/Javadoc, JSON, JPype workflow coverage, serialization tests, guides, and scale budgets

Partial progress on #3154; this PR intentionally does not close the roadmap.

## Capability contract

**Engineering question:** Can NeqSim prove a maximum shared power budget from every declared participant without confusing shaft power with electrical load or accepting incomplete candidate state?

**Baseline:** `ac79c56945b0cdf45a1bcb42e3417dff99e7acbf` (includes #3527 merge `7625545a67d219af20d385a134281bd3c930511e`).

**Current → target maturity:** registered shared-resource metadata and generic immutable samples → authoritative participant-complete total-power evidence integrated into `PlantUtilizationSnapshot`.

**Java authority and views:** `PlantSharedResourceEvidence` and `PlantSharedResourceParticipantSample`; adapters read existing `ProcessSystem.getPower`, `ProcessModel.getPower`, and solved `EnergyBus` reports. Java getters, JSON, and JPype expose the same frozen evidence.

**Inputs:** maximum `SHARED_BUDGET` definition, positive applicable limit, exact calculation ID, completed isolated state, explicit participants/conversions, source provenance, optional verified out-of-service IDs.

**Outputs:** status, deterministic participants, independent total cross-check, aggregate, dimensionless utilization/residual, physical margin/required relief in the target unit, diagnostics, and common plant constraint sample.

**Basis and validity:** process adapters are compressor-and-pump shaft power; EnergyBus adapter is requested electrical load including unmet demand. No shaft-to-electrical efficiency is inferred. Missing observations are unavailable, never zero. Out-of-service is accepted only with observed finite zero power.

**Acceptance:** exact coverage and unit conversion; missing/extra/stale/non-finite/unconverged rejection; changed limit and availability; serialization/immutability; EnergyBus unmet demand; 27-unit M bottleneck transition and restoration; 180-participant/six-area evidence-path budgets.

**Compatibility:** additive Java 8 APIs only; no runtime solver or equipment behavior change.

**Documentation impact:** capacity framework, production optimization guide, industrial baseline, and S/M benchmark evidence updated. The JPype validator is the executable Python example.

**Stop boundary:** no common-shaft speed/torque/driver/gearbox or casing-map model; no separator/piping physics; no optimizer orchestration, caching, allocation, or execution-speed work; no MCP implementation.

## Validation

Local checks on the exact branch content:

- `python devtools/run_spotless.py apply` — pass and stable
- `python devtools/run_spotless.py check` — pass
- `python devtools/check_documentation_search.py` — pass (692 Markdown, 1 standalone HTML)
- focused/adjacent tests: `PlantSharedResourceEvidenceTest`, registry/snapshot/coverage, and EnergyBus suites — pass
- slow `IndustrialPlantOptimizationBaselineTest` — pass
- `mvn -DskipTests compile` — pass
- `mvn -DskipTests javadoc:javadoc` — pass using the installed JDK 17 compiler/Javadoc modules
- `python -m py_compile devtools/validate_plant_capacity_jpype.py` — pass
- `git diff --check` — pass

Measured M evidence: 3 participants, total `918.164876805159 kW`; 120% shared limit leaves a compressor row limiting, 95% makes shared total power limiting with `45.90824384025791 kW` required relief. Restored/cold difference `2.7199348551221192e-8 kW` (relative `2.9623599462728176e-11`).

**VALIDATION PENDING CI:** the JPype script could not execute locally because `JPype1` is absent and package installation was unavailable. Hosted CI must execute that interface and all repository-required gates. Pre-commit/pre-push were unavailable locally; their direct Spotless and documentation equivalents passed.

## CI repair — 2026-09-07

Commit `1d91d4dff7ed05577af15b19007a36c5e13848d9` fixes the failed `IndustrialPlantOptimizationBaselineTest` restoration assertion in [slow shard 1/4](https://github.com/equinor/neqsim/actions/runs/34152878563/job/101838877861).

CI reported a `0.0003080296899 kW` cold/restored difference at approximately `918.165 kW` (`3.35e-7` relative). The old `1e-7` assertion was tighter than the existing `1e-6` relative recalculation thresholds in Stream, Compressor and Separator. The replay budget now uses that 1 ppm precision, and the benchmark JSON records the absolute and relative tolerances. The benchmark guide explains the numerical basis. The production evidence aggregation still uses its separate `1e-10` total cross-check.

Validation on the original PR tree plus this two-file fix, using JDK 17:
- `./mvnw -B -ntp -Dtest=IndustrialPlantOptimizationBaselineTest,PlantSharedResourceEvidenceTest -DexcludedTestGroups= -Djacoco.skip=true test` — PASS, 7 tests, 0 failures/errors/skips (also wrote the S/M JSON report).
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py apply` — exit 0, stable on repeat.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py check` — exit 0.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/check_documentation_search.py` — exit 0, 692 Markdown pages and 1 standalone HTML page.
- `git diff --check` — exit 0.
- Pre-commit/pre-push executables remain unavailable; the direct repository checks passed.

The standalone JDK 17 baseline also passed before the fix; the failure evidence comes from Java 21 CI. The final local replay difference was `1.678608100519341e-6 kW` against a `0.0009181648768337047 kW` budget. **VALIDATION PENDING CI:** new checks are running on the published commit. The PR remains a draft.

## Limits and next step

The 180-row/six-area test qualifies evidence collection shape and result-size/wall-time/used-heap budgets; it is not the still-open >=150-process-unit L fixture and makes no generic speedup claim. After merge, the next dependency-ready #3154 scope is common-shaft speed/power/torque/driver/gearbox evidence with per-casing map qualification.