### PR TITLE
[AI-Assisted] fix(mcp): qualify composed workflow contract

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Run focused runtime-capability Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.GeneralCapabilityRunnerTest test -ntp
 
+      - name: Run focused composed-workflow Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.TaskSolverRunnerTest test -ntp
+
       - name: Run focused pre-flight validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.ValidatorTest test -ntp
 
@@ -132,6 +135,9 @@ jobs:
 
       - name: Run focused real-MCP runtime-capability qualification
         run: cd neqsim-mcp-server && python test_capability_protocol.py
+
+      - name: Run focused real-MCP composed-workflow qualification
+        run: cd neqsim-mcp-server && python test_compose_workflow_protocol.py
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -488,3 +488,27 @@ campaign criteria remain incomplete until their own merged acceptance evidence e
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
 #2937, and merged production-optimization foundations by #2941. This inventory audits existing
 publication only and does not implement competing domain functionality.
+
+## Composed-workflow qualification candidate (inventory 1.31)
+
+The published `composeWorkflow` surface is being qualified as a bounded,
+caller-authored orchestration contract. Direct Java and packaged-MCP evidence
+covers one real shared-fluid flash step, explicit workflow and step accounting,
+stop-on-first-failure behavior, exact unknown-runner diagnostics, malformed and
+missing-step rejection, normal access enforcement, standard response evidence,
+and JSON-RPC/STDIO transport.
+
+The shared-fluid repair is intentionally additive: the original nested
+`fluid` object remains available while its model/components are exposed at
+the selected runner's input root. This does not create a second fluid model or
+change any thermodynamic calculation.
+
+`composeWorkflow` remains `CONFIRMED_GAP` in inventory
+`1.31 / 20+31+20` until the qualification merges and a separate atomic
+promotion increment updates machine-readable coverage. The candidate does not
+establish natural-language planning, arbitrary execution, semantic
+compatibility between steps, transactionality, persistence, distributed
+execution, numerical fidelity, convergence, conservation, optimization,
+facility completeness, external IAM/transport security, tenant isolation,
+plant/control authority, certification, or accountable engineering approval.
+

--- a/neqsim-mcp-server/docs/evidence/COMPOSE_WORKFLOW_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/COMPOSE_WORKFLOW_CONTRACT.md
@@ -1,0 +1,88 @@
+# Bounded composed-workflow contract evidence
+
+## Scope
+
+The `composeWorkflow` MCP tool accepts a caller-authored ordered list of
+supported NeqSim runner steps, executes them sequentially, records each
+result, and stops after the first failed required step. This page defines the
+bounded software contract under direct Java and packaged-MCP qualification.
+It does not certify the scientific calculations selected by a workflow.
+
+## Qualified implementation boundary
+
+`NeqSimTools.composeWorkflow` applies the normal tool-access policy and
+standard response envelope, then delegates to
+`TaskSolverRunner.composeWorkflow`. The runner accepts an explicit workflow
+name, optional shared fluid, and a finite ordered `steps` array. Each step
+selects one of the existing curated runner names and supplies explicit input.
+
+The shared-fluid normalization is additive. The original `fluid` object is
+preserved in `combinedData` and as the nested step field, while its
+model/components are also copied to the step-input root used by calculation
+runners. Step-specific input is applied afterward and therefore remains the
+explicit override. No thermodynamic object, equation, parameter, or result is
+reimplemented by the orchestration layer.
+
+## Direct evidence
+
+- `TaskSolverRunnerTest` executes a real methane TP flash through the
+  composed route and verifies workflow identity, total/completed step counts,
+  successful step output, shared-fluid preservation, and combined result
+  evidence.
+- The Java contract verifies exact `UNKNOWN_RUNNER` diagnostics,
+  stop-on-first-failure behavior, and rejection of missing or malformed step
+  input.
+- `test_compose_workflow_protocol.py` repeats those visible contracts through
+  the packaged server's JSON-RPC/STDIO transport and standard response
+  evidence.
+- `mcp_protocol_qualification.yml` runs the focused Java and packaged suites
+  before the comprehensive MCP regression.
+
+The calculation case is a routing and data-shape fixture. It is not
+independent validation of SRK methane properties.
+
+## Qualified contract
+
+The candidate evidence covers:
+
+1. Explicit workflow identity and ordered caller-authored steps.
+2. The existing curated runner-name dispatch table; unknown runners fail
+   closed.
+3. Shared-fluid preservation and additive root-field normalization for
+   calculation-runner compatibility.
+4. Step-specific input precedence.
+5. Per-step output, duration, runner identity, and success accounting.
+6. Stop after the first failed required step.
+7. Structured missing-step and malformed-input errors.
+8. Normal MCP access enforcement, standard response evidence, and packaged
+   STDIO transport.
+
+## Security, numerical, and engineering boundary
+
+This qualification does not establish:
+
+- natural-language planning, inferred workflow design, or arbitrary code,
+  shell, class, plugin, MCP-tool, or network execution;
+- semantic compatibility or unit conversion between one step's output and the
+  next step's input;
+- transactionality, rollback, persistence, restart recovery, distributed
+  execution, scheduling, quotas, or tenant isolation;
+- scientific accuracy, numerical fidelity, convergence, component or energy
+  conservation, uncertainty, or optimization quality;
+- completeness or suitability of the selected workflow for a real facility;
+- external identity, IAM, authorization, transport security, or a hardened
+  deployment boundary;
+- plant connectivity, control authority, safety certification, or accountable
+  engineering approval.
+
+Callers remain responsible for selecting compatible runner inputs, inspecting
+every step's provenance, validation, quality gate, warnings, assumptions, and
+limitations, and obtaining qualified engineering review.
+
+## Inventory status
+
+`composeWorkflow` remains `CONFIRMED_GAP` in inventory version `1.31`
+with accounting `20 explicit + 31 contract-tested + 20 confirmed gaps`.
+Qualification and promotion are separate atomic increments. A future
+promotion may classify the tool only after this direct evidence merges and
+all authoritative exact-head gates pass.

