### PR TITLE
feat(refinery): add reusable Sarir atmospheric case factory

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -258,6 +258,32 @@ assay.apply();
 traceability. Profile validation completes before existing assay data or thermodynamic
 components are modified.
 
+## Reusable 34-tray case factory
+
+`SarirAtmosphericFractionationCase.create(...)` promotes the qualified sensitivity setup into a
+reusable Java and Python/JPype entry point. It returns the configured crude feed and an unsolved
+`DistillationColumn`, allowing callers to execute, inspect, or extend the case without copying the
+source-to-model tray mapping.
+
+The factory reads only the published 34-valve-tray count, tray-31-from-the-top feed location,
+54,420 kg/h crude rate, 350 degC feed temperature, and 233 kPa absolute feed pressure from
+`SarirAtmosphericReference`. The source tray maps to NeqSim simple-tray index 4 because the
+library numbers simple trays from the bottom and reserves index 0 for the reboiler.
+
+Every unreported property or operating choice remains explicit. Callers must supply 18 cut specific
+gravities, 18 cut molar masses, top and bottom pressures, reboiler temperature, condenser reflux
+ratio, and both liquid side-draw tray indices and fractions. The operating-input object rejects
+non-finite pressures, temperatures, reflux, or fractions; an inverted pressure profile; fractions
+outside [0, 1); the feed tray as a side draw; and a kerosene screen draw at or below the heavier
+diesel screen draw. The existing `SarirAtmosphericAssay` bulk-density and average-molar-mass gates
+remain authoritative for the property profiles.
+
+The returned column uses the qualified MESH-residual numerical controls, but it is intentionally
+unsolved. Steam services, side strippers, pump-arounds, tray efficiencies, and source product rates
+are not configured. In particular, the factory does not tune either side-draw fraction to the
+published plant or HYSYS yields, and creating or solving the case is not evidence of product-yield
+or D86 agreement.
+
 ## Scientific boundary
 
 The source-derived volumes, boiling boundaries, and product-specification rows are reproducible,

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
@@ -1,0 +1,256 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.characterization.SarirAtmosphericAssay;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Reusable, source-bounded atmospheric-fractionation case for the public Sarir refinery reference.
+ *
+ * <p>
+ * The factory derives the published crude-feed rate, temperature, pressure, valve-tray count, and
+ * top-counted feed-tray location from {@link SarirAtmosphericReference}. The source does not publish
+ * per-cut density or molar-mass profiles, endpoint controls, or side-draw locations and fractions,
+ * so callers must provide every one of those values explicitly.
+ * </p>
+ *
+ * <p>
+ * Steam, side strippers, pump-arounds, tray efficiencies, and published plant product rates are not
+ * configured. The returned objects are an executable engineering case, not a reproduction or
+ * calibration of the source plant.
+ * </p>
+ */
+public final class SarirAtmosphericFractionationCase {
+  /** Number of simple trays reported for the atmospheric column. */
+  public static final int SIMPLE_TRAY_COUNT = 34;
+
+  /** NeqSim bottom-up simple-tray index corresponding to source tray 31 from the top. */
+  public static final int FEED_INTERNAL_INDEX = 4;
+
+  private static final double MASS_BALANCE_TOLERANCE = 5.0e-2;
+  private static final double ENTHALPY_BALANCE_TOLERANCE = 5.0e-2;
+  private static final double TEMPERATURE_TOLERANCE_KELVIN = 0.20;
+  private static final double RELAXATION_FACTOR = 0.30;
+  private static final int MAXIMUM_ITERATION_COUNT = 600;
+
+  private final Stream feedStream;
+  private final DistillationColumn column;
+
+  private SarirAtmosphericFractionationCase(Stream feedStream, DistillationColumn column) {
+    this.feedStream = feedStream;
+    this.column = column;
+  }
+
+  /**
+   * Create an executable Sarir atmospheric-fractionation case.
+   *
+   * <p>
+   * Profile validation is delegated to {@link SarirAtmosphericAssay}, including the gates against
+   * the published whole-crude density and average molar mass. No column solve is performed.
+   * </p>
+   *
+   * @param name non-blank case name
+   * @param cutSpecificGravity specific gravity for each of the 18 source-derived cuts
+   * @param cutMolarMassKgPerMol molar mass for each cut, in kg/mol
+   * @param operatingInputs explicit unreported endpoint and side-draw engineering inputs
+   * @return configured feed and column case
+   * @throws NullPointerException if {@code operatingInputs} is {@code null}
+   * @throws IllegalArgumentException if the name, profiles, or operating inputs are invalid
+   */
+  public static SarirAtmosphericFractionationCase create(String name, double[] cutSpecificGravity,
+      double[] cutMolarMassKgPerMol, OperatingInputs operatingInputs) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case name must be non-blank");
+    }
+    Objects.requireNonNull(operatingInputs, "operatingInputs");
+
+    int sourceTrayCount = SarirAtmosphericReference.getColumnTrayCount();
+    int sourceFeedTrayFromTop = SarirAtmosphericReference.getFeedTrayFromTop();
+    int feedInternalIndex = sourceTrayCount - sourceFeedTrayFromTop + 1;
+    if (sourceTrayCount != SIMPLE_TRAY_COUNT || feedInternalIndex != FEED_INTERNAL_INDEX) {
+      throw new IllegalStateException("Sarir source tray mapping no longer matches the qualified case");
+    }
+
+    double feedTemperatureKelvin =
+        SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
+    double feedPressureBara = SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0;
+    SystemInterface crude = new SystemSrkEos(feedTemperatureKelvin, feedPressureBara);
+    OilAssayCharacterisation assay =
+        SarirAtmosphericAssay.create(crude, cutSpecificGravity, cutMolarMassKgPerMol);
+    assay.apply();
+    crude.setMixingRule("classic");
+
+    Stream feed = new Stream(name + " feed", crude);
+    feed.setFlowRate(SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(), "kg/hr");
+    feed.setTemperature(feedTemperatureKelvin, "K");
+    feed.setPressure(feedPressureBara, "bara");
+    feed.run();
+
+    DistillationColumn configuredColumn =
+        new DistillationColumn(name + " column", SIMPLE_TRAY_COUNT, true, true);
+    configuredColumn.addFeedStream(feed, FEED_INTERNAL_INDEX);
+    configuredColumn.setTopPressure(operatingInputs.getTopPressureBara());
+    configuredColumn.setBottomPressure(operatingInputs.getBottomPressureBara());
+    configuredColumn.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
+    configuredColumn.getReboiler().setOutTemperature(operatingInputs.getReboilerTemperatureKelvin());
+    configuredColumn.setCondenserRefluxRatio(operatingInputs.getCondenserRefluxRatio());
+    configuredColumn.setLiquidSideDrawFraction(
+        operatingInputs.getKeroseneSideDrawTray(), operatingInputs.getKeroseneSideDrawFraction());
+    configuredColumn.setLiquidSideDrawFraction(
+        operatingInputs.getDieselSideDrawTray(), operatingInputs.getDieselSideDrawFraction());
+
+    configuredColumn.setSolverType(DistillationColumn.SolverType.MESH_RESIDUAL);
+    configuredColumn.setRelaxationFactor(RELAXATION_FACTOR);
+    configuredColumn.setMaxNumberOfIterations(MAXIMUM_ITERATION_COUNT, true);
+    configuredColumn.setTemperatureTolerance(TEMPERATURE_TOLERANCE_KELVIN);
+    configuredColumn.setMassBalanceTolerance(MASS_BALANCE_TOLERANCE);
+    configuredColumn.setEnthalpyBalanceTolerance(ENTHALPY_BALANCE_TOLERANCE);
+    configuredColumn.setEnforceEnergyBalanceTolerance(true);
+
+    return new SarirAtmosphericFractionationCase(feed, configuredColumn);
+  }
+
+  /**
+   * Return the configured mutable feed stream.
+   *
+   * @return feed stream at the published Sarir rate, temperature, and pressure
+   */
+  public Stream getFeedStream() {
+    return feedStream;
+  }
+
+  /**
+   * Return the configured mutable atmospheric column.
+   *
+   * @return unsolved 34-simple-tray column
+   */
+  public DistillationColumn getColumn() {
+    return column;
+  }
+
+  /**
+   * Explicit engineering inputs for source-unreported column controls.
+   */
+  public static final class OperatingInputs {
+    private final double topPressureBara;
+    private final double bottomPressureBara;
+    private final double reboilerTemperatureKelvin;
+    private final double condenserRefluxRatio;
+    private final int keroseneSideDrawTray;
+    private final double keroseneSideDrawFraction;
+    private final int dieselSideDrawTray;
+    private final double dieselSideDrawFraction;
+
+    /**
+     * Create validated atmospheric-column engineering controls.
+     *
+     * @param topPressureBara column-top pressure, in bar absolute
+     * @param bottomPressureBara column-bottom pressure, in bar absolute
+     * @param reboilerTemperatureKelvin reboiler outlet temperature, in kelvin
+     * @param condenserRefluxRatio condenser reflux ratio, dimensionless and non-negative
+     * @param keroseneSideDrawTray bottom-up NeqSim tray index for the lighter liquid side draw
+     * @param keroseneSideDrawFraction fraction of tray liquid withdrawn, in [0, 1)
+     * @param dieselSideDrawTray bottom-up NeqSim tray index for the heavier liquid side draw
+     * @param dieselSideDrawFraction fraction of tray liquid withdrawn, in [0, 1)
+     * @throws IllegalArgumentException if a value is non-finite or outside its physical or
+     *         topological domain
+     */
+    public OperatingInputs(double topPressureBara, double bottomPressureBara,
+        double reboilerTemperatureKelvin, double condenserRefluxRatio, int keroseneSideDrawTray,
+        double keroseneSideDrawFraction, int dieselSideDrawTray, double dieselSideDrawFraction) {
+      requireFinitePositive(topPressureBara, "Top pressure");
+      requireFinitePositive(bottomPressureBara, "Bottom pressure");
+      requireFinitePositive(reboilerTemperatureKelvin, "Reboiler temperature");
+      requireFiniteNonNegative(condenserRefluxRatio, "Condenser reflux ratio");
+      requireFraction(keroseneSideDrawFraction, "Kerosene side-draw fraction");
+      requireFraction(dieselSideDrawFraction, "Diesel side-draw fraction");
+      requireSideDrawTray(keroseneSideDrawTray, "Kerosene side-draw tray");
+      requireSideDrawTray(dieselSideDrawTray, "Diesel side-draw tray");
+      if (topPressureBara > bottomPressureBara) {
+        throw new IllegalArgumentException("Top pressure must not exceed bottom pressure");
+      }
+      if (keroseneSideDrawTray <= dieselSideDrawTray) {
+        throw new IllegalArgumentException(
+            "Kerosene side-draw tray must be above the diesel side-draw tray");
+      }
+
+      this.topPressureBara = topPressureBara;
+      this.bottomPressureBara = bottomPressureBara;
+      this.reboilerTemperatureKelvin = reboilerTemperatureKelvin;
+      this.condenserRefluxRatio = condenserRefluxRatio;
+      this.keroseneSideDrawTray = keroseneSideDrawTray;
+      this.keroseneSideDrawFraction = keroseneSideDrawFraction;
+      this.dieselSideDrawTray = dieselSideDrawTray;
+      this.dieselSideDrawFraction = dieselSideDrawFraction;
+    }
+
+    /** @return column-top pressure in bar absolute */
+    public double getTopPressureBara() {
+      return topPressureBara;
+    }
+
+    /** @return column-bottom pressure in bar absolute */
+    public double getBottomPressureBara() {
+      return bottomPressureBara;
+    }
+
+    /** @return reboiler outlet temperature in kelvin */
+    public double getReboilerTemperatureKelvin() {
+      return reboilerTemperatureKelvin;
+    }
+
+    /** @return condenser reflux ratio */
+    public double getCondenserRefluxRatio() {
+      return condenserRefluxRatio;
+    }
+
+    /** @return bottom-up NeqSim tray index for the kerosene screen draw */
+    public int getKeroseneSideDrawTray() {
+      return keroseneSideDrawTray;
+    }
+
+    /** @return fraction of tray liquid withdrawn for the kerosene screen draw */
+    public double getKeroseneSideDrawFraction() {
+      return keroseneSideDrawFraction;
+    }
+
+    /** @return bottom-up NeqSim tray index for the diesel screen draw */
+    public int getDieselSideDrawTray() {
+      return dieselSideDrawTray;
+    }
+
+    /** @return fraction of tray liquid withdrawn for the diesel screen draw */
+    public double getDieselSideDrawFraction() {
+      return dieselSideDrawFraction;
+    }
+
+    private static void requireFinitePositive(double value, String label) {
+      if (!Double.isFinite(value) || !(value > 0.0)) {
+        throw new IllegalArgumentException(label + " must be finite and positive");
+      }
+    }
+
+    private static void requireFiniteNonNegative(double value, String label) {
+      if (!Double.isFinite(value) || value < 0.0) {
+        throw new IllegalArgumentException(label + " must be finite and non-negative");
+      }
+    }
+
+    private static void requireFraction(double value, String label) {
+      if (!Double.isFinite(value) || value < 0.0 || value >= 1.0) {
+        throw new IllegalArgumentException(label + " must be finite and in [0, 1)");
+      }
+    }
+
+    private static void requireSideDrawTray(int tray, String label) {
+      if (tray <= 0 || tray > SIMPLE_TRAY_COUNT || tray == FEED_INTERNAL_INDEX) {
+        throw new IllegalArgumentException(
+            label + " must be a simple-tray index distinct from the feed tray");
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
@@ -12,16 +12,15 @@ import neqsim.thermo.system.SystemSrkEos;
  * Reusable, source-bounded atmospheric-fractionation case for the public Sarir refinery reference.
  *
  * <p>
- * The factory derives the published crude-feed rate, temperature, pressure, valve-tray count, and
- * top-counted feed-tray location from {@link SarirAtmosphericReference}. The source does not publish
- * per-cut density or molar-mass profiles, endpoint controls, or side-draw locations and fractions,
- * so callers must provide every one of those values explicitly.
+ * The factory derives the published crude-feed rate, temperature, pressure, valve-tray count, and top-counted feed-tray
+ * location from {@link SarirAtmosphericReference}. The source does not publish per-cut density or molar-mass profiles,
+ * endpoint controls, or side-draw locations and fractions, so callers must provide every one of those values
+ * explicitly.
  * </p>
  *
  * <p>
- * Steam, side strippers, pump-arounds, tray efficiencies, and published plant product rates are not
- * configured. The returned objects are an executable engineering case, not a reproduction or
- * calibration of the source plant.
+ * Steam, side strippers, pump-arounds, tray efficiencies, and published plant product rates are not configured. The
+ * returned objects are an executable engineering case, not a reproduction or calibration of the source plant.
  * </p>
  */
 public final class SarirAtmosphericFractionationCase {
@@ -49,8 +48,8 @@ public final class SarirAtmosphericFractionationCase {
    * Create an executable Sarir atmospheric-fractionation case.
    *
    * <p>
-   * Profile validation is delegated to {@link SarirAtmosphericAssay}, including the gates against
-   * the published whole-crude density and average molar mass. No column solve is performed.
+   * Profile validation is delegated to {@link SarirAtmosphericAssay}, including the gates against the published
+   * whole-crude density and average molar mass. No column solve is performed.
    * </p>
    *
    * @param name non-blank case name
@@ -75,12 +74,10 @@ public final class SarirAtmosphericFractionationCase {
       throw new IllegalStateException("Sarir source tray mapping no longer matches the qualified case");
     }
 
-    double feedTemperatureKelvin =
-        SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
+    double feedTemperatureKelvin = SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
     double feedPressureBara = SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0;
     SystemInterface crude = new SystemSrkEos(feedTemperatureKelvin, feedPressureBara);
-    OilAssayCharacterisation assay =
-        SarirAtmosphericAssay.create(crude, cutSpecificGravity, cutMolarMassKgPerMol);
+    OilAssayCharacterisation assay = SarirAtmosphericAssay.create(crude, cutSpecificGravity, cutMolarMassKgPerMol);
     assay.apply();
     crude.setMixingRule("classic");
 
@@ -90,18 +87,17 @@ public final class SarirAtmosphericFractionationCase {
     feed.setPressure(feedPressureBara, "bara");
     feed.run();
 
-    DistillationColumn configuredColumn =
-        new DistillationColumn(name + " column", SIMPLE_TRAY_COUNT, true, true);
+    DistillationColumn configuredColumn = new DistillationColumn(name + " column", SIMPLE_TRAY_COUNT, true, true);
     configuredColumn.addFeedStream(feed, FEED_INTERNAL_INDEX);
     configuredColumn.setTopPressure(operatingInputs.getTopPressureBara());
     configuredColumn.setBottomPressure(operatingInputs.getBottomPressureBara());
     configuredColumn.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
     configuredColumn.getReboiler().setOutTemperature(operatingInputs.getReboilerTemperatureKelvin());
     configuredColumn.setCondenserRefluxRatio(operatingInputs.getCondenserRefluxRatio());
-    configuredColumn.setLiquidSideDrawFraction(
-        operatingInputs.getKeroseneSideDrawTray(), operatingInputs.getKeroseneSideDrawFraction());
-    configuredColumn.setLiquidSideDrawFraction(
-        operatingInputs.getDieselSideDrawTray(), operatingInputs.getDieselSideDrawFraction());
+    configuredColumn.setLiquidSideDrawFraction(operatingInputs.getKeroseneSideDrawTray(),
+        operatingInputs.getKeroseneSideDrawFraction());
+    configuredColumn.setLiquidSideDrawFraction(operatingInputs.getDieselSideDrawTray(),
+        operatingInputs.getDieselSideDrawFraction());
 
     configuredColumn.setSolverType(DistillationColumn.SolverType.MESH_RESIDUAL);
     configuredColumn.setRelaxationFactor(RELAXATION_FACTOR);
@@ -159,9 +155,9 @@ public final class SarirAtmosphericFractionationCase {
      * @throws IllegalArgumentException if a value is non-finite or outside its physical or
      *         topological domain
      */
-    public OperatingInputs(double topPressureBara, double bottomPressureBara,
-        double reboilerTemperatureKelvin, double condenserRefluxRatio, int keroseneSideDrawTray,
-        double keroseneSideDrawFraction, int dieselSideDrawTray, double dieselSideDrawFraction) {
+    public OperatingInputs(double topPressureBara, double bottomPressureBara, double reboilerTemperatureKelvin,
+        double condenserRefluxRatio, int keroseneSideDrawTray, double keroseneSideDrawFraction, int dieselSideDrawTray,
+        double dieselSideDrawFraction) {
       requireFinitePositive(topPressureBara, "Top pressure");
       requireFinitePositive(bottomPressureBara, "Bottom pressure");
       requireFinitePositive(reboilerTemperatureKelvin, "Reboiler temperature");
@@ -174,8 +170,7 @@ public final class SarirAtmosphericFractionationCase {
         throw new IllegalArgumentException("Top pressure must not exceed bottom pressure");
       }
       if (keroseneSideDrawTray <= dieselSideDrawTray) {
-        throw new IllegalArgumentException(
-            "Kerosene side-draw tray must be above the diesel side-draw tray");
+        throw new IllegalArgumentException("Kerosene side-draw tray must be above the diesel side-draw tray");
       }
 
       this.topPressureBara = topPressureBara;
@@ -248,8 +243,7 @@ public final class SarirAtmosphericFractionationCase {
 
     private static void requireSideDrawTray(int tray, String label) {
       if (tray <= 0 || tray > SIMPLE_TRAY_COUNT || tray == FEED_INTERNAL_INDEX) {
-        throw new IllegalArgumentException(
-            label + " must be a simple-tray index distinct from the feed tray");
+        throw new IllegalArgumentException(label + " must be a simple-tray index distinct from the feed tray");
       }
     }
   }

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
@@ -152,8 +152,7 @@ public final class SarirAtmosphericFractionationCase {
      * @param keroseneSideDrawFraction fraction of tray liquid withdrawn, in [0, 1)
      * @param dieselSideDrawTray bottom-up NeqSim tray index for the heavier liquid side draw
      * @param dieselSideDrawFraction fraction of tray liquid withdrawn, in [0, 1)
-     * @throws IllegalArgumentException if a value is non-finite or outside its physical or
-     *         topological domain
+     * @throws IllegalArgumentException if a value is non-finite or outside its physical or topological domain
      */
     public OperatingInputs(double topPressureBara, double bottomPressureBara, double reboilerTemperatureKelvin,
         double condenserRefluxRatio, int keroseneSideDrawTray, double keroseneSideDrawFraction, int dieselSideDrawTray,

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
@@ -1,0 +1,146 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.SarirAtmosphericFractionationCase.OperatingInputs;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+
+/** Qualification tests for {@link SarirAtmosphericFractionationCase}. */
+public class SarirAtmosphericFractionationCaseTest {
+  private static final double[] SPECIFIC_GRAVITY = { 0.641826000, 0.671826000, 0.691826000, 0.711826000,
+      0.741826000, 0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000,
+      0.901826000, 0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
+  private static final double[] MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992,
+      0.272675861324, 0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318,
+      0.495774293317, 0.545351722649, 0.743661439976 };
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+  private static final double MATERIAL_FLOW_FRACTION = 1.0e-8;
+
+  /** Require explicit inputs to build a conservative, ordered, non-fallback column solve. */
+  @Test
+  @Timeout(value = 180, unit = TimeUnit.SECONDS)
+  public void explicitEngineeringInputsCreateQualifiedColumnCase() {
+    OperatingInputs inputs = qualifiedInputs();
+    SarirAtmosphericFractionationCase model = SarirAtmosphericFractionationCase.create(
+        "Sarir public-reference integration", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, inputs);
+    Stream feed = model.getFeedStream();
+    DistillationColumn column = model.getColumn();
+
+    assertEquals(SarirAtmosphericFractionationCase.FEED_INTERNAL_INDEX, column.getFeedTrayNumber(feed));
+    assertEquals(SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(), feed.getFlowRate("kg/hr"), 1.0e-6);
+    assertEquals(SarirAtmosphericReference.getColumnFeedTemperatureCelsius(),
+        feed.getTemperature("C"), 1.0e-9);
+    assertEquals(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0,
+        feed.getPressure("bara"), 1.0e-12);
+
+    assertEquals(1.20, inputs.getTopPressureBara(), 0.0);
+    assertEquals(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0,
+        inputs.getBottomPressureBara(), 0.0);
+    assertEquals(700.0, inputs.getReboilerTemperatureKelvin(), 0.0);
+    assertEquals(1.0, inputs.getCondenserRefluxRatio(), 0.0);
+    assertEquals(24, inputs.getKeroseneSideDrawTray());
+    assertEquals(0.08, inputs.getKeroseneSideDrawFraction(), 0.0);
+    assertEquals(15, inputs.getDieselSideDrawTray());
+    assertEquals(0.15, inputs.getDieselSideDrawFraction(), 0.0);
+
+    column.run(UUID.randomUUID());
+
+    String diagnostics = column.getConvergenceDiagnostics();
+    assertTrue(column.solved(), diagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(), diagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus(), diagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus(), diagnostics);
+    assertTrue(column.getLastIterationCount() <= 600, diagnostics);
+
+    StreamInterface[] products = { column.getGasOutStream(),
+        column.getSideDrawStream(inputs.getKeroseneSideDrawTray(), DistillationColumn.SideDrawPhase.LIQUID),
+        column.getSideDrawStream(inputs.getDieselSideDrawTray(), DistillationColumn.SideDrawPhase.LIQUID),
+        column.getLiquidOutStream() };
+    assertBalancesAndBoilingOrder(column, feed, products);
+  }
+
+  /** Require unreported operating controls and profiles to fail closed. */
+  @Test
+  public void invalidEngineeringInputsAreRejectedBeforeCaseCreation() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new OperatingInputs(2.5, 2.0, 700.0, 1.0, 24, 0.08, 15, 0.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 15, 0.08, 24, 0.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 24, 1.0, 15, 0.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new OperatingInputs(1.2, 2.33, 700.0, Double.NaN, 24, 0.08, 15, 0.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0,
+            SarirAtmosphericFractionationCase.FEED_INTERNAL_INDEX, 0.08, 15, 0.15));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericFractionationCase.create(" ", SPECIFIC_GRAVITY,
+            MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+    assertThrows(NullPointerException.class,
+        () -> SarirAtmosphericFractionationCase.create("Sarir", SPECIFIC_GRAVITY,
+            MOLAR_MASS_KG_PER_MOL, null));
+
+    double[] inconsistentSpecificGravity = SPECIFIC_GRAVITY.clone();
+    inconsistentSpecificGravity[0] += 0.5;
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericFractionationCase.create("Sarir", inconsistentSpecificGravity,
+            MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+  }
+
+  private static OperatingInputs qualifiedInputs() {
+    return new OperatingInputs(1.20,
+        SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0, 700.0, 1.0, 24, 0.08, 15, 0.15);
+  }
+
+  private static void assertBalancesAndBoilingOrder(DistillationColumn column, Stream feed,
+      StreamInterface[] products) {
+    double feedMassFlow = feed.getFlowRate("kg/hr");
+    double productMassFlow = 0.0;
+    double previousBoilingPoint = Double.NEGATIVE_INFINITY;
+    int materialProductCount = 0;
+
+    for (StreamInterface product : products) {
+      double massFlow = product.getFlowRate("kg/hr");
+      assertTrue(Double.isFinite(massFlow) && massFlow >= 0.0);
+      productMassFlow += massFlow;
+      if (massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow) {
+        double meanBoilingPoint = meanNormalBoilingPoint(product);
+        assertTrue(meanBoilingPoint > previousBoilingPoint,
+            "Material products must become heavier from the column top to the bottoms");
+        previousBoilingPoint = meanBoilingPoint;
+        materialProductCount++;
+      }
+    }
+
+    assertTrue(materialProductCount >= 2);
+    assertEquals(feedMassFlow, productMassFlow, BALANCE_TOLERANCE * feedMassFlow);
+    assertTrue(Double.isFinite(column.getMassBalanceError()));
+    assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(Double.isFinite(column.getEnergyBalanceError()));
+    assertTrue(column.getEnergyBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
+        column.getConvergenceDiagnostics());
+  }
+
+  private static double meanNormalBoilingPoint(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    double mean = 0.0;
+    for (int i = 0; i < composition.length; i++) {
+      assertTrue(Double.isFinite(boilingPoints[i]) && boilingPoints[i] > 0.0);
+      mean += composition[i] * boilingPoints[i];
+    }
+    return mean;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
@@ -16,13 +16,13 @@ import neqsim.thermo.characterization.SarirAtmosphericReference;
 
 /** Qualification tests for {@link SarirAtmosphericFractionationCase}. */
 public class SarirAtmosphericFractionationCaseTest {
-  private static final double[] SPECIFIC_GRAVITY = { 0.641826000, 0.671826000, 0.691826000, 0.711826000,
-      0.741826000, 0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000,
-      0.901826000, 0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
+  private static final double[] SPECIFIC_GRAVITY = { 0.641826000, 0.671826000, 0.691826000, 0.711826000, 0.741826000,
+      0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000, 0.901826000,
+      0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
   private static final double[] MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
-      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992,
-      0.272675861324, 0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318,
-      0.495774293317, 0.545351722649, 0.743661439976 };
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992, 0.272675861324,
+      0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318, 0.495774293317, 0.545351722649,
+      0.743661439976 };
   private static final double BALANCE_TOLERANCE = 5.0e-2;
   private static final double MATERIAL_FLOW_FRACTION = 1.0e-8;
 
@@ -31,21 +31,18 @@ public class SarirAtmosphericFractionationCaseTest {
   @Timeout(value = 180, unit = TimeUnit.SECONDS)
   public void explicitEngineeringInputsCreateQualifiedColumnCase() {
     OperatingInputs inputs = qualifiedInputs();
-    SarirAtmosphericFractionationCase model = SarirAtmosphericFractionationCase.create(
-        "Sarir public-reference integration", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, inputs);
+    SarirAtmosphericFractionationCase model = SarirAtmosphericFractionationCase
+        .create("Sarir public-reference integration", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, inputs);
     Stream feed = model.getFeedStream();
     DistillationColumn column = model.getColumn();
 
     assertEquals(SarirAtmosphericFractionationCase.FEED_INTERNAL_INDEX, column.getFeedTrayNumber(feed));
     assertEquals(SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(), feed.getFlowRate("kg/hr"), 1.0e-6);
-    assertEquals(SarirAtmosphericReference.getColumnFeedTemperatureCelsius(),
-        feed.getTemperature("C"), 1.0e-9);
-    assertEquals(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0,
-        feed.getPressure("bara"), 1.0e-12);
+    assertEquals(SarirAtmosphericReference.getColumnFeedTemperatureCelsius(), feed.getTemperature("C"), 1.0e-9);
+    assertEquals(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0, feed.getPressure("bara"), 1.0e-12);
 
     assertEquals(1.20, inputs.getTopPressureBara(), 0.0);
-    assertEquals(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0,
-        inputs.getBottomPressureBara(), 0.0);
+    assertEquals(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0, inputs.getBottomPressureBara(), 0.0);
     assertEquals(700.0, inputs.getReboilerTemperatureKelvin(), 0.0);
     assertEquals(1.0, inputs.getCondenserRefluxRatio(), 0.0);
     assertEquals(24, inputs.getKeroseneSideDrawTray());
@@ -72,35 +69,28 @@ public class SarirAtmosphericFractionationCaseTest {
   /** Require unreported operating controls and profiles to fail closed. */
   @Test
   public void invalidEngineeringInputsAreRejectedBeforeCaseCreation() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new OperatingInputs(2.5, 2.0, 700.0, 1.0, 24, 0.08, 15, 0.15));
-    assertThrows(IllegalArgumentException.class,
-        () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 15, 0.08, 24, 0.15));
-    assertThrows(IllegalArgumentException.class,
-        () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 24, 1.0, 15, 0.15));
+    assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(2.5, 2.0, 700.0, 1.0, 24, 0.08, 15, 0.15));
+    assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 15, 0.08, 24, 0.15));
+    assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 24, 1.0, 15, 0.15));
     assertThrows(IllegalArgumentException.class,
         () -> new OperatingInputs(1.2, 2.33, 700.0, Double.NaN, 24, 0.08, 15, 0.15));
-    assertThrows(IllegalArgumentException.class,
-        () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0,
-            SarirAtmosphericFractionationCase.FEED_INTERNAL_INDEX, 0.08, 15, 0.15));
+    assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0,
+        SarirAtmosphericFractionationCase.FEED_INTERNAL_INDEX, 0.08, 15, 0.15));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> SarirAtmosphericFractionationCase.create(" ", SPECIFIC_GRAVITY,
-            MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericFractionationCase.create(" ", SPECIFIC_GRAVITY,
+        MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
     assertThrows(NullPointerException.class,
-        () -> SarirAtmosphericFractionationCase.create("Sarir", SPECIFIC_GRAVITY,
-            MOLAR_MASS_KG_PER_MOL, null));
+        () -> SarirAtmosphericFractionationCase.create("Sarir", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, null));
 
     double[] inconsistentSpecificGravity = SPECIFIC_GRAVITY.clone();
     inconsistentSpecificGravity[0] += 0.5;
-    assertThrows(IllegalArgumentException.class,
-        () -> SarirAtmosphericFractionationCase.create("Sarir", inconsistentSpecificGravity,
-            MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericFractionationCase.create("Sarir",
+        inconsistentSpecificGravity, MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
   }
 
   private static OperatingInputs qualifiedInputs() {
-    return new OperatingInputs(1.20,
-        SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0, 700.0, 1.0, 24, 0.08, 15, 0.15);
+    return new OperatingInputs(1.20, SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0, 700.0, 1.0, 24, 0.08,
+        15, 0.15);
   }
 
   private static void assertBalancesAndBoilingOrder(DistillationColumn column, Stream feed,


### PR DESCRIPTION
## Summary
- add a reusable Sarir 34-simple-tray atmospheric-fractionation case factory
- preserve the published source-to-NeqSim feed-tray mapping and feed conditions
- require every unpublished cut property, endpoint control, and side-draw control explicitly
- qualify fail-closed inputs plus a rigorous non-fallback mass/energy-conservative solve
- document the provenance and scientific boundary

## Capability contract
This increment promotes the already-qualified Sarir property-profile sensitivity setup into a Java/JPype-accessible factory. It derives only the source-reported tray count, feed tray, crude rate, temperature, and pressure. Caller-supplied cut profiles remain subject to the existing whole-crude density and molar-mass gates.

## Scientific boundary
Source: Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, published 2022-03-31, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), CC BY 4.0.

The source does not publish per-cut densities/molar masses, column endpoint controls, side-draw locations/fractions, steam quality/enthalpy/injection locations, tray efficiencies, or a resolved pump-around tray-numbering basis. Those inputs remain explicit or excluded. Plant and HYSYS yields remain read-only evidence and are not tuning targets or acceptance thresholds.

## Acceptance
- [ ] targeted unit/integration tests
- [ ] Spotless
- [ ] Javadocs
- [ ] pre-commit and documentation checks
- [ ] exact-head full CI matrix

Campaign: #3305

This PR is intentionally draft-only.