### PR TITLE
feat: add acoustic compressibility conversion

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -749,6 +749,29 @@ compare the recorded checksum with the distributed file, audit the permission
 decision, map source groups to real laboratories and apparatus, and pre-register
 acceptance limits before evaluating a holdout.
 
+### Acoustic compressibility conversion
+
+`PitzerBinaryVolumetricAcousticConversion` provides the missing thermodynamic
+bridge for assessing sound-speed evidence without equating isentropic and
+isothermal response:
+
+$$\kappa_S=\frac{1}{\rho c^2},\qquad
+\kappa_T=\kappa_S+\frac{T\alpha^2}{\rho c_p}.$$
+
+Inputs use SI units: temperature in K, density in kg/m3, speed of sound in m/s,
+volumetric thermal expansivity in 1/K, and mass-specific isobaric heat capacity
+in J/(kg K). Compressibilities are returned in 1/Pa. The uncertainty method
+accepts a full 5-by-5 covariance matrix in that input order, checks that it is
+finite, symmetric, and positive semidefinite, and evaluates
+$u^2(\kappa_T)=J\Sigma J^T$ with an analytic sensitivity Jacobian. This retains
+correlations among measurements instead of silently assuming independence.
+
+The conversion does not fill missing density, expansivity, or heat-capacity
+inputs, infer their covariance, fit any coefficient, or activate a density
+model. Acoustic rows therefore remain inadmissible for volumetric-Pitzer
+calibration until every matched property, uncertainty, source lineage, and
+redistribution right passes the campaign provenance gates.
+
 ### Qualification boundary
 
 - The caller owns coefficient provenance and must keep calibration and
@@ -1030,6 +1053,9 @@ component.setCostaldCharacteristicVolume(newValue);  // cm³/mol
 | `PitzerBinaryVolumetricGroupedValidation.validate(...)` | Fit one lineage set and evaluate a disjoint untouched holdout |
 | `PitzerBinaryVolumetricDatasetProvenance.validateRepositoryObservations(...)` | Check role, license, checksum manifest, row count and state envelope |
 | `PitzerBinaryVolumetricGroupedValidation.validateRepositoryDatasets(...)` | Enforce repository provenance before grouped fitting and holdout evaluation |
