### PR TITLE
[AI-Assisted] feat(optimization): qualify common-shaft train evidence

### DIFF
--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -179,6 +179,40 @@ physical margin, required relief, and diagnostics. Missing observations remain u
 than becoming zero utilization. Rebuild evidence after any process, availability, bus, or limit
 change; never reuse it for a different candidate.
 
+### Qualify a common-shaft compressor train
+
+After all casings and their shared `MechanicalShaft` have completed the same isolated candidate,
+freeze the train's common speed, shaft power, driver, gearbox, torque, and casing-map evidence:
+
+```java
+PlantCommonShaftEvidence trainEvidence = PlantCommonShaftEvidence
+    .builder("Plant", "Compression", "export train", calculationId, shaft,
+        "completed isolated candidate")
+    .casing(casingAPort.getParticipantId(), casingA)
+    .casing(casingBPort.getParticipantId(), casingB)
+    .driver(driverPort.getParticipantId(), driver)
+    .gearbox("export-train-gearbox", gearbox)
+    .speedToleranceRpm(1.0)
+    .powerBalanceToleranceKw(1.0e-6)
+    .maximumTorqueNm(8000.0)
+    .convergenceComplete(fullModelConverged)
+    .build();
+
+if (!trainEvidence.isComplete() || !trainEvidence.isFeasible()) {
+  throw new IllegalStateException(trainEvidence.getDiagnostics().toString());
+}
+PlantUtilizationSnapshot trainSnapshot =
+    trainEvidence.toPlantUtilizationSnapshot();
+```
+
+`calculationId` is the UUID string stored on every completed casing. Casing power must equal that
+casing's exact shaft-input request. Gearbox input includes its configured idle loss and efficiency.
+The gearbox maximum input power is configured in W, while the driver model and evidence report use
+kW. `maximumTorqueNm` is an independently approved limit, not
+a value estimated by the adapter. A line-up or limit change invalidates the old evidence; solve the
+isolated candidate again and build a new snapshot. Through JPype, use the same callback-free builder
+and `toJson()` rather than supplying Python callbacks.
+
 ---
 
 ## Overview

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -147,11 +147,34 @@ shaft participant is accepted only when explicitly named and observed at finite 
 Changing a limit or line-up requires new evidence with a new calculation identity; collection is
 read-only and does not restore process mutations.
 
