### PR TITLE
feat(diagram): improve P&ID proposal legibility

### DIFF
--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -75,7 +75,9 @@ The opt-in registers add a source-linked,
 `P&ID PROPOSAL OVERLAY - REVIEW REQUIRED` layer to the P&ID SVG/PDF sheets
 only. Each proposed nozzle, valve, instrument, and declared interface has an
 independent marker, full-size tag, and stable semantic identity at its canonical
-source equipment. Control/safeguarding relationships use stable, separated
+source equipment. Repeated callouts use deterministic, distributed attachment
+points along the owning equipment boundary instead of converging on one centre
+point. Control/safeguarding relationships use stable, separated
 routing lanes for each source/target equipment pair. PFD rendering, the simulation, and both DEXPI
 exchange profiles remain unchanged. The overlay is review evidence, not a
 complete project P&ID or a qualified symbol catalog.
@@ -94,7 +96,7 @@ the completeness report retains engineering errors and review gaps.
 | Native PFD exchange | Native DEXPI 2.0 Process artifact | Delivery assessment, bundle labels, and full-model topology assertions | External interoperability qualification |
 | P&ID exchange identity | Companion-only child label plus separate native DEXPI 2.0 Plant and Proteus 4.1 proposal artifacts | Plant assessment, profile labels, artifact and deterministic-regeneration assertions | Qualify the full-model proposal and external interoperability |
 | Stream and H&MB companions | Opt-in governed stream/balance artifacts with exact boundary resolution | Valid, missing-case, unknown-boundary, and repeated-delivery tests | Publish and qualify full-model operating values and boundary assignments |
-| Piping and instrumentation content | Opt-in source-linked proposal registers, sidecars, and per-element P&ID-only SVG/PDF callouts | Register fidelity, immutability, signal classification, full-tag/semantic-ID coverage, unique signal-path, profile-difference, and regeneration tests | Supply governed inputs and materialize reviewed per-element exchange content |
+| Piping and instrumentation content | Opt-in source-linked proposal registers, sidecars, and per-element P&ID-only SVG/PDF callouts with distributed equipment-boundary attachment points | Register fidelity, immutability, signal classification, full-tag/semantic-ID and distinct attachment-point coverage, unique signal-path, profile-difference, and regeneration tests | Supply governed inputs and materialize reviewed per-element exchange content |
 | Manual layout and routing | Three persistent proposed A1 sheets, serpentine process-order pins, fixed ports, orthogonal routes, and reciprocal continuations | Layout, renderer, full-model topology, and repeated-delivery tests | Accountable route refinement and reviewed visual baselines |
 | Standards alignment | Explicit scope and no-conformance boundary | Manifest flags and documentation checks | Licensed clause mapping and accountable review |
 

--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -71,14 +71,14 @@ Candidate line bindings require project review. Missing pipe sizes, classes,
 schedules and materials remain `PROJECT_INPUT_REQUIRED`; reducers remain
 `NO_GOVERNED_REDUCER_DECLARATION` rather than invented fittings.
 
-The opt-in registers add a compact, source-linked,
+The opt-in registers add a source-linked,
 `P&ID PROPOSAL OVERLAY - REVIEW REQUIRED` layer to the P&ID SVG/PDF sheets
-only. The layer groups proposed nozzles, valves, instruments, declared
-interfaces, and control/safeguarding signal relationships at their canonical
-source equipment. Every visible proposal marker and signal path carries a
-stable semantic identity. PFD rendering, the simulation, and both DEXPI
+only. Each proposed nozzle, valve, instrument, and declared interface has an
+independent marker, full-size tag, and stable semantic identity at its canonical
+source equipment. Control/safeguarding relationships use stable, separated
+routing lanes for each source/target equipment pair. PFD rendering, the simulation, and both DEXPI
 exchange profiles remain unchanged. The overlay is review evidence, not a
-complete per-element project P&ID or a qualified symbol catalog.
+complete project P&ID or a qualified symbol catalog.
 
 The bundle manifest records that projection boundary and fingerprints all three
 sidecars. `isComplete()` confirms bundle delivery, not an approved P&ID design;
@@ -89,13 +89,13 @@ the completeness report retains engineering errors and review gaps.
 | Requirement | Current implementation | Automated evidence | Remaining acceptance work |
 | --- | --- | --- | --- |
 | One canonical plant, distinct PFD/P&ID profiles | Dual-profile facade, shared source fingerprint, and P&ID-only proposal overlay | `EngineeringDiagramDualProfileDeliveryTest` and full-model profile assertions | Improve whole-sheet clarity without changing the canonical plant |
-| Reviewable vector and PDF sheets | Native A1 SVG/PDF sheets, process-equipment symbols, fixed-port orthogonal routing, flow arrows, and P&ID proposal markers/signals | Renderer tests, bundle artifact checks, and fresh full-sheet/detail inspection | Resolve route, line-label, proposal-tag, and signal-path congestion |
+| Reviewable vector and PDF sheets | Native A1 SVG/PDF sheets, process-equipment symbols, fixed-port orthogonal routing, flow arrows, and independently tagged P&ID proposal markers with separated signal lanes | Renderer tests, bundle artifact checks, and fresh full-sheet/detail inspection | Resolve remaining route and line-label congestion and retain accountable reviewed baselines |
 | Stable regeneration | Deterministic child and bundle manifests plus byte-stable SVG/PDF | Fresh-model repeated-delivery test | Retain accountable reviewed visual baselines |
 | Native PFD exchange | Native DEXPI 2.0 Process artifact | Delivery assessment, bundle labels, and full-model topology assertions | External interoperability qualification |
 | P&ID exchange identity | Companion-only child label plus separate native DEXPI 2.0 Plant and Proteus 4.1 proposal artifacts | Plant assessment, profile labels, artifact and deterministic-regeneration assertions | Qualify the full-model proposal and external interoperability |
 | Stream and H&MB companions | Opt-in governed stream/balance artifacts with exact boundary resolution | Valid, missing-case, unknown-boundary, and repeated-delivery tests | Publish and qualify full-model operating values and boundary assignments |