+| `PitzerBinaryVolumetricAcousticConversion.calculateIsentropicCompressibility(...)` | Convert density and sound speed to isentropic compressibility |
+| `PitzerBinaryVolumetricAcousticConversion.calculateIsothermalCompressibility(...)` | Apply the expansivity and heat-capacity correction in SI units |
+| `PitzerBinaryVolumetricAcousticConversion.convertWithUncertainty(...)` | Propagate a full input covariance through the acoustic conversion |
 
 These methods do not install a parameter dataset or alter a phase. A caller
 must explicitly supply a provenance-qualified `StateParameters` instance.

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricAcousticConversion.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricAcousticConversion.java
@@ -1,0 +1,279 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.linear.EigenDecomposition;
+
+/**
+ * Parameter-neutral conversion of acoustic measurements to volumetric compressibility.
+ *
+ * <p>
+ * Density and speed of sound determine isentropic compressibility. Temperature, volumetric thermal expansivity and
+ * mass-specific isobaric heat capacity supply the thermodynamic correction to isothermal compressibility. This class
+ * only evaluates those identities in SI units; it does not fit or install volumetric Pitzer parameters.
+ * </p>
+ */
+public final class PitzerBinaryVolumetricAcousticConversion {
+  /** Covariance index for temperature in K. */
+  public static final int TEMPERATURE_INDEX = 0;
+  /** Covariance index for density in kg/m3. */
+  public static final int DENSITY_INDEX = 1;
+  /** Covariance index for speed of sound in m/s. */
+  public static final int SOUND_SPEED_INDEX = 2;
+  /** Covariance index for volumetric thermal expansivity in 1/K. */
+  public static final int THERMAL_EXPANSION_INDEX = 3;
+  /** Covariance index for mass-specific isobaric heat capacity in J/(kg K). */
+  public static final int HEAT_CAPACITY_INDEX = 4;
+  /** Number of inputs represented by the covariance matrix and sensitivity Jacobian. */
+  public static final int INPUT_COUNT = 5;
+
+  private static final double COVARIANCE_SYMMETRY_TOLERANCE = 1.0e-12;
+  private static final double CORRELATION_EIGENVALUE_TOLERANCE = 1.0e-10;
+
+  private PitzerBinaryVolumetricAcousticConversion() {
+  }
+
+  /**
+   * Calculate isentropic compressibility from density and speed of sound.
+   *
+   * @param densityKgPerM3 solution density in kg/m3
+   * @param soundSpeedMPerS speed of sound in m/s
+   * @return isentropic compressibility in 1/Pa
+   */
+  public static double calculateIsentropicCompressibility(double densityKgPerM3, double soundSpeedMPerS) {
+    requirePositive(densityKgPerM3, "Density");
+    requirePositive(soundSpeedMPerS, "Speed of sound");
+    double compressibility = 1.0 / (densityKgPerM3 * soundSpeedMPerS * soundSpeedMPerS);
+    requirePositive(compressibility, "Isentropic compressibility");
+    return compressibility;
+  }
+
+  /**
+   * Calculate isothermal compressibility from acoustic and caloric properties.
+   *
+   * @param temperatureK absolute temperature in K
+   * @param densityKgPerM3 solution density in kg/m3
+   * @param soundSpeedMPerS speed of sound in m/s
+   * @param thermalExpansionPerK volumetric thermal expansivity in 1/K
+   * @param specificHeatCapacityJPerKgK mass-specific isobaric heat capacity in J/(kg K)
+   * @return isothermal compressibility in 1/Pa
+   */
+  public static double calculateIsothermalCompressibility(double temperatureK, double densityKgPerM3,
+      double soundSpeedMPerS, double thermalExpansionPerK, double specificHeatCapacityJPerKgK) {
+    validateInputs(temperatureK, densityKgPerM3, soundSpeedMPerS, thermalExpansionPerK, specificHeatCapacityJPerKgK);
+    double isentropicCompressibility = calculateIsentropicCompressibility(densityKgPerM3, soundSpeedMPerS);
+    double isothermalCompressibility = isentropicCompressibility
+        + calculateThermalCorrection(temperatureK, densityKgPerM3, thermalExpansionPerK, specificHeatCapacityJPerKgK);
+    requirePositive(isothermalCompressibility, "Isothermal compressibility");
+    return isothermalCompressibility;
+  }
+
+  /**
+   * Convert acoustic inputs and propagate their full covariance through the analytic Jacobian.
+   *
+   * <p>
+   * Covariance rows and columns must follow the public input-index constants in this class. Entries therefore carry the
+   * products of the corresponding SI input units. The matrix must be finite, symmetric and positive semidefinite.
+   * </p>
+   *
+   * @param temperatureK absolute temperature in K
+   * @param densityKgPerM3 solution density in kg/m3
+   * @param soundSpeedMPerS speed of sound in m/s
+   * @param thermalExpansionPerK volumetric thermal expansivity in 1/K
+   * @param specificHeatCapacityJPerKgK mass-specific isobaric heat capacity in J/(kg K)
+   * @param inputCovariance full 5-by-5 input covariance matrix in the documented order
+   * @return immutable converted values, sensitivities and propagated standard uncertainty
+   */
+  public static ConversionResult convertWithUncertainty(double temperatureK, double densityKgPerM3,
+      double soundSpeedMPerS, double thermalExpansionPerK, double specificHeatCapacityJPerKgK,
+      double[][] inputCovariance) {
+    validateInputs(temperatureK, densityKgPerM3, soundSpeedMPerS, thermalExpansionPerK, specificHeatCapacityJPerKgK);
+    double[][] covariance = validateAndCopyCovariance(inputCovariance);
+
+    double isentropicCompressibility = calculateIsentropicCompressibility(densityKgPerM3, soundSpeedMPerS);
+    double thermalCorrection = calculateThermalCorrection(temperatureK, densityKgPerM3, thermalExpansionPerK,
+        specificHeatCapacityJPerKgK);
+    double isothermalCompressibility = isentropicCompressibility + thermalCorrection;
+    requirePositive(isothermalCompressibility, "Isothermal compressibility");
+
+    double[] jacobian = new double[INPUT_COUNT];
+    jacobian[TEMPERATURE_INDEX] = thermalExpansionPerK * thermalExpansionPerK
+        / (densityKgPerM3 * specificHeatCapacityJPerKgK);
+    jacobian[DENSITY_INDEX] = -isothermalCompressibility / densityKgPerM3;
+    jacobian[SOUND_SPEED_INDEX] = -2.0 * isentropicCompressibility / soundSpeedMPerS;
+    jacobian[THERMAL_EXPANSION_INDEX] = 2.0 * temperatureK * thermalExpansionPerK
+        / (densityKgPerM3 * specificHeatCapacityJPerKgK);
+    jacobian[HEAT_CAPACITY_INDEX] = -thermalCorrection / specificHeatCapacityJPerKgK;
+
+    double propagatedVariance = 0.0;
+    double absoluteContributionSum = 0.0;
+    for (int row = 0; row < INPUT_COUNT; row++) {
+      for (int column = 0; column < INPUT_COUNT; column++) {
+        double contribution = jacobian[row] * covariance[row][column] * jacobian[column];
+        propagatedVariance += contribution;
+        absoluteContributionSum += Math.abs(contribution);
+      }
+    }
+    double negativeTolerance = COVARIANCE_SYMMETRY_TOLERANCE * absoluteContributionSum;
+    if (!Double.isFinite(propagatedVariance) || propagatedVariance < -negativeTolerance) {
+      throw new IllegalArgumentException("Input covariance produces an invalid compressibility variance");
+    }
+    propagatedVariance = Math.max(0.0, propagatedVariance);
+
+    return new ConversionResult(isentropicCompressibility, thermalCorrection, isothermalCompressibility,
+        Math.sqrt(propagatedVariance), jacobian);
+  }
+
+  private static double calculateThermalCorrection(double temperatureK, double densityKgPerM3,
+      double thermalExpansionPerK, double specificHeatCapacityJPerKgK) {
+    double correction = temperatureK * thermalExpansionPerK * thermalExpansionPerK
+        / (densityKgPerM3 * specificHeatCapacityJPerKgK);
+    if (!Double.isFinite(correction) || correction < 0.0) {
+      throw new IllegalArgumentException("Thermal compressibility correction must be finite and non-negative");
+    }
+    return correction;
+  }
+
+  private static void validateInputs(double temperatureK, double densityKgPerM3, double soundSpeedMPerS,
+      double thermalExpansionPerK, double specificHeatCapacityJPerKgK) {
+    requirePositive(temperatureK, "Temperature");
+    requirePositive(densityKgPerM3, "Density");
+    requirePositive(soundSpeedMPerS, "Speed of sound");
+    requireFinite(thermalExpansionPerK, "Thermal expansivity");
+    requirePositive(specificHeatCapacityJPerKgK, "Specific heat capacity");
+  }
+
+  private static double[][] validateAndCopyCovariance(double[][] inputCovariance) {
+    if (inputCovariance == null || inputCovariance.length != INPUT_COUNT) {
+      throw new IllegalArgumentException("Acoustic input covariance must be a 5-by-5 matrix");
+    }
+    double[][] covariance = new double[INPUT_COUNT][INPUT_COUNT];
+    for (int row = 0; row < INPUT_COUNT; row++) {
+      if (inputCovariance[row] == null || inputCovariance[row].length != INPUT_COUNT) {
+        throw new IllegalArgumentException("Acoustic input covariance must be a 5-by-5 matrix");
+      }
+      for (int column = 0; column < INPUT_COUNT; column++) {
+        requireFinite(inputCovariance[row][column], "Acoustic input covariance");
+        covariance[row][column] = inputCovariance[row][column];
+      }
+      if (covariance[row][row] < 0.0) {
+        throw new IllegalArgumentException("Acoustic input covariance diagonal must be non-negative");
+      }
+    }
+
+    for (int row = 0; row < INPUT_COUNT; row++) {
+      for (int column = row + 1; column < INPUT_COUNT; column++) {
+        double covarianceScale = Math.sqrt(covariance[row][row]) * Math.sqrt(covariance[column][column]);
+        requireFinite(covarianceScale, "Acoustic input covariance scale");
+        double difference = Math.abs(covariance[row][column] - covariance[column][row]);
+        if (difference > COVARIANCE_SYMMETRY_TOLERANCE * covarianceScale) {
+          throw new IllegalArgumentException("Acoustic input covariance must be symmetric");
+        }
+        if (covarianceScale == 0.0 && (covariance[row][column] != 0.0 || covariance[column][row] != 0.0)) {
+          throw new IllegalArgumentException("Zero-variance acoustic inputs cannot have non-zero covariance");
+        }
+      }
+    }
+
+    validatePositiveSemidefinite(covariance);
+    return covariance;
+  }
+
+  private static void validatePositiveSemidefinite(double[][] covariance) {
+    int activeCount = 0;
+    for (int index = 0; index < INPUT_COUNT; index++) {
+      if (covariance[index][index] > 0.0) {
+        activeCount++;
+      }
+    }
+    if (activeCount == 0) {
+      return;
+    }
+
+    double[][] correlation = new double[activeCount][activeCount];
+    int correlationRow = 0;
+    for (int row = 0; row < INPUT_COUNT; row++) {
+      if (covariance[row][row] == 0.0) {
+        continue;
+      }
+      int correlationColumn = 0;
+      for (int column = 0; column < INPUT_COUNT; column++) {
+        if (covariance[column][column] == 0.0) {
+          continue;
+        }
+        correlation[correlationRow][correlationColumn] = covariance[row][column] / Math.sqrt(covariance[row][row])
+            / Math.sqrt(covariance[column][column]);
+        correlationColumn++;
+      }
+      correlationRow++;
+    }
+
+    double[] eigenvalues = new EigenDecomposition(new Array2DRowRealMatrix(correlation, false)).getRealEigenvalues();
+    for (double eigenvalue : eigenvalues) {
+      if (!Double.isFinite(eigenvalue) || eigenvalue < -CORRELATION_EIGENVALUE_TOLERANCE) {
+        throw new IllegalArgumentException("Acoustic input covariance must be positive semidefinite");
+      }
+    }
+  }
+
+  private static void requirePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static void requireFinite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+
+  /** Immutable result of acoustic compressibility conversion and uncertainty propagation. */
+  public static final class ConversionResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double isentropicCompressibilityPaInverse;
+    private final double thermalCorrectionPaInverse;
+    private final double isothermalCompressibilityPaInverse;
+    private final double standardUncertaintyPaInverse;
+    private final double[] sensitivityJacobian;
+
+    private ConversionResult(double isentropicCompressibilityPaInverse, double thermalCorrectionPaInverse,
+        double isothermalCompressibilityPaInverse, double standardUncertaintyPaInverse, double[] sensitivityJacobian) {
+      this.isentropicCompressibilityPaInverse = isentropicCompressibilityPaInverse;
+      this.thermalCorrectionPaInverse = thermalCorrectionPaInverse;
+      this.isothermalCompressibilityPaInverse = isothermalCompressibilityPaInverse;
+      this.standardUncertaintyPaInverse = standardUncertaintyPaInverse;
+      this.sensitivityJacobian = sensitivityJacobian.clone();
+    }
+
+    /** @return isentropic compressibility in 1/Pa */
+    public double getIsentropicCompressibilityPaInverse() {
+      return isentropicCompressibilityPaInverse;
+    }
+
+    /** @return thermal correction from isentropic to isothermal compressibility in 1/Pa */
+    public double getThermalCorrectionPaInverse() {
+      return thermalCorrectionPaInverse;
+    }
+
+    /** @return isothermal compressibility in 1/Pa */
+    public double getIsothermalCompressibilityPaInverse() {
+      return isothermalCompressibilityPaInverse;
+    }
+
+    /** @return propagated absolute one-sigma uncertainty in isothermal compressibility, in 1/Pa */
+    public double getStandardUncertaintyPaInverse() {
+      return standardUncertaintyPaInverse;
+    }
+
+    /**
+     * Return the isothermal-compressibility sensitivity to each input.
+     *
+     * @return defensive copy ordered by the public input-index constants
+     */
+    public double[] getSensitivityJacobian() {
+      return sensitivityJacobian.clone();
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricAcousticConversionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricAcousticConversionTest.java
@@ -1,0 +1,143 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/** Tests acoustic-to-isothermal compressibility conversion for volumetric Pitzer evidence. */
+class PitzerBinaryVolumetricAcousticConversionTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 298.15;
+  private static final double DENSITY_KG_PER_M3 = 997.0;
+  private static final double SOUND_SPEED_M_PER_S = 1497.0;
+  private static final double THERMAL_EXPANSION_PER_K = 2.57e-4;
+  private static final double SPECIFIC_HEAT_CAPACITY_J_PER_KG_K = 4181.0;
+
+  @Test
+  void convertsAcousticAndCaloricPropertiesInSiUnits() {
+    double isentropic = PitzerBinaryVolumetricAcousticConversion.calculateIsentropicCompressibility(DENSITY_KG_PER_M3,
+        SOUND_SPEED_M_PER_S);
+    double isothermal = PitzerBinaryVolumetricAcousticConversion.calculateIsothermalCompressibility(TEMPERATURE_K,
+        DENSITY_KG_PER_M3, SOUND_SPEED_M_PER_S, THERMAL_EXPANSION_PER_K, SPECIFIC_HEAT_CAPACITY_J_PER_KG_K);
+
+    assertEquals(4.475702806553850e-10, isentropic, 1.0e-24);
+    assertEquals(4.522944530170047e-10, isothermal, 1.0e-24);
+    assertTrue(isothermal > isentropic);
+  }
+
+  @Test
+  void zeroThermalExpansionMakesIsothermalAndIsentropicValuesEqual() {
+    double isentropic = PitzerBinaryVolumetricAcousticConversion.calculateIsentropicCompressibility(DENSITY_KG_PER_M3,
+        SOUND_SPEED_M_PER_S);
+    double isothermal = PitzerBinaryVolumetricAcousticConversion.calculateIsothermalCompressibility(TEMPERATURE_K,
+        DENSITY_KG_PER_M3, SOUND_SPEED_M_PER_S, 0.0, SPECIFIC_HEAT_CAPACITY_J_PER_KG_K);
+
+    assertEquals(isentropic, isothermal, 0.0);
+  }
+
+  @Test
+  void propagatesIndependentInputUncertaintiesThroughAnalyticSensitivities() {
+    double[] standardUncertainties = { 0.02, 0.10, 0.20, 1.0e-6, 2.0 };
+    double[][] covariance = diagonalCovariance(standardUncertainties);
+
+    PitzerBinaryVolumetricAcousticConversion.ConversionResult result = PitzerBinaryVolumetricAcousticConversion
+        .convertWithUncertainty(TEMPERATURE_K, DENSITY_KG_PER_M3, SOUND_SPEED_M_PER_S, THERMAL_EXPANSION_PER_K,
+            SPECIFIC_HEAT_CAPACITY_J_PER_KG_K, covariance);
+
+    double isentropic = 1.0 / (DENSITY_KG_PER_M3 * SOUND_SPEED_M_PER_S * SOUND_SPEED_M_PER_S);
+    double thermalCorrection = TEMPERATURE_K * THERMAL_EXPANSION_PER_K * THERMAL_EXPANSION_PER_K
+        / (DENSITY_KG_PER_M3 * SPECIFIC_HEAT_CAPACITY_J_PER_KG_K);
+    double isothermal = isentropic + thermalCorrection;
+    double[] expectedJacobian = {
+        THERMAL_EXPANSION_PER_K * THERMAL_EXPANSION_PER_K / (DENSITY_KG_PER_M3 * SPECIFIC_HEAT_CAPACITY_J_PER_KG_K),
+        -isothermal / DENSITY_KG_PER_M3, -2.0 * isentropic / SOUND_SPEED_M_PER_S,
+        2.0 * TEMPERATURE_K * THERMAL_EXPANSION_PER_K / (DENSITY_KG_PER_M3 * SPECIFIC_HEAT_CAPACITY_J_PER_KG_K),
+        -thermalCorrection / SPECIFIC_HEAT_CAPACITY_J_PER_KG_K };
+    double expectedVariance = 0.0;
+    for (int index = 0; index < PitzerBinaryVolumetricAcousticConversion.INPUT_COUNT; index++) {
+      expectedVariance += expectedJacobian[index] * expectedJacobian[index] * covariance[index][index];
+      assertEquals(expectedJacobian[index], result.getSensitivityJacobian()[index],
+          Math.abs(expectedJacobian[index]) * 1.0e-14 + 1.0e-30);
+    }
+
+    assertEquals(isentropic, result.getIsentropicCompressibilityPaInverse(), 1.0e-24);
+    assertEquals(thermalCorrection, result.getThermalCorrectionPaInverse(), 1.0e-24);
+    assertEquals(isothermal, result.getIsothermalCompressibilityPaInverse(), 1.0e-24);
+    assertEquals(Math.sqrt(expectedVariance), result.getStandardUncertaintyPaInverse(), 1.0e-24);
+  }
+
+  @Test
+  void retainsCrossCovarianceTerms() {
+    double[][] covariance = diagonalCovariance(new double[] { 0.0, 0.10, 0.20, 0.0, 0.0 });
+    covariance[PitzerBinaryVolumetricAcousticConversion.DENSITY_INDEX][PitzerBinaryVolumetricAcousticConversion.SOUND_SPEED_INDEX] = 0.01;
+    covariance[PitzerBinaryVolumetricAcousticConversion.SOUND_SPEED_INDEX][PitzerBinaryVolumetricAcousticConversion.DENSITY_INDEX] = 0.01;
+
+    PitzerBinaryVolumetricAcousticConversion.ConversionResult result = PitzerBinaryVolumetricAcousticConversion
+        .convertWithUncertainty(TEMPERATURE_K, DENSITY_KG_PER_M3, SOUND_SPEED_M_PER_S, THERMAL_EXPANSION_PER_K,
+            SPECIFIC_HEAT_CAPACITY_J_PER_KG_K, covariance);
+    double[] jacobian = result.getSensitivityJacobian();
+    double expectedVariance = jacobian[PitzerBinaryVolumetricAcousticConversion.DENSITY_INDEX]
+        * jacobian[PitzerBinaryVolumetricAcousticConversion.DENSITY_INDEX] * 0.01
+        + jacobian[PitzerBinaryVolumetricAcousticConversion.SOUND_SPEED_INDEX]
+            * jacobian[PitzerBinaryVolumetricAcousticConversion.SOUND_SPEED_INDEX] * 0.04
+        + 2.0 * jacobian[PitzerBinaryVolumetricAcousticConversion.DENSITY_INDEX]
+            * jacobian[PitzerBinaryVolumetricAcousticConversion.SOUND_SPEED_INDEX] * 0.01;
+
+    assertEquals(Math.sqrt(expectedVariance), result.getStandardUncertaintyPaInverse(), 1.0e-24);
+  }
+
+  @Test
+  void rejectsNonPhysicalInputsAndMalformedCovariance() {
+    assertThrows(IllegalArgumentException.class,
+        () -> PitzerBinaryVolumetricAcousticConversion.calculateIsentropicCompressibility(0.0, SOUND_SPEED_M_PER_S));
+    assertThrows(IllegalArgumentException.class, () -> PitzerBinaryVolumetricAcousticConversion
+        .calculateIsentropicCompressibility(Double.MAX_VALUE, Double.MAX_VALUE));
+    assertThrows(IllegalArgumentException.class,
+        () -> PitzerBinaryVolumetricAcousticConversion.calculateIsothermalCompressibility(TEMPERATURE_K,
+            DENSITY_KG_PER_M3, SOUND_SPEED_M_PER_S, Double.NaN, SPECIFIC_HEAT_CAPACITY_J_PER_KG_K));
+    assertThrows(IllegalArgumentException.class,
+        () -> convert(new double[PitzerBinaryVolumetricAcousticConversion.INPUT_COUNT
+            - 1][PitzerBinaryVolumetricAcousticConversion.INPUT_COUNT - 1]));
+
+    double[][] asymmetric = diagonalCovariance(new double[] { 1.0, 1.0, 1.0, 1.0, 1.0 });
+    asymmetric[0][1] = 0.1;
+    assertThrows(IllegalArgumentException.class, () -> convert(asymmetric));
+
+    double[][] indefinite = diagonalCovariance(new double[] { 1.0, 1.0, 1.0, 1.0, 1.0 });
+    indefinite[0][1] = 2.0;
+    indefinite[1][0] = 2.0;
+    assertThrows(IllegalArgumentException.class, () -> convert(indefinite));
+
+    double[][] zeroVarianceCorrelation = diagonalCovariance(new double[] { 0.0, 1.0, 1.0, 1.0, 1.0 });
+    zeroVarianceCorrelation[0][1] = 0.1;
+    zeroVarianceCorrelation[1][0] = 0.1;
+    assertThrows(IllegalArgumentException.class, () -> convert(zeroVarianceCorrelation));
+  }
+
+  @Test
+  void returnsDefensiveJacobianCopies() {
+    PitzerBinaryVolumetricAcousticConversion.ConversionResult result = convert(
+        new double[PitzerBinaryVolumetricAcousticConversion.INPUT_COUNT][PitzerBinaryVolumetricAcousticConversion.INPUT_COUNT]);
+
+    double[] first = result.getSensitivityJacobian();
+    double original = first[0];
+    first[0] = Double.NaN;
+
+    assertEquals(original, result.getSensitivityJacobian()[0], 0.0);
+    assertNotSame(first, result.getSensitivityJacobian());
+  }
+
+  private static PitzerBinaryVolumetricAcousticConversion.ConversionResult convert(double[][] covariance) {
+    return PitzerBinaryVolumetricAcousticConversion.convertWithUncertainty(TEMPERATURE_K, DENSITY_KG_PER_M3,
+        SOUND_SPEED_M_PER_S, THERMAL_EXPANSION_PER_K, SPECIFIC_HEAT_CAPACITY_J_PER_KG_K, covariance);
+  }
+
+  private static double[][] diagonalCovariance(double[] standardUncertainties) {
+    double[][] covariance = new double[standardUncertainties.length][standardUncertainties.length];
+    for (int index = 0; index < standardUncertainties.length; index++) {
+      covariance[index][index] = standardUncertainties[index] * standardUncertainties[index];
+    }
+    return covariance;
+  }
+}


### PR DESCRIPTION
## Summary

- add an SI-unit bridge from density and sound speed to isentropic compressibility
- apply the thermodynamic expansivity/heat-capacity correction to isothermal compressibility
- propagate a caller-supplied full covariance matrix through the analytic Jacobian
- fail closed for non-physical inputs and malformed, asymmetric, or non-positive-semidefinite covariance
- document the acoustic evidence boundary for volumetric-Pitzer calibration

## Scientific semantics

This parameter-neutral utility evaluates only:

`κS = 1/(ρc²)`

`κT = κS + Tα²/(ρcp)`

It does not infer missing density, expansivity, heat capacity, or covariance; fit coefficients; install parameters; or activate any density path. Sound speed is therefore not treated as direct isothermal-compressibility evidence.

No experimental rows or coefficients are included. The reserved 197-point Al Ghafri/NIST ThermoML CaCl₂ pressure series remains untouched validation evidence.

## Validation

- `./mvnw spotless:apply`: pass
- `./mvnw spotless:check`: pass
- `./mvnw test -Dtest=PitzerBinaryVolumetricAcousticConversionTest`: 6/6 pass
- `./mvnw checkstyle:check -DskipTests`: pass, 0 violations
- `python3 devtools/check_documentation_search.py`: pass, 693 Markdown pages and 1 standalone HTML page
- `git diff --check`: pass

The branch is based on exact master commit `889f8ceb9293e81f2746b4506a29d8b1423d64ab`. Master advanced independently after the capability started; the frozen head was preserved without rebasing.

## Qualification boundary

- no model activation or default-behavior change
- no database, parameter, solver, tolerance, phase, or MCP payload change
- high-pressure aqueous-density and calcium-sulfate predictions remain fail-closed
- matching redistribution-qualified acoustic, density, expansivity, heat-capacity, covariance, and independent-lineage evidence remains prerequisite to calibration

Campaign: #3144

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**