-This layer is deliberately not operating authority. It does not coordinate a common-shaft driver or
-torque balance, infer electrical efficiency, compute compressor maps, separator capacity, piping
-hydraulics, product quality, emissions, utility allocation, rollback, caching, dirty scheduling, or
-solver acceptance. External optimizer proposals must still be replayed and accepted by the full
-NeqSim model.
+This layer is deliberately not operating authority. It does not infer electrical efficiency,
+compute separator capacity or piping hydraulics, coordinate product quality, emissions or utility
+allocation, restore mutations, cache process results, schedule dirty equipment, or accept solver
+candidates. External optimizer proposals must still be replayed and accepted by the full NeqSim
+model.
+
+### Common-shaft compressor-train evidence
+
+`PlantCommonShaftEvidence` freezes the already solved `MechanicalShaft` allocation together with
+the declared `CompressorDriver`, `Gearbox`, and every casing `Compressor` operating point. The
+adapter performs no equipment run and retains no mutable equipment. The caller supplies the exact
+calculation ID, driver and casing participant IDs, speed and power-balance tolerances, and an
+independently approved maximum torque.
+
+The resulting common snapshot contains distinct constraints for casing-to-shaft speed agreement,
+shaft maximum speed, unmet shaft power, driver speed range and available power, gearbox maximum
+input power, shaft maximum torque, and each casing's minimum signed surge/stonewall map margin.
+Power is in kW, speed in rpm, torque in N m, and map distances are dimensionless. Gearbox input
+power uses the configured efficiency and idle loss; driver speed uses the configured output-to-input ratio;
+torque uses only `power / angular speed`. No rating or map envelope is inferred.
+
+Every active shaft input and the driver output must be declared. A stale bus report, unexpected
+participant, mismatched calculation identity or casing power, chartless or non-finite map point,
+unknown rating, trip, or incomplete convergence makes the evidence incomplete. A finite solved
+point outside its map or beyond a declared speed, power, gearbox, or torque limit remains complete
+but infeasible. Explicitly out-of-service casings qualify only with verified zero requested and
+observed shaft load. Java getters, serialization, `toPlantUtilizationSnapshot()`, and `toJson()`
+expose the same immutable evidence; unavailable JSON numbers are `null`, never zero.
 
 ## Expected equipment coverage before qualification
 

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -61,6 +61,12 @@ shaftTrain.setConsumedPower("compressor", 8.0e6);
 double sparePower = shaftTrain.getNetPower("MW");
 ```
 
+For optimizer acceptance of a multi-casing train, use `PlantCommonShaftEvidence` after the shaft
+allocation and all compressor operating points have completed under one calculation ID. It
+cross-checks exact participant coverage and preserves separate immutable speed, power, torque,
+driver, gearbox, and casing-map constraints. It does not run or restore the train, infer ratings,
+or turn a missing observation into zero utilization.
+
 Point-to-point `EnergyStream` connections reject multiple calculated producers or specification consumers during graph construction. Use `EnergyBus` for intentional multi-party distribution.
 
 ## Coupled networks and repeated execution

--- a/docs/process/optimization/industrial-process-optimization-baseline.md
+++ b/docs/process/optimization/industrial-process-optimization-baseline.md
@@ -99,7 +99,7 @@ an explicit limit basis, provenance, applicability, and failure status.
 | Gathering, routing, and export hydraulics | Network actions, boundary evidence, pipe equipment | Composable | One network constraint registry covering pressure, capacity, line-up availability, and line/route identity. |
 | Compressor map envelope | Speed, power, surge margin, stonewall margin, and discharge-temperature constraints | Composable | Installed-map provenance, corrected-flow/head basis, interpolation/extrapolation status, and complete evidence for chartless or out-of-map points. |
 | Compressor driver and total power | Equipment power constraints, `ProcessModel.getPower(unit)`, power-generation capacity | Composable | Shared driver identity, plant total-power budget, fuel/electrical basis, reserve/spinning margin, and load-shed priority. |
-| Common-shaft trains | `MechanicalShaft`, `EnergyBus`, motor-assisted and motor drive trains | Calculation only | Common speed, driver power, torque, gearbox, train availability, and per-casing map constraints evaluated as one resource. |
+| Common-shaft trains | `PlantCommonShaftEvidence`, `MechanicalShaft`, `CompressorDriver`, `Gearbox`, compressor operating points | Optimizer-qualified for declared steady-state train scope | Requires exact casing/driver participant coverage, current calculation identity, explicit limits, complete convergence, and full candidate replay; it does not add machine physics or restore a candidate. |
 | Two-phase separators | Gas load factor and liquid level; mechanical-design retention and internals calculations | Composable | Gas, liquid, residence, settling, carry-over/carry-under, level, inlet momentum, demister, and slug limits in one immutable snapshot. |
 | Three-phase separators | Gas load factor, level, three-phase process and mechanical-design calculations | Composable | Independent oil/water residence and settling, interface/boot/weir limits, oil-in-water, water-in-oil, slug volume, and phase-availability status. |
 | Pumps | Power, NPSH margin, and flow-rate constraints | Composable | Installed curve/basis, operating envelope, minimum continuous stable flow, driver/shared-power identity, and non-calculable NPSH status. |
@@ -250,17 +250,18 @@ participant/six-area evidence ledger with 2 s capture, 64 MB used-heap growth, 5
 serialization, and 1 MB JSON budgets. This is evidence-path scale qualification, not the still-open
 full L process-model acceptance fixture or a generic execution speedup claim.
 
-This layer does not coordinate a common shaft, compute separator or piping physics, alter process
-solving, or accept an optimizer proposal. Those operations remain later increments and must provide
-qualified samples after a complete full-model solve.
+`PlantCommonShaftEvidence` now qualifies case-C evidence for one declared steady-state train. It
+freezes the solved shaft allocation, driver and gearbox configuration, maximum torque, common speed,
+power balance, and every casing map margin as deterministic registry samples. Missing or stale
+participant evidence is unavailable, while finite physical limit violations remain complete and
+infeasible. The adapter does not compute new compressor or gearbox physics, run or restore process
+equipment, alter process solving, or accept an optimizer proposal.
 
 ## Next dependency-ready increments
 
-1. Add a common-shaft compressor-train
-   resource constraint.
-2. Complete separator and piping evidence adapters before adding fail-closed scalable evaluation
+1. Complete separator and piping evidence adapters before adding fail-closed scalable evaluation
    and solver orchestration.
-3. Execute the full L fixture, then expose the stable evaluator result through current Java and
+2. Execute the full L fixture, then expose the stable evaluator result through current Java and
    Python workflows and execute C, B, and R as
    maintained workflows.
 

--- a/src/main/java/neqsim/process/util/optimizer/PlantCommonShaftEvidence.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantCommonShaftEvidence.java
@@ -1,0 +1,959 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.compressor.CompressorDriver;
+import neqsim.process.equipment.energy.Gearbox;
+import neqsim.process.equipment.stream.EnergyAllocation;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.MechanicalShaft;
+
+/**
+ * Immutable, participant-complete evidence for a common-shaft compressor train.
+ *
+ * <p>
+ * The adapter reads an already solved {@link MechanicalShaft}, the declared driver and gearbox, and each completed
+ * compressor operating point. It does not run or retain any mutable equipment. Shaft speed, casing speed agreement,
+ * requested shaft load, driver power, gearbox input power, output torque, power balance, and every casing map margin
+ * remain separate evidence rows. Missing, unexpected, stale, non-finite, chartless, or unconverged evidence fails
+ * closed.
+ * </p>
+ *
+ * <p>
+ * Torque is the mechanical identity {@code torque = power / angular speed}. Gearbox input power is calculated from the
+ * configured gearbox efficiency, and driver speed from its configured output-to-input speed ratio. No efficiency,
+ * torque limit, speed ratio, or map envelope is invented by this class.
+ * </p>
+ */
+public final class PlantCommonShaftEvidence implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final String SCHEMA_VERSION = "1.0";
+  private static final double MATCH_TOLERANCE = 1.0e-10;
+
+  /** Overall evidence status. */
+  public enum Status {
+    /** Every registered observation is available. */
+    AVAILABLE,
+    /** At least one required observation is unavailable or inconsistent. */
+    INCOMPLETE
+  }
+
+  /** Availability and validity of one casing operating point. */
+  public enum CasingStatus {
+    /** A complete casing and map observation is available. */
+    AVAILABLE,
+    /** The casing is explicitly unavailable and has verified zero shaft load. */
+    OUT_OF_SERVICE,
+    /** The casing observation is missing. */
+    MISSING,
+    /** The casing belongs to another calculation. */
+    STALE,
+    /** The casing calculation did not complete. */
+    INCOMPLETE_CONVERGENCE,
+    /** A required casing value is non-finite. */
+    NON_FINITE_VALUE,
+    /** No active compressor chart is available. */
+    NO_CHART,
+    /** Casing identity or shaft allocation metadata is inconsistent. */
+    METADATA_MISMATCH,
+    /** Reading the casing observation raised an exception. */
+    EXCEPTION
+  }
+
+  /** Immutable evidence for one compressor casing. */
+  public static final class CasingEvidence implements Serializable, Comparable<CasingEvidence> {
+    private static final long serialVersionUID = 1L;
+    private final String participantId;
+    private final String equipmentName;
+    private final CasingStatus status;
+    private final double speedRpm;
+    private final double shaftPowerKw;
+    private final double torqueNm;
+    private final boolean chartActive;
+    private final boolean withinChart;
+    private final double distanceToSurge;
+    private final double distanceToStoneWall;
+    private final double mapMargin;
+    private final String limitingConstraint;
+    private final String provenance;
+    private final String diagnostic;
+
+    private CasingEvidence(String participantId, String equipmentName, CasingStatus status, double speedRpm,
+        double shaftPowerKw, boolean chartActive, boolean withinChart, double distanceToSurge,
+        double distanceToStoneWall, String limitingConstraint, String provenance, String diagnostic) {
+      this.participantId = PlantConstraintScope.requireText(participantId, "Casing participant id");
+      this.equipmentName = PlantConstraintScope.requireText(equipmentName, "Casing equipment name");
+      this.status = status;
+      this.speedRpm = speedRpm;
+      this.shaftPowerKw = shaftPowerKw;
+      this.torqueNm = torque(shaftPowerKw, speedRpm);
+      this.chartActive = chartActive;
+      this.withinChart = withinChart;
+      this.distanceToSurge = distanceToSurge;
+      this.distanceToStoneWall = distanceToStoneWall;
+      this.mapMargin = Math.min(distanceToSurge, distanceToStoneWall);
+      this.limitingConstraint = PlantConstraintScope.safeText(limitingConstraint);
+      this.provenance = PlantConstraintScope.safeText(provenance);
+      this.diagnostic = PlantConstraintScope.safeText(diagnostic);
+    }
+
+    /** @return persistent shaft-network participant identity */
+    public String getParticipantId() {
+      return participantId;
+    }
+
+    /** @return stable casing equipment name */
+    public String getEquipmentName() {
+      return equipmentName;
+    }
+
+    /** @return casing evidence status */
+    public CasingStatus getStatus() {
+      return status;
+    }
+
+    /** @return casing speed in rpm, or NaN */
+    public double getSpeedRpm() {
+      return speedRpm;
+    }
+
+    /** @return absorbed casing shaft power in kW, or NaN */
+    public double getShaftPowerKw() {
+      return shaftPowerKw;
+    }
+
+    /** @return absorbed casing torque in N m, or NaN */
+    public double getTorqueNm() {
+      return torqueNm;
+    }
+
+    /** @return whether a compressor map was active */
+    public boolean isChartActive() {
+      return chartActive;
+    }
+
+    /** @return whether the solved point lies between the surge and stonewall limits */
+    public boolean isWithinChart() {
+      return withinChart;
+    }
+
+    /** @return dimensionless signed distance from surge */
+    public double getDistanceToSurge() {
+      return distanceToSurge;
+    }
+
+    /** @return dimensionless signed distance from stonewall */
+    public double getDistanceToStoneWall() {
+      return distanceToStoneWall;
+    }
+
+    /** @return minimum signed map distance, or NaN */
+    public double getMapMargin() {
+      return mapMargin;
+    }
+
+    /** @return casing-local limiting map constraint */
+    public String getLimitingConstraint() {
+      return limitingConstraint;
+    }
+
+    /** @return runtime evidence provenance */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return fail-closed diagnostic, or empty */
+    public String getDiagnostic() {
+      return diagnostic;
+    }
+
+    /** @return true when the casing observation can participate in constraint evaluation */
+    public boolean isUsable() {
+      return status == CasingStatus.AVAILABLE || status == CasingStatus.OUT_OF_SERVICE;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int compareTo(CasingEvidence other) {
+      return participantId.compareTo(other.participantId);
+    }
+  }
+
+  private static final class CasingInput {
+    private final String participantId;
+    private final Compressor compressor;
+    private final boolean outOfService;
+
+    private CasingInput(String participantId, Compressor compressor, boolean outOfService) {
+      this.participantId = participantId;
+      this.compressor = compressor;
+      this.outOfService = outOfService;
+    }
+  }
+
+  private final String calculationId;
+  private final String shaftName;
+  private final String driverParticipantId;
+  private final String gearboxIdentity;
+  private final String provenance;
+  private final boolean convergenceComplete;
+  private final Status status;
+  private final List<CasingEvidence> casings;
+  private final List<PlantConstraintDefinition> definitions;
+  private final List<PlantConstraintSample> samples;
+  private final List<String> diagnostics;
+  private final double shaftSpeedRpm;
+  private final double driverSpeedRpm;
+  private final double totalCasingPowerKw;
+  private final double totalShaftLoadKw;
+  private final double gearboxInputPowerKw;
+  private final double driverPowerLimitKw;
+  private final double shaftTorqueNm;
+  private final double maximumTorqueNm;
+  private final double unmetPowerKw;
+
+  private PlantCommonShaftEvidence(Builder builder) {
+    calculationId = PlantConstraintScope.requireText(builder.calculationId, "Calculation id");
+    provenance = PlantConstraintScope.requireText(builder.provenance, "Common-shaft provenance");
+    shaftName = PlantConstraintScope.requireText(builder.shaft.getName(), "Mechanical shaft name");
+    driverParticipantId = PlantConstraintScope.requireText(builder.driverParticipantId, "Driver participant id");
+    gearboxIdentity = PlantConstraintScope.requireText(builder.gearboxIdentity, "Gearbox identity");
+    convergenceComplete = builder.convergenceComplete;
+    maximumTorqueNm = builder.maximumTorqueNm;
+    List<String> findings = new ArrayList<String>();
+
+    if (!convergenceComplete) {
+      findings.add("INCOMPLETE_CONVERGENCE");
+    }
+    if (!builder.shaft.hasSolution() || builder.shaft.getLastReport() == null) {
+      findings.add("SHAFT_SOLUTION_STALE_OR_MISSING");
+    }
+    if (builder.shaft.isTripped()) {
+      findings.add("SHAFT_TRIPPED");
+    }
+    shaftSpeedRpm = builder.shaft.getSpeed();
+    if (!Double.isFinite(shaftSpeedRpm) || shaftSpeedRpm <= 0.0) {
+      findings.add("INVALID_SHAFT_SPEED");
+    }
+    if (!Double.isFinite(builder.speedToleranceRpm) || builder.speedToleranceRpm <= 0.0) {
+      findings.add("INVALID_SPEED_TOLERANCE");
+    }
+    if (!Double.isFinite(builder.powerBalanceToleranceKw) || builder.powerBalanceToleranceKw <= 0.0) {
+      findings.add("INVALID_POWER_BALANCE_TOLERANCE");
+    }
+    if (!Double.isFinite(maximumTorqueNm) || maximumTorqueNm <= 0.0) {
+      findings.add("MISSING_MAXIMUM_TORQUE");
+    }
+
+    Map<String, EnergyAllocation> allocations = allocationMap(builder.shaft.getLastReport(), findings);
+    double participantDemandW = 0.0;
+    double participantSupplyW = 0.0;
+    for (EnergyAllocation allocation : allocations.values()) {
+      if (allocation.getDirection() == EnergyPortDirection.INPUT) {
+        participantDemandW += allocation.getRequestedPower();
+      } else if (allocation.getDirection() == EnergyPortDirection.OUTPUT) {
+        participantSupplyW += allocation.getRequestedPower();
+      }
+    }
+    List<CasingEvidence> captured = new ArrayList<CasingEvidence>();
+    double casingTotal = 0.0;
+    double maximumSpeedDeviation = 0.0;
+    boolean casingTotalAvailable = true;
+    for (CasingInput input : new TreeMap<String, CasingInput>(builder.casings).values()) {
+      EnergyAllocation allocation = allocations.remove(input.participantId);
+      CasingEvidence casing = captureCasing(input, allocation, calculationId, provenance);
+      captured.add(casing);
+      if (!casing.isUsable()) {
+        findings.add(input.participantId + "=" + casing.getStatus().name() + diagnosticSuffix(casing.getDiagnostic()));
+        casingTotalAvailable = false;
+      } else {
+        casingTotal += casing.getShaftPowerKw();
+        if (casing.getStatus() != CasingStatus.OUT_OF_SERVICE) {
+          maximumSpeedDeviation = Math.max(maximumSpeedDeviation, Math.abs(casing.getSpeedRpm() - shaftSpeedRpm));
+        }
+      }
+    }
+
+    EnergyAllocation driverAllocation = allocations.remove(driverParticipantId);
+    if (driverAllocation == null || driverAllocation.getDirection() != EnergyPortDirection.OUTPUT) {
+      findings.add("DRIVER_PARTICIPANT_MISSING_OR_NOT_OUTPUT");
+    }
+    for (EnergyAllocation allocation : allocations.values()) {
+      findings.add(allocation.getParticipantId() + "=UNEXPECTED_SHAFT_PARTICIPANT");
+    }
+    Collections.sort(captured);
+    casings = Collections.unmodifiableList(captured);
+    totalCasingPowerKw = casingTotalAvailable ? casingTotal : Double.NaN;
+
+    EnergyNetworkReport report = builder.shaft.getLastReport();
+    double reportDemandKw = report == null ? Double.NaN : report.getRequestedDemand() / 1000.0;
+    if (report != null && !approximatelyEqual(participantDemandW, report.getRequestedDemand())) {
+      findings.add("UNREGISTERED_EXTERNAL_SHAFT_DEMAND");
+    }
+    if (report != null && !approximatelyEqual(participantSupplyW, report.getOfferedSupply())) {
+      findings.add("UNREGISTERED_EXTERNAL_SHAFT_SUPPLY");
+    }
+    if (casingTotalAvailable && !approximatelyEqual(casingTotal, reportDemandKw)) {
+      findings.add("CASING_TOTAL_MISMATCH expected=" + reportDemandKw + " captured=" + casingTotal);
+    }
+    totalShaftLoadKw = Double.isFinite(reportDemandKw) ? reportDemandKw + builder.shaft.getFrictionLoss() / 1000.0
+        : Double.NaN;
+    double driverOfferedPowerKw = driverAllocation == null ? Double.NaN : driverAllocation.getRequestedPower() / 1000.0;
+    double reportUnmetPowerKw = report == null ? Double.NaN : report.getUnmetDemand() / 1000.0;
+    unmetPowerKw = Double.isFinite(totalShaftLoadKw) && Double.isFinite(driverOfferedPowerKw)
+        && Double.isFinite(reportUnmetPowerKw)
+            ? Math.max(reportUnmetPowerKw, Math.max(0.0, totalShaftLoadKw - driverOfferedPowerKw))
+            : Double.NaN;
+
+    double ratio = builder.gearbox.getSpeedRatio();
+    double efficiency = builder.gearbox.getEfficiency();
+    driverSpeedRpm = Double.isFinite(shaftSpeedRpm) && Double.isFinite(ratio) && ratio > 0.0 ? shaftSpeedRpm / ratio
+        : Double.NaN;
+    gearboxInputPowerKw = Double.isFinite(totalShaftLoadKw) && Double.isFinite(efficiency) && efficiency > 0.0
+        && Double.isFinite(builder.gearbox.getIdleLoss())
+            ? totalShaftLoadKw / efficiency + builder.gearbox.getIdleLoss() / 1000.0
+            : Double.NaN;
+    driverPowerLimitKw = builder.driver.getMaxAvailablePowerAtSpeed(driverSpeedRpm);
+    shaftTorqueNm = torque(totalShaftLoadKw, shaftSpeedRpm);
+
+    if (!finiteNonNegative(totalShaftLoadKw) || !finiteNonNegative(gearboxInputPowerKw)
+        || !Double.isFinite(driverPowerLimitKw) || driverPowerLimitKw <= 0.0 || !finiteNonNegative(unmetPowerKw)
+        || !Double.isFinite(shaftTorqueNm)) {
+      findings.add("NON_FINITE_SHAFT_DRIVER_OR_GEARBOX_EVIDENCE");
+    }
+    if (!Double.isFinite(builder.gearbox.getMaximumInputPower()) || builder.gearbox.getMaximumInputPower() <= 0.0) {
+      findings.add("MISSING_GEARBOX_INPUT_POWER_LIMIT");
+    }
+    if (builder.gearbox.isTripped()) {
+      findings.add("GEARBOX_TRIPPED");
+    }
+    if (!Double.isFinite(builder.shaft.getMaximumSpeed())) {
+      findings.add("MISSING_SHAFT_SPEED_LIMIT");
+    }
+    if (!Double.isFinite(builder.driver.getMinSpeed()) || !Double.isFinite(builder.driver.getMaxSpeed())
+        || builder.driver.getMinSpeed() < 0.0 || builder.driver.getMaxSpeed() <= builder.driver.getMinSpeed()) {
+      findings.add("INVALID_DRIVER_SPEED_ENVELOPE");
+    }
+
+    List<PlantConstraintDefinition> capturedDefinitions = buildDefinitions(builder);
+    List<PlantConstraintSample> capturedSamples = buildSamples(builder, capturedDefinitions, maximumSpeedDeviation,
+        findings.isEmpty());
+    definitions = Collections.unmodifiableList(capturedDefinitions);
+    samples = Collections.unmodifiableList(capturedSamples);
+    diagnostics = Collections.unmodifiableList(new ArrayList<String>(findings));
+    status = findings.isEmpty() ? Status.AVAILABLE : Status.INCOMPLETE;
+  }
+
+  /**
+   * Starts a callback-free common-shaft evidence builder.
+   *
+   * @param modelName stable process-model name
+   * @param areaName stable process-area name
+   * @param groupName stable common-shaft group name
+   * @param calculationId exact completed calculation UUID string
+   * @param shaft solved mechanical shaft to sample immediately
+   * @param provenance source of the completed train state
+   * @return new evidence builder
+   */
+  public static Builder builder(String modelName, String areaName, String groupName, String calculationId,
+      MechanicalShaft shaft, String provenance) {
+    return new Builder(modelName, areaName, groupName, calculationId, shaft, provenance);
+  }
+
+  private static Map<String, EnergyAllocation> allocationMap(EnergyNetworkReport report, List<String> diagnostics) {
+    Map<String, EnergyAllocation> result = new TreeMap<String, EnergyAllocation>();
+    if (report == null) {
+      return result;
+    }
+    for (EnergyAllocation allocation : report.getAllocations()) {
+      if (result.put(allocation.getParticipantId(), allocation) != null) {
+        diagnostics.add(allocation.getParticipantId() + "=DUPLICATE_SHAFT_PARTICIPANT");
+      }
+    }
+    return result;
+  }
+
+  private static CasingEvidence captureCasing(CasingInput input, EnergyAllocation allocation, String calculationId,
+      String provenance) {
+    if (input.compressor == null) {
+      return unavailableCasing(input.participantId, input.participantId, CasingStatus.MISSING, provenance,
+          "Compressor object is missing");
+    }
+    String equipmentName = input.compressor.getName();
+    if (allocation == null || allocation.getDirection() != EnergyPortDirection.INPUT) {
+      return unavailableCasing(input.participantId, equipmentName, CasingStatus.METADATA_MISMATCH, provenance,
+          "Shaft input allocation is missing");
+    }
+    try {
+      if (!input.compressor.solved()) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.INCOMPLETE_CONVERGENCE, provenance,
+            "Compressor is not solved");
+      }
+      if (input.compressor.getCalculationIdentifier() == null
+          || !calculationId.equals(input.compressor.getCalculationIdentifier().toString())) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.STALE, provenance,
+            "Compressor calculation identity differs");
+      }
+      Map<String, Object> point = input.compressor.getOperatingPoint();
+      double speed = number(point.get("speed_rpm"));
+      double power = number(point.get("power_kW"));
+      boolean chartActive = Boolean.TRUE.equals(point.get("chartActive"));
+      boolean withinChart = Boolean.TRUE.equals(point.get("withinChart"));
+      double surge = number(point.get("distanceToSurge"));
+      double stonewall = number(point.get("distanceToStoneWall"));
+      String limiting = String.valueOf(point.get("limitingConstraint"));
+      if (!Double.isFinite(speed) || speed < 0.0 || !finiteNonNegative(power)) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.NON_FINITE_VALUE, provenance,
+            "Speed or shaft power is unavailable");
+      }
+      if (!approximatelyEqual(power, allocation.getRequestedPower() / 1000.0)) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.METADATA_MISMATCH, provenance,
+            "Compressor power differs from the shaft request");
+      }
+      if (input.outOfService) {
+        if (power == 0.0 && allocation.getRequestedPower() == 0.0) {
+          return new CasingEvidence(input.participantId, equipmentName, CasingStatus.OUT_OF_SERVICE, 0.0, 0.0, false,
+              true, 0.0, 0.0, "out_of_service", provenance, "Explicitly unavailable with verified zero load");
+        }
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.METADATA_MISMATCH, provenance,
+            "Out-of-service casing retained non-zero shaft load");
+      }
+      if (!chartActive) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.NO_CHART, provenance,
+            "No active casing map");
+      }
+      if (!Double.isFinite(surge) || !Double.isFinite(stonewall)) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.NON_FINITE_VALUE, provenance,
+            "Map margins are unavailable");
+      }
+      return new CasingEvidence(input.participantId, equipmentName, CasingStatus.AVAILABLE, speed, power, true,
+          withinChart, surge, stonewall, limiting, provenance, "");
+    } catch (RuntimeException ex) {
+      return unavailableCasing(input.participantId, equipmentName, CasingStatus.EXCEPTION, provenance, safeMessage(ex));
+    }
+  }
+
+  private static CasingEvidence unavailableCasing(String id, String name, CasingStatus status, String provenance,
+      String diagnostic) {
+    return new CasingEvidence(id, name, status, Double.NaN, Double.NaN, false, false, Double.NaN, Double.NaN,
+        "unavailable", provenance, diagnostic);
+  }
+
+  private List<PlantConstraintDefinition> buildDefinitions(Builder builder) {
+    List<PlantConstraintDefinition> result = new ArrayList<PlantConstraintDefinition>();
+    PlantConstraintScope group = PlantConstraintScope.coupledGroup(builder.modelName, builder.areaName,
+        builder.groupName);
+    PlantConstraintDefinition.Builder speedAgreement = definition("common-speed-deviation", group, "rpm",
+        "maximum absolute casing-to-shaft speed deviation", provenance)
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.COMMON_SETPOINT);
+    for (CasingEvidence casing : casings) {
+      speedAgreement.participant(PlantConstraintParticipant.direct(casing.getParticipantId(), "rpm",
+          "maximum absolute casing-to-shaft speed deviation"));
+    }
+    result.add(speedAgreement.build());
+    result.add(definition("shaft-maximum-speed", group, "rpm", "mechanical shaft speed", provenance).build());
+    result.add(definition("shaft-power-balance", group, "kW", "unmet requested shaft load", provenance).build());
+    result.add(definition("driver-speed-envelope", group, "rpm", "gearbox input and driver speed", provenance)
+        .limitDirection(PlantConstraintDefinition.LimitDirection.RANGE).build());
+    result.add(definition("driver-maximum-power", group, "kW", "driver output required at configured gearbox input",
+        provenance).build());
+    result.add(definition("gearbox-maximum-input-power", group, "kW",
+        "gearbox input power including configured efficiency", provenance).build());
+    result.add(definition("shaft-maximum-torque", group, "N m",
+        "absorbed shaft load plus configured friction at shaft speed", provenance).build());
+    for (CasingEvidence casing : casings) {
+      result.add(definition("compressor-map-margin",
+          PlantConstraintScope.equipment(builder.modelName, builder.areaName, casing.getEquipmentName()), "fraction",
+          "minimum signed distance to surge or stonewall", casing.getProvenance())
+          .limitDirection(PlantConstraintDefinition.LimitDirection.MINIMUM).build());
+    }
+    Collections.sort(result);
+    return result;
+  }
+
+  private static PlantConstraintDefinition.Builder definition(String id, PlantConstraintScope scope, String unit,
+      String basis, String provenance) {
+    return PlantConstraintDefinition.builder(id, scope).category(PlantConstraintDefinition.Category.DESIGN)
+        .severity(ConstraintSeverity.HARD).unit(unit).basis(basis).provenance(provenance).owner("rotating equipment")
+        .calculationMethod("immutable common-shaft post-solve evidence");
+  }
+
+  private List<PlantConstraintSample> buildSamples(Builder builder, List<PlantConstraintDefinition> sourceDefinitions,
+      double speedDeviation, boolean metadataComplete) {
+    Map<String, PlantConstraintDefinition> byId = new LinkedHashMap<String, PlantConstraintDefinition>();
+    for (PlantConstraintDefinition definition : sourceDefinitions) {
+      byId.put(definition.getQualifiedId(), definition);
+    }
+    PlantConstraintScope group = PlantConstraintScope.coupledGroup(builder.modelName, builder.areaName,
+        builder.groupName);
+    List<PlantConstraintSample> result = new ArrayList<PlantConstraintSample>();
+    result.add(maximumSample(byId.get(group.getStableId() + "#common-speed-deviation"), speedDeviation,
+        builder.speedToleranceRpm, "completed casing speed observations", metadataComplete));
+    result.add(maximumSample(byId.get(group.getStableId() + "#shaft-maximum-speed"), shaftSpeedRpm,
+        builder.shaft.getMaximumSpeed(), "completed mechanical shaft state", metadataComplete));
+    result.add(maximumSample(byId.get(group.getStableId() + "#shaft-power-balance"), unmetPowerKw,
+        builder.powerBalanceToleranceKw, "solved mechanical shaft report", metadataComplete));
+    result.add(rangeSample(byId.get(group.getStableId() + "#driver-speed-envelope"), driverSpeedRpm,
+        builder.driver.getMinSpeed(), builder.driver.getMaxSpeed(), "configured driver envelope", metadataComplete));
+    result.add(maximumSample(byId.get(group.getStableId() + "#driver-maximum-power"), gearboxInputPowerKw,
+        driverPowerLimitKw, "configured driver curve", metadataComplete));
+    result.add(maximumSample(byId.get(group.getStableId() + "#gearbox-maximum-input-power"), gearboxInputPowerKw,
+        builder.gearbox.getMaximumInputPower() / 1000.0, "configured gearbox rating", metadataComplete));
+    result.add(maximumSample(byId.get(group.getStableId() + "#shaft-maximum-torque"), shaftTorqueNm, maximumTorqueNm,
+        "configured shaft train torque limit", metadataComplete));
+    for (CasingEvidence casing : casings) {
+      String qualifiedId = PlantConstraintScope
+          .equipment(builder.modelName, builder.areaName, casing.getEquipmentName()).getStableId()
+          + "#compressor-map-margin";
+      result.add(
+          minimumSample(byId.get(qualifiedId), casing.getMapMargin(), 0.0, casing.getProvenance(), casing.isUsable()));
+    }
+    Collections.sort(result,
+        (first, second) -> first.getQualifiedConstraintId().compareTo(second.getQualifiedConstraintId()));
+    return result;
+  }
+
+  private PlantConstraintSample maximumSample(PlantConstraintDefinition definition, double value, double limit,
+      String sampleProvenance, boolean complete) {
+    if (!complete || !Double.isFinite(value) || !Double.isFinite(limit) || limit <= 0.0) {
+      return unavailableSample(definition, sampleProvenance);
+    }
+    double utilization = value / limit;
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId).values(value, limit)
+        .normalized(utilization, utilization - 1.0).physical(limit - value, Math.max(0.0, value - limit))
+        .unit(definition.getUnit()).basis(definition.getBasis()).provenance(sampleProvenance).build();
+  }
+
+  private PlantConstraintSample minimumSample(PlantConstraintDefinition definition, double value, double limit,
+      String sampleProvenance, boolean complete) {
+    if (!complete || !Double.isFinite(value)) {
+      return unavailableSample(definition, sampleProvenance);
+    }
+    double residual = limit - value;
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId).values(value, limit)
+        .normalized(1.0 + residual, residual).physical(value - limit, Math.max(0.0, limit - value))
+        .unit(definition.getUnit()).basis(definition.getBasis()).provenance(sampleProvenance).build();
+  }
+
+  private PlantConstraintSample rangeSample(PlantConstraintDefinition definition, double value, double minimum,
+      double maximum, String sampleProvenance, boolean complete) {
+    if (!complete || !Double.isFinite(value) || !Double.isFinite(minimum) || !Double.isFinite(maximum)
+        || maximum <= minimum) {
+      return unavailableSample(definition, sampleProvenance);
+    }
+    double limit;
+    double margin;
+    double normalizedResidual;
+    double scale = maximum - minimum;
+    if (value < minimum) {
+      limit = minimum;
+      margin = value - minimum;
+      normalizedResidual = (minimum - value) / scale;
+    } else if (value > maximum) {
+      limit = maximum;
+      margin = maximum - value;
+      normalizedResidual = (value - maximum) / scale;
+    } else {
+      double minimumMargin = value - minimum;
+      double maximumMargin = maximum - value;
+      limit = minimumMargin <= maximumMargin ? minimum : maximum;
+      margin = Math.min(minimumMargin, maximumMargin);
+      normalizedResidual = -margin / scale;
+    }
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId).values(value, limit)
+        .normalized(1.0 + normalizedResidual, normalizedResidual).physical(margin, Math.max(0.0, -margin))
+        .unit(definition.getUnit()).basis(definition.getBasis()).provenance(sampleProvenance).build();
+  }
+
+  private PlantConstraintSample unavailableSample(PlantConstraintDefinition definition, String sampleProvenance) {
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId)
+        .status(PlantConstraintSample.SampleStatus.NOT_CALCULABLE).unit(definition.getUnit())
+        .basis(definition.getBasis()).provenance(sampleProvenance).diagnostic("Common-shaft evidence is incomplete")
+        .build();
+  }
+
+  private static double torque(double powerKw, double speedRpm) {
+    if (!finiteNonNegative(powerKw) || !Double.isFinite(speedRpm) || speedRpm <= 0.0) {
+      return Double.NaN;
+    }
+    return powerKw * 1000.0 / (speedRpm * 2.0 * Math.PI / 60.0);
+  }
+
+  private static boolean finiteNonNegative(double value) {
+    return Double.isFinite(value) && value >= 0.0;
+  }
+
+  private static double number(Object value) {
+    return value instanceof Number ? ((Number) value).doubleValue() : Double.NaN;
+  }
+
+  private static boolean approximatelyEqual(double first, double second) {
+    if (!Double.isFinite(first) || !Double.isFinite(second)) {
+      return false;
+    }
+    double scale = Math.max(1.0, Math.max(Math.abs(first), Math.abs(second)));
+    return Math.abs(first - second) <= MATCH_TOLERANCE * scale;
+  }
+
+  private static String safeMessage(RuntimeException exception) {
+    return exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage();
+  }
+
+  private static String diagnosticSuffix(String value) {
+    return value == null || value.isEmpty() ? "" : ":" + value;
+  }
+
+  /** @return common-shaft evidence schema version */
+  public String getSchemaVersion() {
+    return SCHEMA_VERSION;
+  }
+
+  /** @return exact calculation identity */
+  public String getCalculationId() {
+    return calculationId;
+  }
+
+  /** @return mechanical shaft name */
+  public String getShaftName() {
+    return shaftName;
+  }
+
+  /** @return overall evidence status */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** @return true when every required observation is available */
+  public boolean isComplete() {
+    return status == Status.AVAILABLE;
+  }
+
+  /** @return true when the complete common-shaft snapshot is feasible */
+  public boolean isFeasible() {
+    return isComplete() && toPlantUtilizationSnapshot().isFeasible();
+  }
+
+  /** @return immutable deterministic casing evidence */
+  public List<CasingEvidence> getCasings() {
+    return Collections.unmodifiableList(new ArrayList<CasingEvidence>(casings));
+  }
+
+  /** @return immutable definitions for registry integration */
+  public List<PlantConstraintDefinition> getDefinitions() {
+    return Collections.unmodifiableList(new ArrayList<PlantConstraintDefinition>(definitions));
+  }
+
+  /** @return immutable common plant samples */
+  public List<PlantConstraintSample> getSamples() {
+    return Collections.unmodifiableList(new ArrayList<PlantConstraintSample>(samples));
+  }
+
+  /** @return immutable fail-closed diagnostics */
+  public List<String> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<String>(diagnostics));
+  }
+
+  /** @return shaft speed in rpm */
+  public double getShaftSpeedRpm() {
+    return shaftSpeedRpm;
+  }
+
+  /** @return gearbox-input/driver speed in rpm */
+  public double getDriverSpeedRpm() {
+    return driverSpeedRpm;
+  }
+
+  /** @return total casing shaft power in kW, or NaN */
+  public double getTotalCasingPowerKw() {
+    return totalCasingPowerKw;
+  }
+
+  /** @return shaft load including configured friction in kW */
+  public double getTotalShaftLoadKw() {
+    return totalShaftLoadKw;
+  }
+
+  /** @return required gearbox input power in kW */
+  public double getGearboxInputPowerKw() {
+    return gearboxInputPowerKw;
+  }
+
+  /** @return speed-dependent driver power limit in kW */
+  public double getDriverPowerLimitKw() {
+    return driverPowerLimitKw;
+  }
+
+  /** @return absorbed shaft torque in N m */
+  public double getShaftTorqueNm() {
+    return shaftTorqueNm;
+  }
+
+  /** @return configured maximum shaft torque in N m */
+  public double getMaximumTorqueNm() {
+    return maximumTorqueNm;
+  }
+
+  /** @return unmet requested shaft power in kW */
+  public double getUnmetPowerKw() {
+    return unmetPowerKw;
+  }
+
+  /**
+   * Builds a complete common plant utilization snapshot from this frozen evidence.
+   *
+   * @return immutable utilization snapshot
+   */
+  public PlantUtilizationSnapshot toPlantUtilizationSnapshot() {
+    PlantConstraintRegistry registry = new PlantConstraintRegistry();
+    for (PlantConstraintDefinition definition : definitions) {
+      registry.register(definition);
+    }
+    PlantUtilizationSnapshot.Builder snapshot = PlantUtilizationSnapshot.builder(registry, calculationId)
+        .convergenceComplete(convergenceComplete);
+    for (PlantConstraintSample sample : samples) {
+      snapshot.sample(sample);
+    }
+    return snapshot.build();
+  }
+
+  /** @return standards-compliant JSON with null for unavailable numbers */
+  public String toJson() {
+    JsonObject root = new JsonObject();
+    root.addProperty("schemaVersion", SCHEMA_VERSION);
+    root.addProperty("calculationId", calculationId);
+    root.addProperty("shaftName", shaftName);
+    root.addProperty("driverParticipantId", driverParticipantId);
+    root.addProperty("gearboxIdentity", gearboxIdentity);
+    root.addProperty("provenance", provenance);
+    root.addProperty("convergenceComplete", convergenceComplete);
+    root.addProperty("status", status.name());
+    addNumber(root, "shaftSpeedRpm", shaftSpeedRpm);
+    addNumber(root, "driverSpeedRpm", driverSpeedRpm);
+    addNumber(root, "totalCasingPowerKw", totalCasingPowerKw);
+    addNumber(root, "totalShaftLoadKw", totalShaftLoadKw);
+    addNumber(root, "gearboxInputPowerKw", gearboxInputPowerKw);
+    addNumber(root, "driverPowerLimitKw", driverPowerLimitKw);
+    addNumber(root, "shaftTorqueNm", shaftTorqueNm);
+    addNumber(root, "maximumTorqueNm", maximumTorqueNm);
+    addNumber(root, "unmetPowerKw", unmetPowerKw);
+    JsonArray casingRows = new JsonArray();
+    for (CasingEvidence casing : casings) {
+      JsonObject row = new JsonObject();
+      row.addProperty("participantId", casing.getParticipantId());
+      row.addProperty("equipmentName", casing.getEquipmentName());
+      row.addProperty("status", casing.getStatus().name());
+      addNumber(row, "speedRpm", casing.getSpeedRpm());
+      addNumber(row, "shaftPowerKw", casing.getShaftPowerKw());
+      addNumber(row, "torqueNm", casing.getTorqueNm());
+      row.addProperty("chartActive", casing.isChartActive());
+      row.addProperty("withinChart", casing.isWithinChart());
+      addNumber(row, "distanceToSurge", casing.getDistanceToSurge());
+      addNumber(row, "distanceToStoneWall", casing.getDistanceToStoneWall());
+      addNumber(row, "mapMargin", casing.getMapMargin());
+      row.addProperty("limitingConstraint", casing.getLimitingConstraint());
+      row.addProperty("provenance", casing.getProvenance());
+      row.addProperty("diagnostic", casing.getDiagnostic());
+      casingRows.add(row);
+    }
+    root.add("casings", casingRows);
+    JsonArray diagnosticRows = new JsonArray();
+    for (String diagnostic : diagnostics) {
+      diagnosticRows.add(diagnostic);
+    }
+    root.add("diagnostics", diagnosticRows);
+    root.add("utilizationSnapshot", utilizationSnapshotJson());
+    return root.toString();
+  }
+
+  private JsonObject utilizationSnapshotJson() {
+    PlantUtilizationSnapshot snapshot = toPlantUtilizationSnapshot();
+    JsonObject result = new JsonObject();
+    result.addProperty("schemaVersion", snapshot.getSchemaVersion());
+    result.addProperty("calculationId", snapshot.getCalculationId());
+    result.addProperty("registryIdentityDigest", snapshot.getRegistryIdentityDigest());
+    result.addProperty("convergenceComplete", snapshot.isConvergenceComplete());
+    result.addProperty("complete", snapshot.isComplete());
+    result.addProperty("feasible", snapshot.isFeasible());
+    JsonArray rows = new JsonArray();
+    for (PlantConstraintEvidence evidence : snapshot.getEvidence()) {
+      JsonObject row = new JsonObject();
+      row.addProperty("qualifiedConstraintId", evidence.getQualifiedConstraintId());
+      row.addProperty("coverageStatus", evidence.getCoverageStatus().name());
+      row.addProperty("operatingStatus", evidence.getOperatingStatus().name());
+      row.addProperty("hardConstraint", evidence.isHardConstraint());
+      row.addProperty("feasible", evidence.isFeasible());
+      addNumber(row, "normalizedUtilization", evidence.getNormalizedUtilization());
+      addNumber(row, "normalizedResidual", evidence.getNormalizedResidual());
+      row.addProperty("diagnostic", evidence.getDiagnostic());
+      rows.add(row);
+    }
+    result.add("evidence", rows);
+    return result;
+  }
+
+  private static void addNumber(JsonObject target, String name, double value) {
+    if (Double.isFinite(value)) {
+      target.addProperty(name, value);
+    } else {
+      target.add(name, JsonNull.INSTANCE);
+    }
+  }
+
+  /** Callback-free common-shaft evidence builder. */
+  public static final class Builder {
+    private final String modelName;
+    private final String areaName;
+    private final String groupName;
+    private final String calculationId;
+    private final MechanicalShaft shaft;
+    private final String provenance;
+    private final Map<String, CasingInput> casings = new LinkedHashMap<String, CasingInput>();
+    private boolean convergenceComplete;
+    private double speedToleranceRpm = Double.NaN;
+    private double powerBalanceToleranceKw = Double.NaN;
+    private double maximumTorqueNm = Double.NaN;
+    private String driverParticipantId = "";
+    private CompressorDriver driver;
+    private String gearboxIdentity = "";
+    private Gearbox gearbox;
+
+    private Builder(String modelName, String areaName, String groupName, String calculationId, MechanicalShaft shaft,
+        String provenance) {
+      this.modelName = PlantConstraintScope.requireText(modelName, "Model name");
+      this.areaName = PlantConstraintScope.requireText(areaName, "Area name");
+      this.groupName = PlantConstraintScope.requireText(groupName, "Coupled group name");
+      this.calculationId = calculationId;
+      if (shaft == null) {
+        throw new IllegalArgumentException("Mechanical shaft is required");
+      }
+      this.shaft = shaft;
+      this.provenance = provenance;
+    }
+
+    /**
+     * Adds an in-service compressor casing keyed by its shaft participant identity.
+     *
+     * @param participantId persistent shaft-input participant identity
+     * @param compressor completed casing compressor
+     * @return this builder
+     */
+    public Builder casing(String participantId, Compressor compressor) {
+      return casing(participantId, compressor, false);
+    }
+
+    /**
+     * Adds a compressor casing with an explicit availability state.
+     *
+     * @param participantId persistent shaft-input participant identity
+     * @param compressor completed casing compressor
+     * @param outOfService true only when zero shaft load must be verified
+     * @return this builder
+     */
+    public Builder casing(String participantId, Compressor compressor, boolean outOfService) {
+      String id = PlantConstraintScope.requireText(participantId, "Casing participant id");
+      if (casings.containsKey(id)) {
+        throw new IllegalArgumentException("Duplicate casing participant " + id);
+      }
+      casings.put(id, new CasingInput(id, compressor, outOfService));
+      return this;
+    }
+
+    /**
+     * Sets the expected shaft-network driver output and configured driver model.
+     *
+     * @param participantId persistent shaft-output participant identity
+     * @param value configured driver model
+     * @return this builder
+     */
+    public Builder driver(String participantId, CompressorDriver value) {
+      driverParticipantId = PlantConstraintScope.requireText(participantId, "Driver participant id");
+      if (value == null) {
+        throw new IllegalArgumentException("Compressor driver is required");
+      }
+      driver = value;
+      return this;
+    }
+
+    /**
+     * Sets the gearbox identity and configured gearbox model.
+     *
+     * @param identity stable caller-owned gearbox identity
+     * @param value configured gearbox model
+     * @return this builder
+     */
+    public Builder gearbox(String identity, Gearbox value) {
+      gearboxIdentity = PlantConstraintScope.requireText(identity, "Gearbox identity");
+      if (value == null) {
+        throw new IllegalArgumentException("Gearbox is required");
+      }
+      gearbox = value;
+      return this;
+    }
+
+    /**
+     * Sets the maximum allowed casing-to-shaft speed deviation.
+     *
+     * @param value positive tolerance in rpm
+     * @return this builder
+     */
+    public Builder speedToleranceRpm(double value) {
+      speedToleranceRpm = value;
+      return this;
+    }
+
+    /**
+     * Sets the maximum accepted unmet shaft load.
+     *
+     * @param value positive tolerance in kW
+     * @return this builder
+     */
+    public Builder powerBalanceToleranceKw(double value) {
+      powerBalanceToleranceKw = value;
+      return this;
+    }
+
+    /**
+     * Sets the independently configured maximum shaft torque.
+     *
+     * @param value positive torque limit in N m
+     * @return this builder
+     */
+    public Builder maximumTorqueNm(double value) {
+      maximumTorqueNm = value;
+      return this;
+    }
+
+    /**
+     * Declares whether the complete isolated candidate converged.
+     *
+     * @param value true only after the full applicable process convergence checks pass
+     * @return this builder
+     */
+    public Builder convergenceComplete(boolean value) {
+      convergenceComplete = value;
+      return this;
+    }
+
+    /** @return immutable common-shaft evidence */
+    public PlantCommonShaftEvidence build() {
+      if (casings.isEmpty()) {
+        throw new IllegalArgumentException("At least one compressor casing is required");
+      }
+      if (driver == null || gearbox == null) {
+        throw new IllegalArgumentException("Driver and gearbox are required");
+      }
+      return new PlantCommonShaftEvidence(this);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/PlantCommonShaftEvidence.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantCommonShaftEvidence.java
@@ -437,6 +437,10 @@ public final class PlantCommonShaftEvidence implements Serializable {
         return unavailableCasing(input.participantId, equipmentName, CasingStatus.NON_FINITE_VALUE, provenance,
             "Map margins are unavailable");
       }
+      if (withinChart != (surge >= 0.0 && stonewall >= 0.0)) {
+        return unavailableCasing(input.participantId, equipmentName, CasingStatus.METADATA_MISMATCH, provenance,
+            "Chart status disagrees with signed map margins");
+      }
       return new CasingEvidence(input.participantId, equipmentName, CasingStatus.AVAILABLE, speed, power, true,
           withinChart, surge, stonewall, limiting, provenance, "");
     } catch (RuntimeException ex) {
@@ -476,7 +480,8 @@ public final class PlantCommonShaftEvidence implements Serializable {
       result.add(definition("compressor-map-margin",
           PlantConstraintScope.equipment(builder.modelName, builder.areaName, casing.getEquipmentName()), "fraction",
           "minimum signed distance to surge or stonewall", casing.getProvenance())
-          .limitDirection(PlantConstraintDefinition.LimitDirection.MINIMUM).build());
+          .limitDirection(PlantConstraintDefinition.LimitDirection.MINIMUM)
+          .enabled(casing.getStatus() != CasingStatus.OUT_OF_SERVICE).build());
     }
     Collections.sort(result);
     return result;

--- a/src/test/java/neqsim/process/util/optimizer/PlantCommonShaftEvidenceTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PlantCommonShaftEvidenceTest.java
@@ -99,9 +99,33 @@ class PlantCommonShaftEvidenceTest {
         .build();
 
     assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertTrue(evidence.isFeasible());
     assertTrue(evidence.getCasings().stream()
         .anyMatch(casing -> casing.getStatus() == PlantCommonShaftEvidence.CasingStatus.OUT_OF_SERVICE));
+    assertTrue(evidence.toPlantUtilizationSnapshot().getEvidence().stream()
+        .anyMatch(row -> row.getOperatingStatus() == PlantConstraintEvidence.OperatingStatus.DISABLED));
     assertEquals(400.0, evidence.getTotalCasingPowerKw(), 1.0e-12);
+  }
+
+  @Test
+  void inconsistentChartFlagAndSignedMarginsFailClosed() {
+    TrainFixture fixture = trainFixture(800.0, 900.0);
+    StubCompressor casingA = new StubCompressor("casing A", 10000.0, 400.0, 0.12, 0.18, true,
+        UUID.fromString(CALCULATION_ID));
+    StubCompressor casingB = new StubCompressor("casing B", 10000.0, 350.0, -0.01, 0.21, true,
+        UUID.fromString(CALCULATION_ID));
+    casingB.operatingPoint.put("withinChart", true);
+
+    PlantCommonShaftEvidence evidence = PlantCommonShaftEvidence
+        .builder("medium production model", "compression", "export train", CALCULATION_ID, fixture.shaft,
+            "completed isolated candidate")
+        .casing(fixture.casingAPort.getParticipantId(), casingA).casing(fixture.casingBPort.getParticipantId(), casingB)
+        .driver(fixture.driverPort.getParticipantId(), fixture.driver).gearbox("gearbox-1", fixture.gearbox)
+        .speedToleranceRpm(1.0).powerBalanceToleranceKw(1.0e-6).maximumTorqueNm(800.0).convergenceComplete(true)
+        .build();
+
+    assertFalse(evidence.isComplete());
+    assertTrue(evidence.getDiagnostics().stream().anyMatch(value -> value.contains("METADATA_MISMATCH")));
   }
 
   @Test

--- a/src/test/java/neqsim/process/util/optimizer/PlantCommonShaftEvidenceTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PlantCommonShaftEvidenceTest.java
@@ -1,0 +1,265 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.compressor.CompressorDriver;
+import neqsim.process.equipment.compressor.DriverType;
+import neqsim.process.equipment.energy.Gearbox;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+
+/** Engineering acceptance tests for immutable common-shaft evidence. */
+class PlantCommonShaftEvidenceTest {
+  private static final String CALCULATION_ID = "8b8533a7-65a8-4ca1-a62d-5f2d4c6b8e10";
+
+  @Test
+  void completeTrainExposesSpeedPowerTorqueAndCasingMapEvidence() throws Exception {
+    TrainFixture fixture = trainFixture(800.0, 900.0);
+    PlantCommonShaftEvidence evidence = fixture.evidence(400.0, 350.0, 10000.0, 0.12, 0.18, 0.08, 0.21, true);
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertTrue(evidence.isFeasible());
+    assertEquals(2, evidence.getCasings().size());
+    assertEquals(750.0, evidence.getTotalCasingPowerKw(), 1.0e-12);
+    assertEquals(760.0, evidence.getTotalShaftLoadKw(), 1.0e-12);
+    assertEquals(760.0 / 0.98, evidence.getGearboxInputPowerKw(), 1.0e-12);
+    assertEquals(10000.0, evidence.getDriverSpeedRpm(), 0.0);
+    assertEquals(760000.0 / (10000.0 * 2.0 * Math.PI / 60.0), evidence.getShaftTorqueNm(), 1.0e-10);
+    assertEquals(9, evidence.getDefinitions().size());
+    assertEquals(9, evidence.getSamples().size());
+    assertTrue(evidence.toPlantUtilizationSnapshot().isComplete());
+
+    JsonObject json = JsonParser.parseString(evidence.toJson()).getAsJsonObject();
+    assertEquals("1.0", json.get("schemaVersion").getAsString());
+    assertEquals("AVAILABLE", json.get("status").getAsString());
+    assertEquals(2, json.getAsJsonArray("casings").size());
+    assertTrue(json.getAsJsonObject("utilizationSnapshot").get("complete").getAsBoolean());
+
+    PlantCommonShaftEvidence restored = roundTrip(evidence);
+    assertNotSame(evidence, restored);
+    assertEquals(evidence.toJson(), restored.toJson());
+  }
+
+  @Test
+  void physicalViolationsRemainCompleteAndIdentifyConstraintBottleneck() {
+    TrainFixture fixture = trainFixture(800.0, 700.0);
+    PlantCommonShaftEvidence evidence = fixture.evidence(400.0, 350.0, 10006.0, 0.12, 0.18, -0.03, 0.21, true);
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertFalse(evidence.isFeasible());
+    assertTrue(evidence.getSamples().stream().anyMatch(sample -> sample.getNormalizedResidual() > 0.0));
+    assertTrue(
+        evidence.getCasings().stream().anyMatch(casing -> !casing.isWithinChart() && casing.getMapMargin() < 0.0));
+  }
+
+  @Test
+  void shaftFrictionIsIncludedInPowerBalanceAndCanBecomeBinding() {
+    TrainFixture fixture = trainFixture(755.0, 900.0);
+    PlantCommonShaftEvidence evidence = fixture.evidence(400.0, 350.0, 10000.0, 0.12, 0.18, 0.08, 0.21, true);
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertFalse(evidence.isFeasible());
+    assertEquals(5.0, evidence.getUnmetPowerKw(), 1.0e-12);
+    assertEquals(760.0, evidence.getTotalShaftLoadKw(), 1.0e-12);
+  }
+
+  @Test
+  void explicitlyUnavailableCasingRequiresAndPreservesVerifiedZeroLoad() {
+    TrainFixture fixture = trainFixture(500.0, 900.0);
+    fixture.casingBPort.setRequestedPower(0.0, "kW");
+    fixture.shaft.solveBalance();
+    StubCompressor casingA = new StubCompressor("casing A", 10000.0, 400.0, 0.12, 0.18, true,
+        UUID.fromString(CALCULATION_ID));
+    StubCompressor casingB = new StubCompressor("casing B", 0.0, 0.0, 0.0, 0.0, false, UUID.fromString(CALCULATION_ID));
+
+    PlantCommonShaftEvidence evidence = PlantCommonShaftEvidence
+        .builder("medium production model", "compression", "export train", CALCULATION_ID, fixture.shaft,
+            "completed isolated candidate")
+        .casing(fixture.casingAPort.getParticipantId(), casingA)
+        .casing(fixture.casingBPort.getParticipantId(), casingB, true)
+        .driver(fixture.driverPort.getParticipantId(), fixture.driver).gearbox("gearbox-1", fixture.gearbox)
+        .speedToleranceRpm(1.0).powerBalanceToleranceKw(1.0e-6).maximumTorqueNm(800.0).convergenceComplete(true)
+        .build();
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertTrue(evidence.getCasings().stream()
+        .anyMatch(casing -> casing.getStatus() == PlantCommonShaftEvidence.CasingStatus.OUT_OF_SERVICE));
+    assertEquals(400.0, evidence.getTotalCasingPowerKw(), 1.0e-12);
+  }
+
+  @Test
+  void staleChartlessUnexpectedAndUnconvergedPathsFailClosedWithJsonNulls() {
+    TrainFixture fixture = trainFixture(800.0, 900.0);
+    EnergyPort unexpected = port("unexpected", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, fixture.shaft);
+    unexpected.setRequestedPower(1.0, "kW");
+    fixture.shaft.solveBalance();
+
+    PlantCommonShaftEvidence evidence = fixture.evidenceWithCalculationIds(400.0, 350.0, 10000.0, UUID.randomUUID(),
+        UUID.fromString(CALCULATION_ID), false, false);
+
+    assertFalse(evidence.isComplete());
+    assertFalse(evidence.isFeasible());
+    assertTrue(evidence.getDiagnostics().stream().anyMatch(value -> value.contains("UNEXPECTED_SHAFT_PARTICIPANT")));
+    assertTrue(evidence.getDiagnostics().stream().anyMatch(value -> value.contains("STALE")));
+    assertTrue(evidence.getDiagnostics().stream().anyMatch(value -> value.contains("NO_CHART")));
+    assertTrue(evidence.getDiagnostics().contains("INCOMPLETE_CONVERGENCE"));
+    JsonObject json = JsonParser.parseString(evidence.toJson()).getAsJsonObject();
+    assertTrue(json.get("totalCasingPowerKw").isJsonNull());
+    assertTrue(json.getAsJsonArray("casings").get(0).getAsJsonObject().get("shaftPowerKw").isJsonNull());
+    assertFalse(json.getAsJsonObject("utilizationSnapshot").get("complete").getAsBoolean());
+  }
+
+  @Test
+  void changedShaftStateInvalidatesEvidenceUntilBalanceIsSolvedAgain() {
+    TrainFixture fixture = trainFixture(800.0, 900.0);
+    PlantCommonShaftEvidence cold = fixture.evidence(400.0, 350.0, 10000.0, 0.12, 0.18, 0.08, 0.21, true);
+    assertTrue(cold.isComplete());
+
+    fixture.driverPort.setDuty(810.0, "kW");
+    PlantCommonShaftEvidence stale = fixture.evidence(400.0, 350.0, 10000.0, 0.12, 0.18, 0.08, 0.21, true);
+    assertFalse(stale.isComplete());
+    assertTrue(stale.getDiagnostics().contains("SHAFT_SOLUTION_STALE_OR_MISSING"));
+
+    fixture.driverPort.setDuty(800.0, "kW");
+    fixture.shaft.solveBalance();
+    PlantCommonShaftEvidence restored = fixture.evidence(400.0, 350.0, 10000.0, 0.12, 0.18, 0.08, 0.21, true);
+    assertTrue(restored.isComplete(), restored.getDiagnostics().toString());
+    assertEquals(cold.toJson(), restored.toJson());
+  }
+
+  private static PlantCommonShaftEvidence roundTrip(PlantCommonShaftEvidence evidence) throws Exception {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(buffer)) {
+      output.writeObject(evidence);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      return (PlantCommonShaftEvidence) input.readObject();
+    }
+  }
+
+  private static TrainFixture trainFixture(double driverSupplyKw, double gearboxLimitKw) {
+    MechanicalShaft shaft = new MechanicalShaft("export compression shaft");
+    shaft.setSpeed(10000.0);
+    shaft.setMaximumSpeed(12000.0);
+    shaft.setFrictionLoss(10.0e3);
+    EnergyPort driver = port("driver", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, shaft);
+    driver.setDuty(driverSupplyKw, "kW");
+    EnergyPort casingA = port("casing-a", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    casingA.setRequestedPower(400.0, "kW");
+    EnergyPort casingB = port("casing-b", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    casingB.setRequestedPower(350.0, "kW");
+    shaft.solveBalance();
+
+    CompressorDriver driverModel = new CompressorDriver(DriverType.ELECTRIC_MOTOR, 900.0);
+    driverModel.setMinSpeed(8000.0);
+    driverModel.setMaxSpeed(12000.0);
+    Gearbox gearbox = new Gearbox("train gearbox");
+    gearbox.setEfficiency(0.98);
+    gearbox.setSpeedRatio(1.0);
+    gearbox.setMaximumInputPower(gearboxLimitKw * 1000.0);
+    return new TrainFixture(shaft, driver, casingA, casingB, driverModel, gearbox);
+  }
+
+  private static EnergyPort port(String name, EnergyPortDirection direction, EnergyPortMode mode,
+      MechanicalShaft shaft) {
+    EnergyPort port = new EnergyPort(name, EnergyType.SHAFT_WORK, direction, mode);
+    port.connect(shaft);
+    return port;
+  }
+
+  private static final class TrainFixture {
+    private final MechanicalShaft shaft;
+    private final EnergyPort driverPort;
+    private final EnergyPort casingAPort;
+    private final EnergyPort casingBPort;
+    private final CompressorDriver driver;
+    private final Gearbox gearbox;
+
+    private TrainFixture(MechanicalShaft shaft, EnergyPort driverPort, EnergyPort casingAPort, EnergyPort casingBPort,
+        CompressorDriver driver, Gearbox gearbox) {
+      this.shaft = shaft;
+      this.driverPort = driverPort;
+      this.casingAPort = casingAPort;
+      this.casingBPort = casingBPort;
+      this.driver = driver;
+      this.gearbox = gearbox;
+    }
+
+    private PlantCommonShaftEvidence evidence(double casingAKw, double casingBKw, double casingBSpeedRpm,
+        double casingASurge, double casingAStonewall, double casingBSurge, double casingBStonewall,
+        boolean convergenceComplete) {
+      return evidenceWithCalculationIds(casingAKw, casingBKw, casingBSpeedRpm, UUID.fromString(CALCULATION_ID),
+          UUID.fromString(CALCULATION_ID), true, convergenceComplete, casingASurge, casingAStonewall, casingBSurge,
+          casingBStonewall);
+    }
+
+    private PlantCommonShaftEvidence evidenceWithCalculationIds(double casingAKw, double casingBKw,
+        double casingBSpeedRpm, UUID casingACalculationId, UUID casingBCalculationId, boolean casingBChartActive,
+        boolean convergenceComplete) {
+      return evidenceWithCalculationIds(casingAKw, casingBKw, casingBSpeedRpm, casingACalculationId,
+          casingBCalculationId, casingBChartActive, convergenceComplete, 0.12, 0.18, 0.08, 0.21);
+    }
+
+    private PlantCommonShaftEvidence evidenceWithCalculationIds(double casingAKw, double casingBKw,
+        double casingBSpeedRpm, UUID casingACalculationId, UUID casingBCalculationId, boolean casingBChartActive,
+        boolean convergenceComplete, double casingASurge, double casingAStonewall, double casingBSurge,
+        double casingBStonewall) {
+      StubCompressor casingA = new StubCompressor("casing A", 10000.0, casingAKw, casingASurge, casingAStonewall, true,
+          casingACalculationId);
+      StubCompressor casingB = new StubCompressor("casing B", casingBSpeedRpm, casingBKw, casingBSurge,
+          casingBStonewall, casingBChartActive, casingBCalculationId);
+      return PlantCommonShaftEvidence
+          .builder("medium production model", "compression", "export train", CALCULATION_ID, shaft,
+              "completed isolated candidate")
+          .casing(casingAPort.getParticipantId(), casingA).casing(casingBPort.getParticipantId(), casingB)
+          .driver(driverPort.getParticipantId(), driver).gearbox("gearbox-1", gearbox).speedToleranceRpm(1.0)
+          .powerBalanceToleranceKw(1.0e-6).maximumTorqueNm(800.0).convergenceComplete(convergenceComplete).build();
+    }
+  }
+
+  private static final class StubCompressor extends Compressor {
+    private static final long serialVersionUID = 1L;
+    private final Map<String, Object> operatingPoint;
+
+    private StubCompressor(String name, double speedRpm, double powerKw, double distanceToSurge,
+        double distanceToStoneWall, boolean chartActive, UUID calculationId) {
+      super(name);
+      operatingPoint = new LinkedHashMap<String, Object>();
+      operatingPoint.put("speed_rpm", speedRpm);
+      operatingPoint.put("power_kW", powerKw);
+      operatingPoint.put("chartActive", chartActive);
+      operatingPoint.put("withinChart", distanceToSurge >= 0.0 && distanceToStoneWall >= 0.0);
+      operatingPoint.put("distanceToSurge", distanceToSurge);
+      operatingPoint.put("distanceToStoneWall", distanceToStoneWall);
+      operatingPoint.put("limitingConstraint", "compressor map");
+      setCalculationIdentifier(calculationId);
+    }
+
+    @Override
+    public boolean solved() {
+      return true;
+    }
+
+    @Override
+    public Map<String, Object> getOperatingPoint() {
+      return new LinkedHashMap<String, Object>(operatingPoint);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3154 roadmap criterion 4 with immutable, fail-closed common-shaft compressor-train evidence.

- freezes one already solved `MechanicalShaft` plus the declared `CompressorDriver`, `Gearbox`, and every casing operating point
- emits separate constraint rows for common speed, shaft speed, shaft power balance, driver speed/power, gearbox input power, shaft torque, and each casing map margin
- requires exact shaft participant coverage and current calculation identity
- reports unavailable values as Java `NaN` and JSON `null`, never zero utilization
- preserves complete-but-infeasible evidence for real speed, power, torque, gearbox, and map-limit violations
- retains no mutable process, shaft, driver, gearbox, compressor, callback, or supplier reference

## Capability contract

**Engineering question:** Can a completed multi-casing train be accepted or rejected from one deterministic evidence snapshot without inventing machine physics or hiding missing coverage?

**Current to target maturity:** Existing shaft, driver, gearbox, and compressor-map calculations were composable/calculation-only. This batch adds optimizer-qualified evidence for one explicitly declared steady-state train scope.

**Exact baseline:** `fdaebb7306d3cacb799a6ac6726d103c9520eb21`  
**Published head:** `54a8b9c6f19335850b5c3bf8c4aac38c2ec6c59d`

**Java authority and views:** `PlantCommonShaftEvidence` samples the current public `MechanicalShaft` allocation report, `CompressorDriver` limits, `Gearbox` configuration, and `Compressor.getOperatingPoint()`. Its callback-free builder, Java serialization, `toPlantUtilizationSnapshot()`, and standards-compliant `toJson()` expose the same frozen evidence to Java and JPype callers.

**Inputs, units, basis, provenance and validity:**

- shaft/casing/driver speed: rpm
- casing, shaft, driver, gearbox power: kW; gearbox rating remains configured in W
- shaft torque: N m from `power / angular speed`
- casing map margin: dimensionless minimum signed surge/stonewall distance
- gearbox input uses the configured efficiency and idle loss
- driver speed uses the configured output-to-input gearbox ratio
- maximum torque and all tolerances are explicit caller-owned inputs
- each casing must be solved under the exact UUID calculation identity and have an active finite map observation
- provenance is caller-supplied and retained in definitions, samples, casing rows, and JSON

**Fail-closed acceptance:** stale/missing bus solution, unexpected or missing participants, external shaft supply/demand, mismatched casing power, stale calculation identity, chartless/non-finite casing, unknown ratings, shaft/gearbox trip, or incomplete convergence makes the snapshot incomplete. Explicitly unavailable casings require verified zero requested and observed load.

**Compatibility:** additive Java 8 API; deterministic ordering; immutable serializable evidence; no existing process, equipment, map, solver, tolerance, or default behavior changes.

**Stop boundary:** no new compressor/driver/gearbox physics, anti-surge orchestration, dynamic behavior, candidate mutation/restoration, generic execution/caching/allocation (#2939), flash/column/pipeline internals, or MCP exposure (#3153).

## Engineering acceptance

The focused deterministic two-casing fixture verifies:

- 400 + 350 = **750 kW** casing shaft load
- **760 kW** total shaft load including 10 kW configured friction
- **775.5102040816327 kW** required gearbox input at 0.98 efficiency
- **725.7465406141296 N m** shaft torque at 10,000 rpm
- friction-induced 5 kW power shortfall is detected even when the underlying bus has served its participant demand
- a finite outside-map point and speed/gearbox violations remain complete but infeasible
- stale, chartless, unexpected-participant and unconverged paths are incomplete
- explicit zero-load out-of-service casing handling with its map constraint retained as disabled
- contradictory `withinChart` flags and signed map margins fail closed
- changed shaft state invalidates evidence; exact restoration reproduces byte-identical JSON
- Java serialization round-trip and JSON `null` for unavailable numbers

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local validation from the exact published files:

- Maven bootstrap through the required `work-with-neqsim` helper: passed
- `PlantCommonShaftEvidenceTest`: 7/7 passed
- adjacent matrix `PlantCommonShaftEvidenceTest, PlantUtilizationSnapshotTest, PlantSharedResourceEvidenceTest, EnergyBusTest, EnergyBusAllocationTest, EnergyBusDispatchStrategyTest`: passed
- direct Spotless apply/check: passed
- documentation-search audit: passed (693 Markdown pages and one standalone HTML page)
- Maven Javadocs: passed using an environment-only launcher for the runtime's installed `jdk.javadoc` module
- `git diff --check`: passed
- local `pre-commit` executable was absent; task-local installation was blocked by transient network approval, so no local pre-commit result is claimed

Hosted Java 8/21, full tests, Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, and repository-policy checks remain authoritative.

## Documentation impact

Updated:

- Capacity Constraint Framework: common-shaft evidence contract and failure semantics
- Production Optimization Guide: executable Java/JPype-friendly builder workflow
- Energy Streams: optimizer-acceptance boundary for `MechanicalShaft`
- Industrial optimization baseline: roadmap criterion 4 status and remaining dependencies

No notebook is changed. The historical 27-unit S/M fixture remains compatibility evidence only; this PR makes no generic performance or full 150-unit L-case claim.

Keep this PR draft-only. Do not merge, mark ready, enable auto-merge, rebase, force-push, close, replace, or abandon it for capacity.