-| Piping and instrumentation content | Opt-in source-linked proposal registers, sidecars, and compact P&ID-only SVG/PDF overlay | Register fidelity, immutability, signal classification, visible semantic-ID, profile-difference, and regeneration tests | Supply governed inputs; replace grouped teaching markers with legible reviewed per-element drawing and exchange projections |
-| Manual layout and routing | Three persistent proposed A1 sheets, stable pins, fixed ports, orthogonal routes, and reciprocal continuations | Layout, renderer, full-model topology, and repeated-delivery tests | Accountable route refinement and reviewed visual baselines |
+| Piping and instrumentation content | Opt-in source-linked proposal registers, sidecars, and per-element P&ID-only SVG/PDF callouts | Register fidelity, immutability, signal classification, full-tag/semantic-ID coverage, unique signal-path, profile-difference, and regeneration tests | Supply governed inputs and materialize reviewed per-element exchange content |
+| Manual layout and routing | Three persistent proposed A1 sheets, serpentine process-order pins, fixed ports, orthogonal routes, and reciprocal continuations | Layout, renderer, full-model topology, and repeated-delivery tests | Accountable route refinement and reviewed visual baselines |
 | Standards alignment | Explicit scope and no-conformance boundary | Manifest flags and documentation checks | Licensed clause mapping and accountable review |
 
 ## Engineering and qualification boundary
@@ -145,6 +145,6 @@ and the separate native DEXPI 2.0 Plant and Proteus 4.1 P&ID proposal exchanges.
 Passing automation establishes deterministic generation only. Fresh
 full-sheet/detail inspection must still reject unreadable or congested routes,
 labels, markers, and signals. Project metadata, completed and reviewed
-line/nozzle/valve/reducer/instrument/control registers, legible per-element
-drawing and exchange projection, and accountable discipline review remain
+line/nozzle/valve/reducer/instrument/control registers, reviewed exchange
+projection, and accountable discipline review remain
 mandatory before visual acceptance.

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -140,9 +140,11 @@ instruments, declared isolation/drain/vent/relief interfaces, and control or saf
 relationships.
 
 Each register row receives its own symbol and full tag at its source equipment. Category-specific
-callout rails use stable spacing, and control/safeguarding relationships use deterministic lanes per
-source/target equipment pair instead of sharing one overlapping center path. The overlay is still not
-a substitute for project-approved symbols, routing, data, or discipline checking.
+callout rails use stable spacing and distribute repeated connections across deterministic perimeter
+points on the owning equipment instead of converging on one centre point. Control/safeguarding
+relationships use deterministic lanes per source/target equipment pair instead of sharing one
+overlapping centre path. The overlay is still not a substitute for project-approved symbols,
+routing, data, or discipline checking.
 Supplying `null` preserves existing PFD and legacy renderer bytes. The overlay does not alter the
 document topology or either DEXPI exchange profile, and it does not infer pipe size, class, schedule,
 material, reducer duty, completed control logic, or safety design.

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -134,13 +134,15 @@ layout refinement is required.
 
 The five-argument `NativeEngineeringDiagramRenderer` constructor accepts an optional
 `EngineeringDiagramPidRegisters` snapshot. A non-null snapshot must have the same canonical source
-graph fingerprint as the rendered document set. The renderer then adds a compact,
+graph fingerprint as the rendered document set. The renderer then adds a deterministic,
 review-required overlay to SVG and PDF with stable semantic identities for proposed nozzles, valves,
 instruments, declared isolation/drain/vent/relief interfaces, and control or safeguarding signal
 relationships.
 
-The overlay groups proposal categories at their source equipment to keep the projection
-deterministic. It is not a substitute for individually legible, project-approved symbols and tags.
+Each register row receives its own symbol and full tag at its source equipment. Category-specific
+callout rails use stable spacing, and control/safeguarding relationships use deterministic lanes per
+source/target equipment pair instead of sharing one overlapping center path. The overlay is still not
+a substitute for project-approved symbols, routing, data, or discipline checking.
 Supplying `null` preserves existing PFD and legacy renderer bytes. The overlay does not alter the
 document topology or either DEXPI exchange profile, and it does not infer pipe size, class, schedule,
 material, reducer duty, completed control logic, or safety design.

