### PR TITLE
[AI-Assisted] fix(refinery): preserve valid viscosity blends before 3.20.0

### DIFF
--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -192,6 +192,11 @@ The double logarithm requires every positive-mass source viscosity to be finite 
 0.2 cSt. A zero-mass source is ignored and may leave its viscosity unresolved. The temperature is
 stored with the immutable result but is not used to extrapolate viscosity.
 
+Equal-viscosity sources are valid when their masses are supplied: blending three equal masses at
+20 cSt returns 20 cSt. Floating-point summation can put the blended VBN just outside the source
+interval, so the result is clamped to that interval after input and finiteness checks. This also
+preserves blends of nearly equal viscosities without rejecting valid recipes.
+
 ```java
 RefineryViscosityBlend viscosityBlend = RefineryViscosityBlend.fromMassBasis(
     new double[] {5000.0, 12000.0},

--- a/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryViscosityBlend.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
  * The empirical Refutas relation transforms each source kinematic viscosity to a viscosity blending number, mixes those
  * numbers by normalized mass fraction, and applies the analytical inverse. Every contributing viscosity must be
  * resolved at the same caller-supplied temperature. This class does not mutate an assay or thermodynamic system.
+ * Roundoff at a source bound is clamped to that bound, preserving blends of equal-viscosity sources.
  * </p>
  */
 public final class RefineryViscosityBlend implements Serializable {
@@ -64,10 +65,12 @@ public final class RefineryViscosityBlend implements Serializable {
       maximumSourceBlendNumber = Math.max(maximumSourceBlendNumber, sourceBlendNumber);
     }
 
-    if (!Double.isFinite(resolvedBlendNumber) || resolvedBlendNumber < minimumSourceBlendNumber
-        || resolvedBlendNumber > maximumSourceBlendNumber) {
+    if (!Double.isFinite(resolvedBlendNumber)) {
       throw new IllegalArgumentException("Blend viscosity number must be finite and bounded");
     }
+    // Validated non-negative masses make this a convex combination. Summation roundoff
+    // can cross a source bound, especially when all source viscosities are equal.
+    resolvedBlendNumber = Math.max(minimumSourceBlendNumber, Math.min(maximumSourceBlendNumber, resolvedBlendNumber));
 
     double resolvedKinematicViscosity = calculateKinematicViscosityCSt(resolvedBlendNumber);
     massFractions = resolvedMassFractions;

--- a/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryViscosityBlendTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 /** Tests the fail-closed empirical refinery viscosity blend screen. */
@@ -50,6 +51,45 @@ public class RefineryViscosityBlendTest {
     sourceBlendNumbers[0] = Double.NaN;
     assertArrayEquals(new double[] { 0.4, 0.6 }, base.getMassFractions(), 1.0e-15);
     assertTrue(Double.isFinite(base.getSourceViscosityBlendingNumbers()[0]));
+  }
+
+  @Test
+  public void equalViscositySourcesPreserveTheirCommonValue() {
+    double[] viscositiesCSt = { 0.3, 1.0, 20.0, 375.0, 10000.0 };
+    int[] sourceCounts = { 3, 6, 7, 10, 1000 };
+    for (double viscosityCSt : viscositiesCSt) {
+      for (int sourceCount : sourceCounts) {
+        double[] sourceMasses = new double[sourceCount];
+        double[] sourceViscosities = new double[sourceCount];
+        Arrays.fill(sourceMasses, 1.0);
+        Arrays.fill(sourceViscosities, viscosityCSt);
+
+        RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(sourceMasses, sourceViscosities, 40.0);
+
+        assertEquals(RefineryViscosityBlend.calculateViscosityBlendingNumber(viscosityCSt),
+            blend.getViscosityBlendingNumber(), 0.0);
+        assertEquals(viscosityCSt, blend.getKinematicViscosityCSt(), viscosityCSt * 1.0e-12);
+        assertEquals(1.0, Arrays.stream(blend.getMassFractions()).sum(), 1.0e-14);
+      }
+    }
+  }
+
+  @Test
+  public void nearlyEqualSourceViscositiesRemainBoundedInEitherOrder() {
+    double lowerViscosityCSt = 20.0;
+    double upperViscosityCSt = Math.nextUp(lowerViscosityCSt);
+    double lowerBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(lowerViscosityCSt);
+    double upperBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(upperViscosityCSt);
+    double[][] sourceViscosities = { { lowerViscosityCSt, lowerViscosityCSt, upperViscosityCSt },
+        { upperViscosityCSt, lowerViscosityCSt, lowerViscosityCSt } };
+    for (double[] viscosities : sourceViscosities) {
+      RefineryViscosityBlend blend = RefineryViscosityBlend.fromMassBasis(new double[] { 1.0, 1.0, 1.0 }, viscosities,
+          40.0);
+
+      assertTrue(blend.getViscosityBlendingNumber() >= lowerBlendNumber);
+      assertTrue(blend.getViscosityBlendingNumber() <= upperBlendNumber);
+      assertEquals(lowerViscosityCSt, blend.getKinematicViscosityCSt(), 1.0e-12);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

The new refinery viscosity API rejects valid fixed-mass recipes on current master `f30b7d2c64acc0dacc59855143bc6ce27fa76622`. For example, mixing three equal masses whose viscosities are all 20 cSt at 40 °C throws `IllegalArgumentException: Blend viscosity number must be finite and bounded`.

The normalized weighted sum can round just outside the source VBN interval. When every source has the same viscosity, that interval has zero width, so an ordinary summation error makes a physically valid recipe fail. Nearly equal viscosities reproduce the same failure.

This was found during the requested 3.20.0 release audit. It affects the API introduced in #3545 and used by #3552. Relates to #3305.

## Change

- Keep the existing input and finite-result checks, then clamp summation roundoff to the mathematically guaranteed source VBN interval.
- Add regressions for equal viscosities from 0.3 to 10,000 cSt with 3, 6, 7, 10 and 1,000 sources, plus nearly equal sources in both orders.
- Retain existing binary reference, target-planner, invalid-input, zero-mass and immutability coverage.
- Document the endpoint behavior in the class Javadoc and refinery assay guide.

The Refutas correlation, units, public signatures and stored result shape are unchanged. Equal-viscosity *target planning* still rejects a non-unique ratio; a recipe with supplied masses is valid.

## Validation

Baseline is exact current-master source, verified against the GitHub tree `af5614bee1cafc87bc6bc6d1e3eb5b58f6e644e1`. Local execution used JDK 17.0.20.

- Before the fix: `./mvnw -B -ntp -Dtest=RefineryViscosityBlendTest -Djacoco.skip=true test` — exit 1; 10 tests, 2 errors from the new regressions.
- After the fix: `./mvnw -B -ntp -Dtest=RefineryViscosityBlendTest,RefineryAssayBlendTest,ComponentDatabaseIntegrityTest,UnifacDatabaseIntegrityTest,PropylbenzeneUnifacGroupsTest,PhaseGEUnifacUMRPRUTest,UMRPRUOilDropoutReproTest,MultiInputMixerPhaseRegressionTest,CoolerMassBalanceRegressionTest,PitzerBinaryVolumetricGroupedValidationTest -Djacoco.skip=true test` — exit 0; **40 tests, 0 failures, 0 errors, 0 skipped**.
- `java -m jdk.compiler/com.sun.tools.javac.Main --release 8 ... RefineryViscosityBlend.java` — exit 0; changed production class compiles for Java 8.
- Javadoc/doclint for the changed class — exit 0; five existing warnings for undocumented private serialized fields.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py apply` — exit 0, stable on repeat.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py check` — exit 0.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/check_documentation_search.py` — exit 0; 693 Markdown pages and 1 standalone HTML page.
- `git diff --check` against the reconstructed master index — exit 0.

Maven was configured through the work-with-neqsim skill's bootstrap helper before the first build. The local pre-commit executable/module is unavailable; the required direct formatting and documentation gates above passed.

**Documentation impact:** the valid fixed-mass equal-viscosity behavior and numerical bound treatment are documented in the same PR.

**READY TO MERGE:** all exact-head GitHub Actions pass on `ec1035c6150b9a091d838478708ff21084efb4c4`, including Java 8 and Java 21 tests on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, agent-skill checks, Spotless, pre-commit, documentation search, CodeQL, and PaperLab. The PR is mergeable with no comments, reviews, or unresolved threads. Current target-side changes overlap none of the three owned files. The draft remains preserved; no rebase or synchronization is required.

The existing release PR #3460 already contains the version bump and release-branch publication fix; this PR adds only the uncovered numerical bug fix.
