### PR TITLE
[AI-Assisted] style: fix shared UMR-PRU Spotless failure

### DIFF
--- a/src/test/java/neqsim/thermodynamicoperations/flashops/UMRPRUGroupTableFlashQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/UMRPRUGroupTableFlashQualificationTest.java
@@ -11,13 +11,13 @@ import neqsim.thermo.system.SystemUMRPRUMCEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
- * Qualification of TP-flash lifecycle behavior for component families added to the maintained
- * UMR-PRU UNIFAC group table.
+ * Qualification of TP-flash lifecycle behavior for component families added to the maintained UMR-PRU UNIFAC group
+ * table.
  *
  * <p>
- * The fluids are synthetic numerical regressions. They verify that newly resolvable aromatic,
- * cyclic, hydrogen/inert, and substituted-naphthene mixtures remain finite and conservative; they
- * are not independent parameter or experimental PVT validation.
+ * The fluids are synthetic numerical regressions. They verify that newly resolvable aromatic, cyclic, hydrogen/inert,
+ * and substituted-naphthene mixtures remain finite and conservative; they are not independent parameter or experimental
+ * PVT validation.
  * </p>
  */
 class UMRPRUGroupTableFlashQualificationTest {
@@ -26,16 +26,14 @@ class UMRPRUGroupTableFlashQualificationTest {
   private static final double FUGACITY_TOLERANCE = 1.0e-8;
 
   private static final FluidCase[] CASES = {
-      new FluidCase("aromatic-heavy", 298.15, 10.0, new String[] {"methane", "propylbenzene"},
-          new double[] {0.90, 0.10}),
-      new FluidCase("cyclic-light", 285.15, 20.0, new String[] {"methane", "c-propane", "c-C4"},
-          new double[] {0.80, 0.10, 0.10}),
-      new FluidCase("hydrogen-inert", 280.15, 50.0,
-          new String[] {"hydrogen", "argon", "methane", "n-hexane"},
-          new double[] {0.10, 0.02, 0.83, 0.05}),
-      new FluidCase("substituted-naphthene", 310.15, 15.0,
-          new String[] {"methane", "n-Bcychexane", "Pent-CC6"},
-          new double[] {0.80, 0.10, 0.10})};
+      new FluidCase("aromatic-heavy", 298.15, 10.0, new String[] { "methane", "propylbenzene" },
+          new double[] { 0.90, 0.10 }),
+      new FluidCase("cyclic-light", 285.15, 20.0, new String[] { "methane", "c-propane", "c-C4" },
+          new double[] { 0.80, 0.10, 0.10 }),
+      new FluidCase("hydrogen-inert", 280.15, 50.0, new String[] { "hydrogen", "argon", "methane", "n-hexane" },
+          new double[] { 0.10, 0.02, 0.83, 0.05 }),
+      new FluidCase("substituted-naphthene", 310.15, 15.0, new String[] { "methane", "n-Bcychexane", "Pent-CC6" },
+          new double[] { 0.80, 0.10, 0.10 }) };
 
   /** Ordinary, multiphase, and deliberately poor beta estimates must agree at nominal states. */
   @Test
@@ -68,8 +66,8 @@ class UMRPRUGroupTableFlashQualificationTest {
       reused.setTemperature(testCase.temperatureK + 1.0);
       reused.setPressure(testCase.pressureBara * 1.02, "bara");
       flash(reused);
-      SystemInterface freshChanged =
-          flash(testCase.create(testCase.temperatureK + 1.0, testCase.pressureBara * 1.02, true));
+      SystemInterface freshChanged = flash(
+          testCase.create(testCase.temperatureK + 1.0, testCase.pressureBara * 1.02, true));
       assertEquivalentState(freshChanged, reused, 1.0e-8, testCase.name + " changed state");
 
       reused.setTemperature(testCase.temperatureK);
@@ -111,16 +109,14 @@ class UMRPRUGroupTableFlashQualificationTest {
             label + " composition " + phase + "/" + component);
         compositionTotal += composition;
       }
-      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE,
-          label + " composition normalization " + phase);
+      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE, label + " composition normalization " + phase);
       assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0,
           label + " compressibility " + phase);
     }
     assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
 
     double materialResidual = maximumComponentMaterialBalanceResidual(system);
-    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
-        label + " material-balance residual " + materialResidual);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE, label + " material-balance residual " + materialResidual);
 
     if (system.getNumberOfPhases() == 1) {
       assertEquals(1.0, system.getBeta(0), NORMALIZATION_TOLERANCE, label + " single-phase beta");
@@ -131,16 +127,14 @@ class UMRPRUGroupTableFlashQualificationTest {
       }
     } else {
       double fugacityResidual = maximumComparableLogFugacityResidual(system);
-      assertTrue(fugacityResidual < FUGACITY_TOLERANCE,
-          label + " fugacity residual " + fugacityResidual);
+      assertTrue(fugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + fugacityResidual);
     }
 
     assertTrue(Double.isFinite(system.getGibbsEnergy()), label + " Gibbs energy");
     assertTrue(Double.isFinite(system.getEnthalpy()), label + " enthalpy");
   }
 
-  private void assertEquivalentState(SystemInterface expected, SystemInterface actual,
-      double tolerance, String label) {
+  private void assertEquivalentState(SystemInterface expected, SystemInterface actual, double tolerance, String label) {
     assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases(), label + " phase count");
     assertClosedState(expected, label + " expected");
     assertClosedState(actual, label + " actual");
@@ -148,25 +142,20 @@ class UMRPRUGroupTableFlashQualificationTest {
     for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
       PhaseType type = expected.getPhase(expectedPhase).getType();
       int actualPhase = findPhase(actual, type);
-      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
-          label + " beta " + type);
-      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(),
-          tolerance, label + " compressibility " + type);
-      for (int component = 0;
-          component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance, label + " beta " + type);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), tolerance,
+          label + " compressibility " + type);
+      for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
         assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
             actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
             label + " composition " + type + "/" + component);
       }
     }
-    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance,
-        label + " Gibbs energy");
-    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance,
-        label + " enthalpy");
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance, label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance, label + " enthalpy");
   }
 
-  private void assertExtensiveEquals(double expected, double actual, double relativeTolerance,
-      String label) {
+  private void assertExtensiveEquals(double expected, double actual, double relativeTolerance, String label) {
     assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
   }
 
@@ -181,8 +170,7 @@ class UMRPRUGroupTableFlashQualificationTest {
 
   private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
     double maximumResidual = 0.0;
-    for (int component = 0;
-        component < system.getPhase(0).getNumberOfComponents(); component++) {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       double recovered = 0.0;
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
         recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
@@ -196,23 +184,17 @@ class UMRPRUGroupTableFlashQualificationTest {
   private double maximumComparableLogFugacityResidual(SystemInterface system) {
     double maximumResidual = 0.0;
     int comparisons = 0;
-    for (int component = 0;
-        component < system.getPhase(0).getNumberOfComponents(); component++) {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       for (int firstPhase = 0; firstPhase < system.getNumberOfPhases(); firstPhase++) {
-        for (int secondPhase = firstPhase + 1; secondPhase < system.getNumberOfPhases();
-            secondPhase++) {
+        for (int secondPhase = firstPhase + 1; secondPhase < system.getNumberOfPhases(); secondPhase++) {
           double firstComposition = system.getPhase(firstPhase).getComponent(component).getx();
           double secondComposition = system.getPhase(secondPhase).getComponent(component).getx();
-          double firstCoefficient =
-              system.getPhase(firstPhase).getComponent(component).getFugacityCoefficient();
-          double secondCoefficient =
-              system.getPhase(secondPhase).getComponent(component).getFugacityCoefficient();
-          if (firstComposition > 1.0e-20 && secondComposition > 1.0e-20
-              && Double.isFinite(firstCoefficient) && firstCoefficient > 0.0
-              && Double.isFinite(secondCoefficient) && secondCoefficient > 0.0) {
-            maximumResidual = Math.max(maximumResidual,
-                Math.abs(Math.log(firstComposition * firstCoefficient)
-                    - Math.log(secondComposition * secondCoefficient)));
+          double firstCoefficient = system.getPhase(firstPhase).getComponent(component).getFugacityCoefficient();
+          double secondCoefficient = system.getPhase(secondPhase).getComponent(component).getFugacityCoefficient();
+          if (firstComposition > 1.0e-20 && secondComposition > 1.0e-20 && Double.isFinite(firstCoefficient)
+              && firstCoefficient > 0.0 && Double.isFinite(secondCoefficient) && secondCoefficient > 0.0) {
+            maximumResidual = Math.max(maximumResidual, Math
+                .abs(Math.log(firstComposition * firstCoefficient) - Math.log(secondComposition * secondCoefficient)));
             comparisons++;
           }
         }
@@ -229,8 +211,7 @@ class UMRPRUGroupTableFlashQualificationTest {
     private final String[] components;
     private final double[] moles;
 
-    private FluidCase(String name, double temperatureK, double pressureBara, String[] components,
-        double[] moles) {
+    private FluidCase(String name, double temperatureK, double pressureBara, String[] components, double[] moles) {
       this.name = name;
       this.temperatureK = temperatureK;
       this.pressureBara = pressureBara;


### PR DESCRIPTION
The Spotless failure reported on #3558 comes from `UMRPRUGroupTableFlashQualificationTest.java`, which is already on `master` and is included in GitHub's temporary PR merge checkout. The same upstream formatting violation also affects other open PRs.

This applies the repository's Eclipse formatter to that single test file. Java tokens, string literals, assertions, tolerances, test inputs, and normalized comment text are unchanged. Merge this fix into `master` to remove the shared formatting blocker.

Validation on exact base `feccfa7791d23437670f6192c0d18be9b6a12567` with NeqSim 3.19.0, OpenJDK 17, and the configured primary Python runtime:

- Maven prepared with the work-with-neqsim `scripts/prepare_maven.py` helper.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py check` before repair — exit 1; reproduced the reported single-file violation.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py apply` — exit 0; exactly one intended file changed.
- Repeated the apply command — exit 0; file blob unchanged.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py check` after repair — exit 0.
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/check_documentation_search.py` — exit 0; 693 Markdown pages and 1 standalone HTML page audited.
- `git diff --check` — exit 0.
- Compared Java tokens, exact literals, and normalized comment text against the original — identical.
- Local `pre-commit` is unavailable; direct formatting and documentation gates passed.
- Numerical tests were not rerun for this formatting-only change.

Documentation impact: none. The adjacent TP-flash lifecycle guide and test Javadocs retain the same inputs, acceptance criteria, and validity boundaries.

**VALIDATION PENDING CI.** Draft PR; no merge or auto-merge requested.