### PR TITLE
[AI-Assisted] feat(refinery): add binary quality-constrained blend planning

### DIFF
--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -238,6 +238,60 @@ compliance, dynamic-viscosity conversion, viscosity-temperature extrapolation, n
 behavior, pressure correction, phase behavior, compatibility, multi-source or multi-property
 optimization, economics, or control.
 
+
+## Binary quality-constrained blend envelope
+
+`RefineryBinaryBlendEnvelope` combines the already-qualified bulk-property and viscosity
+screens for exactly two resolved sources. For first-source mass fraction `x`, API gravity,
+sulfur, nitrogen, and VBN are affine in `x`:
+
+$P_{blend}=xP_1+(1-x)P_2$
+
+For API gravity this follows from the ideal-additive-volume relation because
+$API=141.5/SG-131.5$. For viscosity, $P$ is VBN and the final value is obtained through the
+published Refutas inverse. The implementation intersects every inclusive property interval with
+$0\leq x\leq1$ and fails closed when the intersection is empty.
+
+```java
+RefineryBinaryBlendEnvelope envelope =
+    RefineryBinaryBlendEnvelope.fromQualityConstraints(
+        new double[] {0.847, 0.771},
+        new double[] {0.020, 0.005},
+        new double[] {0.0020, 0.0005},
+        new double[] {550.0, 375.0},
+        50.0,
+        35.56021251475798,
+        52.0278858625162,
+        0.014,
+        0.01,
+        411.7708156677767,
+        550.0);
+
+double minimumFirstFraction = envelope.getMinimumFirstSourceMassFraction();
+double maximumFirstFraction = envelope.getMaximumFirstSourceMassFraction();
+RefineryBinaryBlendEnvelope.Plan minimumCost = envelope.planMinimumCost(1.0, 2.0);
+double selectedFirstFraction = minimumCost.getFirstSourceMassFraction();
+double selectedCost = minimumCost.getUnitCostPerMass();
+double selectedApi = minimumCost.getAssayBlend().getApiGravity();
+double selectedViscosity = minimumCost.getViscosityBlend().getKinematicViscosityCSt();
+```
+
+The documented arithmetic case gives a closed first-source interval of 0.25-0.60. With source
+costs 1 and 2 per common mass unit, the unique minimum-cost endpoint is 0.60 and the blended unit
+cost is 1.40. Reversing the costs selects 0.25. Equal costs fail closed when the feasible interval
+contains more than one point; a single-point feasible interval remains valid.
+
+The specific-gravity endpoints 0.847 and 0.771 are preserved public DOE/OEDI assay values used by
+the existing bulk-blend qualification. The viscosities and quality values are arithmetic
+integration evidence, not measured blend data. The viscosity relation retains the Centeno et al.
+provenance, [DOI 10.1016/j.fuel.2011.02.028](https://doi.org/10.1016/j.fuel.2011.02.028).
+
+This bounded analytical planner is not a generic optimizer. It does not predict excess volume,
+viscosity-temperature behavior, phase or asphaltene compatibility, measured product quality,
+uncertainty, nonlinear economics, multi-source feasibility, or control actions. Every source
+property must already be resolved on the documented basis, and costs must use one common
+currency-per-mass basis.
+
 ## Per-cut UOP/Watson characterization factor
 
 `AssayCut.getWatsonCharacterizationFactor()` calculates the dimensionless UOP/Watson factor from the same authoritative density and representative-boiling-point inputs used by the assay workflow:

--- a/src/main/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelope.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelope.java
@@ -7,10 +7,9 @@ import java.util.Arrays;
  * Immutable feasible mass-fraction envelope for a quality-constrained binary refinery blend.
  *
  * <p>
- * The envelope combines the existing ideal-additive-volume specific-gravity rule, linear
- * sulfur/nitrogen bookkeeping, and common-temperature Refutas kinematic-viscosity rule. It does
- * not mutate an assay or thermodynamic system and does not introduce an independent property
- * correlation.
+ * The envelope combines the existing ideal-additive-volume specific-gravity rule, linear sulfur/nitrogen bookkeeping,
+ * and common-temperature Refutas kinematic-viscosity rule. It does not mutate an assay or thermodynamic system and does
+ * not introduce an independent property correlation.
  * </p>
  */
 public final class RefineryBinaryBlendEnvelope implements Serializable {
@@ -25,12 +24,10 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
   private final double minimumFirstSourceMassFraction;
   private final double maximumFirstSourceMassFraction;
 
-  private RefineryBinaryBlendEnvelope(double[] sourceSpecificGravities,
-      double[] sourceSulfurMassFractions, double[] sourceNitrogenMassFractions,
-      double[] sourceKinematicViscositiesCSt, double temperatureCelsius,
+  private RefineryBinaryBlendEnvelope(double[] sourceSpecificGravities, double[] sourceSulfurMassFractions,
+      double[] sourceNitrogenMassFractions, double[] sourceKinematicViscositiesCSt, double temperatureCelsius,
       double minimumApiGravity, double maximumApiGravity, double maximumSulfurMassFraction,
-      double maximumNitrogenMassFraction, double minimumKinematicViscosityCSt,
-      double maximumKinematicViscosityCSt) {
+      double maximumNitrogenMassFraction, double minimumKinematicViscosityCSt, double maximumKinematicViscosityCSt) {
     requireBinaryArray(sourceSpecificGravities, "specific gravities");
     requireBinaryArray(sourceSulfurMassFractions, "sulfur mass fractions");
     requireBinaryArray(sourceNitrogenMassFractions, "nitrogen mass fractions");
@@ -41,20 +38,17 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
     if (!Double.isFinite(temperatureCelsius)) {
       throw new IllegalArgumentException("Common viscosity temperature must be finite");
     }
-    if (!Double.isFinite(minimumKinematicViscosityCSt)
-        || !Double.isFinite(maximumKinematicViscosityCSt)
-        || !(minimumKinematicViscosityCSt > 0.2)
-        || maximumKinematicViscosityCSt < minimumKinematicViscosityCSt) {
+    if (!Double.isFinite(minimumKinematicViscosityCSt) || !Double.isFinite(maximumKinematicViscosityCSt)
+        || !(minimumKinematicViscosityCSt > 0.2) || maximumKinematicViscosityCSt < minimumKinematicViscosityCSt) {
       throw new IllegalArgumentException(
           "Kinematic-viscosity bounds must be finite, ordered, and greater than 0.2 cSt");
     }
 
     // Reuse the qualified property implementations as the authoritative input-domain checks.
-    double[] equalMasses = {1.0, 1.0};
-    RefineryAssayBlend.fromBulkProperties(equalMasses, sourceSpecificGravities,
-        sourceSulfurMassFractions, sourceNitrogenMassFractions);
-    RefineryViscosityBlend.fromMassBasis(equalMasses, sourceKinematicViscositiesCSt,
-        temperatureCelsius);
+    double[] equalMasses = { 1.0, 1.0 };
+    RefineryAssayBlend.fromBulkProperties(equalMasses, sourceSpecificGravities, sourceSulfurMassFractions,
+        sourceNitrogenMassFractions);
+    RefineryViscosityBlend.fromMassBasis(equalMasses, sourceKinematicViscositiesCSt, temperatureCelsius);
 
     this.sourceSpecificGravities = Arrays.copyOf(sourceSpecificGravities, 2);
     this.sourceSulfurMassFractions = Arrays.copyOf(sourceSulfurMassFractions, 2);
@@ -62,26 +56,23 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
     this.sourceKinematicViscositiesCSt = Arrays.copyOf(sourceKinematicViscositiesCSt, 2);
     this.temperatureCelsius = temperatureCelsius;
 
-    double[] interval = {0.0, 1.0};
+    double[] interval = { 0.0, 1.0 };
     double firstApiGravity = calculateApiGravity(sourceSpecificGravities[0]);
     double secondApiGravity = calculateApiGravity(sourceSpecificGravities[1]);
-    intersectLinearConstraint(interval, firstApiGravity, secondApiGravity, minimumApiGravity,
-        maximumApiGravity, "API-gravity");
-    intersectLinearConstraint(interval, sourceSulfurMassFractions[0],
-        sourceSulfurMassFractions[1], 0.0, maximumSulfurMassFraction, "sulfur");
-    intersectLinearConstraint(interval, sourceNitrogenMassFractions[0],
-        sourceNitrogenMassFractions[1], 0.0, maximumNitrogenMassFraction, "nitrogen");
+    intersectLinearConstraint(interval, firstApiGravity, secondApiGravity, minimumApiGravity, maximumApiGravity,
+        "API-gravity");
+    intersectLinearConstraint(interval, sourceSulfurMassFractions[0], sourceSulfurMassFractions[1], 0.0,
+        maximumSulfurMassFraction, "sulfur");
+    intersectLinearConstraint(interval, sourceNitrogenMassFractions[0], sourceNitrogenMassFractions[1], 0.0,
+        maximumNitrogenMassFraction, "nitrogen");
 
-    double firstBlendNumber = RefineryViscosityBlend
-        .calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[0]);
+    double firstBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[0]);
     double secondBlendNumber = RefineryViscosityBlend
         .calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[1]);
-    double minimumBlendNumber = RefineryViscosityBlend
-        .calculateViscosityBlendingNumber(minimumKinematicViscosityCSt);
-    double maximumBlendNumber = RefineryViscosityBlend
-        .calculateViscosityBlendingNumber(maximumKinematicViscosityCSt);
-    intersectLinearConstraint(interval, firstBlendNumber, secondBlendNumber,
-        minimumBlendNumber, maximumBlendNumber, "kinematic viscosity");
+    double minimumBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(minimumKinematicViscosityCSt);
+    double maximumBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(maximumKinematicViscosityCSt);
+    intersectLinearConstraint(interval, firstBlendNumber, secondBlendNumber, minimumBlendNumber, maximumBlendNumber,
+        "kinematic viscosity");
 
     minimumFirstSourceMassFraction = interval[0];
     maximumFirstSourceMassFraction = interval[1];
@@ -104,17 +95,14 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
    * @return immutable feasible binary envelope
    * @throws IllegalArgumentException for invalid sources, bounds, or an empty feasible interval
    */
-  public static RefineryBinaryBlendEnvelope fromQualityConstraints(
-      double[] sourceSpecificGravities, double[] sourceSulfurMassFractions,
-      double[] sourceNitrogenMassFractions, double[] sourceKinematicViscositiesCSt,
-      double temperatureCelsius, double minimumApiGravity, double maximumApiGravity,
-      double maximumSulfurMassFraction, double maximumNitrogenMassFraction,
-      double minimumKinematicViscosityCSt, double maximumKinematicViscosityCSt) {
-    return new RefineryBinaryBlendEnvelope(sourceSpecificGravities,
-        sourceSulfurMassFractions, sourceNitrogenMassFractions,
-        sourceKinematicViscositiesCSt, temperatureCelsius, minimumApiGravity,
-        maximumApiGravity, maximumSulfurMassFraction, maximumNitrogenMassFraction,
-        minimumKinematicViscosityCSt, maximumKinematicViscosityCSt);
+  public static RefineryBinaryBlendEnvelope fromQualityConstraints(double[] sourceSpecificGravities,
+      double[] sourceSulfurMassFractions, double[] sourceNitrogenMassFractions, double[] sourceKinematicViscositiesCSt,
+      double temperatureCelsius, double minimumApiGravity, double maximumApiGravity, double maximumSulfurMassFraction,
+      double maximumNitrogenMassFraction, double minimumKinematicViscosityCSt, double maximumKinematicViscosityCSt) {
+    return new RefineryBinaryBlendEnvelope(sourceSpecificGravities, sourceSulfurMassFractions,
+        sourceNitrogenMassFractions, sourceKinematicViscositiesCSt, temperatureCelsius, minimumApiGravity,
+        maximumApiGravity, maximumSulfurMassFraction, maximumNitrogenMassFraction, minimumKinematicViscosityCSt,
+        maximumKinematicViscosityCSt);
   }
 
   /** @return inclusive minimum first-source mass fraction */
@@ -166,16 +154,15 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
    * Select the unique minimum-cost endpoint of the feasible interval.
    *
    * <p>
-   * Costs may use any common currency per common mass unit. Equal costs fail closed when the
-   * feasible interval contains more than one point because the optimum is then non-unique.
+   * Costs may use any common currency per common mass unit. Equal costs fail closed when the feasible interval contains
+   * more than one point because the optimum is then non-unique.
    * </p>
    *
    * @param firstSourceCostPerMass non-negative first-source unit cost
    * @param secondSourceCostPerMass non-negative second-source unit cost
    * @return immutable minimum-cost combined property plan
    */
-  public Plan planMinimumCost(double firstSourceCostPerMass,
-      double secondSourceCostPerMass) {
+  public Plan planMinimumCost(double firstSourceCostPerMass, double secondSourceCostPerMass) {
     requireNonNegativeFinite(firstSourceCostPerMass, "First-source cost");
     requireNonNegativeFinite(secondSourceCostPerMass, "Second-source cost");
     double firstMassFraction;
@@ -192,27 +179,25 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
     return createPlan(firstMassFraction, firstSourceCostPerMass, secondSourceCostPerMass, true);
   }
 
-  private Plan createPlan(double firstSourceMassFraction, double firstSourceCostPerMass,
-      double secondSourceCostPerMass, boolean costAvailable) {
-    if (!Double.isFinite(firstSourceMassFraction)
-        || firstSourceMassFraction < minimumFirstSourceMassFraction
+  private Plan createPlan(double firstSourceMassFraction, double firstSourceCostPerMass, double secondSourceCostPerMass,
+      boolean costAvailable) {
+    if (!Double.isFinite(firstSourceMassFraction) || firstSourceMassFraction < minimumFirstSourceMassFraction
         || firstSourceMassFraction > maximumFirstSourceMassFraction) {
       throw new IllegalArgumentException("First-source mass fraction must lie inside the feasible interval");
     }
-    double[] masses = {firstSourceMassFraction, 1.0 - firstSourceMassFraction};
-    RefineryAssayBlend assayBlend = RefineryAssayBlend.fromBulkProperties(masses,
-        sourceSpecificGravities, sourceSulfurMassFractions, sourceNitrogenMassFractions);
-    RefineryViscosityBlend viscosityBlend = RefineryViscosityBlend.fromMassBasis(masses,
-        sourceKinematicViscositiesCSt, temperatureCelsius);
+    double[] masses = { firstSourceMassFraction, 1.0 - firstSourceMassFraction };
+    RefineryAssayBlend assayBlend = RefineryAssayBlend.fromBulkProperties(masses, sourceSpecificGravities,
+        sourceSulfurMassFractions, sourceNitrogenMassFractions);
+    RefineryViscosityBlend viscosityBlend = RefineryViscosityBlend.fromMassBasis(masses, sourceKinematicViscositiesCSt,
+        temperatureCelsius);
     double unitCost = costAvailable
-        ? firstSourceMassFraction * firstSourceCostPerMass
-            + (1.0 - firstSourceMassFraction) * secondSourceCostPerMass
+        ? firstSourceMassFraction * firstSourceCostPerMass + (1.0 - firstSourceMassFraction) * secondSourceCostPerMass
         : Double.NaN;
     return new Plan(firstSourceMassFraction, assayBlend, viscosityBlend, costAvailable, unitCost);
   }
 
-  private static void intersectLinearConstraint(double[] interval, double firstValue,
-      double secondValue, double minimumValue, double maximumValue, String propertyName) {
+  private static void intersectLinearConstraint(double[] interval, double firstValue, double secondValue,
+      double minimumValue, double maximumValue, String propertyName) {
     double slope = firstValue - secondValue;
     if (slope == 0.0) {
       if (firstValue < minimumValue || firstValue > maximumValue) {
@@ -229,14 +214,12 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
     double updatedMaximum = Math.min(interval[1], propertyMaximumFraction);
     if (updatedMinimum > updatedMaximum) {
       if (updatedMinimum - updatedMaximum <= FRACTION_ROUNDOFF_TOLERANCE) {
-        double sharedBoundary = Math.max(0.0,
-            Math.min(1.0, 0.5 * (updatedMinimum + updatedMaximum)));
+        double sharedBoundary = Math.max(0.0, Math.min(1.0, 0.5 * (updatedMinimum + updatedMaximum)));
         interval[0] = sharedBoundary;
         interval[1] = sharedBoundary;
         return;
       }
-      throw new IllegalArgumentException(
-          "No feasible binary blend satisfies the " + propertyName + " constraint");
+      throw new IllegalArgumentException("No feasible binary blend satisfies the " + propertyName + " constraint");
     }
     interval[0] = Math.max(0.0, updatedMinimum);
     interval[1] = Math.min(1.0, updatedMaximum);
@@ -252,10 +235,8 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
     }
   }
 
-  private static void requireFiniteOrderedBounds(double minimumValue, double maximumValue,
-      String propertyName) {
-    if (!Double.isFinite(minimumValue) || !Double.isFinite(maximumValue)
-        || maximumValue < minimumValue) {
+  private static void requireFiniteOrderedBounds(double minimumValue, double maximumValue, String propertyName) {
+    if (!Double.isFinite(minimumValue) || !Double.isFinite(maximumValue) || maximumValue < minimumValue) {
       throw new IllegalArgumentException(propertyName + " bounds must be finite and ordered");
     }
   }
@@ -281,9 +262,8 @@ public final class RefineryBinaryBlendEnvelope implements Serializable {
     private final boolean unitCostAvailable;
     private final double unitCostPerMass;
 
-    private Plan(double firstSourceMassFraction, RefineryAssayBlend assayBlend,
-        RefineryViscosityBlend viscosityBlend, boolean unitCostAvailable,
-        double unitCostPerMass) {
+    private Plan(double firstSourceMassFraction, RefineryAssayBlend assayBlend, RefineryViscosityBlend viscosityBlend,
+        boolean unitCostAvailable, double unitCostPerMass) {
       this.firstSourceMassFraction = firstSourceMassFraction;
       this.assayBlend = assayBlend;
       this.viscosityBlend = viscosityBlend;

--- a/src/main/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelope.java
+++ b/src/main/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelope.java
@@ -1,0 +1,330 @@
+package neqsim.thermo.characterization;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable feasible mass-fraction envelope for a quality-constrained binary refinery blend.
+ *
+ * <p>
+ * The envelope combines the existing ideal-additive-volume specific-gravity rule, linear
+ * sulfur/nitrogen bookkeeping, and common-temperature Refutas kinematic-viscosity rule. It does
+ * not mutate an assay or thermodynamic system and does not introduce an independent property
+ * correlation.
+ * </p>
+ */
+public final class RefineryBinaryBlendEnvelope implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double FRACTION_ROUNDOFF_TOLERANCE = 1.0e-14;
+
+  private final double[] sourceSpecificGravities;
+  private final double[] sourceSulfurMassFractions;
+  private final double[] sourceNitrogenMassFractions;
+  private final double[] sourceKinematicViscositiesCSt;
+  private final double temperatureCelsius;
+  private final double minimumFirstSourceMassFraction;
+  private final double maximumFirstSourceMassFraction;
+
+  private RefineryBinaryBlendEnvelope(double[] sourceSpecificGravities,
+      double[] sourceSulfurMassFractions, double[] sourceNitrogenMassFractions,
+      double[] sourceKinematicViscositiesCSt, double temperatureCelsius,
+      double minimumApiGravity, double maximumApiGravity, double maximumSulfurMassFraction,
+      double maximumNitrogenMassFraction, double minimumKinematicViscosityCSt,
+      double maximumKinematicViscosityCSt) {
+    requireBinaryArray(sourceSpecificGravities, "specific gravities");
+    requireBinaryArray(sourceSulfurMassFractions, "sulfur mass fractions");
+    requireBinaryArray(sourceNitrogenMassFractions, "nitrogen mass fractions");
+    requireBinaryArray(sourceKinematicViscositiesCSt, "kinematic viscosities");
+    requireFiniteOrderedBounds(minimumApiGravity, maximumApiGravity, "API-gravity");
+    requireMassFraction(maximumSulfurMassFraction, "Maximum sulfur mass fraction");
+    requireMassFraction(maximumNitrogenMassFraction, "Maximum nitrogen mass fraction");
+    if (!Double.isFinite(temperatureCelsius)) {
+      throw new IllegalArgumentException("Common viscosity temperature must be finite");
+    }
+    if (!Double.isFinite(minimumKinematicViscosityCSt)
+        || !Double.isFinite(maximumKinematicViscosityCSt)
+        || !(minimumKinematicViscosityCSt > 0.2)
+        || maximumKinematicViscosityCSt < minimumKinematicViscosityCSt) {
+      throw new IllegalArgumentException(
+          "Kinematic-viscosity bounds must be finite, ordered, and greater than 0.2 cSt");
+    }
+
+    // Reuse the qualified property implementations as the authoritative input-domain checks.
+    double[] equalMasses = {1.0, 1.0};
+    RefineryAssayBlend.fromBulkProperties(equalMasses, sourceSpecificGravities,
+        sourceSulfurMassFractions, sourceNitrogenMassFractions);
+    RefineryViscosityBlend.fromMassBasis(equalMasses, sourceKinematicViscositiesCSt,
+        temperatureCelsius);
+
+    this.sourceSpecificGravities = Arrays.copyOf(sourceSpecificGravities, 2);
+    this.sourceSulfurMassFractions = Arrays.copyOf(sourceSulfurMassFractions, 2);
+    this.sourceNitrogenMassFractions = Arrays.copyOf(sourceNitrogenMassFractions, 2);
+    this.sourceKinematicViscositiesCSt = Arrays.copyOf(sourceKinematicViscositiesCSt, 2);
+    this.temperatureCelsius = temperatureCelsius;
+
+    double[] interval = {0.0, 1.0};
+    double firstApiGravity = calculateApiGravity(sourceSpecificGravities[0]);
+    double secondApiGravity = calculateApiGravity(sourceSpecificGravities[1]);
+    intersectLinearConstraint(interval, firstApiGravity, secondApiGravity, minimumApiGravity,
+        maximumApiGravity, "API-gravity");
+    intersectLinearConstraint(interval, sourceSulfurMassFractions[0],
+        sourceSulfurMassFractions[1], 0.0, maximumSulfurMassFraction, "sulfur");
+    intersectLinearConstraint(interval, sourceNitrogenMassFractions[0],
+        sourceNitrogenMassFractions[1], 0.0, maximumNitrogenMassFraction, "nitrogen");
+
+    double firstBlendNumber = RefineryViscosityBlend
+        .calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[0]);
+    double secondBlendNumber = RefineryViscosityBlend
+        .calculateViscosityBlendingNumber(sourceKinematicViscositiesCSt[1]);
+    double minimumBlendNumber = RefineryViscosityBlend
+        .calculateViscosityBlendingNumber(minimumKinematicViscosityCSt);
+    double maximumBlendNumber = RefineryViscosityBlend
+        .calculateViscosityBlendingNumber(maximumKinematicViscosityCSt);
+    intersectLinearConstraint(interval, firstBlendNumber, secondBlendNumber,
+        minimumBlendNumber, maximumBlendNumber, "kinematic viscosity");
+
+    minimumFirstSourceMassFraction = interval[0];
+    maximumFirstSourceMassFraction = interval[1];
+  }
+
+  /**
+   * Build the feasible binary mass-fraction interval for explicit product-quality limits.
+   *
+   * @param sourceSpecificGravities two source specific gravities
+   * @param sourceSulfurMassFractions two total-sulfur mass fractions on a 0-1 basis
+   * @param sourceNitrogenMassFractions two total-nitrogen mass fractions on a 0-1 basis
+   * @param sourceKinematicViscositiesCSt two source viscosities in cSt at the common temperature
+   * @param temperatureCelsius common source-viscosity temperature in degrees Celsius
+   * @param minimumApiGravity inclusive minimum blend API gravity
+   * @param maximumApiGravity inclusive maximum blend API gravity
+   * @param maximumSulfurMassFraction inclusive maximum blend sulfur mass fraction
+   * @param maximumNitrogenMassFraction inclusive maximum blend nitrogen mass fraction
+   * @param minimumKinematicViscosityCSt inclusive minimum blend viscosity in cSt
+   * @param maximumKinematicViscosityCSt inclusive maximum blend viscosity in cSt
+   * @return immutable feasible binary envelope
+   * @throws IllegalArgumentException for invalid sources, bounds, or an empty feasible interval
+   */
+  public static RefineryBinaryBlendEnvelope fromQualityConstraints(
+      double[] sourceSpecificGravities, double[] sourceSulfurMassFractions,
+      double[] sourceNitrogenMassFractions, double[] sourceKinematicViscositiesCSt,
+      double temperatureCelsius, double minimumApiGravity, double maximumApiGravity,
+      double maximumSulfurMassFraction, double maximumNitrogenMassFraction,
+      double minimumKinematicViscosityCSt, double maximumKinematicViscosityCSt) {
+    return new RefineryBinaryBlendEnvelope(sourceSpecificGravities,
+        sourceSulfurMassFractions, sourceNitrogenMassFractions,
+        sourceKinematicViscositiesCSt, temperatureCelsius, minimumApiGravity,
+        maximumApiGravity, maximumSulfurMassFraction, maximumNitrogenMassFraction,
+        minimumKinematicViscosityCSt, maximumKinematicViscosityCSt);
+  }
+
+  /** @return inclusive minimum first-source mass fraction */
+  public double getMinimumFirstSourceMassFraction() {
+    return minimumFirstSourceMassFraction;
+  }
+
+  /** @return inclusive maximum first-source mass fraction */
+  public double getMaximumFirstSourceMassFraction() {
+    return maximumFirstSourceMassFraction;
+  }
+
+  /** @return common viscosity temperature in degrees Celsius */
+  public double getTemperatureCelsius() {
+    return temperatureCelsius;
+  }
+
+  /** @return defensive copy of the two source specific gravities */
+  public double[] getSourceSpecificGravities() {
+    return Arrays.copyOf(sourceSpecificGravities, 2);
+  }
+
+  /** @return defensive copy of the two source sulfur mass fractions */
+  public double[] getSourceSulfurMassFractions() {
+    return Arrays.copyOf(sourceSulfurMassFractions, 2);
+  }
+
+  /** @return defensive copy of the two source nitrogen mass fractions */
+  public double[] getSourceNitrogenMassFractions() {
+    return Arrays.copyOf(sourceNitrogenMassFractions, 2);
+  }
+
+  /** @return defensive copy of the two source viscosities in cSt */
+  public double[] getSourceKinematicViscositiesCSt() {
+    return Arrays.copyOf(sourceKinematicViscositiesCSt, 2);
+  }
+
+  /**
+   * Evaluate one caller-selected point inside the feasible interval.
+   *
+   * @param firstSourceMassFraction first-source mass fraction
+   * @return immutable combined property plan without cost metadata
+   */
+  public Plan evaluateAtFirstSourceMassFraction(double firstSourceMassFraction) {
+    return createPlan(firstSourceMassFraction, Double.NaN, Double.NaN, false);
+  }
+
+  /**
+   * Select the unique minimum-cost endpoint of the feasible interval.
+   *
+   * <p>
+   * Costs may use any common currency per common mass unit. Equal costs fail closed when the
+   * feasible interval contains more than one point because the optimum is then non-unique.
+   * </p>
+   *
+   * @param firstSourceCostPerMass non-negative first-source unit cost
+   * @param secondSourceCostPerMass non-negative second-source unit cost
+   * @return immutable minimum-cost combined property plan
+   */
+  public Plan planMinimumCost(double firstSourceCostPerMass,
+      double secondSourceCostPerMass) {
+    requireNonNegativeFinite(firstSourceCostPerMass, "First-source cost");
+    requireNonNegativeFinite(secondSourceCostPerMass, "Second-source cost");
+    double firstMassFraction;
+    if (firstSourceCostPerMass < secondSourceCostPerMass) {
+      firstMassFraction = maximumFirstSourceMassFraction;
+    } else if (firstSourceCostPerMass > secondSourceCostPerMass) {
+      firstMassFraction = minimumFirstSourceMassFraction;
+    } else if (minimumFirstSourceMassFraction == maximumFirstSourceMassFraction) {
+      firstMassFraction = minimumFirstSourceMassFraction;
+    } else {
+      throw new IllegalArgumentException(
+          "Equal source costs do not define a unique minimum-cost blend inside this envelope");
+    }
+    return createPlan(firstMassFraction, firstSourceCostPerMass, secondSourceCostPerMass, true);
+  }
+
+  private Plan createPlan(double firstSourceMassFraction, double firstSourceCostPerMass,
+      double secondSourceCostPerMass, boolean costAvailable) {
+    if (!Double.isFinite(firstSourceMassFraction)
+        || firstSourceMassFraction < minimumFirstSourceMassFraction
+        || firstSourceMassFraction > maximumFirstSourceMassFraction) {
+      throw new IllegalArgumentException("First-source mass fraction must lie inside the feasible interval");
+    }
+    double[] masses = {firstSourceMassFraction, 1.0 - firstSourceMassFraction};
+    RefineryAssayBlend assayBlend = RefineryAssayBlend.fromBulkProperties(masses,
+        sourceSpecificGravities, sourceSulfurMassFractions, sourceNitrogenMassFractions);
+    RefineryViscosityBlend viscosityBlend = RefineryViscosityBlend.fromMassBasis(masses,
+        sourceKinematicViscositiesCSt, temperatureCelsius);
+    double unitCost = costAvailable
+        ? firstSourceMassFraction * firstSourceCostPerMass
+            + (1.0 - firstSourceMassFraction) * secondSourceCostPerMass
+        : Double.NaN;
+    return new Plan(firstSourceMassFraction, assayBlend, viscosityBlend, costAvailable, unitCost);
+  }
+
+  private static void intersectLinearConstraint(double[] interval, double firstValue,
+      double secondValue, double minimumValue, double maximumValue, String propertyName) {
+    double slope = firstValue - secondValue;
+    if (slope == 0.0) {
+      if (firstValue < minimumValue || firstValue > maximumValue) {
+        throw new IllegalArgumentException("No feasible binary blend satisfies the " + propertyName + " constraint");
+      }
+      return;
+    }
+
+    double firstIntersection = (minimumValue - secondValue) / slope;
+    double secondIntersection = (maximumValue - secondValue) / slope;
+    double propertyMinimumFraction = Math.min(firstIntersection, secondIntersection);
+    double propertyMaximumFraction = Math.max(firstIntersection, secondIntersection);
+    double updatedMinimum = Math.max(interval[0], propertyMinimumFraction);
+    double updatedMaximum = Math.min(interval[1], propertyMaximumFraction);
+    if (updatedMinimum > updatedMaximum) {
+      if (updatedMinimum - updatedMaximum <= FRACTION_ROUNDOFF_TOLERANCE) {
+        double sharedBoundary = Math.max(0.0,
+            Math.min(1.0, 0.5 * (updatedMinimum + updatedMaximum)));
+        interval[0] = sharedBoundary;
+        interval[1] = sharedBoundary;
+        return;
+      }
+      throw new IllegalArgumentException(
+          "No feasible binary blend satisfies the " + propertyName + " constraint");
+    }
+    interval[0] = Math.max(0.0, updatedMinimum);
+    interval[1] = Math.min(1.0, updatedMaximum);
+  }
+
+  private static double calculateApiGravity(double specificGravity) {
+    return 141.5 / specificGravity - 131.5;
+  }
+
+  private static void requireBinaryArray(double[] values, String propertyName) {
+    if (values == null || values.length != 2) {
+      throw new IllegalArgumentException("Exactly two source " + propertyName + " are required");
+    }
+  }
+
+  private static void requireFiniteOrderedBounds(double minimumValue, double maximumValue,
+      String propertyName) {
+    if (!Double.isFinite(minimumValue) || !Double.isFinite(maximumValue)
+        || maximumValue < minimumValue) {
+      throw new IllegalArgumentException(propertyName + " bounds must be finite and ordered");
+    }
+  }
+
+  private static void requireMassFraction(double value, String propertyName) {
+    if (!Double.isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException(propertyName + " must be finite and between 0 and 1");
+    }
+  }
+
+  private static void requireNonNegativeFinite(double value, String propertyName) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(propertyName + " must be finite and non-negative");
+    }
+  }
+
+  /** Immutable evaluated blend inside a {@link RefineryBinaryBlendEnvelope}. */
+  public static final class Plan implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double firstSourceMassFraction;
+    private final RefineryAssayBlend assayBlend;
+    private final RefineryViscosityBlend viscosityBlend;
+    private final boolean unitCostAvailable;
+    private final double unitCostPerMass;
+
+    private Plan(double firstSourceMassFraction, RefineryAssayBlend assayBlend,
+        RefineryViscosityBlend viscosityBlend, boolean unitCostAvailable,
+        double unitCostPerMass) {
+      this.firstSourceMassFraction = firstSourceMassFraction;
+      this.assayBlend = assayBlend;
+      this.viscosityBlend = viscosityBlend;
+      this.unitCostAvailable = unitCostAvailable;
+      this.unitCostPerMass = unitCostPerMass;
+    }
+
+    /** @return first-source mass fraction */
+    public double getFirstSourceMassFraction() {
+      return firstSourceMassFraction;
+    }
+
+    /** @return second-source mass fraction */
+    public double getSecondSourceMassFraction() {
+      return 1.0 - firstSourceMassFraction;
+    }
+
+    /** @return immutable ideal-volume and linear-quality blend result */
+    public RefineryAssayBlend getAssayBlend() {
+      return assayBlend;
+    }
+
+    /** @return immutable Refutas viscosity blend result */
+    public RefineryViscosityBlend getViscosityBlend() {
+      return viscosityBlend;
+    }
+
+    /** @return whether minimum-cost metadata is available */
+    public boolean hasUnitCost() {
+      return unitCostAvailable;
+    }
+
+    /**
+     * @return blend cost in the same currency per mass unit supplied to the planner
+     * @throws IllegalStateException when this plan was evaluated without costs
+     */
+    public double getUnitCostPerMass() {
+      if (!unitCostAvailable) {
+        throw new IllegalStateException("Unit cost is unavailable for an uncosted blend evaluation");
+      }
+      return unitCostPerMass;
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelopeTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelopeTest.java
@@ -1,0 +1,190 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests binary refinery quality-envelope and minimum-cost planning. */
+public class RefineryBinaryBlendEnvelopeTest {
+  private static final double[] SOURCE_SPECIFIC_GRAVITIES = {0.847, 0.771};
+  private static final double[] SOURCE_SULFUR_MASS_FRACTIONS = {0.020, 0.005};
+  private static final double[] SOURCE_NITROGEN_MASS_FRACTIONS = {0.0020, 0.0005};
+  private static final double[] SOURCE_VISCOSITIES_CST = {550.0, 375.0};
+
+  @Test
+  public void independentConstraintsRecoverAnalyticalFeasibleIntervalAndCostEndpoints() {
+    double minimumFirstFraction = 0.25;
+    double maximumFirstFraction = 0.60;
+    double minimumViscosity = viscosityAtFirstFraction(minimumFirstFraction);
+    double maximumSulfur = sulfurAtFirstFraction(maximumFirstFraction);
+
+    RefineryBinaryBlendEnvelope envelope = RefineryBinaryBlendEnvelope.fromQualityConstraints(
+        SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+        SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0,
+        Math.min(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
+        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)), maximumSulfur, 0.01,
+        minimumViscosity, 550.0);
+
+    assertEquals(minimumFirstFraction, envelope.getMinimumFirstSourceMassFraction(), 1.0e-14);
+    assertEquals(maximumFirstFraction, envelope.getMaximumFirstSourceMassFraction(), 1.0e-14);
+    assertEquals(50.0, envelope.getTemperatureCelsius(), 0.0);
+
+    RefineryBinaryBlendEnvelope.Plan firstSourceCheaper = envelope.planMinimumCost(1.0, 2.0);
+    RefineryBinaryBlendEnvelope.Plan secondSourceCheaper = envelope.planMinimumCost(3.0, 2.0);
+    assertPlan(firstSourceCheaper, maximumFirstFraction, 1.4);
+    assertPlan(secondSourceCheaper, minimumFirstFraction, 2.25);
+  }
+
+  @Test
+  public void sourceOrderReversalReversesEnvelopeAndPreservesPhysicalPlans() {
+    RefineryBinaryBlendEnvelope forward = createEnvelope(0.25, 0.60);
+    RefineryBinaryBlendEnvelope reversed = RefineryBinaryBlendEnvelope.fromQualityConstraints(
+        reverse(SOURCE_SPECIFIC_GRAVITIES), reverse(SOURCE_SULFUR_MASS_FRACTIONS),
+        reverse(SOURCE_NITROGEN_MASS_FRACTIONS), reverse(SOURCE_VISCOSITIES_CST), 50.0,
+        Math.min(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
+        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
+        sulfurAtFirstFraction(0.60), 0.01, viscosityAtFirstFraction(0.25), 550.0);
+
+    assertEquals(0.40, reversed.getMinimumFirstSourceMassFraction(), 1.0e-14);
+    assertEquals(0.75, reversed.getMaximumFirstSourceMassFraction(), 1.0e-14);
+    RefineryBinaryBlendEnvelope.Plan forwardPlan = forward.evaluateAtFirstSourceMassFraction(0.60);
+    RefineryBinaryBlendEnvelope.Plan reversedPlan = reversed.evaluateAtFirstSourceMassFraction(0.40);
+    assertEquals(forwardPlan.getAssayBlend().getSpecificGravity(),
+        reversedPlan.getAssayBlend().getSpecificGravity(), 1.0e-15);
+    assertEquals(forwardPlan.getAssayBlend().getSulfurMassFraction(),
+        reversedPlan.getAssayBlend().getSulfurMassFraction(), 1.0e-15);
+    assertEquals(forwardPlan.getViscosityBlend().getKinematicViscosityCSt(),
+        reversedPlan.getViscosityBlend().getKinematicViscosityCSt(), 1.0e-12);
+  }
+
+  @Test
+  public void exactConstraintCanProduceSinglePointAndEqualCostPlan() {
+    double fraction = 0.40;
+    double exactApi = apiAtFirstFraction(fraction);
+    RefineryBinaryBlendEnvelope envelope = RefineryBinaryBlendEnvelope.fromQualityConstraints(
+        SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+        SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, exactApi, exactApi,
+        1.0, 1.0, 375.0, 550.0);
+
+    assertEquals(fraction, envelope.getMinimumFirstSourceMassFraction(), 1.0e-14);
+    assertEquals(fraction, envelope.getMaximumFirstSourceMassFraction(), 1.0e-14);
+    RefineryBinaryBlendEnvelope.Plan plan = envelope.planMinimumCost(2.0, 2.0);
+    assertEquals(fraction, plan.getFirstSourceMassFraction(), 1.0e-14);
+    assertEquals(2.0, plan.getUnitCostPerMass(), 0.0);
+  }
+
+  @Test
+  public void returnedSourcesAreDefensiveAndUncostedPlansFailClosedForCost() {
+    RefineryBinaryBlendEnvelope envelope = createEnvelope(0.25, 0.60);
+    double[] gravities = envelope.getSourceSpecificGravities();
+    double[] sulfur = envelope.getSourceSulfurMassFractions();
+    double[] nitrogen = envelope.getSourceNitrogenMassFractions();
+    double[] viscosities = envelope.getSourceKinematicViscositiesCSt();
+    gravities[0] = 1.0;
+    sulfur[0] = 1.0;
+    nitrogen[0] = 1.0;
+    viscosities[0] = 1.0;
+
+    assertArrayEquals(SOURCE_SPECIFIC_GRAVITIES, envelope.getSourceSpecificGravities(), 0.0);
+    assertArrayEquals(SOURCE_SULFUR_MASS_FRACTIONS,
+        envelope.getSourceSulfurMassFractions(), 0.0);
+    assertArrayEquals(SOURCE_NITROGEN_MASS_FRACTIONS,
+        envelope.getSourceNitrogenMassFractions(), 0.0);
+    assertArrayEquals(SOURCE_VISCOSITIES_CST,
+        envelope.getSourceKinematicViscositiesCSt(), 0.0);
+
+    RefineryBinaryBlendEnvelope.Plan plan = envelope.evaluateAtFirstSourceMassFraction(0.40);
+    assertFalse(plan.hasUnitCost());
+    assertThrows(IllegalStateException.class, plan::getUnitCostPerMass);
+    assertArrayEquals(new double[] {0.40, 0.60}, plan.getAssayBlend().getMassFractions(),
+        1.0e-15);
+  }
+
+  @Test
+  public void infeasibleInvalidAndNonUniqueInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
+            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, 60.0, 70.0,
+            1.0, 1.0, 375.0, 550.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
+            new double[] {0.8}, SOURCE_SULFUR_MASS_FRACTIONS,
+            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, -100.0, 100.0,
+            1.0, 1.0, 375.0, 550.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
+            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, Double.NaN, -100.0,
+            100.0, 1.0, 1.0, 375.0, 550.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
+            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, 10.0, 0.0,
+            1.0, 1.0, 375.0, 550.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
+            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, -100.0, 100.0,
+            1.1, 1.0, 375.0, 550.0));
+
+    RefineryBinaryBlendEnvelope envelope = createEnvelope(0.25, 0.60);
+    assertThrows(IllegalArgumentException.class, () -> envelope.evaluateAtFirstSourceMassFraction(0.20));
+    assertThrows(IllegalArgumentException.class, () -> envelope.evaluateAtFirstSourceMassFraction(Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> envelope.planMinimumCost(-1.0, 2.0));
+    assertThrows(IllegalArgumentException.class, () -> envelope.planMinimumCost(2.0, 2.0));
+  }
+
+  private static RefineryBinaryBlendEnvelope createEnvelope(double minimumFirstFraction,
+      double maximumFirstFraction) {
+    return RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+        SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS,
+        SOURCE_VISCOSITIES_CST, 50.0,
+        Math.min(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
+        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
+        sulfurAtFirstFraction(maximumFirstFraction), 0.01,
+        viscosityAtFirstFraction(minimumFirstFraction), 550.0);
+  }
+
+  private static void assertPlan(RefineryBinaryBlendEnvelope.Plan plan,
+      double expectedFirstFraction, double expectedCost) {
+    assertTrue(plan.hasUnitCost());
+    assertEquals(expectedFirstFraction, plan.getFirstSourceMassFraction(), 1.0e-14);
+    assertEquals(1.0 - expectedFirstFraction, plan.getSecondSourceMassFraction(), 1.0e-14);
+    assertEquals(expectedCost, plan.getUnitCostPerMass(), 1.0e-14);
+    assertEquals(apiAtFirstFraction(expectedFirstFraction), plan.getAssayBlend().getApiGravity(),
+        1.0e-13);
+    assertEquals(sulfurAtFirstFraction(expectedFirstFraction),
+        plan.getAssayBlend().getSulfurMassFraction(), 1.0e-15);
+    assertEquals(viscosityAtFirstFraction(expectedFirstFraction),
+        plan.getViscosityBlend().getKinematicViscosityCSt(), 1.0e-12);
+    assertEquals(50.0, plan.getViscosityBlend().getTemperatureCelsius(), 0.0);
+  }
+
+  private static double apiAtFirstFraction(double firstFraction) {
+    return firstFraction * (141.5 / SOURCE_SPECIFIC_GRAVITIES[0] - 131.5)
+        + (1.0 - firstFraction) * (141.5 / SOURCE_SPECIFIC_GRAVITIES[1] - 131.5);
+  }
+
+  private static double sulfurAtFirstFraction(double firstFraction) {
+    return firstFraction * SOURCE_SULFUR_MASS_FRACTIONS[0]
+        + (1.0 - firstFraction) * SOURCE_SULFUR_MASS_FRACTIONS[1];
+  }
+
+  private static double viscosityAtFirstFraction(double firstFraction) {
+    double firstBlendNumber = RefineryViscosityBlend
+        .calculateViscosityBlendingNumber(SOURCE_VISCOSITIES_CST[0]);
+    double secondBlendNumber = RefineryViscosityBlend
+        .calculateViscosityBlendingNumber(SOURCE_VISCOSITIES_CST[1]);
+    return RefineryViscosityBlend.calculateKinematicViscosityCSt(
+        firstFraction * firstBlendNumber + (1.0 - firstFraction) * secondBlendNumber);
+  }
+
+  private static double[] reverse(double[] values) {
+    return new double[] {values[1], values[0]};
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelopeTest.java
+++ b/src/test/java/neqsim/thermo/characterization/RefineryBinaryBlendEnvelopeTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 
 /** Tests binary refinery quality-envelope and minimum-cost planning. */
 public class RefineryBinaryBlendEnvelopeTest {
-  private static final double[] SOURCE_SPECIFIC_GRAVITIES = {0.847, 0.771};
-  private static final double[] SOURCE_SULFUR_MASS_FRACTIONS = {0.020, 0.005};
-  private static final double[] SOURCE_NITROGEN_MASS_FRACTIONS = {0.0020, 0.0005};
-  private static final double[] SOURCE_VISCOSITIES_CST = {550.0, 375.0};
+  private static final double[] SOURCE_SPECIFIC_GRAVITIES = { 0.847, 0.771 };
+  private static final double[] SOURCE_SULFUR_MASS_FRACTIONS = { 0.020, 0.005 };
+  private static final double[] SOURCE_NITROGEN_MASS_FRACTIONS = { 0.0020, 0.0005 };
+  private static final double[] SOURCE_VISCOSITIES_CST = { 550.0, 375.0 };
 
   @Test
   public void independentConstraintsRecoverAnalyticalFeasibleIntervalAndCostEndpoints() {
@@ -22,12 +22,10 @@ public class RefineryBinaryBlendEnvelopeTest {
     double minimumViscosity = viscosityAtFirstFraction(minimumFirstFraction);
     double maximumSulfur = sulfurAtFirstFraction(maximumFirstFraction);
 
-    RefineryBinaryBlendEnvelope envelope = RefineryBinaryBlendEnvelope.fromQualityConstraints(
-        SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
-        SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0,
+    RefineryBinaryBlendEnvelope envelope = RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+        SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0,
         Math.min(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
-        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)), maximumSulfur, 0.01,
-        minimumViscosity, 550.0);
+        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)), maximumSulfur, 0.01, minimumViscosity, 550.0);
 
     assertEquals(minimumFirstFraction, envelope.getMinimumFirstSourceMassFraction(), 1.0e-14);
     assertEquals(maximumFirstFraction, envelope.getMaximumFirstSourceMassFraction(), 1.0e-14);
@@ -46,15 +44,15 @@ public class RefineryBinaryBlendEnvelopeTest {
         reverse(SOURCE_SPECIFIC_GRAVITIES), reverse(SOURCE_SULFUR_MASS_FRACTIONS),
         reverse(SOURCE_NITROGEN_MASS_FRACTIONS), reverse(SOURCE_VISCOSITIES_CST), 50.0,
         Math.min(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
-        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
-        sulfurAtFirstFraction(0.60), 0.01, viscosityAtFirstFraction(0.25), 550.0);
+        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)), sulfurAtFirstFraction(0.60), 0.01,
+        viscosityAtFirstFraction(0.25), 550.0);
 
     assertEquals(0.40, reversed.getMinimumFirstSourceMassFraction(), 1.0e-14);
     assertEquals(0.75, reversed.getMaximumFirstSourceMassFraction(), 1.0e-14);
     RefineryBinaryBlendEnvelope.Plan forwardPlan = forward.evaluateAtFirstSourceMassFraction(0.60);
     RefineryBinaryBlendEnvelope.Plan reversedPlan = reversed.evaluateAtFirstSourceMassFraction(0.40);
-    assertEquals(forwardPlan.getAssayBlend().getSpecificGravity(),
-        reversedPlan.getAssayBlend().getSpecificGravity(), 1.0e-15);
+    assertEquals(forwardPlan.getAssayBlend().getSpecificGravity(), reversedPlan.getAssayBlend().getSpecificGravity(),
+        1.0e-15);
     assertEquals(forwardPlan.getAssayBlend().getSulfurMassFraction(),
         reversedPlan.getAssayBlend().getSulfurMassFraction(), 1.0e-15);
     assertEquals(forwardPlan.getViscosityBlend().getKinematicViscosityCSt(),
@@ -65,9 +63,8 @@ public class RefineryBinaryBlendEnvelopeTest {
   public void exactConstraintCanProduceSinglePointAndEqualCostPlan() {
     double fraction = 0.40;
     double exactApi = apiAtFirstFraction(fraction);
-    RefineryBinaryBlendEnvelope envelope = RefineryBinaryBlendEnvelope.fromQualityConstraints(
-        SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
-        SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, exactApi, exactApi,
+    RefineryBinaryBlendEnvelope envelope = RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+        SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, exactApi, exactApi,
         1.0, 1.0, 375.0, 550.0);
 
     assertEquals(fraction, envelope.getMinimumFirstSourceMassFraction(), 1.0e-14);
@@ -90,46 +87,36 @@ public class RefineryBinaryBlendEnvelopeTest {
     viscosities[0] = 1.0;
 
     assertArrayEquals(SOURCE_SPECIFIC_GRAVITIES, envelope.getSourceSpecificGravities(), 0.0);
-    assertArrayEquals(SOURCE_SULFUR_MASS_FRACTIONS,
-        envelope.getSourceSulfurMassFractions(), 0.0);
-    assertArrayEquals(SOURCE_NITROGEN_MASS_FRACTIONS,
-        envelope.getSourceNitrogenMassFractions(), 0.0);
-    assertArrayEquals(SOURCE_VISCOSITIES_CST,
-        envelope.getSourceKinematicViscositiesCSt(), 0.0);
+    assertArrayEquals(SOURCE_SULFUR_MASS_FRACTIONS, envelope.getSourceSulfurMassFractions(), 0.0);
+    assertArrayEquals(SOURCE_NITROGEN_MASS_FRACTIONS, envelope.getSourceNitrogenMassFractions(), 0.0);
+    assertArrayEquals(SOURCE_VISCOSITIES_CST, envelope.getSourceKinematicViscositiesCSt(), 0.0);
 
     RefineryBinaryBlendEnvelope.Plan plan = envelope.evaluateAtFirstSourceMassFraction(0.40);
     assertFalse(plan.hasUnitCost());
     assertThrows(IllegalStateException.class, plan::getUnitCostPerMass);
-    assertArrayEquals(new double[] {0.40, 0.60}, plan.getAssayBlend().getMassFractions(),
-        1.0e-15);
+    assertArrayEquals(new double[] { 0.40, 0.60 }, plan.getAssayBlend().getMassFractions(), 1.0e-15);
   }
 
   @Test
   public void infeasibleInvalidAndNonUniqueInputsFailClosed() {
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
-            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
-            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, 60.0, 70.0,
-            1.0, 1.0, 375.0, 550.0));
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+            SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, 60.0, 70.0, 1.0,
+            1.0, 375.0, 550.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
-            new double[] {0.8}, SOURCE_SULFUR_MASS_FRACTIONS,
-            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, -100.0, 100.0,
-            1.0, 1.0, 375.0, 550.0));
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(new double[] { 0.8 }, SOURCE_SULFUR_MASS_FRACTIONS,
+            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, -100.0, 100.0, 1.0, 1.0, 375.0, 550.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
-            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
-            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, Double.NaN, -100.0,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+            SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, Double.NaN, -100.0,
             100.0, 1.0, 1.0, 375.0, 550.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
-            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
-            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, 10.0, 0.0,
-            1.0, 1.0, 375.0, 550.0));
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+            SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, 10.0, 0.0, 1.0,
+            1.0, 375.0, 550.0));
     assertThrows(IllegalArgumentException.class,
-        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(
-            SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
-            SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, -100.0, 100.0,
+        () -> RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
+            SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0, -100.0, 100.0,
             1.1, 1.0, 375.0, 550.0));
 
     RefineryBinaryBlendEnvelope envelope = createEnvelope(0.25, 0.60);
@@ -139,29 +126,24 @@ public class RefineryBinaryBlendEnvelopeTest {
     assertThrows(IllegalArgumentException.class, () -> envelope.planMinimumCost(2.0, 2.0));
   }
 
-  private static RefineryBinaryBlendEnvelope createEnvelope(double minimumFirstFraction,
-      double maximumFirstFraction) {
-    return RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES,
-        SOURCE_SULFUR_MASS_FRACTIONS, SOURCE_NITROGEN_MASS_FRACTIONS,
-        SOURCE_VISCOSITIES_CST, 50.0,
+  private static RefineryBinaryBlendEnvelope createEnvelope(double minimumFirstFraction, double maximumFirstFraction) {
+    return RefineryBinaryBlendEnvelope.fromQualityConstraints(SOURCE_SPECIFIC_GRAVITIES, SOURCE_SULFUR_MASS_FRACTIONS,
+        SOURCE_NITROGEN_MASS_FRACTIONS, SOURCE_VISCOSITIES_CST, 50.0,
         Math.min(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
-        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)),
-        sulfurAtFirstFraction(maximumFirstFraction), 0.01,
+        Math.max(apiAtFirstFraction(0.0), apiAtFirstFraction(1.0)), sulfurAtFirstFraction(maximumFirstFraction), 0.01,
         viscosityAtFirstFraction(minimumFirstFraction), 550.0);
   }
 
-  private static void assertPlan(RefineryBinaryBlendEnvelope.Plan plan,
-      double expectedFirstFraction, double expectedCost) {
+  private static void assertPlan(RefineryBinaryBlendEnvelope.Plan plan, double expectedFirstFraction,
+      double expectedCost) {
     assertTrue(plan.hasUnitCost());
     assertEquals(expectedFirstFraction, plan.getFirstSourceMassFraction(), 1.0e-14);
     assertEquals(1.0 - expectedFirstFraction, plan.getSecondSourceMassFraction(), 1.0e-14);
     assertEquals(expectedCost, plan.getUnitCostPerMass(), 1.0e-14);
-    assertEquals(apiAtFirstFraction(expectedFirstFraction), plan.getAssayBlend().getApiGravity(),
-        1.0e-13);
-    assertEquals(sulfurAtFirstFraction(expectedFirstFraction),
-        plan.getAssayBlend().getSulfurMassFraction(), 1.0e-15);
-    assertEquals(viscosityAtFirstFraction(expectedFirstFraction),
-        plan.getViscosityBlend().getKinematicViscosityCSt(), 1.0e-12);
+    assertEquals(apiAtFirstFraction(expectedFirstFraction), plan.getAssayBlend().getApiGravity(), 1.0e-13);
+    assertEquals(sulfurAtFirstFraction(expectedFirstFraction), plan.getAssayBlend().getSulfurMassFraction(), 1.0e-15);
+    assertEquals(viscosityAtFirstFraction(expectedFirstFraction), plan.getViscosityBlend().getKinematicViscosityCSt(),
+        1.0e-12);
     assertEquals(50.0, plan.getViscosityBlend().getTemperatureCelsius(), 0.0);
   }
 
@@ -171,20 +153,17 @@ public class RefineryBinaryBlendEnvelopeTest {
   }
 
   private static double sulfurAtFirstFraction(double firstFraction) {
-    return firstFraction * SOURCE_SULFUR_MASS_FRACTIONS[0]
-        + (1.0 - firstFraction) * SOURCE_SULFUR_MASS_FRACTIONS[1];
+    return firstFraction * SOURCE_SULFUR_MASS_FRACTIONS[0] + (1.0 - firstFraction) * SOURCE_SULFUR_MASS_FRACTIONS[1];
   }
 
   private static double viscosityAtFirstFraction(double firstFraction) {
-    double firstBlendNumber = RefineryViscosityBlend
-        .calculateViscosityBlendingNumber(SOURCE_VISCOSITIES_CST[0]);
-    double secondBlendNumber = RefineryViscosityBlend
-        .calculateViscosityBlendingNumber(SOURCE_VISCOSITIES_CST[1]);
-    return RefineryViscosityBlend.calculateKinematicViscosityCSt(
-        firstFraction * firstBlendNumber + (1.0 - firstFraction) * secondBlendNumber);
+    double firstBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(SOURCE_VISCOSITIES_CST[0]);
+    double secondBlendNumber = RefineryViscosityBlend.calculateViscosityBlendingNumber(SOURCE_VISCOSITIES_CST[1]);
+    return RefineryViscosityBlend
+        .calculateKinematicViscosityCSt(firstFraction * firstBlendNumber + (1.0 - firstFraction) * secondBlendNumber);
   }
 
   private static double[] reverse(double[] values) {
-    return new double[] {values[1], values[0]};
+    return new double[] { values[1], values[0] };
   }
 }


### PR DESCRIPTION
## Summary

Advances #3305 with a transparent binary refinery blend feasibility envelope and bounded minimum-cost endpoint planner.

- intersects inclusive API-gravity, maximum sulfur, maximum nitrogen, and common-temperature kinematic-viscosity constraints in first-source mass-fraction space
- reuses `RefineryAssayBlend` and `RefineryViscosityBlend` as the authoritative property implementations
- exposes the closed feasible interval and caller-selected combined property plans
- chooses the unique least-cost feasible endpoint analytically
- fails closed for empty envelopes, invalid sources/bounds/costs, out-of-envelope selections, and equal-cost non-unique optima
- preserves source order, explicit temperature, immutable results, and defensive source arrays

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5579665099

## Exact continuity and scope

- Exact base: `fdaebb7306d3cacb799a6ac6726d103c9520eb21`
- Published head before hosted formatting: `5a8e2314508e1ce611558a862e1f741a92d718da`
- Preserved exact head after the single hosted formatting repair: `07a7bd008726ac84be7287ae2e6d1a387aefc36e`
- Branch: `ai/3305-binary-blend-envelope`
- Three ordered commits; exactly three intended files
- Sole active #3305 implementation PR
- Positively identified autonomous implementation occupancy becomes **4/10** (#3556, #3562, #3563, and this PR)
- Zero changed-file overlap with those three PRs, uncounted #3558, or release PR #3460

## Engineering acceptance

The focused case uses public DOE/OEDI specific-gravity endpoints 0.847 and 0.771 together with explicit arithmetic sulfur, nitrogen, and viscosity inputs. Independent constraints recover a first-source feasible interval of 0.25-0.60. Costs 1 and 2 select 0.60 at unit cost 1.40; reversed relative costs select 0.25. Tests also cover source-order reversal, exact single-point feasibility, equal-cost uniqueness, defensive access, reconstruction through both qualified property classes, and invalid/infeasible inputs.

## Provenance and scientific boundary

Ideal additive volume and linear sulfur/nitrogen bookkeeping retain the existing public DOE/OEDI qualification. The Refutas relation and mass basis retain Centeno et al., *Fuel* 90 (2011), DOI https://doi.org/10.1016/j.fuel.2011.02.028. Interval intersection and endpoint cost selection are transparent algebra.

This is not a generic or multi-source optimizer and makes no claim for excess volume, viscosity-temperature behavior, phase/asphaltene compatibility, measured product accuracy, uncertainty, nonlinear economics, ASTM compliance, or control. It changes no thermodynamic model, correlation, parameter, dataset, existing API behavior, or assay state.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local checks on the published production source:

- Java 8 source compilation through JDK 17 `jdk.compiler --release 8`: passed using signature-compatible property stubs
- independent arithmetic harness for interval recovery, least-cost endpoint, reconstruction, and equal-cost failure: passed
- Javadoc/doclint for the new production class: completed with only private-field documentation warnings
- initial structural audit: three commits ahead, zero behind the frozen base, exactly three intended files
- exact hosted Spotless artifact applied to the two Java files only; engineering behavior is unchanged
- fresh exact-head CI is authoritative

A full repository checkout and Maven/JUnit environment are unavailable in this run. Hosted Java 8/21 Ubuntu/Windows tests, slow shards, Javadocs, Spotless, pre-commit, documentation, CodeQL, PaperLab, and agent-skill checks are authoritative.

## Documentation impact

`docs/thermo/characterization/refinery_assay.md` documents the affine transformed-property basis, Java/JPype-facing API, worked interval/cost result, provenance, and stop boundary.

Keep this PR draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity.