### PR TITLE
[AI-Assisted] feat(pitzer): enforce dataset provenance before fitting

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -727,6 +727,28 @@ validation result is admissible only when those lineages are genuinely
 independent, all rows and uncertainties have qualified provenance, and the
 acceptance limits were fixed before the holdout was evaluated.
 
+### Repository dataset provenance
+
+`PitzerBinaryVolumetricDatasetProvenance` records a machine-auditable manifest
+for observations distributed with NeqSim. Each source-lineage record fixes its
+calibration or validation role, full citation and stable URL, license and
+redistribution decision, SHA-256 source-file checksum, uncertainty basis, exact
+row count, and molality, temperature and pressure envelope.
+
+`validateRepositoryDatasets(...)` checks both observation lists against that
+manifest before fitting. It fails closed for an undeclared lineage, role or row
+count mismatch, a state outside the declared envelope, or any source whose
+redistribution status is restricted or unknown. The original
+`validate(...)` method remains available for caller-owned private or in-memory
+data that are not bundled with NeqSim.
+
+The manifest verifies declared metadata against the supplied observations. It
+does not hash source bytes, prove that a license interpretation is correct, or
+prove experimental independence. Repository maintainers must separately
+compare the recorded checksum with the distributed file, audit the permission
+decision, map source groups to real laboratories and apparatus, and pre-register
+acceptance limits before evaluating a holdout.
+
 ### Qualification boundary
 
 - The caller owns coefficient provenance and must keep calibration and
@@ -1006,6 +1028,8 @@ component.setCostaldCharacteristicVolume(newValue);  // cm³/mol
 | `PitzerBinaryVolumetricRegression.fit(...)` | Fit caller-supplied one-state observations with SVD rank checks |
 | `FitResult.getGroupStatistics()` | Inspect residuals by laboratory or source lineage |
 | `PitzerBinaryVolumetricGroupedValidation.validate(...)` | Fit one lineage set and evaluate a disjoint untouched holdout |
