### PR TITLE
[AI-Assisted] feat(kinetics): expose segment H2S endpoint loss rates

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -169,6 +169,34 @@ ordering after different prior depletion. These values are analytical bookkeepin
 dissolved sulfide under the same constant-oxygen assumption. They do not define oxygen
 consumption, sulfur products, stoichiometric source terms, or a pipeline control-volume coupling.
 
+## Endpoint loss-rate evidence
+
+Each segment also reports the instantaneous total-sulfide loss rate at its inlet and outlet for
+the lower-rate, nominal, and upper-rate paths:
+
+$
+r_{r,i,\mathrm{in}} = k_{r,i}[\mathrm{O_2}]_i c_{r,i,\mathrm{in}}, \qquad
+r_{r,i,\mathrm{out}} = k_{r,i}[\mathrm{O_2}]_i c_{r,i,\mathrm{out}}.
+$
+
+The rate unit is mol total sulfide/(kg water h). The local retention factor is
+
+$
+R_{r,i}=\exp\left(-k_{r,i}[\mathrm{O_2}]_i\Delta t_i\right),
+\qquad c_{r,i,\mathrm{out}}=c_{r,i,\mathrm{in}}R_{r,i}.
+$
+
+For a positive-duration segment, the outlet loss rate cannot exceed its inlet loss rate. A
+zero-duration segment gives exactly `R = 1` and equal endpoint rates. Multiplying local retention
+factors across unchanged-state segment subdivisions recovers the unsplit retention and final
+inventory.
+
+These endpoint rates are differential screening evidence evaluated under the source's
+constant-oxygen assumption. They are not a time-averaged control-volume source, a conversion to
+molar flow, oxygen consumption, or product stoichiometry. Creating a pipeline source term requires
+separate water inventory, phase transfer, reaction products, energy, pressure, and numerical
+coupling evidence.
+
 ## Piecewise target crossing
 
 `AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -220,6 +220,41 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.trajectory_test)
 
+    def test_endpoint_loss_rate_contract_is_documented_and_executable(self):
+        for token in (
+            "Endpoint loss-rate evidence",
+            "instantaneous total-sulfide loss rate",
+            r"r_{r,i,\mathrm{in}} = k_{r,i}[\mathrm{O_2}]_i c_{r,i,\mathrm{in}}",
+            r"r_{r,i,\mathrm{out}} = k_{r,i}[\mathrm{O_2}]_i c_{r,i,\mathrm{out}}",
+            "mol total sulfide/(kg water h)",
+            r"R_{r,i}=\exp\left(-k_{r,i}[\mathrm{O_2}]_i\Delta t_i\right)",
+            "zero-duration segment gives exactly `R = 1`",
+            "not a time-averaged control-volume source",
+            "Creating a pipeline source term requires",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "getLowerRateInletLossRateMolalityPerHour()",
+            "getLowerRateOutletLossRateMolalityPerHour()",
+            "getLowerRateRetentionFactor()",
+            "getNominalInletLossRateMolalityPerHour()",
+            "getNominalOutletLossRateMolalityPerHour()",
+            "getNominalRetentionFactor()",
+            "getUpperRateInletLossRateMolalityPerHour()",
+            "getUpperRateOutletLossRateMolalityPerHour()",
+            "getUpperRateRetentionFactor()",
+        ):
+            self.assertIn(token, self.trajectory)
+
+        for token in (
+            "testSegmentEndpointLossRatesMatchDifferentialEquation",
+            "testSegmentRetentionFactorsCloseInventoryUpdate",
+            "testZeroDurationEndpointRatesAndRetentionAreExact",
+            "testRetentionFactorProductIsSplitInvariant",
+        ):
+            self.assertIn(token, self.trajectory_test)
+
     def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
         for token in (
             "Piecewise target crossing",

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -581,6 +581,51 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
     public double getUpperRateReactedTotalSulfideMolality() {
       return upperRateReactedTotalSulfideMolality;
     }
+
+    /** @return instantaneous inlet loss rate for the lower-rate path [mol/(kg water h)]. */
+    public double getLowerRateInletLossRateMolalityPerHour() {
+      return lowerPseudoFirstOrderRate * lowerRateInletTotalSulfideMolality;
+    }
+
+    /** @return instantaneous outlet loss rate for the lower-rate path [mol/(kg water h)]. */
+    public double getLowerRateOutletLossRateMolalityPerHour() {
+      return lowerPseudoFirstOrderRate * lowerRateOutletTotalSulfideMolality;
+    }
+
+    /** @return local lower-rate retained fraction across this segment. */
+    public double getLowerRateRetentionFactor() {
+      return Math.exp(-lowerRateExposure);
+    }
+
+    /** @return instantaneous inlet loss rate for the nominal path [mol/(kg water h)]. */
+    public double getNominalInletLossRateMolalityPerHour() {
+      return nominalPseudoFirstOrderRate * nominalInletTotalSulfideMolality;
+    }
+
+    /** @return instantaneous outlet loss rate for the nominal path [mol/(kg water h)]. */
+    public double getNominalOutletLossRateMolalityPerHour() {
+      return nominalPseudoFirstOrderRate * nominalOutletTotalSulfideMolality;
+    }
+
+    /** @return local nominal retained fraction across this segment. */
+    public double getNominalRetentionFactor() {
+      return Math.exp(-nominalExposure);
+    }
+
+    /** @return instantaneous inlet loss rate for the upper-rate path [mol/(kg water h)]. */
+    public double getUpperRateInletLossRateMolalityPerHour() {
+      return upperPseudoFirstOrderRate * upperRateInletTotalSulfideMolality;
+    }
+
+    /** @return instantaneous outlet loss rate for the upper-rate path [mol/(kg water h)]. */
+    public double getUpperRateOutletLossRateMolalityPerHour() {
+      return upperPseudoFirstOrderRate * upperRateOutletTotalSulfideMolality;
+    }
+
+    /** @return local upper-rate retained fraction across this segment. */
+    public double getUpperRateRetentionFactor() {
+      return Math.exp(-upperRateExposure);
+    }
   }
 
   /** Immutable result of an exact piecewise exposure trajectory. */

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -242,6 +242,96 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
   }
 
   @Test
+  void testSegmentEndpointLossRatesMatchDifferentialEquation() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory.advance(
+        INITIAL_TOTAL_SULFIDE_MOLALITY,
+        Arrays.asList(referenceSegment(3.0),
+            new AqueousHydrogenSulfideOxidationTrajectory.Segment(7.0, 310.15, 7.0, 1.5, 220.0e-6)));
+
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : result.getSegmentResults()) {
+      assertEquals(segment.getLowerPseudoFirstOrderRate() * segment.getLowerRateInletTotalSulfideMolality(),
+          segment.getLowerRateInletLossRateMolalityPerHour(), 0.0);
+      assertEquals(segment.getLowerPseudoFirstOrderRate() * segment.getLowerRateOutletTotalSulfideMolality(),
+          segment.getLowerRateOutletLossRateMolalityPerHour(), 0.0);
+      assertEquals(segment.getNominalPseudoFirstOrderRate() * segment.getNominalInletTotalSulfideMolality(),
+          segment.getNominalInletLossRateMolalityPerHour(), 0.0);
+      assertEquals(segment.getNominalPseudoFirstOrderRate() * segment.getNominalOutletTotalSulfideMolality(),
+          segment.getNominalOutletLossRateMolalityPerHour(), 0.0);
+      assertEquals(segment.getUpperPseudoFirstOrderRate() * segment.getUpperRateInletTotalSulfideMolality(),
+          segment.getUpperRateInletLossRateMolalityPerHour(), 0.0);
+      assertEquals(segment.getUpperPseudoFirstOrderRate() * segment.getUpperRateOutletTotalSulfideMolality(),
+          segment.getUpperRateOutletLossRateMolalityPerHour(), 0.0);
+      assertTrue(segment.getLowerRateOutletLossRateMolalityPerHour()
+          <= segment.getLowerRateInletLossRateMolalityPerHour());
+      assertTrue(segment.getNominalOutletLossRateMolalityPerHour()
+          <= segment.getNominalInletLossRateMolalityPerHour());
+      assertTrue(segment.getUpperRateOutletLossRateMolalityPerHour()
+          <= segment.getUpperRateInletLossRateMolalityPerHour());
+    }
+  }
+
+  @Test
+  void testSegmentRetentionFactorsCloseInventoryUpdate() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory.advance(
+        INITIAL_TOTAL_SULFIDE_MOLALITY,
+        Arrays.asList(referenceSegment(3.0),
+            new AqueousHydrogenSulfideOxidationTrajectory.Segment(7.0, 310.15, 7.0, 1.5, 220.0e-6)));
+
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : result.getSegmentResults()) {
+      assertEquals(segment.getLowerRateOutletTotalSulfideMolality(),
+          segment.getLowerRateInletTotalSulfideMolality() * segment.getLowerRateRetentionFactor(), 1.0e-20);
+      assertEquals(segment.getNominalOutletTotalSulfideMolality(),
+          segment.getNominalInletTotalSulfideMolality() * segment.getNominalRetentionFactor(), 1.0e-20);
+      assertEquals(segment.getUpperRateOutletTotalSulfideMolality(),
+          segment.getUpperRateInletTotalSulfideMolality() * segment.getUpperRateRetentionFactor(), 1.0e-20);
+      assertTrue(segment.getLowerRateRetentionFactor() >= 0.0);
+      assertTrue(segment.getLowerRateRetentionFactor() <= 1.0);
+      assertTrue(segment.getNominalRetentionFactor() >= 0.0);
+      assertTrue(segment.getNominalRetentionFactor() <= 1.0);
+      assertTrue(segment.getUpperRateRetentionFactor() >= 0.0);
+      assertTrue(segment.getUpperRateRetentionFactor() <= 1.0);
+    }
+  }
+
+  @Test
+  void testZeroDurationEndpointRatesAndRetentionAreExact() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory.advance(
+        INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0), referenceSegment(0.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult identity = result.getSegmentResults().get(1);
+
+    assertEquals(1.0, identity.getLowerRateRetentionFactor(), 0.0);
+    assertEquals(1.0, identity.getNominalRetentionFactor(), 0.0);
+    assertEquals(1.0, identity.getUpperRateRetentionFactor(), 0.0);
+    assertEquals(identity.getLowerRateInletLossRateMolalityPerHour(),
+        identity.getLowerRateOutletLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getNominalInletLossRateMolalityPerHour(),
+        identity.getNominalOutletLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getUpperRateInletLossRateMolalityPerHour(),
+        identity.getUpperRateOutletLossRateMolalityPerHour(), 0.0);
+  }
+
+  @Test
+  void testRetentionFactorProductIsSplitInvariant() {
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(2.0 * halfLife)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(halfLife), referenceSegment(halfLife)));
+
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult whole = unsplit.getSegmentResults().get(0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult first = split.getSegmentResults().get(0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult second = split.getSegmentResults().get(1);
+    assertEquals(whole.getLowerRateRetentionFactor(),
+        first.getLowerRateRetentionFactor() * second.getLowerRateRetentionFactor(), 1.0e-15);
+    assertEquals(whole.getNominalRetentionFactor(),
+        first.getNominalRetentionFactor() * second.getNominalRetentionFactor(), 1.0e-15);
+    assertEquals(whole.getUpperRateRetentionFactor(),
+        first.getUpperRateRetentionFactor() * second.getUpperRateRetentionFactor(), 1.0e-15);
+    assertEquals(unsplit.getFinalTotalSulfideMolality(), split.getFinalTotalSulfideMolality(), 1.0e-20);
+  }
+
+  @Test
   void testPiecewiseTargetCrossingMatchesSingleStateInverse() {
     AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult single = AqueousHydrogenSulfideOxidationKinetics
         .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH);

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -243,9 +243,8 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
 
   @Test
   void testSegmentEndpointLossRatesMatchDifferentialEquation() {
-    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory.advance(
-        INITIAL_TOTAL_SULFIDE_MOLALITY,
-        Arrays.asList(referenceSegment(3.0),
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0),
             new AqueousHydrogenSulfideOxidationTrajectory.Segment(7.0, 310.15, 7.0, 1.5, 220.0e-6)));
 
     for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : result.getSegmentResults()) {
@@ -261,20 +260,18 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
           segment.getUpperRateInletLossRateMolalityPerHour(), 0.0);
       assertEquals(segment.getUpperPseudoFirstOrderRate() * segment.getUpperRateOutletTotalSulfideMolality(),
           segment.getUpperRateOutletLossRateMolalityPerHour(), 0.0);
-      assertTrue(segment.getLowerRateOutletLossRateMolalityPerHour()
-          <= segment.getLowerRateInletLossRateMolalityPerHour());
-      assertTrue(segment.getNominalOutletLossRateMolalityPerHour()
-          <= segment.getNominalInletLossRateMolalityPerHour());
-      assertTrue(segment.getUpperRateOutletLossRateMolalityPerHour()
-          <= segment.getUpperRateInletLossRateMolalityPerHour());
+      assertTrue(
+          segment.getLowerRateOutletLossRateMolalityPerHour() <= segment.getLowerRateInletLossRateMolalityPerHour());
+      assertTrue(segment.getNominalOutletLossRateMolalityPerHour() <= segment.getNominalInletLossRateMolalityPerHour());
+      assertTrue(
+          segment.getUpperRateOutletLossRateMolalityPerHour() <= segment.getUpperRateInletLossRateMolalityPerHour());
     }
   }
 
   @Test
   void testSegmentRetentionFactorsCloseInventoryUpdate() {
-    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory.advance(
-        INITIAL_TOTAL_SULFIDE_MOLALITY,
-        Arrays.asList(referenceSegment(3.0),
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0),
             new AqueousHydrogenSulfideOxidationTrajectory.Segment(7.0, 310.15, 7.0, 1.5, 220.0e-6)));
 
     for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : result.getSegmentResults()) {
@@ -295,8 +292,8 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
 
   @Test
   void testZeroDurationEndpointRatesAndRetentionAreExact() {
-    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory.advance(
-        INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0), referenceSegment(0.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0), referenceSegment(0.0)));
     AqueousHydrogenSulfideOxidationTrajectory.SegmentResult identity = result.getSegmentResults().get(1);
 
     assertEquals(1.0, identity.getLowerRateRetentionFactor(), 0.0);
@@ -304,8 +301,8 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
     assertEquals(1.0, identity.getUpperRateRetentionFactor(), 0.0);
     assertEquals(identity.getLowerRateInletLossRateMolalityPerHour(),
         identity.getLowerRateOutletLossRateMolalityPerHour(), 0.0);
-    assertEquals(identity.getNominalInletLossRateMolalityPerHour(),
-        identity.getNominalOutletLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getNominalInletLossRateMolalityPerHour(), identity.getNominalOutletLossRateMolalityPerHour(),
+        0.0);
     assertEquals(identity.getUpperRateInletLossRateMolalityPerHour(),
         identity.getUpperRateOutletLossRateMolalityPerHour(), 0.0);
   }


### PR DESCRIPTION
## Summary

Advances #3318 with analytical endpoint loss-rate evidence for every segment of the qualified aqueous H₂S/O₂ trajectory.

For each lower-rate, nominal, and upper-rate Millero fit-scatter path, `SegmentResult` now exposes:

- instantaneous inlet loss rate `r_in = k[O2] c_in`;
- instantaneous outlet loss rate `r_out = k[O2] c_out`;
- local retention `R = exp(-k[O2] Δt)`.

Loss-rate units are mol total sulfide/(kg water h). The accessors derive values from the existing stored rate, exposure, and inventory; no kinetic parameter, fitted constant, constructor state, or serialized field is added.

Scientific source and domain remain unchanged: Millero et al. (1987), https://doi.org/10.1021/es00159a003

Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5575526127

## Exact-head contract

- Branch point: `f30b7d2c64acc0dacc59855143bc6ce27fa76622`
- Published head: `af917ad3bb3f4232990480e006f56829229f95dd`
- Branch: `codex/3318-h2s-segment-loss-rates`
- Four ordered commits and exactly four intended changed files.
- Zero changed-file overlap with the only other identified autonomous PR, #3555.

## Numerical gates

Focused tests require:

- all six endpoint rates reproduce the differential equation exactly;
- every positive-duration outlet rate is no greater than its inlet rate;
- `c_out = c_in R` for all three paths;
- each retention factor is finite and bounded in `[0, 1]`;
- a zero-duration segment has exactly `R = 1` and equal endpoint rates;
- products of unchanged-state split retention factors reproduce the unsplit factor;
- final inventory remains split-invariant.

Independent reference audit at 298.15 K, pH 8, I=0.723 mol/kg, O₂=250 µmol/kg, initial sulfide 25 µmol/kg, and 10 h gives:

- `k = 123.61753672611606 kg water/(mol h)`;
- pseudo-first-order rate `0.030904384181529014 h⁻¹`;
- retention `0.7341485829141302`;
- inlet/outlet loss rates `7.726096045382254e-7` and `5.672102463175847e-7 mol/(kg water h)`;
- zero differential and inventory identity residuals.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Connector-side audit passed: four commits ahead and zero behind the recorded base; four intended paths only; balanced Java braces; no tabs or trailing whitespace; nine new accessors, four focused tests, guide section, and executable documentation contract present.

No local Maven, Java, Spotless, pre-commit, or Python execution is claimed. Hosted GitHub Actions on this exact head are authoritative.

## Documentation and stop boundary

The H₂S/O₂ guide documents equations, units, zero-duration behavior, split invariance, and integration boundaries.

This is differential atmospheric-aqueous screening evidence only. It is not a time-averaged control-volume source, molar-flow conversion, O₂ consumption, sulfur-product stoichiometry, pH/speciation (#3144), pressure correction, TP-flash (#2937), transient mutation (#2911), pipeline/TwoFluid coupling, corrosion model, R1–R8 binding, or MCP exposure (#3153).

This is the sole active #3318 implementation PR. Portfolio occupancy becomes **2/10**, below the target/ceiling. Keep draft-only: do not rebase, synchronize with `master`, force-push, merge, enable auto-merge, mark ready, close, or replace work for capacity.