--- a/src/main/java/neqsim/process/examples/Comparesimulations2EngineeringDiagramReference.java
+++ b/src/main/java/neqsim/process/examples/Comparesimulations2EngineeringDiagramReference.java
@@ -148,13 +148,18 @@ public final class Comparesimulations2EngineeringDiagramReference {
   private static EngineeringDiagramLayoutRegister place(EngineeringDiagramLayoutRegister register, String sheet,
       String[] names, Map<String, String> equipmentIds) {
     EngineeringDiagramLayoutRegister result = register;
+    int columns = names.length >= 13 ? 5 : 4;
+    int rows = (names.length + columns - 1) / columns;
     for (int index = 0; index < names.length; index++) {
       String objectId = equipmentIds.get(names[index]);
       if (objectId == null) {
         throw new IllegalStateException("Proposed layout references missing canonical equipment: " + names[index]);
       }
-      double x = 90.0 + (index % 5) * 145.0;
-      double y = 105.0 + (index / 5) * 150.0;
+      int row = index / columns;
+      int positionInRow = index % columns;
+      int column = row % 2 == 0 ? positionInRow : columns - 1 - positionInRow;
+      double x = 90.0 + column * (660.0 / (columns - 1));
+      double y = rows == 1 ? 280.0 : 100.0 + row * (360.0 / (rows - 1));
       result = result
           .withAssignment(new SheetAssignment(objectId, sheet, SOURCE + ":proposed-layout",
               EngineeringDiagramLayoutRegister.EvidenceState.PROPOSED, RECORDED_BY, RECORDED_AT, REVISION))

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -1080,9 +1080,10 @@ public final class NativeEngineeringDiagramRenderer {
       Map<String, Object> row = rows.get(index);
       String id = textValue(row.get("id"));
       Point marker = pidMarkerPosition(equipment, register, index, rows.size());
+      Point connection = pidMarkerConnectionPoint(equipment, register, index, rows.size());
       proposalPositions.put(id, marker);
       proposalOwners.put(id, equipmentId);
-      addPidMarker(page, register, equipment, marker, id, textValue(row.get("tag")));
+      addPidMarker(page, register, connection, marker, id, textValue(row.get("tag")));
     }
   }
 
@@ -1099,15 +1100,27 @@ public final class NativeEngineeringDiagramRenderer {
     return new Point(equipment.x + centered * PID_HORIZONTAL_MARKER_SPACING, y);
   }
 
-  private static void addPidMarker(Page page, String register, Point equipment, Point marker, String id, String tag) {
+  private static Point pidMarkerConnectionPoint(Point equipment, String register, int index, int count) {
+    double fraction = count == 1 ? 0.5 : (double) index / (count - 1);
+    if ("nozzles".equals(register) || "interfaces".equals(register)) {
+      double y = equipment.y - OBJECT_HEIGHT / 2.0 + 3.0 + fraction * (OBJECT_HEIGHT - 6.0);
+      double x = "nozzles".equals(register) ? equipment.x - OBJECT_WIDTH / 2.0 : equipment.x + OBJECT_WIDTH / 2.0;
+      return new Point(x, y);
+    }
+    double x = equipment.x - OBJECT_WIDTH / 2.0 + 4.0 + fraction * (OBJECT_WIDTH - 8.0);
+    double y = "instruments".equals(register) ? equipment.y - OBJECT_HEIGHT / 2.0 : equipment.y + OBJECT_HEIGHT / 2.0;
+    return new Point(x, y);
+  }
+
+  private static void addPidMarker(Page page, String register, Point connection, Point marker, String id, String tag) {
     String semanticId = "pid-proposal:" + id;
     if ("instruments".equals(register)) {
       page.commands.add(Command.polygon(
           Arrays.asList(new Point(marker.x, marker.y - 3.0), new Point(marker.x + 3.0, marker.y),
               new Point(marker.x, marker.y + 3.0), new Point(marker.x - 3.0, marker.y)),
           "#2563eb", "#ffffff", 0.6, semanticId));
-      page.commands.add(Command.line(marker.x, marker.y + 3.0, equipment.x, equipment.y - OBJECT_HEIGHT / 2.0,
-          "#2563eb", 0.4, semanticId + ":connection", ""));
+      page.commands.add(Command.line(marker.x, marker.y + 3.0, connection.x, connection.y, "#2563eb", 0.4,
+          semanticId + ":connection", ""));
     } else if ("valves".equals(register)) {
       page.commands
           .add(Command.polygon(Arrays.asList(new Point(marker.x - 3.5, marker.y - 2.5), new Point(marker.x, marker.y),
@@ -1115,19 +1128,19 @@ public final class NativeEngineeringDiagramRenderer {
       page.commands
           .add(Command.polygon(Arrays.asList(new Point(marker.x + 3.5, marker.y - 2.5), new Point(marker.x, marker.y),
               new Point(marker.x + 3.5, marker.y + 2.5)), "#7c2d12", "#ffffff", 0.6, semanticId + ":half"));
-      page.commands.add(Command.line(marker.x, marker.y - 2.5, equipment.x, equipment.y + OBJECT_HEIGHT / 2.0,
-          "#7c2d12", 0.4, semanticId + ":connection", ""));
+      page.commands.add(Command.line(marker.x, marker.y - 2.5, connection.x, connection.y, "#7c2d12", 0.4,
+          semanticId + ":connection", ""));
     } else if ("interfaces".equals(register)) {
       page.commands.add(
           Command.polygon(Arrays.asList(new Point(marker.x - 3.0, marker.y - 3.0), new Point(marker.x + 3.0, marker.y),
               new Point(marker.x - 3.0, marker.y + 3.0)), "#6d28d9", "#ffffff", 0.6, semanticId));
-      page.commands.add(Command.line(marker.x - 3.0, marker.y, equipment.x + OBJECT_WIDTH / 2.0, equipment.y, "#6d28d9",
-          0.4, semanticId + ":connection", ""));
+      page.commands.add(Command.line(marker.x - 3.0, marker.y, connection.x, connection.y, "#6d28d9", 0.4,
+          semanticId + ":connection", ""));
     } else {
       page.commands
           .add(Command.rect(marker.x - 1.5, marker.y - 1.5, 3.0, 3.0, "#0891b2", "#ffffff", 0.5, semanticId, ""));
-      page.commands.add(Command.line(marker.x + 1.5, marker.y, equipment.x - OBJECT_WIDTH / 2.0, equipment.y, "#0891b2",
-          0.4, semanticId + ":connection", ""));
+      page.commands.add(Command.line(marker.x + 1.5, marker.y, connection.x, connection.y, "#0891b2", 0.4,
+          semanticId + ":connection", ""));
     }
     if ("nozzles".equals(register)) {
       page.commands

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -1,6 +1,3 @@
-Warning: truncated output (original token count: 20674)
-Total output lines: 1754
-
 package neqsim.process.processmodel.diagram;
 
 import java.io.ByteArrayOutputStream;
@@ -841,7 +838,52 @@ public final class NativeEngineeringDiagramRenderer {
         : convention.getFillColor();
     if (shape == SymbolShape.PROCESS_EQUIPMENT) {
       addProcessEquipmentSymbol(page, object, position, stroke, fill);
-    } else if (shape …674 tokens truncated…quals(family)) {
+    } else if (shape == SymbolShape.LINE_TERMINAL) {
+      addLineTerminalSymbol(page, object, position, stroke, fill);
+    } else {
+      page.commands.add(symbolCommand(shape, position, stroke, fill, object.getId()));
+    }
+    String primary = displayLabel(object);
+    page.commands.add(Command.text(position.x, position.y - 0.8, 2.8, primary, "#111827", object.getId(), "middle"));
+    String secondary = shape == SymbolShape.PROCESS_EQUIPMENT ? equipmentFamily(object) : object.getKind().name();
+    page.commands.add(Command.text(position.x, position.y + 4.0, 2.0, secondary, "#4b5563", object.getId(), "middle"));
+  }
+
+  private static void addProcessEquipmentSymbol(Page page, SemanticObject object, Point position, String stroke,
+      String fill) {
+    String family = equipmentFamily(object);
+    double left = position.x - OBJECT_WIDTH / 2.0;
+    double right = position.x + OBJECT_WIDTH / 2.0;
+    double top = position.y - OBJECT_HEIGHT / 2.0;
+    double bottom = position.y + OBJECT_HEIGHT / 2.0;
+    if ("SEPARATOR".equals(family)) {
+      page.commands.add(Command.polygon(Arrays.asList(new Point(left + 7.0, top), new Point(right - 7.0, top),
+          new Point(right, top + 5.0), new Point(right, bottom - 5.0), new Point(right - 7.0, bottom),
+          new Point(left + 7.0, bottom), new Point(left, bottom - 5.0), new Point(left, top + 5.0)), stroke, fill, 0.7,
+          object.getId()));
+      page.commands.add(Command.line(left + 2.0, position.y + 2.5, right - 2.0, position.y + 2.5, stroke, 0.5, "", ""));
+      return;
+    }
+    if ("HEAT EXCHANGER".equals(family)) {
+      page.commands.add(Command.polygon(Arrays.asList(new Point(position.x, top), new Point(right, position.y),
+          new Point(position.x, bottom), new Point(left, position.y)), stroke, fill, 0.7, object.getId()));
+      page.commands.add(Command.line(left + 8.0, top + 3.0, right - 8.0, bottom - 3.0, stroke, 0.5, "", ""));
+      page.commands.add(Command.line(left + 8.0, bottom - 3.0, right - 8.0, top + 3.0, stroke, 0.5, "", ""));
+      return;
+    }
+    if ("COMPRESSOR".equals(family)) {
+      page.commands.add(Command.polygon(Arrays.asList(new Point(left, position.y - 4.0), new Point(right, top),
+          new Point(right, bottom), new Point(left, position.y + 4.0)), stroke, fill, 0.7, object.getId()));
+      return;
+    }
+    if ("PUMP".equals(family)) {
+      page.commands.add(Command.polygon(
+          Arrays.asList(new Point(left + 5.0, top), new Point(right - 8.0, top), new Point(right, position.y),
+              new Point(right - 8.0, bottom), new Point(left + 5.0, bottom), new Point(left, position.y)),
+          stroke, fill, 0.7, object.getId()));
+      return;
+    }
+    if ("VALVE".equals(family)) {
       page.commands.add(Command.polygon(
           Arrays.asList(new Point(left, top), new Point(position.x, position.y), new Point(left, bottom)), stroke, fill,
           0.7, object.getId()));

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -1,3 +1,6 @@
+Warning: truncated output (original token count: 20674)
+Total output lines: 1754
+
 package neqsim.process.processmodel.diagram;
 
 import java.io.ByteArrayOutputStream;
@@ -52,6 +55,10 @@ public final class NativeEngineeringDiagramRenderer {
   private static final double PORT_MARKER_SIZE = 1.8;
   private static final double PORT_SLOT_MARGIN = 2.0;
   private static final double PARALLEL_LANE_SPACING = 4.0;
+  private static final double PID_TAG_TEXT_SIZE = 2.2;
+  private static final double PID_HORIZONTAL_MARKER_SPACING = 24.0;
+  private static final double PID_VERTICAL_MARKER_SPACING = 10.0;
+  private static final double PID_SIGNAL_LANE_SPACING = 3.0;
 
   /** Controlled paper sizes supported by the native renderer. */
   public enum SheetFormat {
@@ -834,52 +841,7 @@ public final class NativeEngineeringDiagramRenderer {
         : convention.getFillColor();
     if (shape == SymbolShape.PROCESS_EQUIPMENT) {
       addProcessEquipmentSymbol(page, object, position, stroke, fill);
-    } else if (shape == SymbolShape.LINE_TERMINAL) {
-      addLineTerminalSymbol(page, object, position, stroke, fill);
-    } else {
-      page.commands.add(symbolCommand(shape, position, stroke, fill, object.getId()));
-    }
-    String primary = displayLabel(object);
-    page.commands.add(Command.text(position.x, position.y - 0.8, 2.8, primary, "#111827", object.getId(), "middle"));
-    String secondary = shape == SymbolShape.PROCESS_EQUIPMENT ? equipmentFamily(object) : object.getKind().name();
-    page.commands.add(Command.text(position.x, position.y + 4.0, 2.0, secondary, "#4b5563", object.getId(), "middle"));
-  }
-
-  private static void addProcessEquipmentSymbol(Page page, SemanticObject object, Point position, String stroke,
-      String fill) {
-    String family = equipmentFamily(object);
-    double left = position.x - OBJECT_WIDTH / 2.0;
-    double right = position.x + OBJECT_WIDTH / 2.0;
-    double top = position.y - OBJECT_HEIGHT / 2.0;
-    double bottom = position.y + OBJECT_HEIGHT / 2.0;
-    if ("SEPARATOR".equals(family)) {
-      page.commands.add(Command.polygon(Arrays.asList(new Point(left + 7.0, top), new Point(right - 7.0, top),
-          new Point(right, top + 5.0), new Point(right, bottom - 5.0), new Point(right - 7.0, bottom),
-          new Point(left + 7.0, bottom), new Point(left, bottom - 5.0), new Point(left, top + 5.0)), stroke, fill, 0.7,
-          object.getId()));
-      page.commands.add(Command.line(left + 2.0, position.y + 2.5, right - 2.0, position.y + 2.5, stroke, 0.5, "", ""));
-      return;
-    }
-    if ("HEAT EXCHANGER".equals(family)) {
-      page.commands.add(Command.polygon(Arrays.asList(new Point(position.x, top), new Point(right, position.y),
-          new Point(position.x, bottom), new Point(left, position.y)), stroke, fill, 0.7, object.getId()));
-      page.commands.add(Command.line(left + 8.0, top + 3.0, right - 8.0, bottom - 3.0, stroke, 0.5, "", ""));
-      page.commands.add(Command.line(left + 8.0, bottom - 3.0, right - 8.0, top + 3.0, stroke, 0.5, "", ""));
-      return;
-    }
-    if ("COMPRESSOR".equals(family)) {
-      page.commands.add(Command.polygon(Arrays.asList(new Point(left, position.y - 4.0), new Point(right, top),
-          new Point(right, bottom), new Point(left, position.y + 4.0)), stroke, fill, 0.7, object.getId()));
-      return;
-    }
-    if ("PUMP".equals(family)) {
-      page.commands.add(Command.polygon(
-          Arrays.asList(new Point(left + 5.0, top), new Point(right - 8.0, top), new Point(right, position.y),
-              new Point(right - 8.0, bottom), new Point(left + 5.0, bottom), new Point(left, position.y)),
-          stroke, fill, 0.7, object.getId()));
-      return;
-    }
-    if ("VALVE".equals(family)) {
+    } else if (shape …674 tokens truncated…quals(family)) {
       page.commands.add(Command.polygon(
           Arrays.asList(new Point(left, top), new Point(position.x, position.y), new Point(left, bottom)), stroke, fill,
           0.7, object.getId()));
@@ -1014,6 +976,7 @@ public final class NativeEngineeringDiagramRenderer {
       }
     }
     Map<String, Point> proposalPositions = new TreeMap<String, Point>();
+    Map<String, String> proposalOwners = new TreeMap<String, String>();
     List<String> equipmentIds = new ArrayList<String>(positions.keySet());
     Collections.sort(equipmentIds);
     for (String equipmentId : equipmentIds) {
@@ -1022,16 +985,20 @@ public final class NativeEngineeringDiagramRenderer {
         continue;
       }
       Point equipment = positions.get(equipmentId);
-      addPidMarker(page, equipmentId, "nozzles", rowsByEquipment, equipment,
-          new Point(equipment.x - OBJECT_WIDTH / 2.0 - 4.0, equipment.y), proposalPositions);
-      addPidMarker(page, equipmentId, "instruments", rowsByEquipment, equipment,
-          new Point(equipment.x, equipment.y - OBJECT_HEIGHT / 2.0 - 7.0), proposalPositions);
-      addPidMarker(page, equipmentId, "valves", rowsByEquipment, equipment,
-          new Point(equipment.x, equipment.y + OBJECT_HEIGHT / 2.0 + 7.0), proposalPositions);
-      addPidMarker(page, equipmentId, "interfaces", rowsByEquipment, equipment,
-          new Point(equipment.x + OBJECT_WIDTH / 2.0 + 8.0, equipment.y - 7.0), proposalPositions);
+      addPidMarkers(page, equipmentId, "nozzles", rowsByEquipment, equipment, proposalPositions, proposalOwners);
+      addPidMarkers(page, equipmentId, "instruments", rowsByEquipment, equipment, proposalPositions, proposalOwners);
+      addPidMarkers(page, equipmentId, "valves", rowsByEquipment, equipment, proposalPositions, proposalOwners);
+      addPidMarkers(page, equipmentId, "interfaces", rowsByEquipment, equipment, proposalPositions, proposalOwners);
     }
-    for (Map<String, Object> signal : proposalRows(registerData, "controlSignals")) {
+    List<Map<String, Object>> signals = proposalRows(registerData, "controlSignals");
+    Collections.sort(signals, new Comparator<Map<String, Object>>() {
+      @Override
+      public int compare(Map<String, Object> left, Map<String, Object> right) {
+        return signalId(left).compareTo(signalId(right));
+      }
+    });
+    Map<String, Double> signalLanes = pidSignalLanes(signals, proposalOwners);
+    for (Map<String, Object> signal : signals) {
       String sourceId = textValue(signal.get("sourcePidElementId"));
       String targetId = textValue(signal.get("targetPidElementId"));
       Point source = proposalPositions.get(sourceId);
@@ -1040,11 +1007,13 @@ public final class NativeEngineeringDiagramRenderer {
         continue;
       }
       List<Point> points;
+      double lane = signalLanes.containsKey(signalId(signal)) ? signalLanes.get(signalId(signal)).doubleValue() : 0.0;
       if (distance(source, target) < 0.001) {
-        points = Arrays.asList(source, new Point(source.x + 5.0, source.y - 5.0), new Point(source.x + 10.0, source.y),
-            source);
+        double loop = 8.0 + Math.abs(lane);
+        points = Arrays.asList(source, new Point(source.x + loop, source.y - loop),
+            new Point(source.x + loop * 2.0, source.y), source);
       } else {
-        double middleX = (source.x + target.x) / 2.0;
+        double middleX = (source.x + target.x) / 2.0 + lane;
         points = Arrays.asList(source, new Point(middleX, source.y), new Point(middleX, target.y), target);
       }
       page.commands
@@ -1052,9 +1021,9 @@ public final class NativeEngineeringDiagramRenderer {
     }
   }
 
-  private static void addPidMarker(Page page, String equipmentId, String register,
-      Map<String, List<Map<String, Object>>> rowsByEquipment, Point equipment, Point marker,
-      Map<String, Point> proposalPositions) {
+  private static void addPidMarkers(Page page, String equipmentId, String register,
+      Map<String, List<Map<String, Object>>> rowsByEquipment, Point equipment, Map<String, Point> proposalPositions,
+      Map<String, String> proposalOwners) {
     List<Map<String, Object>> rows = rowsByEquipment.get(equipmentId + "|" + register);
     if (rows == null || rows.isEmpty()) {
       return;
@@ -1065,13 +1034,31 @@ public final class NativeEngineeringDiagramRenderer {
         return textValue(left.get("id")).compareTo(textValue(right.get("id")));
       }
     });
-    String firstId = textValue(rows.get(0).get("id"));
-    String firstTag = textValue(rows.get(0).get("tag"));
-    for (Map<String, Object> row : rows) {
-      proposalPositions.put(textValue(row.get("id")), marker);
+    for (int index = 0; index < rows.size(); index++) {
+      Map<String, Object> row = rows.get(index);
+      String id = textValue(row.get("id"));
+      Point marker = pidMarkerPosition(equipment, register, index, rows.size());
+      proposalPositions.put(id, marker);
+      proposalOwners.put(id, equipmentId);
+      addPidMarker(page, register, equipment, marker, id, textValue(row.get("tag")));
     }
-    String count = rows.size() == 1 ? "" : " +" + (rows.size() - 1);
-    String semanticId = "pid-proposal:" + firstId;
+  }
+
+  private static Point pidMarkerPosition(Point equipment, String register, int index, int count) {
+    double centered = index - (count - 1) / 2.0;
+    if ("nozzles".equals(register)) {
+      return new Point(equipment.x - OBJECT_WIDTH / 2.0 - 14.0, equipment.y + centered * PID_VERTICAL_MARKER_SPACING);
+    }
+    if ("interfaces".equals(register)) {
+      return new Point(equipment.x + OBJECT_WIDTH / 2.0 + 16.0, equipment.y + centered * PID_VERTICAL_MARKER_SPACING);
+    }
+    double y = "instruments".equals(register) ? equipment.y - OBJECT_HEIGHT / 2.0 - 15.0
+        : equipment.y + OBJECT_HEIGHT / 2.0 + 16.0;
+    return new Point(equipment.x + centered * PID_HORIZONTAL_MARKER_SPACING, y);
+  }
+
+  private static void addPidMarker(Page page, String register, Point equipment, Point marker, String id, String tag) {
+    String semanticId = "pid-proposal:" + id;
     if ("instruments".equals(register)) {
       page.commands.add(Command.polygon(
           Arrays.asList(new Point(marker.x, marker.y - 3.0), new Point(marker.x + 3.0, marker.y),
@@ -1086,16 +1073,64 @@ public final class NativeEngineeringDiagramRenderer {
       page.commands
           .add(Command.polygon(Arrays.asList(new Point(marker.x + 3.5, marker.y - 2.5), new Point(marker.x, marker.y),
               new Point(marker.x + 3.5, marker.y + 2.5)), "#7c2d12", "#ffffff", 0.6, semanticId + ":half"));
+      page.commands.add(Command.line(marker.x, marker.y - 2.5, equipment.x, equipment.y + OBJECT_HEIGHT / 2.0,
+          "#7c2d12", 0.4, semanticId + ":connection", ""));
     } else if ("interfaces".equals(register)) {
       page.commands.add(
           Command.polygon(Arrays.asList(new Point(marker.x - 3.0, marker.y - 3.0), new Point(marker.x + 3.0, marker.y),
               new Point(marker.x - 3.0, marker.y + 3.0)), "#6d28d9", "#ffffff", 0.6, semanticId));
+      page.commands.add(Command.line(marker.x - 3.0, marker.y, equipment.x + OBJECT_WIDTH / 2.0, equipment.y, "#6d28d9",
+          0.4, semanticId + ":connection", ""));
     } else {
       page.commands
           .add(Command.rect(marker.x - 1.5, marker.y - 1.5, 3.0, 3.0, "#0891b2", "#ffffff", 0.5, semanticId, ""));
+      page.commands.add(Command.line(marker.x + 1.5, marker.y, equipment.x - OBJECT_WIDTH / 2.0, equipment.y, "#0891b2",
+          0.4, semanticId + ":connection", ""));
     }
-    page.commands
-        .add(Command.text(marker.x, marker.y - 4.5, 1.5, firstTag + count, "#111827", semanticId + ":tag", "middle"));
+    if ("nozzles".equals(register)) {
+      page.commands
+          .add(Command.text(marker.x - 4.0, marker.y, PID_TAG_TEXT_SIZE, tag, "#111827", semanticId + ":tag", "end"));
+    } else if ("interfaces".equals(register)) {
+      page.commands
+          .add(Command.text(marker.x + 4.0, marker.y, PID_TAG_TEXT_SIZE, tag, "#111827", semanticId + ":tag", ""));
+    } else {
+      page.commands.add(
+          Command.text(marker.x, marker.y - 4.8, PID_TAG_TEXT_SIZE, tag, "#111827", semanticId + ":tag", "middle"));
+    }
+  }
+
+  private static Map<String, Double> pidSignalLanes(List<Map<String, Object>> signals,
+      Map<String, String> proposalOwners) {
+    Map<String, List<Map<String, Object>>> byOwnerPair = new TreeMap<String, List<Map<String, Object>>>();
+    for (Map<String, Object> signal : signals) {
+      String source = textValue(signal.get("sourcePidElementId"));
+      String target = textValue(signal.get("targetPidElementId"));
+      String pair = textValue(proposalOwners.get(source)) + "|" + textValue(proposalOwners.get(target));
+      List<Map<String, Object>> group = byOwnerPair.get(pair);
+      if (group == null) {
+        group = new ArrayList<Map<String, Object>>();
+        byOwnerPair.put(pair, group);
+      }
+      group.add(signal);
+    }
+    Map<String, Double> result = new TreeMap<String, Double>();
+    for (List<Map<String, Object>> group : byOwnerPair.values()) {
+      Collections.sort(group, new Comparator<Map<String, Object>>() {
+        @Override
+        public int compare(Map<String, Object> left, Map<String, Object> right) {
+          return signalId(left).compareTo(signalId(right));
+        }
+      });
+      for (int index = 0; index < group.size(); index++) {
+        double centered = index - (group.size() - 1) / 2.0;
+        result.put(signalId(group.get(index)), Double.valueOf(centered * PID_SIGNAL_LANE_SPACING));
+      }
+    }
+    return result;
+  }
+
+  private static String signalId(Map<String, Object> signal) {
+    return textValue(signal.get("sourcePidElementId")) + ":" + textValue(signal.get("targetPidElementId"));
   }
 
   private static List<Map<String, Object>> proposalRows(Map<String, Object> data, String register) {

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -11,6 +11,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import neqsim.process.processmodel.ProcessSystem;
@@ -67,7 +73,8 @@ class EngineeringDiagramDualProfileDeliveryTest {
     assertEquals(baseline.getPfd().getRendering().getSvgBySheetId(), report.getPfd().getRendering().getSvgBySheetId());
     assertNotEquals(baseline.getPid().getRendering().getSvgBySheetId(),
         report.getPid().getRendering().getSvgBySheetId());
-    assertTrue(report.getPid().getRendering().getSvgBySheetId().toString().contains("P&amp;ID PROPOSAL OVERLAY"));
+    String pidSvg = String.join("\n", report.getPid().getRendering().getSvgBySheetId().values());
+    assertTrue(pidSvg.contains("P&amp;ID PROPOSAL OVERLAY"));
     assertFalse(report.getPfd().getRendering().getSvgBySheetId().toString().contains("P&amp;ID PROPOSAL OVERLAY"));
     EngineeringDiagramPidRegisters registers = report.getPidEngineeringRegisters();
     assertEquals(report.getPid().getDocumentSet().getSourceGraphFingerprint(), registers.getSourceGraphFingerprint());
@@ -78,6 +85,26 @@ class EngineeringDiagramDualProfileDeliveryTest {
     assertTrue(registers.getControlSignalCount() > 0);
     assertTrue(registers.getInterfaceCount() > 0);
     assertTrue(registers.getGapCount() > 0);
+    int proposalCount = 0;
+    for (String register : new String[] { "nozzles", "valves", "instruments", "interfaces" }) {
+      for (Map<String, Object> row : rows(registers, register)) {
+        String id = String.valueOf(row.get("id"));
+        String tag = String.valueOf(row.get("tag"));
+        assertTrue(pidSvg.contains("data-semantic-id=\"pid-proposal:" + id + "\""), id);
+        assertTrue(pidSvg.contains(">" + tag + "</text>"), tag);
+        proposalCount++;
+      }
+    }
+    assertTrue(proposalCount > 4);
+    assertFalse(pidSvg.contains(" +1</text>"));
+    assertTrue(pidSvg.contains("font-size=\"2.2\""));
+    List<Map<String, Object>> signals = rows(registers, "controlSignals");
+    assertTrue(signals.size() > 1);
+    for (Map<String, Object> signal : signals) {
+      String signalId = "pid-signal:" + signal.get("sourcePidElementId") + ":" + signal.get("targetPidElementId");
+      assertTrue(pidSvg.contains("data-semantic-id=\"" + signalId + "\""), signalId);
+    }
+    assertEquals(signals.size(), signalPaths(pidSvg).size());
     assertTrue(((java.util.List<?>) registers.toMap().get("nozzles")).stream().anyMatch(
         row -> !((java.util.List<?>) ((java.util.Map<?, ?>) row).get("candidateSemanticConnectionIds")).isEmpty()));
     for (String file : new String[] { "pid-design-model.json", "pid-completeness-report.json",
@@ -122,5 +149,20 @@ class EngineeringDiagramDualProfileDeliveryTest {
         .deliver(EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), existing, request));
     assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramDualProfileDelivery.Request
         .builder(" ", "A", "PFD-10-001", "PID-10-001", "Separation and compression").build());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> rows(EngineeringDiagramPidRegisters registers, String name) {
+    return (List<Map<String, Object>>) (List<?>) registers.toMap().get(name);
+  }
+
+  private static Set<String> signalPaths(String svg) {
+    Pattern pattern = Pattern.compile("<polyline points=\"([^\"]+)\"[^>]+data-semantic-id=\"pid-signal:[^\"]+\"");
+    Matcher matcher = pattern.matcher(svg);
+    Set<String> result = new HashSet<String>();
+    while (matcher.find()) {
+      result.add(matcher.group(1));
+    }
+    return result;
   }
 }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -86,10 +86,18 @@ class EngineeringDiagramDualProfileDeliveryTest {
     assertTrue(registers.getInterfaceCount() > 0);
     assertTrue(registers.getGapCount() > 0);
     int proposalCount = 0;
+    Map<String, List<String>> proposalIdsByOwnerAndRegister = new java.util.TreeMap<String, List<String>>();
     for (String register : new String[] { "nozzles", "valves", "instruments", "interfaces" }) {
       for (Map<String, Object> row : rows(registers, register)) {
         String id = String.valueOf(row.get("id"));
         String tag = String.valueOf(row.get("tag"));
+        String group = row.get("semanticEquipmentId") + "|" + register;
+        List<String> proposalIds = proposalIdsByOwnerAndRegister.get(group);
+        if (proposalIds == null) {
+          proposalIds = new java.util.ArrayList<String>();
+          proposalIdsByOwnerAndRegister.put(group, proposalIds);
+        }
+        proposalIds.add(id);
         assertTrue(pidSvg.contains("data-semantic-id=\"pid-proposal:" + id + "\""), id);
         assertTrue(pidSvg.contains(">" + tag + "</text>"), tag);
         proposalCount++;
@@ -98,6 +106,16 @@ class EngineeringDiagramDualProfileDeliveryTest {
     assertTrue(proposalCount > 4);
     assertFalse(pidSvg.contains(" +1</text>"));
     assertTrue(pidSvg.contains("font-size=\"2.2\""));
+    for (Map.Entry<String, List<String>> entry : proposalIdsByOwnerAndRegister.entrySet()) {
+      if (entry.getValue().size() < 2) {
+        continue;
+      }
+      Set<String> ownerTerminals = new HashSet<String>();
+      for (String id : entry.getValue()) {
+        ownerTerminals.add(proposalConnectionTerminal(pidSvg, id));
+      }
+      assertEquals(entry.getValue().size(), ownerTerminals.size(), entry.getKey());
+    }
     List<Map<String, Object>> signals = rows(registers, "controlSignals");
     assertTrue(signals.size() > 1);
     for (Map<String, Object> signal : signals) {
@@ -164,5 +182,14 @@ class EngineeringDiagramDualProfileDeliveryTest {
       result.add(matcher.group(1));
     }
     return result;
+  }
+
+  private static String proposalConnectionTerminal(String svg, String proposalId) {
+    Pattern pattern = Pattern.compile("<polyline points=\"([^\"]+)\"[^>]+data-semantic-id=\""
+        + Pattern.quote("pid-proposal:" + proposalId + ":connection") + "\"");
+    Matcher matcher = pattern.matcher(svg);
+    assertTrue(matcher.find(), proposalId);
+    String[] points = matcher.group(1).split(" ");
+    return points[points.length - 1];
   }
 }


### PR DESCRIPTION
## Scope

Successor to merged #3558 at the next safe shared-lane boundary. This bounded batch improves the model-generated `comparesimulations2` P&ID proposal without changing the canonical process topology or the PFD/DEXPI profile boundaries.

- renders every nozzle, valve, instrument, and declared interface as an independently identifiable proposal element with its full tag
- assigns stable `pid-proposal:<register-id>` SVG identities
- gives each control/safeguarding signal a deterministic collision-resistant lane
- improves the persistent A1 placement with a five-column serpentine process order
- adds tests first and updates the requirement-to-evidence guidance

## Validation

- `NativeEngineeringDiagramRendererTest`: 10/10
- `EngineeringDiagramDualProfileDeliveryTest`: 4/4
- `Comparesimulations2EngineeringDiagramReferenceTest`: 1/1 full-model slow reference
- Spotless apply/check, documentation-search audit, and `git diff --check`: pass
- fresh generation: four A1 PFD sheets and four A1 P&ID sheets in SVG/PDF
- source topology fingerprint unchanged: `69bd4378c3c444906f1109d1a233ae9acccdf86ce2e47577bfbf8b577936d045`
- every fresh sheet inspected full-sheet and at 200 dpi

## Whole-sheet gate

Visual acceptance remains **blocked**. The proposal evidence is now individually readable at detail scale, but the automatic overview remains sparse and route/off-page-label congestion plus dense signal/callout fans remain on manual sheets. External interoperability qualification and clean retained-output notebook publication also remain outside this batch.

`24-VB-01` is not present in the runnable model and was not fabricated. The P&ID remains a review-required teaching proposal, not a completed safety design or construction document. No ISO/ISA conformance, certification, safety credit, or engineering approval is claimed. Native DEXPI 2.0 Plant and Proteus 4.1 claims remain distinct.

Relates to #1332 and #2899.