### PR TITLE
[AI-Assisted] test(mcp): qualify bounded task solver contract

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run focused runtime-capability Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.GeneralCapabilityRunnerTest test -ntp
 
-      - name: Run focused composed-workflow Java contract
+      - name: Run focused task-solver and composed-workflow Java contracts
         run: mvn -B -Dtest=neqsim.mcp.runners.TaskSolverRunnerTest test -ntp
 
       - name: Run focused pre-flight validator Java contract
@@ -138,6 +138,9 @@ jobs:
 
       - name: Run focused real-MCP composed-workflow qualification
         run: cd neqsim-mcp-server && python test_compose_workflow_protocol.py
+
+      - name: Run focused real-MCP task-solver qualification
+        run: cd neqsim-mcp-server && python test_solve_task_protocol.py
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -261,7 +261,7 @@ Interfaces may change between minor versions.
 | `runFieldEconomics`          | NPV/IRR/cash flow with fiscal regimes + decline curves              |
 | `runDynamic`                 | Transient dynamic simulation with auto-instrumented PID controllers |
 | `runBioprocess`              | Bioprocessing reactors (AD, fermentation, gasification, pyrolysis)  |
-| `solveTask`                  | Autonomous task solver — results require engineer review           |
+| `solveTask`                  | Keyword-routed fixed plans — results require engineer review       |
 | `composeWorkflow`            | Chain simulation steps into multi-domain workflows                  |
 | `bridgeTaskWorkflow`         | Convert MCP tool output to task_solve results.json format           |
 | `manageSession`              | Persistent simulation sessions                                      |
@@ -272,6 +272,22 @@ Interfaces may change between minor versions.
 | `manageValidationProfile`    | Jurisdiction-specific validation profiles                           |
 | `runPlugin`                  | Run or list registered MCP runner plugins                           |
 | `runCapability`              | Discover runtime methods and invoke bounded JSON-safe static calculations |
+
+### Bounded task-solver contract
+
+`solveTask` requires a non-blank task description and recognizes only the
+documented keyword families for compression, separation, dehydration,
+pipeline, PVT, flow assurance, reservoir, economics, and dynamic studies.
+Each family maps to a deterministic fixed plan of existing NeqSim runners.
+The caller supplies the fluid and runner parameters; unsupported descriptions
+fail closed. Step outputs are collected in the report but are not
+semantically translated into later runner inputs.
+
+This contract does not establish general natural-language planning, arbitrary
+tool or code execution, semantic compatibility between steps, numerical
+validity, convergence, conservation, facility completeness, certification, or
+engineering approval. See
+[the bounded qualification evidence](docs/evidence/TASK_SOLVER_CONTRACT.md).
 
 ### Enforcement Example
 

--- a/neqsim-mcp-server/docs/evidence/TASK_SOLVER_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/TASK_SOLVER_CONTRACT.md
@@ -1,0 +1,70 @@
+# Bounded task-solver qualification evidence
+
+## Scope
+
+The `solveTask` MCP tool accepts a non-blank caller-authored task description
+plus structured fluid and runner parameters. Supported keywords select one of
+nine deterministic fixed plans backed by existing NeqSim runners. The runner
+executes those steps in order, records each result, stops after a failed
+required step, optionally validates the collected output, and returns explicit
+plan and completion accounting.
+
+This page records qualification evidence only. `solveTask` remains a
+`CONFIRMED_GAP` in the Phase 0 evidence inventory until a separate promotion
+increment atomically updates all inventory surfaces.
+
+## Qualified implementation boundary
+
+`NeqSimTools.solveTask` applies the normal Tier 3 tool-access policy and
+standard response envelope, then delegates to
+`TaskSolverRunner.solveTask`. The bounded router recognizes keyword families
+for compression, separation, dehydration, pipeline, PVT, flow assurance,
+reservoir, economics, and dynamic studies. Descriptions outside those
+families fail with `UNSUPPORTED_TASK`; absent or blank descriptions fail
+with `MISSING_TASK`.
+
+The shared `fluid` object is preserved in the report and its canonical model
+and components are exposed to runner inputs that use top-level fields.
+Caller-supplied `parameters` and step overrides remain authoritative.
+Results are collected under named step records; the solver does not infer
+semantic transformations between one runner's output and the next runner's
+input.
+
+A task report exposes `status`, `success`, `taskType`, `totalSteps`,
+`completedSteps`, the planned steps, executed step results, optional
+validation, and combined collected data. A required runner failure produces a
+top-level `TASK_STEP_FAILED` diagnostic and preserves the first underlying
+runner error code as `causeCode`.
+
+## Direct evidence
+
+The focused Java contract in
+`src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java` covers:
+
+- a real PVT saturation-pressure calculation using a shared canonical fluid;
+- deterministic task classification and fixed-plan accounting;
+- stop-on-required-failure behavior and explicit error status;
+- missing, blank, malformed, and unsupported task rejection.
+
+The packaged `neqsim-mcp-server/test_solve_task_protocol.py` harness starts
+the shaded server over STDIO and repeats seven transport-level scenarios,
+including discovery text, standard envelopes, the real PVT route, diagnostic
+preservation, and inventory continuity. The comprehensive MCP regression keeps
+a supported PVT task on the authoritative 71-tool surface.
+
+## Evidence boundary
+
+This evidence does not establish general natural-language task understanding,
+open-ended planning, arbitrary runner or code execution, semantic result
+chaining, numerical accuracy, convergence, conservation, facility
+completeness, standards compliance, production hardening, transport or
+identity security, plant or control authority, certification, or engineering
+approval. Each underlying calculation retains its own model, applicability,
+validation, and trust boundaries.
+
+## Inventory continuity
+
+Phase 0 stays at inventory version `1.32` with `20` explicit-trust tools,
+`32` contract-tested tools, and `19` confirmed gaps. No promotion candidate
+is created. Phase 0 remains incomplete and
+`scientificValidationComplete=false`.