+| `PitzerBinaryVolumetricDatasetProvenance.validateRepositoryObservations(...)` | Check role, license, checksum manifest, row count and state envelope |
+| `PitzerBinaryVolumetricGroupedValidation.validateRepositoryDatasets(...)` | Enforce repository provenance before grouped fitting and holdout evaluation |
 
 These methods do not install a parameter dataset or alter a phase. A caller
 must explicitly supply a provenance-qualified `StateParameters` instance.

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
@@ -124,7 +124,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
 
   /** @return immutable source records sorted by source-lineage identifier */
   public List<SourceRecord> getSources() {
-    return sources;
+    return Collections.unmodifiableList(new ArrayList<SourceRecord>(sources));
   }
 
   /**

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
@@ -1,0 +1,373 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Immutable provenance manifest for repository-distributed binary volumetric Pitzer observations.
+ *
+ * <p>
+ * The manifest binds every declared source lineage to its calibration or validation role, citation,
+ * license, redistribution decision, file checksum, uncertainty basis, row count, and state envelope.
+ * It checks metadata-to-observation consistency before repository-distributed observations are fitted
+ * or evaluated. It does not prove experimental independence or calculate a checksum from source bytes.
+ * </p>
+ */
+public final class PitzerBinaryVolumetricDatasetProvenance implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Intended use of one source lineage. */
+  public enum DatasetRole {
+    /** Observations may be supplied to the weighted regression. */
+    CALIBRATION,
+    /** Observations remain untouched until holdout evaluation. */
+    VALIDATION
+  }
+
+  /** Audited permission to redistribute the represented rows. */
+  public enum RedistributionStatus {
+    /** Redistribution is explicitly permitted under the recorded license. */
+    PERMITTED,
+    /** Redistribution is explicitly restricted. */
+    RESTRICTED,
+    /** Redistribution permission has not been established. */
+    UNKNOWN
+  }
+
+  private final List<SourceRecord> sources;
+  private final Map<String, SourceRecord> sourcesByGroup;
+
+  /**
+   * Construct an immutable manifest.
+   *
+   * @param sourceRecords one record for every represented laboratory or source lineage
+   */
+  public PitzerBinaryVolumetricDatasetProvenance(List<SourceRecord> sourceRecords) {
+    if (sourceRecords == null || sourceRecords.isEmpty()) {
+      throw new IllegalArgumentException("Volumetric Pitzer provenance sources must not be null or empty");
+    }
+    Map<String, SourceRecord> sortedSources = new TreeMap<String, SourceRecord>();
+    for (SourceRecord source : sourceRecords) {
+      if (source == null) {
+        throw new IllegalArgumentException("Volumetric Pitzer provenance sources must not contain null");
+      }
+      if (sortedSources.put(source.getSourceGroup(), source) != null) {
+        throw new IllegalArgumentException("Duplicate volumetric Pitzer source lineage: " + source.getSourceGroup());
+      }
+    }
+    sourcesByGroup = Collections.unmodifiableMap(sortedSources);
+    sources = Collections.unmodifiableList(new ArrayList<SourceRecord>(sortedSources.values()));
+  }
+
+  /**
+   * Validate repository-distributed observations against one declared role.
+   *
+   * <p>
+   * Every observation must have a declared source, permitted redistribution, the declared role and
+   * molality range. The common temperature and pressure must lie within each used source envelope,
+   * and the number of observations for each source must exactly match its manifest record.
+   * </p>
+   *
+   * @param observations observations to validate
+   * @param role required dataset role
+   * @param temperatureK common temperature in K
+   * @param pressurePa common absolute pressure in Pa
+   */
+  public void validateRepositoryObservations(
+      List<PitzerBinaryVolumetricRegression.Observation> observations,
+      DatasetRole role,
+      double temperatureK,
+      double pressurePa) {
+    if (observations == null || observations.isEmpty()) {
+      throw new IllegalArgumentException("Repository volumetric Pitzer observations must not be null or empty");
+    }
+    if (role == null) {
+      throw new IllegalArgumentException("Volumetric Pitzer dataset role must not be null");
+    }
+    requirePositive(temperatureK, "Dataset temperature");
+    requirePositive(pressurePa, "Dataset pressure");
+
+    Map<String, Integer> observedCounts = new TreeMap<String, Integer>();
+    for (PitzerBinaryVolumetricRegression.Observation observation : observations) {
+      if (observation == null) {
+        throw new IllegalArgumentException("Repository volumetric Pitzer observations must not contain null");
+      }
+      SourceRecord source = sourcesByGroup.get(observation.getSourceGroup());
+      if (source == null) {
+        throw new IllegalArgumentException(
+            "Observation has no provenance record: " + observation.getSourceGroup());
+      }
+      if (source.getRole() != role) {
+        throw new IllegalArgumentException(
+            "Observation source role mismatch for " + observation.getSourceGroup());
+      }
+      source.requireRepositoryRedistributable();
+      if (!source.containsState(
+          observation.getMolality(), temperatureK, pressurePa)) {
+        throw new IllegalArgumentException(
+            "Observation is outside the declared source envelope: " + observation.getSourceGroup());
+      }
+      Integer previousCount = observedCounts.get(observation.getSourceGroup());
+      observedCounts.put(observation.getSourceGroup(), previousCount == null ? 1 : previousCount + 1);
+    }
+
+    for (SourceRecord source : sources) {
+      if (source.getRole() == role) {
+        Integer actualCount = observedCounts.get(source.getSourceGroup());
+        int count = actualCount == null ? 0 : actualCount;
+        if (count != source.getObservationCount()) {
+          throw new IllegalArgumentException(
+              "Observation count mismatch for "
+                  + source.getSourceGroup()
+                  + ": expected "
+                  + source.getObservationCount()
+                  + " but found "
+                  + count);
+        }
+      }
+    }
+  }
+
+  /** @return immutable source records sorted by source-lineage identifier */
+  public List<SourceRecord> getSources() {
+    return sources;
+  }
+
+  /**
+   * Return one source record.
+   *
+   * @param sourceGroup laboratory or source-lineage identifier
+   * @return matching source record, or null when absent
+   */
+  public SourceRecord getSource(String sourceGroup) {
+    if (sourceGroup == null) {
+      return null;
+    }
+    return sourcesByGroup.get(sourceGroup.trim());
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be empty");
+    }
+    return value.trim();
+  }
+
+  private static String optionalText(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static void requirePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static void requireRange(double minimum, double maximum, double lowerBound, String name) {
+    if (!Double.isFinite(minimum)
+        || !Double.isFinite(maximum)
+        || minimum < lowerBound
+        || maximum < minimum) {
+      throw new IllegalArgumentException(name + " range is invalid");
+    }
+  }
+
+  /** Immutable provenance record for one laboratory or source lineage. */
+  public static final class SourceRecord implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String sourceGroup;
+    private final DatasetRole role;
+    private final String citation;
+    private final String sourceUrl;
+    private final String licenseId;
+    private final String licenseUrl;
+    private final RedistributionStatus redistributionStatus;
+    private final String sha256;
+    private final String uncertaintyBasis;
+    private final int observationCount;
+    private final double minimumMolality;
+    private final double maximumMolality;
+    private final double minimumTemperatureK;
+    private final double maximumTemperatureK;
+    private final double minimumPressurePa;
+    private final double maximumPressurePa;
+
+    /**
+     * Construct a source-lineage record.
+     *
+     * @param sourceGroup non-empty laboratory or source-lineage identifier
+     * @param role calibration or validation role
+     * @param citation full citation or DOI description
+     * @param sourceUrl stable source URL
+     * @param licenseId license identifier, or an explicit unknown/restricted marker
+     * @param licenseUrl license URL; mandatory when redistribution is permitted
+     * @param redistributionStatus audited redistribution decision
+     * @param sha256 lowercase or uppercase SHA-256 of the distributed source file
+     * @param uncertaintyBasis description of the absolute one-sigma uncertainty mapping
+     * @param observationCount exact number of represented observations
+     * @param minimumMolality minimum formula-unit molality in mol/kg solvent
+     * @param maximumMolality maximum formula-unit molality in mol/kg solvent
+     * @param minimumTemperatureK minimum temperature in K
+     * @param maximumTemperatureK maximum temperature in K
+     * @param minimumPressurePa minimum absolute pressure in Pa
+     * @param maximumPressurePa maximum absolute pressure in Pa
+     */
+    public SourceRecord(
+        String sourceGroup,
+        DatasetRole role,
+        String citation,
+        String sourceUrl,
+        String licenseId,
+        String licenseUrl,
+        RedistributionStatus redistributionStatus,
+        String sha256,
+        String uncertaintyBasis,
+        int observationCount,
+        double minimumMolality,
+        double maximumMolality,
+        double minimumTemperatureK,
+        double maximumTemperatureK,
+        double minimumPressurePa,
+        double maximumPressurePa) {
+      this.sourceGroup = requireText(sourceGroup, "Source group");
+      if (role == null) {
+        throw new IllegalArgumentException("Dataset role must not be null");
+      }
+      this.role = role;
+      this.citation = requireText(citation, "Source citation");
+      this.sourceUrl = requireText(sourceUrl, "Source URL");
+      this.licenseId = requireText(licenseId, "License identifier");
+      this.licenseUrl = optionalText(licenseUrl);
+      if (redistributionStatus == null) {
+        throw new IllegalArgumentException("Redistribution status must not be null");
+      }
+      this.redistributionStatus = redistributionStatus;
+      String normalizedChecksum = requireText(sha256, "Source SHA-256").toLowerCase(Locale.ROOT);
+      if (!normalizedChecksum.matches("[0-9a-f]{64}")) {
+        throw new IllegalArgumentException("Source SHA-256 must contain exactly 64 hexadecimal characters");
+      }
+      this.sha256 = normalizedChecksum;
+      this.uncertaintyBasis = requireText(uncertaintyBasis, "Uncertainty basis");
+      if (observationCount <= 0) {
+        throw new IllegalArgumentException("Source observation count must be positive");
+      }
+      this.observationCount = observationCount;
+      requireRange(minimumMolality, maximumMolality, 0.0, "Source molality");
+      requireRange(minimumTemperatureK, maximumTemperatureK, Double.MIN_VALUE, "Source temperature");
+      requireRange(minimumPressurePa, maximumPressurePa, Double.MIN_VALUE, "Source pressure");
+      this.minimumMolality = minimumMolality;
+      this.maximumMolality = maximumMolality;
+      this.minimumTemperatureK = minimumTemperatureK;
+      this.maximumTemperatureK = maximumTemperatureK;
+      this.minimumPressurePa = minimumPressurePa;
+      this.maximumPressurePa = maximumPressurePa;
+
+      if (redistributionStatus == RedistributionStatus.PERMITTED && this.licenseUrl.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Permitted redistribution requires a non-empty license URL");
+      }
+    }
+
+    private boolean containsState(double molality, double temperatureK, double pressurePa) {
+      return molality >= minimumMolality
+          && molality <= maximumMolality
+          && temperatureK >= minimumTemperatureK
+          && temperatureK <= maximumTemperatureK
+          && pressurePa >= minimumPressurePa
+          && pressurePa <= maximumPressurePa;
+    }
+
+    private void requireRepositoryRedistributable() {
+      if (redistributionStatus != RedistributionStatus.PERMITTED) {
+        throw new IllegalArgumentException(
+            "Repository redistribution is not permitted for " + sourceGroup);
+      }
+    }
+
+    /** @return laboratory or source-lineage identifier */
+    public String getSourceGroup() {
+      return sourceGroup;
+    }
+
+    /** @return calibration or validation role */
+    public DatasetRole getRole() {
+      return role;
+    }
+
+    /** @return full citation or DOI description */
+    public String getCitation() {
+      return citation;
+    }
+
+    /** @return stable source URL */
+    public String getSourceUrl() {
+      return sourceUrl;
+    }
+
+    /** @return recorded license identifier */
+    public String getLicenseId() {
+      return licenseId;
+    }
+
+    /** @return recorded license URL, or an empty string */
+    public String getLicenseUrl() {
+      return licenseUrl;
+    }
+
+    /** @return audited redistribution status */
+    public RedistributionStatus getRedistributionStatus() {
+      return redistributionStatus;
+    }
+
+    /** @return normalized lowercase SHA-256 of the distributed source file */
+    public String getSha256() {
+      return sha256;
+    }
+
+    /** @return description of the absolute one-sigma uncertainty mapping */
+    public String getUncertaintyBasis() {
+      return uncertaintyBasis;
+    }
+
+    /** @return exact number of represented observations */
+    public int getObservationCount() {
+      return observationCount;
+    }
+
+    /** @return minimum formula-unit molality in mol/kg solvent */
+    public double getMinimumMolality() {
+      return minimumMolality;
+    }
+
+    /** @return maximum formula-unit molality in mol/kg solvent */
+    public double getMaximumMolality() {
+      return maximumMolality;
+    }
+
+    /** @return minimum temperature in K */
+    public double getMinimumTemperatureK() {
+      return minimumTemperatureK;
+    }
+
+    /** @return maximum temperature in K */
+    public double getMaximumTemperatureK() {
+      return maximumTemperatureK;
+    }
+
+    /** @return minimum absolute pressure in Pa */
+    public double getMinimumPressurePa() {
+      return minimumPressurePa;
+    }
+
+    /** @return maximum absolute pressure in Pa */
+    public double getMaximumPressurePa() {
+      return maximumPressurePa;
+    }
+  }
+}

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
@@ -12,10 +12,10 @@ import java.util.TreeMap;
  * Immutable provenance manifest for repository-distributed binary volumetric Pitzer observations.
  *
  * <p>