--- a/neqsim-mcp-server/test_compose_workflow_protocol.py
+++ b/neqsim-mcp-server/test_compose_workflow_protocol.py
@@ -1,0 +1,331 @@
+"""Focused packaged-MCP qualification for composed workflows.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO
+and qualifies one real shared-fluid calculation, explicit accounting,
+stop-on-first-failure behavior, invalid input handling, unchanged inventory,
+standard envelopes, and real transport. It does not establish arbitrary
+execution, semantic compatibility between steps, transactionality,
+persistence, numerical fidelity, convergence, conservation, facility
+completeness, plant authority, certification, or engineering approval.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC client."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-compose-workflow-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"MCP tool returned non-JSON content: {error}: {text}"
+            )
+
+    def call_workflow(self, request):
+        return self.call_tool(
+            "composeWorkflow", {"workflowJson": json.dumps(request)}
+        )
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope fields."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "tool",
+        "code",
+        "errors",
+        "message",
+        "provenance",
+        "validation",
+        "qualityGate",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def assert_standard_success(response):
+    """Require a successful standard composeWorkflow envelope."""
+    result = payload(response)
+    require(result.get("status") == "success", "workflow request failed", response)
+    require(result.get("tool") == "composeWorkflow", "tool identity drifted", response)
+    require(
+        result.get("validation", {}).get("valid") is True,
+        "workflow response lacks valid standard evidence",
+        response,
+    )
+    require(
+        result.get("qualityGate", {}).get("verdict") == "passed",
+        "workflow response did not pass its software gate",
+        response,
+    )
+    return result
+
+
+def assert_error(response, expected_code):
+    """Require invalid workflow input to fail closed."""
+    result = payload(response)
+    require(result.get("status") == "error", "workflow did not fail closed", response)
+    errors = result.get("errors", [])
+    code = result.get("code")
+    if code is None and errors:
+        code = errors[0].get("code")
+    require(code == expected_code, "workflow error code drifted", result)
+    return result
+
+
+def test_shared_fluid_flash(client):
+    result = assert_standard_success(
+        client.call_workflow(
+            {
+                "workflow": "bounded-flash",
+                "fluid": {
+                    "model": "SRK",
+                    "components": {"methane": 1.0},
+                },
+                "steps": [
+                    {
+                        "runner": "flash",
+                        "name": "feed_flash",
+                        "input": {
+                            "temperature": {"value": 25.0, "unit": "C"},
+                            "pressure": {"value": 50.0, "unit": "bara"},
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    require(result.get("workflow") == "bounded-flash", "workflow identity drifted", result)
+    require(
+        result.get("totalSteps") == 1
+        and result.get("completedSteps") == 1
+        and result.get("success") is True,
+        "workflow accounting drifted",
+        result,
+    )
+    step = result.get("steps", [{}])[0]
+    require(
+        step.get("step") == "feed_flash"
+        and step.get("runner") == "flash"
+        and step.get("success") is True,
+        "flash step accounting drifted",
+        step,
+    )
+    require(
+        step.get("output", {}).get("status") == "success",
+        "shared fluid did not reach the flash runner",
+        step,
+    )
+    combined = result.get("combinedData", {})
+    require(
+        combined.get("fluid", {}).get("components", {}).get("methane") == 1.0
+        and "feed_flash_result" in combined,
+        "shared fluid or result evidence was not preserved",
+        combined,
+    )
+
+
+def test_unknown_runner_stops(client):
+    result = assert_standard_success(
+        client.call_workflow(
+            {
+                "workflow": "fail-closed",
+                "steps": [
+                    {"runner": "arbitrary", "name": "blocked", "input": {}},
+                    {"runner": "flash", "name": "skipped", "input": {}},
+                ],
+            }
+        )
+    )
+    require(
+        result.get("totalSteps") == 2
+        and result.get("completedSteps") == 1
+        and result.get("success") is False,
+        "workflow did not stop on the first failed step",
+        result,
+    )
+    steps = result.get("steps", [])
+    require(len(steps) == 1 and steps[0].get("success") is False, "failed step drifted", result)
+    output = steps[0].get("output", {})
+    errors = output.get("errors", [])
+    require(
+        output.get("status") == "error"
+        and errors
+        and errors[0].get("code") == "UNKNOWN_RUNNER",
+        "unknown runner diagnostic drifted",
+        output,
+    )
+    require(
+        "skipped_result" not in result.get("combinedData", {}),
+        "a step after the failure was executed",
+        result,
+    )
+
+
+def test_missing_steps_fails_closed(client):
+    assert_error(
+        client.call_workflow({"workflow": "missing-steps"}),
+        "MISSING_STEPS",
+    )
+
+
+def test_malformed_step_fails_closed(client):
+    assert_error(
+        client.call_workflow(
+            {
+                "workflow": "malformed-step",
+                "steps": [
+                    {
+                        "runner": "flash",
+                        "name": "malformed",
+                        "input": "not-an-object",
+                    }
+                ],
+            }
+        ),
+        "WORKFLOW_ERROR",
+    )
+
+
+def test_inventory_remains_candidate(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    require(result.get("status") == "success", "capabilities request failed", result)
+    inventory = result.get("phase0EvidenceInventory", {})
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get("composeWorkflow", {})
+    require(
+        inventory.get("inventoryVersion") == "1.31"
+        and limitations.get("contractTestedToolCount") == 31
+        and limitations.get("confirmedGapToolCount") == 20,
+        "qualification changed inventory accounting",
+        inventory,
+    )
+    require(
+        record.get("coverageStatus") == "CONFIRMED_GAP",
+        "composeWorkflow was promoted before evidence merged",
+        record,
+    )
+    require(
+        limitations.get("contractPromotionCandidateCount") == 0,
+        "qualification queued a promotion inside inventory",
+        limitations,
+    )
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("shared-fluid flash", test_shared_fluid_flash),
+        ("unknown runner stops", test_unknown_runner_stops),
+        ("missing steps fail closed", test_missing_steps_fails_closed),
+        ("malformed step fails closed", test_malformed_step_fails_closed),
+        ("inventory remains candidate", test_inventory_remains_candidate),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} composed-workflow scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/src/main/java/neqsim/mcp/runners/TaskSolverRunner.java
+++ b/src/main/java/neqsim/mcp/runners/TaskSolverRunner.java
@@ -184,7 +184,13 @@ public final class TaskSolverRunner {
         // Build step input: merge step-specific input with carry-forward data
         JsonObject stepInput = new JsonObject();
         if (carryForward.has("fluid")) {
-          stepInput.add("fluid", carryForward.get("fluid"));
+          JsonElement fluid = carryForward.get("fluid");
+          stepInput.add("fluid", fluid.deepCopy());
+          if (fluid.isJsonObject()) {
+            for (Map.Entry<String, JsonElement> entry : fluid.getAsJsonObject().entrySet()) {
+              stepInput.add(entry.getKey(), entry.getValue().deepCopy());
+            }
+          }
         }
         if (stepDef.has("input")) {
           JsonObject specific = stepDef.getAsJsonObject("input");

--- a/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
@@ -116,8 +116,7 @@ class TaskSolverRunnerTest {
     assertFalse(completed.get("success").getAsBoolean());
     JsonObject output = completed.getAsJsonObject("output");
     assertEquals("error", output.get("status").getAsString());
-    assertEquals("UNKNOWN_RUNNER",
-        output.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("UNKNOWN_RUNNER", output.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
     assertFalse(result.getAsJsonObject("combinedData").has("skipped_result"));
   }
 
@@ -128,8 +127,7 @@ class TaskSolverRunnerTest {
 
     JsonObject result = JsonParser.parseString(TaskSolverRunner.composeWorkflow(request.toString())).getAsJsonObject();
     assertEquals("error", result.get("status").getAsString());
-    assertEquals("MISSING_STEPS",
-        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("MISSING_STEPS", result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   @Test
@@ -147,8 +145,7 @@ class TaskSolverRunnerTest {
 
     JsonObject result = JsonParser.parseString(TaskSolverRunner.composeWorkflow(request.toString())).getAsJsonObject();
     assertEquals("error", result.get("status").getAsString());
-    assertEquals("WORKFLOW_ERROR",
-        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("WORKFLOW_ERROR", result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   @Test

--- a/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
@@ -1,9 +1,11 @@
 package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -24,7 +26,6 @@ class TaskSolverRunnerTest {
     String result = TaskSolverRunner.solveTask(json);
     assertNotNull(result);
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    // solveTask returns "success" boolean on success, or "status":"error" on failure
     assertTrue(obj.has("success") || obj.has("status"), "Should have success or status field: " + result);
   }
 
@@ -39,8 +40,115 @@ class TaskSolverRunnerTest {
     String result = TaskSolverRunner.composeWorkflow(json);
     assertNotNull(result);
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    // composeWorkflow returns "workflow" and "success" fields
     assertTrue(obj.has("workflow") || obj.has("status"), "Should have workflow or status field: " + result);
+  }
+
+  @Test
+  void testComposeWorkflowRunsSharedFluidFlash() {
+    JsonObject fluid = new JsonObject();
+    fluid.addProperty("model", "SRK");
+    JsonObject components = new JsonObject();
+    components.addProperty("methane", 1.0);
+    fluid.add("components", components);
+
+    JsonObject stepInput = new JsonObject();
+    JsonObject temperature = new JsonObject();
+    temperature.addProperty("value", 25.0);
+    temperature.addProperty("unit", "C");
+    stepInput.add("temperature", temperature);
+    JsonObject pressure = new JsonObject();
+    pressure.addProperty("value", 50.0);
+    pressure.addProperty("unit", "bara");
+    stepInput.add("pressure", pressure);
+
+    JsonObject step = new JsonObject();
+    step.addProperty("runner", "flash");
+    step.addProperty("name", "feed_flash");
+    step.add("input", stepInput);
+    JsonArray steps = new JsonArray();
+    steps.add(step);
+
+    JsonObject request = new JsonObject();
+    request.addProperty("workflow", "bounded-flash");
+    request.add("fluid", fluid);
+    request.add("steps", steps);
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.composeWorkflow(request.toString())).getAsJsonObject();
+    assertEquals("bounded-flash", result.get("workflow").getAsString());
+    assertEquals(1, result.get("totalSteps").getAsInt());
+    assertEquals(1, result.get("completedSteps").getAsInt());
+    assertTrue(result.get("success").getAsBoolean());
+
+    JsonObject completed = result.getAsJsonArray("steps").get(0).getAsJsonObject();
+    assertEquals("feed_flash", completed.get("step").getAsString());
+    assertEquals("flash", completed.get("runner").getAsString());
+    assertTrue(completed.get("success").getAsBoolean());
+    assertEquals("success", completed.getAsJsonObject("output").get("status").getAsString());
+    assertTrue(result.getAsJsonObject("combinedData").has("fluid"));
+    assertTrue(result.getAsJsonObject("combinedData").has("feed_flash_result"));
+  }
+
+  @Test
+  void testComposeWorkflowStopsOnUnknownRunner() {
+    JsonArray steps = new JsonArray();
+    JsonObject blocked = new JsonObject();
+    blocked.addProperty("runner", "arbitrary");
+    blocked.addProperty("name", "blocked");
+    blocked.add("input", new JsonObject());
+    steps.add(blocked);
+
+    JsonObject skipped = new JsonObject();
+    skipped.addProperty("runner", "flash");
+    skipped.addProperty("name", "skipped");
+    skipped.add("input", new JsonObject());
+    steps.add(skipped);
+
+    JsonObject request = new JsonObject();
+    request.addProperty("workflow", "fail-closed");
+    request.add("steps", steps);
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.composeWorkflow(request.toString())).getAsJsonObject();
+    assertEquals(2, result.get("totalSteps").getAsInt());
+    assertEquals(1, result.get("completedSteps").getAsInt());
+    assertFalse(result.get("success").getAsBoolean());
+
+    JsonObject completed = result.getAsJsonArray("steps").get(0).getAsJsonObject();
+    assertFalse(completed.get("success").getAsBoolean());
+    JsonObject output = completed.getAsJsonObject("output");
+    assertEquals("error", output.get("status").getAsString());
+    assertEquals("UNKNOWN_RUNNER",
+        output.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertFalse(result.getAsJsonObject("combinedData").has("skipped_result"));
+  }
+
+  @Test
+  void testComposeWorkflowRejectsMissingSteps() {
+    JsonObject request = new JsonObject();
+    request.addProperty("workflow", "missing-steps");
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.composeWorkflow(request.toString())).getAsJsonObject();
+    assertEquals("error", result.get("status").getAsString());
+    assertEquals("MISSING_STEPS",
+        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+  }
+
+  @Test
+  void testComposeWorkflowRejectsMalformedStepInput() {
+    JsonObject step = new JsonObject();
+    step.addProperty("runner", "flash");
+    step.addProperty("name", "malformed");
+    step.addProperty("input", "not-an-object");
+    JsonArray steps = new JsonArray();
+    steps.add(step);
+
+    JsonObject request = new JsonObject();
+    request.addProperty("workflow", "malformed-step");
+    request.add("steps", steps);
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.composeWorkflow(request.toString())).getAsJsonObject();
+    assertEquals("error", result.get("status").getAsString());
+    assertEquals("WORKFLOW_ERROR",
+        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Qualifies the bounded `composeWorkflow` contract and repairs shared-fluid routing through the existing canonical runners.

- preserves the caller's nested `fluid` object and additively exposes its model/components at each step-input root
- exercises a real methane TP flash through direct Java and packaged JSON-RPC/STDIO routes
- verifies explicit workflow/step accounting and combined evidence
- stops after the first failed required step with exact `UNKNOWN_RUNNER` diagnostics
- rejects missing and malformed step definitions
- records explicit orchestration, numerical, security, and engineering boundaries

The normalization delegates all calculations to existing NeqSim runners. It adds no thermodynamic model, equation, parameter, schema, generic execution route, external integration, or plant/control authority.

Advances #3153. Capability contract: https://github.com/equinor/neqsim/issues/3153#issuecomment-5580230462

## Exact continuity and scope

- Exact base: `fdaebb7306d3cacb799a6ac6726d103c9520eb21`
- Initial published head: `9707821e6b292b7e49504dbf18826828fcada92e`
- Current repaired head: `43b88cf9da504f24744b494e65c06c5cf98ba4d3`
- Branch: `ai/mcp-qualify-compose-workflow-3153`
- Six intended files: one bounded runner repair, one Java contract, one packaged harness, one CI workflow, and two evidence pages
- The sole repair commit applies the exact hosted Spotless output to `TaskSolverRunnerTest.java`; behavior and file scope are unchanged
- No overlap with active autonomous PRs #3556, #3562, #3563, or #3564

## Capability contract

**Engineering question:** Can a caller-authored ordered workflow execute supported NeqSim runners with shared fluid/context, observable step accounting, stop-on-first-failure semantics, and fail-closed invalid input through the packaged MCP server?

**Qualified boundary:** explicit ordered steps, curated runner dispatch, additive shared-fluid normalization, step-specific override precedence, per-step output/timing/success evidence, stop after the first failed required step, structured missing/malformed/unknown-runner failures, normal access enforcement, standard envelopes, and packaged transport.

**Stop boundary:** no natural-language planning, arbitrary code/tool/network execution, semantic compatibility between steps, transactionality, rollback, persistence, distributed execution, quotas or tenant isolation, numerical fidelity, convergence, conservation, uncertainty, optimization quality, facility completeness, external IAM/transport security, plant/control authority, certification, or accountable engineering approval.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI** on `43b88cf9da504f24744b494e65c06c5cf98ba4d3`.

Passing on the repaired exact head:

- composed-workflow Java: **7/7**
- packaged composed-workflow MCP: **5/5**
- comprehensive MCP regression: **330/330**
- CodeQL, pre-commit, documentation search, Spotless, PaperLab, Javadocs, and agent-skill validation

Still active without a reported failure:

- Java 8/21 Ubuntu/Windows fast tests and four slow shards

Inventory intentionally remains `1.31 / 20+31+20`; `composeWorkflow` remains `CONFIRMED_GAP` pending separate promotion after merged qualification evidence. There are no reviews or unresolved review threads.

## Workflow boundary

Keep this PR open and draft. Do not merge, enable auto-merge, mark ready for review, synchronize with `master`, rebase, force-push, close, replace, restart, or abandon it for portfolio capacity. Positively identified autonomous implementation occupancy is **5/10**.