--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
@@ -1458,23 +1458,24 @@ public class NeqSimTools {
   // ═══════════════════════════════════════════════════════════════════════════
 
   /**
-   * Solve a high-level engineering task by automatic planning and execution.
+   * Route a supported engineering task to a bounded fixed plan of existing runners.
    *
    * @param taskJson JSON with task description and parameters
-   * @return JSON with execution plan, step results, validation, and report
+   * @return JSON with keyword classification, fixed plan, step results, validation, and report
    */
-  @Tool(description = "[EXPERIMENTAL — Tier 3] Solve a complete engineering task. "
-      + "Takes a high-level description "
-      + "(e.g., 'Design a 3-stage compression system from 5 to 150 bara'), automatically "
-      + "classifies the task, builds a multi-step execution plan, executes each step, "
-      + "chains results between steps, runs engineering validation against industry rules, "
-      + "and returns a structured report. Limited validation — results require independent "
-      + "review. Not available in STUDY_TEAM, DIGITAL_TWIN, or ENTERPRISE modes.")
+  @Tool(description = "[EXPERIMENTAL — Tier 3] Route a supported engineering task through "
+      + "a deterministic fixed plan of existing NeqSim runners. Keyword families cover "
+      + "compression, separation, dehydration, pipeline, PVT, flow assurance, reservoir, "
+      + "economics, and dynamic studies. The caller supplies the fluid and runner parameters; "
+      + "unsupported task descriptions fail closed. Results are collected for review, not "
+      + "semantically transformed between steps. Limited validation — results require "
+      + "independent engineering review. Not available in STUDY_TEAM, DIGITAL_TWIN, "
+      + "or ENTERPRISE modes.")
   public String solveTask(
-      @ToolArg(description = "JSON with: 'task' (natural language description), "
-          + "'fluid' (composition), 'parameters' (task-specific values like outletPressure, "
-          + "stages, intercoolerTemp), optional 'process' (equipment definitions), "
-          + "optional 'validate' (true/false, default true).") String taskJson) {
+      @ToolArg(description = "JSON with: required non-blank 'task' (keyword-based description), "
+          + "'fluid' (canonical model and composition), 'parameters' (runner-specific values), "
+          + "optional 'process' (equipment definitions), and optional 'validate' "
+          + "(true/false, default true).") String taskJson) {
     String policyBlocked = enforceToolAccess("solveTask");
     if (policyBlocked != null) {
       return policyBlocked;

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -2135,11 +2135,21 @@ def test_session_lifecycle():
 # --- Task solver tools ---
 
 def test_solve_task():
-    """Solve a simple engineering task."""
+    """Route a supported PVT task through the bounded fixed-plan solver."""
     print("\n=== Solve Task ===")
     r = call_tool("solveTask", {
-        "task": "Calculate the density of methane at 25C and 50 bar",
-        "fluid": json.dumps({"methane": 1.0}),
+        "task": "Run a PVT saturation pressure analysis",
+        "fluid": {
+            "model": "PR",
+            "components": {
+                "methane": 0.70,
+                "ethane": 0.10,
+                "propane": 0.05,
+                "n-heptane": 0.15,
+            },
+        },
+        "parameters": {"experiment": "saturationPressure"},
+        "validate": False,
     })
     check("solveTask status=success", r.get("status") == "success", r.get("message", ""))
 

--- a/neqsim-mcp-server/test_solve_task_protocol.py
+++ b/neqsim-mcp-server/test_solve_task_protocol.py
@@ -1,0 +1,252 @@
+"""Packaged-MCP qualification for the bounded solveTask contract.
+
+The scenarios exercise real STDIO transport, fixed-plan discovery, one
+shared-fluid PVT calculation, explicit accounting, fail-closed inputs,
+required-step stop behavior, and unchanged Phase 0 inventory. They do not
+establish general language planning, arbitrary execution, semantic result
+chaining, numerical fidelity, convergence, plant authority, certification, or
+engineering approval.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+def require(condition, message, detail=None):
+    if condition:
+        return
+    suffix = "" if detail is None else "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in ("status", "tool", "code", "errors", "message", "validation", "qualityGate"):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+class McpClient:
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "neqsim-task-solver-contract-test", "version": "1.0"},
+            },
+        })
+        require("result" in self.receive(), "MCP initialize did not return a result")
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def request(self, method, params):
+        self.send({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": method,
+            "params": params,
+        })
+        return self.receive()
+
+    def list_tools(self):
+        return self.request("tools/list", {}).get("result", {}).get("tools", [])
+
+    def call_tool(self, name, arguments):
+        response = self.request("tools/call", {"name": name, "arguments": arguments})
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(f"MCP tool returned non-JSON content: {error}: {text}")
+
+    def call_task(self, request):
+        return self.call_tool("solveTask", {"taskJson": json.dumps(request)})
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def assert_success(response):
+    result = payload(response)
+    require(result.get("status") == "success", "task request failed", response)
+    require(result.get("tool") == "solveTask", "tool identity drifted", response)
+    require(result.get("validation", {}).get("valid") is True,
+            "standard validation evidence drifted", response)
+    require(result.get("qualityGate", {}).get("verdict") == "passed",
+            "software gate did not pass", response)
+    return result
+
+
+def assert_error(response, expected_code):
+    result = payload(response)
+    require(result.get("status") == "error", "task did not fail closed", response)
+    errors = result.get("errors", [])
+    code = result.get("code")
+    if code is None and errors:
+        code = errors[0].get("code")
+    require(code == expected_code, "task error code drifted", result)
+    return result
+
+
+def test_bounded_discovery(client):
+    tool = next((item for item in client.list_tools()
+                 if item.get("name") == "solveTask"), None)
+    require(tool is not None, "solveTask is missing from tools/list")
+    description = tool.get("description", "")
+    require("deterministic fixed plan" in description
+            and "unsupported task descriptions fail closed" in description
+            and "independent engineering review" in description,
+            "solveTask discovery boundary drifted", tool)
+
+
+def test_shared_fluid_pvt(client):
+    result = assert_success(client.call_task({
+        "task": "Run a PVT saturation pressure analysis",
+        "fluid": {
+            "model": "PR",
+            "components": {
+                "methane": 0.70,
+                "ethane": 0.10,
+                "propane": 0.05,
+                "n-heptane": 0.15,
+            },
+        },
+        "parameters": {"experiment": "saturationPressure"},
+        "validate": False,
+    }))
+    require(result.get("taskType") == "pvt"
+            and result.get("totalSteps") == 1
+            and result.get("completedSteps") == 1
+            and result.get("success") is True,
+            "PVT task accounting drifted", result)
+    step = result.get("stepResults", [{}])[0]
+    require(step.get("step") == "pvt_study"
+            and step.get("runner") == "pvt"
+            and step.get("success") is True
+            and step.get("output", {}).get("status") == "success",
+            "PVT task did not reach the canonical runner", step)
+    combined = result.get("combinedData", {})
+    require(combined.get("fluid", {}).get("components", {}).get("methane") == 0.70
+            and "pvt_study_result" in combined,
+            "shared fluid or PVT result evidence was not preserved", combined)
+
+
+def test_missing_task(client):
+    assert_error(client.call_task({"validate": False}), "MISSING_TASK")
+
+
+def test_blank_and_malformed_task(client):
+    assert_error(client.call_task({"task": "   ", "validate": False}), "MISSING_TASK")
+    assert_error(client.call_tool("solveTask", {"taskJson": "{"}), "TASK_ERROR")
+
+
+def test_unsupported_task(client):
+    assert_error(client.call_task({
+        "task": "Write a poem about offshore weather",
+        "validate": False,
+    }), "UNSUPPORTED_TASK")
+
+
+def test_required_failure_stops(client):
+    result = assert_error(client.call_task({
+        "task": "Design two-stage compression",
+        "parameters": {},
+        "validate": False,
+    }), "TASK_STEP_FAILED")
+    require(result.get("taskType") == "compression"
+            and result.get("totalSteps") == 3
+            and result.get("completedSteps") == 1
+            and result.get("success") is False,
+            "required-step failure accounting drifted", result)
+    require(result.get("errors", [{}])[0].get("causeCode") == "MISSING_COMPONENTS",
+            "underlying runner diagnostic was not preserved", result)
+
+
+def test_inventory_unchanged(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    require(result.get("status") == "success", "capabilities request failed", result)
+    inventory = result.get("phase0EvidenceInventory", {})
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get("solveTask", {})
+    require(inventory.get("inventoryVersion") == "1.32"
+            and limitations.get("contractTestedToolCount") == 32
+            and limitations.get("confirmedGapToolCount") == 19,
+            "qualification unexpectedly changed inventory", inventory)
+    require(record.get("coverageStatus") == "CONFIRMED_GAP",
+            "solveTask was promoted during qualification", record)
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("bounded discovery", test_bounded_discovery),
+        ("shared-fluid PVT", test_shared_fluid_pvt),
+        ("missing task", test_missing_task),
+        ("blank and malformed task", test_blank_and_malformed_task),
+        ("unsupported task", test_unsupported_task),
+        ("required failure stops", test_required_failure_stops),
+        ("inventory unchanged", test_inventory_unchanged),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} task-solver scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/src/main/java/neqsim/mcp/runners/TaskSolverRunner.java
+++ b/src/main/java/neqsim/mcp/runners/TaskSolverRunner.java
@@ -17,9 +17,9 @@ import com.google.gson.JsonParser;
  * Two capabilities in one class:
  * </p>
  * <ul>
- * <li><b>solve_task</b> — Takes a high-level engineering task description and structured parameters, classifies the
- * task, builds a multi-step execution plan (sequence of existing runners), executes each step passing results between
- * them, validates the combined output, and returns a structured engineering report.</li>
+ * <li><b>solve_task</b> — Takes a high-level engineering task description and structured parameters, classifies
+ * supported keywords into a fixed plan of existing runners, executes each step with shared caller input, optionally
+ * validates the collected output, and returns a structured engineering report.</li>
  * <li><b>compose_workflow</b> — Chains multiple domain runners in sequence (e.g., Reservoir → Process → Pipeline →
  * Economics) with automatic data flow between stages.</li>
  * </ul>
@@ -65,13 +65,23 @@ public final class TaskSolverRunner {
 
     try {
       JsonObject input = JsonParser.parseString(json).getAsJsonObject();
-      String task = input.has("task") ? input.get("task").getAsString() : "";
+      if (!input.has("task") || input.get("task").isJsonNull()
+          || !input.get("task").isJsonPrimitive()
+          || !input.get("task").getAsJsonPrimitive().isString()
+          || input.get("task").getAsString().trim().isEmpty()) {
+        return errorJson("MISSING_TASK", "Provide a non-blank string 'task' description");
+      }
+      String task = input.get("task").getAsString().trim();
 
-      // Step 1: Classify the task
-      String taskType = classifyTask(task, input);
+      // Step 1: Classify only the keyword families backed by explicit fixed plans.
+      String taskType = classifyTask(task);
+      if (taskType == null) {
+        return errorJson("UNSUPPORTED_TASK",
+            "Task description does not match a supported fixed-plan keyword family");
+      }
 
       // Step 2: Build execution plan
-      List<PlanStep> plan = buildPlan(taskType, input);
+      List<PlanStep> plan = buildPlan(taskType);
 
       // Step 3: Execute each step
       List<StepResult> stepResults = new ArrayList<StepResult>();
@@ -101,7 +111,7 @@ public final class TaskSolverRunner {
           } else {
             carryForward.add(step.name + "_result", parsed);
           }
-          result.success = !parsed.has("errors");
+          result.success = isSuccessfulResponse(parsed);
         } catch (Exception e) {
           result.success = false;
           result.errorMessage = e.getMessage();
@@ -250,10 +260,9 @@ public final class TaskSolverRunner {
    * Classifies a task description into a category.
    *
    * @param task the task description
-   * @param input the full input JSON
-   * @return the task category
+   * @return the task category, or {@code null} when no fixed plan is supported
    */
-  private static String classifyTask(String task, JsonObject input) {
+  private static String classifyTask(String task) {
     String lower = task.toLowerCase();
 
     if (lower.contains("compress") || lower.contains("compressor")) {
@@ -274,15 +283,6 @@ public final class TaskSolverRunner {
     if (lower.contains("hydrate") || lower.contains("wax") || lower.contains("flow assurance")) {
       return "flow_assurance";
     }
-    if (lower.contains("co2") || lower.contains("carbon capture") || lower.contains("ccs")) {
-      return "ccs";
-    }
-    if (lower.contains("hydrogen") || lower.contains("h2")) {
-      return "hydrogen";
-    }
-    if (lower.contains("distill") || lower.contains("column") || lower.contains("tower")) {
-      return "distillation";
-    }
     if (lower.contains("reservoir") || lower.contains("depletion")) {
       return "reservoir";
     }
@@ -292,11 +292,7 @@ public final class TaskSolverRunner {
     if (lower.contains("dynamic") || lower.contains("transient") || lower.contains("blowdown")) {
       return "dynamic";
     }
-    if (lower.contains("heat exchang") || lower.contains("cooler") || lower.contains("heater")) {
-      return "heat_exchange";
-    }
-
-    return "general_process";
+    return null;
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -307,10 +303,9 @@ public final class TaskSolverRunner {
    * Builds an execution plan based on task type.
    *
    * @param taskType the classified task type
-   * @param input the full input JSON
    * @return list of plan steps
    */
-  private static List<PlanStep> buildPlan(String taskType, JsonObject input) {
+  private static List<PlanStep> buildPlan(String taskType) {
     List<PlanStep> plan = new ArrayList<PlanStep>();
 
     switch (taskType) {
@@ -384,11 +379,21 @@ public final class TaskSolverRunner {
   private static String buildStepInput(PlanStep step, JsonObject originalInput, JsonObject carryForward) {
     JsonObject stepInput = new JsonObject();
 
-    // Always include fluid
+    // Preserve the shared fluid and expose its canonical model/components to
+    // runners whose native JSON contract uses top-level fields.
+    JsonElement fluid = null;
     if (originalInput.has("fluid")) {
-      stepInput.add("fluid", originalInput.get("fluid"));
+      fluid = originalInput.get("fluid");
     } else if (carryForward.has("fluid")) {
-      stepInput.add("fluid", carryForward.get("fluid"));
+      fluid = carryForward.get("fluid");
+    }
+    if (fluid != null) {
+      stepInput.add("fluid", fluid.deepCopy());
+      if (fluid.isJsonObject()) {
+        for (Map.Entry<String, JsonElement> entry : fluid.getAsJsonObject().entrySet()) {
+          stepInput.add(entry.getKey(), entry.getValue().deepCopy());
+        }
+      }
     }
 
     // Include parameters
@@ -460,6 +465,27 @@ public final class TaskSolverRunner {
     }
   }
 
+  /**
+   * Determines whether a runner response represents a successful step.
+   *
+   * @param response parsed runner response
+   * @return true only when no explicit error, blocked status, or false success is present
+   */
+  private static boolean isSuccessfulResponse(JsonObject response) {
+    if (response.has("errors") && response.get("errors").isJsonArray()
+        && response.getAsJsonArray("errors").size() > 0) {
+      return false;
+    }
+    if (response.has("status") && response.get("status").isJsonPrimitive()) {
+      String status = response.get("status").getAsString();
+      if ("error".equalsIgnoreCase(status) || "blocked".equalsIgnoreCase(status)) {
+        return false;
+      }
+    }
+    return !response.has("success") || !response.get("success").isJsonPrimitive()
+        || response.get("success").getAsBoolean();
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Report building
   // ═══════════════════════════════════════════════════════════════════════════
@@ -483,6 +509,8 @@ public final class TaskSolverRunner {
     report.addProperty("task", task);
     report.addProperty("taskType", taskType);
     report.addProperty("totalTimeMs", totalTimeMs);
+    report.addProperty("totalSteps", plan.size());
+    report.addProperty("completedSteps", results.size());
 
     // Overall success
     boolean allSuccess = true;
@@ -492,7 +520,37 @@ public final class TaskSolverRunner {
         break;
       }
     }
+    report.addProperty("status", allSuccess ? "success" : "error");
     report.addProperty("success", allSuccess);
+    if (!allSuccess) {
+      JsonArray errors = new JsonArray();
+      JsonObject error = new JsonObject();
+      error.addProperty("code", "TASK_STEP_FAILED");
+      error.addProperty("message", "A required task step failed");
+      for (StepResult result : results) {
+        if (!result.success) {
+          error.addProperty("step", result.stepName);
+          try {
+            JsonObject output = JsonParser.parseString(result.output).getAsJsonObject();
+            if (output.has("errors") && output.get("errors").isJsonArray()
+                && output.getAsJsonArray("errors").size() > 0) {
+              JsonObject nested = output.getAsJsonArray("errors").get(0).getAsJsonObject();
+              if (nested.has("code")) {
+                error.addProperty("causeCode", nested.get("code").getAsString());
+              }
+              if (nested.has("message")) {
+                error.addProperty("causeMessage", nested.get("message").getAsString());
+              }
+            }
+          } catch (Exception ignored) {
+            // Keep the stable task-level diagnostic when a runner returned non-JSON.
+          }
+          break;
+        }
+      }
+      errors.add(error);
+      report.add("errors", errors);
+    }
 
     // Plan
     JsonArray planArray = new JsonArray();

--- a/src/main/java/neqsim/mcp/runners/TaskSolverRunner.java
+++ b/src/main/java/neqsim/mcp/runners/TaskSolverRunner.java
@@ -65,10 +65,8 @@ public final class TaskSolverRunner {
 
     try {
       JsonObject input = JsonParser.parseString(json).getAsJsonObject();
-      if (!input.has("task") || input.get("task").isJsonNull()
-          || !input.get("task").isJsonPrimitive()
-          || !input.get("task").getAsJsonPrimitive().isString()
-          || input.get("task").getAsString().trim().isEmpty()) {
+      if (!input.has("task") || input.get("task").isJsonNull() || !input.get("task").isJsonPrimitive()
+          || !input.get("task").getAsJsonPrimitive().isString() || input.get("task").getAsString().trim().isEmpty()) {
         return errorJson("MISSING_TASK", "Provide a non-blank string 'task' description");
       }
       String task = input.get("task").getAsString().trim();
@@ -76,8 +74,7 @@ public final class TaskSolverRunner {
       // Step 1: Classify only the keyword families backed by explicit fixed plans.
       String taskType = classifyTask(task);
       if (taskType == null) {
-        return errorJson("UNSUPPORTED_TASK",
-            "Task description does not match a supported fixed-plan keyword family");
+        return errorJson("UNSUPPORTED_TASK", "Task description does not match a supported fixed-plan keyword family");
       }
 
       // Step 2: Build execution plan

--- a/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
@@ -18,15 +18,102 @@ import com.google.gson.JsonParser;
 class TaskSolverRunnerTest {
 
   @Test
-  void testSolveCompressionTask() {
-    String json = "{" + "\"task\": \"Design 2-stage compression from 10 to 80 bara\"," + "\"fluid\": {"
-        + "  \"model\": \"SRK\"," + "  \"components\": {\"methane\": 0.90, \"ethane\": 0.07, \"propane\": 0.03}" + "},"
-        + "\"parameters\": {" + "  \"outletPressure\": 80.0," + "  \"stages\": 2" + "}" + "}";
+  void testSolvePvtTaskRoutesSharedFluid() {
+    JsonObject fluid = new JsonObject();
+    fluid.addProperty("model", "PR");
+    JsonObject components = new JsonObject();
+    components.addProperty("methane", 0.70);
+    components.addProperty("ethane", 0.10);
+    components.addProperty("propane", 0.05);
+    components.addProperty("n-heptane", 0.15);
+    fluid.add("components", components);
 
-    String result = TaskSolverRunner.solveTask(json);
-    assertNotNull(result);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertTrue(obj.has("success") || obj.has("status"), "Should have success or status field: " + result);
+    JsonObject parameters = new JsonObject();
+    parameters.addProperty("experiment", "saturationPressure");
+
+    JsonObject request = new JsonObject();
+    request.addProperty("task", "Run a PVT saturation pressure analysis");
+    request.add("fluid", fluid);
+    request.add("parameters", parameters);
+    request.addProperty("validate", false);
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.solveTask(request.toString())).getAsJsonObject();
+    assertEquals("success", result.get("status").getAsString(), result.toString());
+    assertTrue(result.get("success").getAsBoolean());
+    assertEquals("pvt", result.get("taskType").getAsString());
+    assertEquals(1, result.get("totalSteps").getAsInt());
+    assertEquals(1, result.get("completedSteps").getAsInt());
+
+    JsonObject step = result.getAsJsonArray("stepResults").get(0).getAsJsonObject();
+    assertEquals("pvt_study", step.get("step").getAsString());
+    assertEquals("pvt", step.get("runner").getAsString());
+    assertTrue(step.get("success").getAsBoolean());
+    assertEquals("success", step.getAsJsonObject("output").get("status").getAsString());
+    assertTrue(result.getAsJsonObject("combinedData").getAsJsonObject("fluid")
+        .getAsJsonObject("components").has("methane"));
+    assertTrue(result.getAsJsonObject("combinedData").has("pvt_study_result"));
+  }
+
+  @Test
+  void testSolveCompressionTaskStopsOnRequiredFailure() {
+    JsonObject request = new JsonObject();
+    request.addProperty("task", "Design two-stage compression");
+    request.add("parameters", new JsonObject());
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.solveTask(request.toString())).getAsJsonObject();
+    assertEquals("error", result.get("status").getAsString());
+    assertFalse(result.get("success").getAsBoolean());
+    assertEquals("compression", result.get("taskType").getAsString());
+    assertEquals(3, result.get("totalSteps").getAsInt());
+    assertEquals(1, result.get("completedSteps").getAsInt());
+    assertEquals("flash_feed",
+        result.getAsJsonArray("stepResults").get(0).getAsJsonObject().get("step").getAsString());
+  }
+
+  @Test
+  void testSolveRejectsMissingTask() {
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.solveTask("{}")).getAsJsonObject();
+    assertEquals("error", result.get("status").getAsString());
+    assertEquals("MISSING_TASK",
+        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+  }
+
+  @Test
+  void testSolveRejectsBlankOrMalformedTask() {
+    JsonObject blank =
+        JsonParser.parseString(TaskSolverRunner.solveTask("{\"task\":\"   \"}")).getAsJsonObject();
+    assertEquals("MISSING_TASK",
+        blank.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+
+    JsonObject malformed = JsonParser.parseString(TaskSolverRunner.solveTask("{")).getAsJsonObject();
+    assertEquals("TASK_ERROR",
+        malformed.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+  }
+
+  @Test
+  void testSolveRejectsUnsupportedTask() {
+    JsonObject request = new JsonObject();
+    request.addProperty("task", "Write a poem about offshore weather");
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.solveTask(request.toString())).getAsJsonObject();
+    assertEquals("error", result.get("status").getAsString());
+    assertEquals("UNSUPPORTED_TASK",
+        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+  }
+
+  @Test
+  void testSolveFailureUsesErrorEnvelope() {
+    JsonObject request = new JsonObject();
+    request.addProperty("task", "Run a PVT analysis");
+    request.addProperty("validate", false);
+
+    JsonObject result = JsonParser.parseString(TaskSolverRunner.solveTask(request.toString())).getAsJsonObject();
+    assertEquals("error", result.get("status").getAsString());
+    assertFalse(result.get("success").getAsBoolean());
+    assertEquals("TASK_STEP_FAILED",
+        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("MISSING_EXPERIMENT",
+        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("causeCode").getAsString());
   }
 
   @Test

--- a/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/TaskSolverRunnerTest.java
@@ -49,8 +49,8 @@ class TaskSolverRunnerTest {
     assertEquals("pvt", step.get("runner").getAsString());
     assertTrue(step.get("success").getAsBoolean());
     assertEquals("success", step.getAsJsonObject("output").get("status").getAsString());
-    assertTrue(result.getAsJsonObject("combinedData").getAsJsonObject("fluid")
-        .getAsJsonObject("components").has("methane"));
+    assertTrue(
+        result.getAsJsonObject("combinedData").getAsJsonObject("fluid").getAsJsonObject("components").has("methane"));
     assertTrue(result.getAsJsonObject("combinedData").has("pvt_study_result"));
   }
 
@@ -66,28 +66,23 @@ class TaskSolverRunnerTest {
     assertEquals("compression", result.get("taskType").getAsString());
     assertEquals(3, result.get("totalSteps").getAsInt());
     assertEquals(1, result.get("completedSteps").getAsInt());
-    assertEquals("flash_feed",
-        result.getAsJsonArray("stepResults").get(0).getAsJsonObject().get("step").getAsString());
+    assertEquals("flash_feed", result.getAsJsonArray("stepResults").get(0).getAsJsonObject().get("step").getAsString());
   }
 
   @Test
   void testSolveRejectsMissingTask() {
     JsonObject result = JsonParser.parseString(TaskSolverRunner.solveTask("{}")).getAsJsonObject();
     assertEquals("error", result.get("status").getAsString());
-    assertEquals("MISSING_TASK",
-        result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("MISSING_TASK", result.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   @Test
   void testSolveRejectsBlankOrMalformedTask() {
-    JsonObject blank =
-        JsonParser.parseString(TaskSolverRunner.solveTask("{\"task\":\"   \"}")).getAsJsonObject();
-    assertEquals("MISSING_TASK",
-        blank.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    JsonObject blank = JsonParser.parseString(TaskSolverRunner.solveTask("{\"task\":\"   \"}")).getAsJsonObject();
+    assertEquals("MISSING_TASK", blank.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
 
     JsonObject malformed = JsonParser.parseString(TaskSolverRunner.solveTask("{")).getAsJsonObject();
-    assertEquals("TASK_ERROR",
-        malformed.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("TASK_ERROR", malformed.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- require a non-blank task and reject unsupported descriptions instead of inventing a generic process plan
- route only nine documented keyword families to deterministic fixed plans of existing NeqSim runners
- preserve the canonical shared fluid while exposing its model/components to native runner inputs
- give failed plans an explicit error envelope with planned/completed accounting and the first runner cause code
- qualify the boundary with seven Java task checks and seven real packaged-MCP scenarios

## Capability contract

This is the qualification increment frozen in [campaign #3153](https://github.com/equinor/neqsim/issues/3153#issuecomment-5586510933).

Exact base: `a45494614346ba2331d17edd20f0e93f8f30afc9`  
Initial published head: `6b6911ef68fe16e447fea7cbbf2c6f8d9112a538`  
Current repaired head: `45b5f2891e93bd8299bf8982dec3e1042de44734`

The solver remains Tier 3 and `DESKTOP_ENGINEER`-only. It is a bounded keyword router, not a general planner. Each accepted family maps to a fixed sequence of canonical NeqSim runners. Inputs stay caller-authored; step outputs are collected for review and are not semantically translated into later inputs.

## Acceptance

- [x] focused `TaskSolverRunnerTest`: **12/12**, including seven solve-task contract checks
- [x] focused packaged `test_solve_task_protocol.py`: **7/7**
- [x] comprehensive packaged MCP regression: **331/331**
- [ ] Java 8/21 fast matrix and four slow shards
- [x] Javadocs and documentation search
- [x] CodeQL, pre-commit, Spotless, PaperLab, and agent validation
- [x] no review findings or unresolved threads

The initial pre-commit failure was Spotless-only. Commit `45b5f2891e93bd8299bf8982dec3e1042de44734` applies the exact hosted formatter artifact to the two Java files; no contract behavior changed.

Classification: **VALIDATION PENDING CI** while the Java fast/slow matrix remains active.

## Inventory and boundaries

Inventory intentionally remains `1.32 / 20+32+19`; `solveTask` stays `CONFIRMED_GAP` pending a separate promotion.

This increment does not establish general natural-language planning, arbitrary tool/plugin/code execution, semantic result chaining, numerical fidelity, convergence, conservation, facility completeness, plant/control authority, security hardening, certification, or engineering approval. Results require independent engineering review.

## Coordination

The two base commits after #3570 touch only adsorption code/tests. Open autonomous drafts #3573, #3574, and #3576 change refinery, thermophysical-property, and engineering-diagram files respectively; none overlaps this MCP increment. Autonomous occupancy is **4/10** including this draft.

This PR is intentionally draft-only. Do not merge, rebase, synchronize, enable auto-merge, or mark ready for review as part of the #3153 automation.