- * The manifest binds every declared source lineage to its calibration or validation role, citation,
- * license, redistribution decision, file checksum, uncertainty basis, row count, and state envelope.
- * It checks metadata-to-observation consistency before repository-distributed observations are fitted
- * or evaluated. It does not prove experimental independence or calculate a checksum from source bytes.
+ * The manifest binds every declared source lineage to its calibration or validation role, citation, license,
+ * redistribution decision, file checksum, uncertainty basis, row count, and state envelope. It checks
+ * metadata-to-observation consistency before repository-distributed observations are fitted or evaluated. It does not
+ * prove experimental independence or calculate a checksum from source bytes.
  * </p>
  */
 public final class PitzerBinaryVolumetricDatasetProvenance implements Serializable {
@@ -68,9 +68,9 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
    * Validate repository-distributed observations against one declared role.
    *
    * <p>
-   * Every observation must have a declared source, permitted redistribution, the declared role and
-   * molality range. The common temperature and pressure must lie within each used source envelope,
-   * and the number of observations for each source must exactly match its manifest record.
+   * Every observation must have a declared source, permitted redistribution, the declared role and molality range. The
+   * common temperature and pressure must lie within each used source envelope, and the number of observations for each
+   * source must exactly match its manifest record.
    * </p>
    *
    * @param observations observations to validate
@@ -78,11 +78,8 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
    * @param temperatureK common temperature in K
    * @param pressurePa common absolute pressure in Pa
    */
-  public void validateRepositoryObservations(
-      List<PitzerBinaryVolumetricRegression.Observation> observations,
-      DatasetRole role,
-      double temperatureK,
-      double pressurePa) {
+  public void validateRepositoryObservations(List<PitzerBinaryVolumetricRegression.Observation> observations,
+      DatasetRole role, double temperatureK, double pressurePa) {
     if (observations == null || observations.isEmpty()) {
       throw new IllegalArgumentException("Repository volumetric Pitzer observations must not be null or empty");
     }
@@ -99,16 +96,13 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
       }
       SourceRecord source = sourcesByGroup.get(observation.getSourceGroup());
       if (source == null) {
-        throw new IllegalArgumentException(
-            "Observation has no provenance record: " + observation.getSourceGroup());
+        throw new IllegalArgumentException("Observation has no provenance record: " + observation.getSourceGroup());
       }
       if (source.getRole() != role) {
-        throw new IllegalArgumentException(
-            "Observation source role mismatch for " + observation.getSourceGroup());
+        throw new IllegalArgumentException("Observation source role mismatch for " + observation.getSourceGroup());
       }
       source.requireRepositoryRedistributable();
-      if (!source.containsState(
-          observation.getMolality(), temperatureK, pressurePa)) {
+      if (!source.containsState(observation.getMolality(), temperatureK, pressurePa)) {
         throw new IllegalArgumentException(
             "Observation is outside the declared source envelope: " + observation.getSourceGroup());
       }
@@ -121,13 +115,8 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
         Integer actualCount = observedCounts.get(source.getSourceGroup());
         int count = actualCount == null ? 0 : actualCount;
         if (count != source.getObservationCount()) {
-          throw new IllegalArgumentException(
-              "Observation count mismatch for "
-                  + source.getSourceGroup()
-                  + ": expected "
-                  + source.getObservationCount()
-                  + " but found "
-                  + count);
+          throw new IllegalArgumentException("Observation count mismatch for " + source.getSourceGroup() + ": expected "
+              + source.getObservationCount() + " but found " + count);
         }
       }
     }
@@ -169,10 +158,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
   }
 
   private static void requireRange(double minimum, double maximum, double lowerBound, String name) {
-    if (!Double.isFinite(minimum)
-        || !Double.isFinite(maximum)
-        || minimum < lowerBound
-        || maximum < minimum) {
+    if (!Double.isFinite(minimum) || !Double.isFinite(maximum) || minimum < lowerBound || maximum < minimum) {
       throw new IllegalArgumentException(name + " range is invalid");
     }
   }
@@ -218,23 +204,10 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
      * @param minimumPressurePa minimum absolute pressure in Pa
      * @param maximumPressurePa maximum absolute pressure in Pa
      */
-    public SourceRecord(
-        String sourceGroup,
-        DatasetRole role,
-        String citation,
-        String sourceUrl,
-        String licenseId,
-        String licenseUrl,
-        RedistributionStatus redistributionStatus,
-        String sha256,
-        String uncertaintyBasis,
-        int observationCount,
-        double minimumMolality,
-        double maximumMolality,
-        double minimumTemperatureK,
-        double maximumTemperatureK,
-        double minimumPressurePa,
-        double maximumPressurePa) {
+    public SourceRecord(String sourceGroup, DatasetRole role, String citation, String sourceUrl, String licenseId,
+        String licenseUrl, RedistributionStatus redistributionStatus, String sha256, String uncertaintyBasis,
+        int observationCount, double minimumMolality, double maximumMolality, double minimumTemperatureK,
+        double maximumTemperatureK, double minimumPressurePa, double maximumPressurePa) {
       this.sourceGroup = requireText(sourceGroup, "Source group");
       if (role == null) {
         throw new IllegalArgumentException("Dataset role must not be null");
@@ -269,24 +242,18 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
       this.maximumPressurePa = maximumPressurePa;
 
       if (redistributionStatus == RedistributionStatus.PERMITTED && this.licenseUrl.isEmpty()) {
-        throw new IllegalArgumentException(
-            "Permitted redistribution requires a non-empty license URL");
+        throw new IllegalArgumentException("Permitted redistribution requires a non-empty license URL");
       }
     }
 
     private boolean containsState(double molality, double temperatureK, double pressurePa) {
-      return molality >= minimumMolality
-          && molality <= maximumMolality
-          && temperatureK >= minimumTemperatureK
-          && temperatureK <= maximumTemperatureK
-          && pressurePa >= minimumPressurePa
-          && pressurePa <= maximumPressurePa;
+      return molality >= minimumMolality && molality <= maximumMolality && temperatureK >= minimumTemperatureK
+          && temperatureK <= maximumTemperatureK && pressurePa >= minimumPressurePa && pressurePa <= maximumPressurePa;
     }
 
     private void requireRepositoryRedistributable() {
       if (redistributionStatus != RedistributionStatus.PERMITTED) {
-        throw new IllegalArgumentException(
-            "Repository redistribution is not permitted for " + sourceGroup);
+        throw new IllegalArgumentException("Repository redistribution is not permitted for " + sourceGroup);
       }
     }
 

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
@@ -46,10 +46,9 @@ public final class PitzerBinaryVolumetricGroupedValidation implements Serializab
    * Validate repository-distributed provenance before fitting and holdout evaluation.
    *
    * <p>
-   * The provenance manifest must assign every observation to its declared calibration or
-   * validation role and establish repository redistribution permission, file checksum,
-   * uncertainty basis, row count, and state envelope. The original caller-supplied
-   * {@link #validate(List, List, double, double, double)} path remains available for private or
+   * The provenance manifest must assign every observation to its declared calibration or validation role and establish
+   * repository redistribution permission, file checksum, uncertainty basis, row count, and state envelope. The original
+   * caller-supplied {@link #validate(List, List, double, double, double)} path remains available for private or
    * in-memory data that are not distributed with NeqSim.
    * </p>
    *
@@ -61,32 +60,18 @@ public final class PitzerBinaryVolumetricGroupedValidation implements Serializab
    * @param debyeHuckelVolumeSlope caller-supplied Debye-Huckel volume slope in SI units
    * @return immutable calibration fit and held-out residual diagnostics
    */
-  public ValidationResult validateRepositoryDatasets(
-      PitzerBinaryVolumetricDatasetProvenance provenance,
+  public ValidationResult validateRepositoryDatasets(PitzerBinaryVolumetricDatasetProvenance provenance,
       List<PitzerBinaryVolumetricRegression.Observation> calibrationObservations,
-      List<PitzerBinaryVolumetricRegression.Observation> validationObservations,
-      double temperatureK,
-      double pressurePa,
+      List<PitzerBinaryVolumetricRegression.Observation> validationObservations, double temperatureK, double pressurePa,
       double debyeHuckelVolumeSlope) {
     if (provenance == null) {
       throw new IllegalArgumentException("Volumetric Pitzer dataset provenance must not be null");
     }
-    provenance.validateRepositoryObservations(
-        calibrationObservations,
-        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-        temperatureK,
-        pressurePa);
-    provenance.validateRepositoryObservations(
-        validationObservations,
-        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
-        temperatureK,
-        pressurePa);
-    return validate(
-        calibrationObservations,
-        validationObservations,
-        temperatureK,
-        pressurePa,
-        debyeHuckelVolumeSlope);
+    provenance.validateRepositoryObservations(calibrationObservations,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, temperatureK, pressurePa);
+    provenance.validateRepositoryObservations(validationObservations,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION, temperatureK, pressurePa);
+    return validate(calibrationObservations, validationObservations, temperatureK, pressurePa, debyeHuckelVolumeSlope);
   }
 
   /**

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
@@ -43,6 +43,53 @@ public final class PitzerBinaryVolumetricGroupedValidation implements Serializab
   }
 
   /**
+   * Validate repository-distributed provenance before fitting and holdout evaluation.
+   *
+   * <p>
+   * The provenance manifest must assign every observation to its declared calibration or
+   * validation role and establish repository redistribution permission, file checksum,
+   * uncertainty basis, row count, and state envelope. The original caller-supplied
+   * {@link #validate(List, List, double, double, double)} path remains available for private or
+   * in-memory data that are not distributed with NeqSim.
+   * </p>
+   *
+   * @param provenance repository dataset provenance manifest
+   * @param calibrationObservations observations used by the weighted regression
+   * @param validationObservations observations used only after the fit is complete
+   * @param temperatureK common temperature in K
+   * @param pressurePa common absolute pressure in Pa
+   * @param debyeHuckelVolumeSlope caller-supplied Debye-Huckel volume slope in SI units
+   * @return immutable calibration fit and held-out residual diagnostics
+   */
+  public ValidationResult validateRepositoryDatasets(
+      PitzerBinaryVolumetricDatasetProvenance provenance,
+      List<PitzerBinaryVolumetricRegression.Observation> calibrationObservations,
+      List<PitzerBinaryVolumetricRegression.Observation> validationObservations,
+      double temperatureK,
+      double pressurePa,
+      double debyeHuckelVolumeSlope) {
+    if (provenance == null) {
+      throw new IllegalArgumentException("Volumetric Pitzer dataset provenance must not be null");
+    }
+    provenance.validateRepositoryObservations(
+        calibrationObservations,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+        temperatureK,
+        pressurePa);
+    provenance.validateRepositoryObservations(
+        validationObservations,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+        temperatureK,
+        pressurePa);
+    return validate(
+        calibrationObservations,
+        validationObservations,
+        temperatureK,
+        pressurePa,
+        debyeHuckelVolumeSlope);
+  }
+
+  /**
    * Fit calibration observations and evaluate an untouched, lineage-disjoint holdout.
    *
    * @param calibrationObservations observations used by the weighted regression

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
@@ -1,6 +1,7 @@
 package neqsim.thermo.phase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
@@ -125,6 +126,7 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
 
     assertEquals("a-source", provenance.getSources().get(0).getSourceGroup());
     assertEquals(checksum('b'), provenance.getSource("a-source").getSha256());
+    assertNotSame(provenance.getSources(), provenance.getSources());
     assertThrows(UnsupportedOperationException.class,
         () -> provenance.getSources()
             .add(source("new-source", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
@@ -18,46 +18,27 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
   private static final double BETA1_DERIVATIVE = -0.7e-10;
   private static final double CPHI_DERIVATIVE = 1.1e-11;
   private static final double STANDARD_UNCERTAINTY = 2.0e-8;
-  private static final double[] CALIBRATION_MOLALITIES =
-      {0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0};
-  private static final double[] VALIDATION_MOLALITIES = {0.1, 1.5, 4.0};
+  private static final double[] CALIBRATION_MOLALITIES = { 0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0 };
+  private static final double[] VALIDATION_MOLALITIES = { 0.1, 1.5, 4.0 };
 
   @Test
   void validatesPermittedRepositoryDatasetsBeforeGroupedEvaluation() {
     PitzerBinaryVolumetricModel model = calciumChlorideModel();
-    List<PitzerBinaryVolumetricRegression.Observation> calibration =
-        observations(model, CALIBRATION_MOLALITIES, "calibration-laboratory");
-    List<PitzerBinaryVolumetricRegression.Observation> validation =
-        observations(model, VALIDATION_MOLALITIES, "validation-laboratory");
-    PitzerBinaryVolumetricDatasetProvenance provenance =
-        new PitzerBinaryVolumetricDatasetProvenance(
-            Arrays.asList(
-                source(
-                    "calibration-laboratory",
-                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                    CALIBRATION_MOLALITIES.length,
-                    0.02,
-                    6.0,
-                    'A'),
-                source(
-                    "validation-laboratory",
-                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
-                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                    VALIDATION_MOLALITIES.length,
-                    0.1,
-                    4.0,
-                    'B')));
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(model, CALIBRATION_MOLALITIES,
+        "calibration-laboratory");
+    List<PitzerBinaryVolumetricRegression.Observation> validation = observations(model, VALIDATION_MOLALITIES,
+        "validation-laboratory");
+    PitzerBinaryVolumetricDatasetProvenance provenance = new PitzerBinaryVolumetricDatasetProvenance(Arrays.asList(
+        source("calibration-laboratory", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, CALIBRATION_MOLALITIES.length, 0.02,
+            6.0, 'A'),
+        source("validation-laboratory", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, VALIDATION_MOLALITIES.length, 0.1,
+            4.0, 'B')));
 
-    PitzerBinaryVolumetricGroupedValidation.ValidationResult result =
-        new PitzerBinaryVolumetricGroupedValidation(model)
-            .validateRepositoryDatasets(
-                provenance,
-                calibration,
-                validation,
-                TEMPERATURE_K,
-                PRESSURE_PA,
-                DEBYE_HUCKEL_VOLUME_SLOPE);
+    PitzerBinaryVolumetricGroupedValidation.ValidationResult result = new PitzerBinaryVolumetricGroupedValidation(model)
+        .validateRepositoryDatasets(provenance, calibration, validation, TEMPERATURE_K, PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE);
 
     assertEquals(LIMITING_VOLUME, result.getCalibrationFit().getLimitingApparentMolarVolume(), 1.0e-17);
     assertEquals(VALIDATION_MOLALITIES.length, result.getObservationCount());
@@ -66,202 +47,88 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
 
   @Test
   void rejectsRestrictedOrUnknownRedistributionBeforeFitting() {
-    List<PitzerBinaryVolumetricRegression.Observation> calibration =
-        observations(calciumChlorideModel(), CALIBRATION_MOLALITIES, "restricted-source");
-    PitzerBinaryVolumetricDatasetProvenance provenance =
-        new PitzerBinaryVolumetricDatasetProvenance(
-            Collections.singletonList(
-                source(
-                    "restricted-source",
-                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.RESTRICTED,
-                    CALIBRATION_MOLALITIES.length,
-                    0.02,
-                    6.0,
-                    'C')));
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(calciumChlorideModel(),
+        CALIBRATION_MOLALITIES, "restricted-source");
+    PitzerBinaryVolumetricDatasetProvenance provenance = new PitzerBinaryVolumetricDatasetProvenance(Collections
+        .singletonList(source("restricted-source", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.RESTRICTED, CALIBRATION_MOLALITIES.length,
+            0.02, 6.0, 'C')));
 
-    IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                provenance.validateRepositoryObservations(
-                    calibration,
-                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                    TEMPERATURE_K,
-                    PRESSURE_PA));
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> provenance.validateRepositoryObservations(calibration,
+            PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, TEMPERATURE_K, PRESSURE_PA));
     assertTrue(exception.getMessage().contains("not permitted"));
   }
 
   @Test
   void rejectsUndeclaredRoleCountAndEnvelopeMismatches() {
     PitzerBinaryVolumetricModel model = calciumChlorideModel();
-    List<PitzerBinaryVolumetricRegression.Observation> calibration =
-        observations(model, CALIBRATION_MOLALITIES, "calibration-laboratory");
-    PitzerBinaryVolumetricDatasetProvenance wrongCount =
-        manifest(
-            source(
-                "calibration-laboratory",
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                CALIBRATION_MOLALITIES.length - 1,
-                0.02,
-                6.0,
-                'D'));
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            wrongCount.validateRepositoryObservations(
-                calibration,
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                TEMPERATURE_K,
-                PRESSURE_PA));
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(model, CALIBRATION_MOLALITIES,
+        "calibration-laboratory");
+    PitzerBinaryVolumetricDatasetProvenance wrongCount = manifest(
+        source("calibration-laboratory", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, CALIBRATION_MOLALITIES.length - 1,
+            0.02, 6.0, 'D'));
+    assertThrows(IllegalArgumentException.class, () -> wrongCount.validateRepositoryObservations(calibration,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, TEMPERATURE_K, PRESSURE_PA));
 
-    PitzerBinaryVolumetricDatasetProvenance wrongRole =
-        manifest(
-            source(
-                "calibration-laboratory",
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
-                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                CALIBRATION_MOLALITIES.length,
-                0.02,
-                6.0,
-                'E'));
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            wrongRole.validateRepositoryObservations(
-                calibration,
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                TEMPERATURE_K,
-                PRESSURE_PA));
+    PitzerBinaryVolumetricDatasetProvenance wrongRole = manifest(
+        source("calibration-laboratory", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, CALIBRATION_MOLALITIES.length, 0.02,
+            6.0, 'E'));
+    assertThrows(IllegalArgumentException.class, () -> wrongRole.validateRepositoryObservations(calibration,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, TEMPERATURE_K, PRESSURE_PA));
 
-    PitzerBinaryVolumetricDatasetProvenance narrowEnvelope =
-        manifest(
-            source(
-                "calibration-laboratory",
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                CALIBRATION_MOLALITIES.length,
-                0.02,
-                5.0,
-                'F'));
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            narrowEnvelope.validateRepositoryObservations(
-                calibration,
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                TEMPERATURE_K,
-                PRESSURE_PA));
+    PitzerBinaryVolumetricDatasetProvenance narrowEnvelope = manifest(
+        source("calibration-laboratory", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, CALIBRATION_MOLALITIES.length, 0.02,
+            5.0, 'F'));
+    assertThrows(IllegalArgumentException.class, () -> narrowEnvelope.validateRepositoryObservations(calibration,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, TEMPERATURE_K, PRESSURE_PA));
 
-    List<PitzerBinaryVolumetricRegression.Observation> undeclared =
-        observations(model, CALIBRATION_MOLALITIES, "different-lineage");
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            narrowEnvelope.validateRepositoryObservations(
-                undeclared,
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                TEMPERATURE_K,
-                PRESSURE_PA));
+    List<PitzerBinaryVolumetricRegression.Observation> undeclared = observations(model, CALIBRATION_MOLALITIES,
+        "different-lineage");
+    assertThrows(IllegalArgumentException.class, () -> narrowEnvelope.validateRepositoryObservations(undeclared,
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, TEMPERATURE_K, PRESSURE_PA));
   }
 
   @Test
   void rejectsInvalidChecksumsDuplicatesAndIncompletePermittedLicenses() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
-                "source",
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                "Synthetic source",
-                "https://example.test/source",
-                "CC-BY-4.0",
-                "https://creativecommons.org/licenses/by/4.0/",
-                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                "not-a-checksum",
-                "Absolute one-sigma synthetic uncertainty",
-                1,
-                0.0,
-                1.0,
-                298.15,
-                323.15,
-                1.0e5,
-                20.0e6));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricDatasetProvenance.SourceRecord("source",
+            PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
+            "https://example.test/source", "CC-BY-4.0", "https://creativecommons.org/licenses/by/4.0/",
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, "not-a-checksum",
+            "Absolute one-sigma synthetic uncertainty", 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
 
-    PitzerBinaryVolumetricDatasetProvenance.SourceRecord duplicate =
-        source(
-            "duplicate",
-            PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-            1,
-            0.0,
-            1.0,
-            '1');
-    assertThrows(
-        IllegalArgumentException.class,
+    PitzerBinaryVolumetricDatasetProvenance.SourceRecord duplicate = source("duplicate",
+        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+        PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, 1, 0.0, 1.0, '1');
+    assertThrows(IllegalArgumentException.class,
         () -> new PitzerBinaryVolumetricDatasetProvenance(Arrays.asList(duplicate, duplicate)));
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
-                "source",
-                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                "Synthetic source",
-                "https://example.test/source",
-                "CC-BY-4.0",
-                "",
-                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                checksum('2'),
-                "Absolute one-sigma synthetic uncertainty",
-                1,
-                0.0,
-                1.0,
-                298.15,
-                323.15,
-                1.0e5,
-                20.0e6));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricDatasetProvenance.SourceRecord("source",
+            PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
+            "https://example.test/source", "CC-BY-4.0", "",
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('2'),
+            "Absolute one-sigma synthetic uncertainty", 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
   }
 
   @Test
   void exposesImmutableSortedRecordsAndNormalizedChecksum() {
-    PitzerBinaryVolumetricDatasetProvenance provenance =
-        new PitzerBinaryVolumetricDatasetProvenance(
-            Arrays.asList(
-                source(
-                    "z-source",
-                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
-                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                    1,
-                    0.0,
-                    1.0,
-                    'A'),
-                source(
-                    "a-source",
-                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                    1,
-                    0.0,
-                    1.0,
-                    'B')));
+    PitzerBinaryVolumetricDatasetProvenance provenance = new PitzerBinaryVolumetricDatasetProvenance(Arrays.asList(
+        source("z-source", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, 1, 0.0, 1.0, 'A'),
+        source("a-source", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, 1, 0.0, 1.0, 'B')));
 
     assertEquals("a-source", provenance.getSources().get(0).getSourceGroup());
     assertEquals(checksum('b'), provenance.getSource("a-source").getSha256());
-    assertThrows(
-        UnsupportedOperationException.class,
-        () ->
-            provenance
-                .getSources()
-                .add(
-                    source(
-                        "new-source",
-                        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
-                        PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
-                        1,
-                        0.0,
-                        1.0,
-                        'C')));
+    assertThrows(UnsupportedOperationException.class,
+        () -> provenance.getSources()
+            .add(source("new-source", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, 1, 0.0, 1.0, 'C')));
   }
 
   private static PitzerBinaryVolumetricDatasetProvenance manifest(
@@ -269,54 +136,29 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
     return new PitzerBinaryVolumetricDatasetProvenance(Collections.singletonList(source));
   }
 
-  private static PitzerBinaryVolumetricDatasetProvenance.SourceRecord source(
-      String sourceGroup,
+  private static PitzerBinaryVolumetricDatasetProvenance.SourceRecord source(String sourceGroup,
       PitzerBinaryVolumetricDatasetProvenance.DatasetRole role,
-      PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus status,
-      int observationCount,
-      double minimumMolality,
-      double maximumMolality,
-      char checksumCharacter) {
-    return new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
-        sourceGroup,
-        role,
-        "Synthetic source for provenance tests",
-        "https://example.test/" + sourceGroup,
-        status == PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED
-            ? "CC-BY-4.0"
-            : "RESTRICTED",
+      PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus status, int observationCount, double minimumMolality,
+      double maximumMolality, char checksumCharacter) {
+    return new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(sourceGroup, role,
+        "Synthetic source for provenance tests", "https://example.test/" + sourceGroup,
+        status == PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED ? "CC-BY-4.0" : "RESTRICTED",
         status == PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED
             ? "https://creativecommons.org/licenses/by/4.0/"
             : "",
-        status,
-        checksum(checksumCharacter),
-        "Absolute one-sigma synthetic uncertainty",
-        observationCount,
-        minimumMolality,
-        maximumMolality,
-        TEMPERATURE_K,
-        TEMPERATURE_K,
-        PRESSURE_PA,
-        PRESSURE_PA);
+        status, checksum(checksumCharacter), "Absolute one-sigma synthetic uncertainty", observationCount,
+        minimumMolality, maximumMolality, TEMPERATURE_K, TEMPERATURE_K, PRESSURE_PA, PRESSURE_PA);
   }
 
-  private static List<PitzerBinaryVolumetricRegression.Observation> observations(
-      PitzerBinaryVolumetricModel model, double[] molalities, String sourceGroup) {
-    PitzerBinaryVolumetricModel.StateParameters parameters =
-        new PitzerBinaryVolumetricModel.StateParameters(
-            TEMPERATURE_K,
-            PRESSURE_PA,
-            DEBYE_HUCKEL_VOLUME_SLOPE,
-            BETA0_DERIVATIVE,
-            BETA1_DERIVATIVE,
-            CPHI_DERIVATIVE);
-    PitzerBinaryVolumetricRegression.Observation[] observations =
-        new PitzerBinaryVolumetricRegression.Observation[molalities.length];
+  private static List<PitzerBinaryVolumetricRegression.Observation> observations(PitzerBinaryVolumetricModel model,
+      double[] molalities, String sourceGroup) {
+    PitzerBinaryVolumetricModel.StateParameters parameters = new PitzerBinaryVolumetricModel.StateParameters(
+        TEMPERATURE_K, PRESSURE_PA, DEBYE_HUCKEL_VOLUME_SLOPE, BETA0_DERIVATIVE, BETA1_DERIVATIVE, CPHI_DERIVATIVE);
+    PitzerBinaryVolumetricRegression.Observation[] observations = new PitzerBinaryVolumetricRegression.Observation[molalities.length];
     for (int index = 0; index < molalities.length; index++) {
       double volume = model.calculateApparentMolarVolume(molalities[index], LIMITING_VOLUME, parameters);
-      observations[index] =
-          new PitzerBinaryVolumetricRegression.Observation(
-              molalities[index], volume, STANDARD_UNCERTAINTY, sourceGroup);
+      observations[index] = new PitzerBinaryVolumetricRegression.Observation(molalities[index], volume,
+          STANDARD_UNCERTAINTY, sourceGroup);
     }
     return Arrays.asList(observations);
   }

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
@@ -1,0 +1,333 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests repository-admissible provenance for volumetric Pitzer datasets. */
+class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 323.15;
+  private static final double PRESSURE_PA = 20.0e6;
+  private static final double DEBYE_HUCKEL_VOLUME_SLOPE = 1.2e-6;
+  private static final double LIMITING_VOLUME = 17.6e-6;
+  private static final double BETA0_DERIVATIVE = 2.0e-10;
+  private static final double BETA1_DERIVATIVE = -0.7e-10;
+  private static final double CPHI_DERIVATIVE = 1.1e-11;
+  private static final double STANDARD_UNCERTAINTY = 2.0e-8;
+  private static final double[] CALIBRATION_MOLALITIES =
+      {0.02, 0.08, 0.2, 0.5, 1.0, 2.0, 3.5, 5.0, 6.0};
+  private static final double[] VALIDATION_MOLALITIES = {0.1, 1.5, 4.0};
+
+  @Test
+  void validatesPermittedRepositoryDatasetsBeforeGroupedEvaluation() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    List<PitzerBinaryVolumetricRegression.Observation> calibration =
+        observations(model, CALIBRATION_MOLALITIES, "calibration-laboratory");
+    List<PitzerBinaryVolumetricRegression.Observation> validation =
+        observations(model, VALIDATION_MOLALITIES, "validation-laboratory");
+    PitzerBinaryVolumetricDatasetProvenance provenance =
+        new PitzerBinaryVolumetricDatasetProvenance(
+            Arrays.asList(
+                source(
+                    "calibration-laboratory",
+                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                    CALIBRATION_MOLALITIES.length,
+                    0.02,
+                    6.0,
+                    'A'),
+                source(
+                    "validation-laboratory",
+                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                    VALIDATION_MOLALITIES.length,
+                    0.1,
+                    4.0,
+                    'B')));
+
+    PitzerBinaryVolumetricGroupedValidation.ValidationResult result =
+        new PitzerBinaryVolumetricGroupedValidation(model)
+            .validateRepositoryDatasets(
+                provenance,
+                calibration,
+                validation,
+                TEMPERATURE_K,
+                PRESSURE_PA,
+                DEBYE_HUCKEL_VOLUME_SLOPE);
+
+    assertEquals(LIMITING_VOLUME, result.getCalibrationFit().getLimitingApparentMolarVolume(), 1.0e-17);
+    assertEquals(VALIDATION_MOLALITIES.length, result.getObservationCount());
+    assertEquals(0.0, result.getChiSquare(), 1.0e-15);
+  }
+
+  @Test
+  void rejectsRestrictedOrUnknownRedistributionBeforeFitting() {
+    List<PitzerBinaryVolumetricRegression.Observation> calibration =
+        observations(calciumChlorideModel(), CALIBRATION_MOLALITIES, "restricted-source");
+    PitzerBinaryVolumetricDatasetProvenance provenance =
+        new PitzerBinaryVolumetricDatasetProvenance(
+            Collections.singletonList(
+                source(
+                    "restricted-source",
+                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.RESTRICTED,
+                    CALIBRATION_MOLALITIES.length,
+                    0.02,
+                    6.0,
+                    'C')));
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                provenance.validateRepositoryObservations(
+                    calibration,
+                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                    TEMPERATURE_K,
+                    PRESSURE_PA));
+    assertTrue(exception.getMessage().contains("not permitted"));
+  }
+
+  @Test
+  void rejectsUndeclaredRoleCountAndEnvelopeMismatches() {
+    PitzerBinaryVolumetricModel model = calciumChlorideModel();
+    List<PitzerBinaryVolumetricRegression.Observation> calibration =
+        observations(model, CALIBRATION_MOLALITIES, "calibration-laboratory");
+    PitzerBinaryVolumetricDatasetProvenance wrongCount =
+        manifest(
+            source(
+                "calibration-laboratory",
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                CALIBRATION_MOLALITIES.length - 1,
+                0.02,
+                6.0,
+                'D'));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            wrongCount.validateRepositoryObservations(
+                calibration,
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                TEMPERATURE_K,
+                PRESSURE_PA));
+
+    PitzerBinaryVolumetricDatasetProvenance wrongRole =
+        manifest(
+            source(
+                "calibration-laboratory",
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                CALIBRATION_MOLALITIES.length,
+                0.02,
+                6.0,
+                'E'));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            wrongRole.validateRepositoryObservations(
+                calibration,
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                TEMPERATURE_K,
+                PRESSURE_PA));
+
+    PitzerBinaryVolumetricDatasetProvenance narrowEnvelope =
+        manifest(
+            source(
+                "calibration-laboratory",
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                CALIBRATION_MOLALITIES.length,
+                0.02,
+                5.0,
+                'F'));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            narrowEnvelope.validateRepositoryObservations(
+                calibration,
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                TEMPERATURE_K,
+                PRESSURE_PA));
+
+    List<PitzerBinaryVolumetricRegression.Observation> undeclared =
+        observations(model, CALIBRATION_MOLALITIES, "different-lineage");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            narrowEnvelope.validateRepositoryObservations(
+                undeclared,
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                TEMPERATURE_K,
+                PRESSURE_PA));
+  }
+
+  @Test
+  void rejectsInvalidChecksumsDuplicatesAndIncompletePermittedLicenses() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
+                "source",
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                "Synthetic source",
+                "https://example.test/source",
+                "CC-BY-4.0",
+                "https://creativecommons.org/licenses/by/4.0/",
+                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                "not-a-checksum",
+                "Absolute one-sigma synthetic uncertainty",
+                1,
+                0.0,
+                1.0,
+                298.15,
+                323.15,
+                1.0e5,
+                20.0e6));
+
+    PitzerBinaryVolumetricDatasetProvenance.SourceRecord duplicate =
+        source(
+            "duplicate",
+            PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+            PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+            1,
+            0.0,
+            1.0,
+            '1');
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PitzerBinaryVolumetricDatasetProvenance(Arrays.asList(duplicate, duplicate)));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
+                "source",
+                PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                "Synthetic source",
+                "https://example.test/source",
+                "CC-BY-4.0",
+                "",
+                PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                checksum('2'),
+                "Absolute one-sigma synthetic uncertainty",
+                1,
+                0.0,
+                1.0,
+                298.15,
+                323.15,
+                1.0e5,
+                20.0e6));
+  }
+
+  @Test
+  void exposesImmutableSortedRecordsAndNormalizedChecksum() {
+    PitzerBinaryVolumetricDatasetProvenance provenance =
+        new PitzerBinaryVolumetricDatasetProvenance(
+            Arrays.asList(
+                source(
+                    "z-source",
+                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.VALIDATION,
+                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                    1,
+                    0.0,
+                    1.0,
+                    'A'),
+                source(
+                    "a-source",
+                    PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                    PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                    1,
+                    0.0,
+                    1.0,
+                    'B')));
+
+    assertEquals("a-source", provenance.getSources().get(0).getSourceGroup());
+    assertEquals(checksum('b'), provenance.getSource("a-source").getSha256());
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            provenance
+                .getSources()
+                .add(
+                    source(
+                        "new-source",
+                        PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
+                        PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED,
+                        1,
+                        0.0,
+                        1.0,
+                        'C')));
+  }
+
+  private static PitzerBinaryVolumetricDatasetProvenance manifest(
+      PitzerBinaryVolumetricDatasetProvenance.SourceRecord source) {
+    return new PitzerBinaryVolumetricDatasetProvenance(Collections.singletonList(source));
+  }
+
+  private static PitzerBinaryVolumetricDatasetProvenance.SourceRecord source(
+      String sourceGroup,
+      PitzerBinaryVolumetricDatasetProvenance.DatasetRole role,
+      PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus status,
+      int observationCount,
+      double minimumMolality,
+      double maximumMolality,
+      char checksumCharacter) {
+    return new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
+        sourceGroup,
+        role,
+        "Synthetic source for provenance tests",
+        "https://example.test/" + sourceGroup,
+        status == PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED
+            ? "CC-BY-4.0"
+            : "RESTRICTED",
+        status == PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED
+            ? "https://creativecommons.org/licenses/by/4.0/"
+            : "",
+        status,
+        checksum(checksumCharacter),
+        "Absolute one-sigma synthetic uncertainty",
+        observationCount,
+        minimumMolality,
+        maximumMolality,
+        TEMPERATURE_K,
+        TEMPERATURE_K,
+        PRESSURE_PA,
+        PRESSURE_PA);
+  }
+
+  private static List<PitzerBinaryVolumetricRegression.Observation> observations(
+      PitzerBinaryVolumetricModel model, double[] molalities, String sourceGroup) {
+    PitzerBinaryVolumetricModel.StateParameters parameters =
+        new PitzerBinaryVolumetricModel.StateParameters(
+            TEMPERATURE_K,
+            PRESSURE_PA,
+            DEBYE_HUCKEL_VOLUME_SLOPE,
+            BETA0_DERIVATIVE,
+            BETA1_DERIVATIVE,
+            CPHI_DERIVATIVE);
+    PitzerBinaryVolumetricRegression.Observation[] observations =
+        new PitzerBinaryVolumetricRegression.Observation[molalities.length];
+    for (int index = 0; index < molalities.length; index++) {
+      double volume = model.calculateApparentMolarVolume(molalities[index], LIMITING_VOLUME, parameters);
+      observations[index] =
+          new PitzerBinaryVolumetricRegression.Observation(
+              molalities[index], volume, STANDARD_UNCERTAINTY, sourceGroup);
+    }
+    return Arrays.asList(observations);
+  }
+
+  private static String checksum(char value) {
+    char[] characters = new char[64];
+    Arrays.fill(characters, value);
+    return new String(characters);
+  }
+
+  private static PitzerBinaryVolumetricModel calciumChlorideModel() {
+    return new PitzerBinaryVolumetricModel(1, 2, 2, -1);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3144 with a parameter- and dataset-neutral provenance gate for repository-distributed volumetric-Pitzer calibration and validation observations.

- records calibration/validation role, citation, stable source URL, license, redistribution status, SHA-256, uncertainty basis, exact row count, and molality/T/P envelope for every source lineage
- rejects undeclared lineages, duplicate manifests, role/count/envelope mismatches, invalid checksums, and restricted or unknown redistribution before fitting
- adds an explicit repository-admissible grouped-validation path
- preserves the existing caller-supplied validation API for private or in-memory data
- changes no parameters, datasets, default models, solver behavior, or thermodynamic results

Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5577996052

## Exact continuity and scope

- Exact base: `e90f7a95f4fb21016c79395d459315753bc1a8d6`
- Exact head: `dfe1eac37ef2f19b6d7dbb425abca80fcc2fd14a`
- Branch: `ai/3144-volumetric-pitzer-provenance-manifest`
- Nine ordered commits; exactly four intended files
- No active #3144 PR existed before publication
- Five identified autonomous PRs (#3560, #3555, #3559, #3557, #3556) have no changed-file overlap with this package or density-model guide
- No rebase, master synchronization, force-push, or modification of another exact head

Qualified remote blobs:

- provenance manifest: `b187a96f9bf9bbde605e7375a2befd24ac39f664`
- grouped-validator integration: `94b5033187579bf2aa0561c3f0c1ec145d88e714`
- focused tests: `f05cad2c9fc259f28d2832f3454b0b1e5ffc4f95`
- documentation: `6d252d0aa35bc68b2bf8f556f37dd7272167dca3`

Each remote blob was compared with the locally formatted and tested file and is byte-identical.

## Scientific contract

The new manifest is an auditable software boundary. It does not prove experimental independence, interpret a license, or calculate a checksum from external bytes. Maintainers must still:

1. compare the recorded SHA-256 with the distributed source file;
2. verify the recorded permission and attribution;
3. map source groups to real laboratories, apparatus, publications, and reuse lineage;
4. preserve reported units and absolute one-sigma uncertainty mapping; and
5. pre-register acceptance limits before evaluating the untouched holdout.

The 197-point Al Ghafri/NIST ThermoML series remains reserved as independent validation evidence.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local validation on the exact four remote blobs:

- `PitzerBinaryVolumetricDatasetProvenanceTest`: **5/5 passed**
- existing grouped validation: **4/4 passed**
- existing regression: **4/4 passed**
- existing kernel: **6/6 passed**
- total focused tests: **19/19 passed**, zero failures/errors/skips
- code-quality repair: `getSources()` returns a fresh unmodifiable defensive copy; consecutive-call identity is covered by regression
- production and test compilation completed under the repository Maven build
- `python3 devtools/run_spotless.py apply`: passed
- `python3 devtools/run_spotless.py check`: passed
- `python3 devtools/check_documentation_search.py`: passed (693 Markdown and one standalone HTML page)
- `git diff --check`: passed
- local pre-commit executable: unavailable; no pre-commit result is claimed

The first focused Maven attempt hit a transient Maven Central DNS failure after bootstrap. The unchanged tree passed completely on immediate retry. Hosted Java 8/21, Windows/Ubuntu, slow shards, Javadocs, CodeQL, formatting, documentation, PaperLab, and repository-policy checks remain authoritative.

## Documentation impact

`docs/physical_properties/density_models.md` documents the repository-admissibility API, enforced metadata, caller-owned-data compatibility, and the boundary between manifest consistency and scientific/license verification.

## Stop boundary

This PR adds no experimental row, CaCl₂ coefficient, Ksp, `Vdelta`, activity/reaction parameter, phase connection, solver change, tolerance change, or MCP payload. Quantitative high-pressure aqueous density and calcium-sulfate prediction remain fail-closed pending redistribution-qualified compressed-CaCl₂ calibration evidence and independent laboratory-grouped validation.

Portfolio occupancy becomes **6/10**. Keep this PR draft-only: do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity.

Generated with AI assistance.