### PR TITLE
feat(diagram): compact P&ID proposal routing

### DIFF
--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -74,11 +74,12 @@ schedules and materials remain `PROJECT_INPUT_REQUIRED`; reducers remain
 The opt-in registers add a source-linked,
 `P&ID PROPOSAL OVERLAY - REVIEW REQUIRED` layer to the P&ID SVG/PDF sheets
 only. Each proposed nozzle, valve, instrument, and declared interface has an
-independent marker, full-size tag, and stable semantic identity at its canonical
-source equipment. Repeated callouts use deterministic, distributed attachment
-points along the owning equipment boundary instead of converging on one centre
-point. Control/safeguarding relationships use stable, separated
-routing lanes for each source/target equipment pair. PFD rendering, the simulation, and both DEXPI
+independent marker, legible full tag, and stable semantic identity at its canonical
+source equipment. Dense instrument and valve callouts use deterministic four-column
+racks with multiple rows plus distributed attachment points along the owning
+equipment boundary instead of one wide converging fan. Same-equipment
+control/safeguarding relationships use alternating external tracks; other
+relationships retain stable separated lanes. PFD rendering, the simulation, and both DEXPI
 exchange profiles remain unchanged. The overlay is review evidence, not a
 complete project P&ID or a qualified symbol catalog.
 
@@ -91,7 +92,7 @@ the completeness report retains engineering errors and review gaps.
 | Requirement | Current implementation | Automated evidence | Remaining acceptance work |
 | --- | --- | --- | --- |
 | One canonical plant, distinct PFD/P&ID profiles | Dual-profile facade, shared source fingerprint, and P&ID-only proposal overlay | `EngineeringDiagramDualProfileDeliveryTest` and full-model profile assertions | Improve whole-sheet clarity without changing the canonical plant |
-| Reviewable vector and PDF sheets | Native A1 SVG/PDF sheets, process-equipment symbols, fixed-port orthogonal routing, flow arrows, and independently tagged P&ID proposal markers with separated signal lanes | Renderer tests, bundle artifact checks, and fresh full-sheet/detail inspection | Resolve remaining route and line-label congestion and retain accountable reviewed baselines |
+| Reviewable vector and PDF sheets | Native A1 SVG/PDF sheets, process-equipment symbols, fixed-port orthogonal routing, flow arrows, compact multi-row P&ID proposal racks, and external same-equipment signal tracks | Renderer tests, rack-span/row/track checks, bundle artifact checks, and fresh full-sheet/detail inspection | Resolve remaining process-route and off-page-label congestion and retain accountable reviewed baselines |
 | Stable regeneration | Deterministic child and bundle manifests plus byte-stable SVG/PDF | Fresh-model repeated-delivery test | Retain accountable reviewed visual baselines |
 | Native PFD exchange | Native DEXPI 2.0 Process artifact | Delivery assessment, bundle labels, and full-model topology assertions | External interoperability qualification |
 | P&ID exchange identity | Companion-only child label plus separate native DEXPI 2.0 Plant and Proteus 4.1 proposal artifacts | Plant assessment, profile labels, artifact and deterministic-regeneration assertions | Qualify the full-model proposal and external interoperability |

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -52,10 +52,12 @@ public final class NativeEngineeringDiagramRenderer {
   private static final double PORT_MARKER_SIZE = 1.8;
   private static final double PORT_SLOT_MARGIN = 2.0;
   private static final double PARALLEL_LANE_SPACING = 4.0;
-  private static final double PID_TAG_TEXT_SIZE = 2.2;
-  private static final double PID_HORIZONTAL_MARKER_SPACING = 24.0;
+  private static final double PID_TAG_TEXT_SIZE = 2.5;
+  private static final double PID_HORIZONTAL_MARKER_SPACING = 28.0;
   private static final double PID_VERTICAL_MARKER_SPACING = 10.0;
   private static final double PID_SIGNAL_LANE_SPACING = 3.0;
+  private static final double PID_SIGNAL_TRACK_OFFSET = 48.0;
+  private static final int PID_MARKERS_PER_ROW = 4;
 
   /** Controlled paper sizes supported by the native renderer. */
   public enum SheetFormat {
@@ -1040,6 +1042,7 @@ public final class NativeEngineeringDiagramRenderer {
       }
     });
     Map<String, Double> signalLanes = pidSignalLanes(signals, proposalOwners);
+    Map<String, Double> signalTracks = pidSignalTracks(signals, proposalOwners);
     for (Map<String, Object> signal : signals) {
       String sourceId = textValue(signal.get("sourcePidElementId"));
       String targetId = textValue(signal.get("targetPidElementId"));
@@ -1054,6 +1057,11 @@ public final class NativeEngineeringDiagramRenderer {
         double loop = 8.0 + Math.abs(lane);
         points = Arrays.asList(source, new Point(source.x + loop, source.y - loop),
             new Point(source.x + loop * 2.0, source.y), source);
+      } else if (signalTracks.containsKey(signalId(signal))) {
+        String ownerId = proposalOwners.get(sourceId);
+        Point owner = positions.get(ownerId);
+        double trackX = owner.x + signalTracks.get(signalId(signal)).doubleValue();
+        points = Arrays.asList(source, new Point(trackX, source.y), new Point(trackX, target.y), target);
       } else {
         double middleX = (source.x + target.x) / 2.0 + lane;
         points = Arrays.asList(source, new Point(middleX, source.y), new Point(middleX, target.y), target);
@@ -1088,16 +1096,24 @@ public final class NativeEngineeringDiagramRenderer {
   }
 
   private static Point pidMarkerPosition(Point equipment, String register, int index, int count) {
-    double centered = index - (count - 1) / 2.0;
     if ("nozzles".equals(register)) {
+      double centered = index - (count - 1) / 2.0;
       return new Point(equipment.x - OBJECT_WIDTH / 2.0 - 14.0, equipment.y + centered * PID_VERTICAL_MARKER_SPACING);
     }
     if ("interfaces".equals(register)) {
+      double centered = index - (count - 1) / 2.0;
       return new Point(equipment.x + OBJECT_WIDTH / 2.0 + 16.0, equipment.y + centered * PID_VERTICAL_MARKER_SPACING);
     }
+    int row = index / PID_MARKERS_PER_ROW;
+    int rowStart = row * PID_MARKERS_PER_ROW;
+    int rowCount = Math.min(PID_MARKERS_PER_ROW, count - rowStart);
+    int column = index - rowStart;
+    double centered = column - (rowCount - 1) / 2.0;
     double y = "instruments".equals(register) ? equipment.y - OBJECT_HEIGHT / 2.0 - 15.0
         : equipment.y + OBJECT_HEIGHT / 2.0 + 16.0;
-    return new Point(equipment.x + centered * PID_HORIZONTAL_MARKER_SPACING, y);
+    double rowDirection = "instruments".equals(register) ? -1.0 : 1.0;
+    return new Point(equipment.x + centered * PID_HORIZONTAL_MARKER_SPACING,
+        y + rowDirection * row * PID_VERTICAL_MARKER_SPACING);
   }
 
   private static Point pidMarkerConnectionPoint(Point equipment, String register, int index, int count) {
@@ -1179,6 +1195,39 @@ public final class NativeEngineeringDiagramRenderer {
       for (int index = 0; index < group.size(); index++) {
         double centered = index - (group.size() - 1) / 2.0;
         result.put(signalId(group.get(index)), Double.valueOf(centered * PID_SIGNAL_LANE_SPACING));
+      }
+    }
+    return result;
+  }
+
+  private static Map<String, Double> pidSignalTracks(List<Map<String, Object>> signals,
+      Map<String, String> proposalOwners) {
+    Map<String, List<Map<String, Object>>> byOwner = new TreeMap<String, List<Map<String, Object>>>();
+    for (Map<String, Object> signal : signals) {
+      String sourceOwner = textValue(proposalOwners.get(textValue(signal.get("sourcePidElementId"))));
+      String targetOwner = textValue(proposalOwners.get(textValue(signal.get("targetPidElementId"))));
+      if (sourceOwner.isEmpty() || !sourceOwner.equals(targetOwner)) {
+        continue;
+      }
+      List<Map<String, Object>> group = byOwner.get(sourceOwner);
+      if (group == null) {
+        group = new ArrayList<Map<String, Object>>();
+        byOwner.put(sourceOwner, group);
+      }
+      group.add(signal);
+    }
+    Map<String, Double> result = new TreeMap<String, Double>();
+    for (List<Map<String, Object>> group : byOwner.values()) {
+      Collections.sort(group, new Comparator<Map<String, Object>>() {
+        @Override
+        public int compare(Map<String, Object> left, Map<String, Object> right) {
+          return signalId(left).compareTo(signalId(right));
+        }
+      });
+      for (int index = 0; index < group.size(); index++) {
+        double direction = index % 2 == 0 ? -1.0 : 1.0;
+        double offset = PID_SIGNAL_TRACK_OFFSET + index / 2 * PID_SIGNAL_LANE_SPACING;
+        result.put(signalId(group.get(index)), Double.valueOf(direction * offset));
       }
     }
     return result;

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -225,7 +225,7 @@ class EngineeringDiagramDualProfileDeliveryTest {
     String[] points = rawPoints.split(" ");
     String[] coordinates = points[0].split(",", 2);
     String context = proposalId + " points=\"" + rawPoints + "\"";
-    return new double[] {parseCoordinate(coordinates[0], context), parseCoordinate(coordinates[1], context)};
+    return new double[] { parseCoordinate(coordinates[0], context), parseCoordinate(coordinates[1], context) };
   }
 
   private static double parseCoordinate(String value, String context) {

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -140,10 +140,12 @@ class EngineeringDiagramDualProfileDeliveryTest {
       String sourceId = String.valueOf(signal.get("sourcePidElementId"));
       String targetId = String.valueOf(signal.get("targetPidElementId"));
       if (proposalOwnerById.get(sourceId).equals(proposalOwnerById.get(targetId))) {
-        String[] points = pointsForSemanticId(pidSvg, signalId).split(" ");
-        double sourceX = Double.parseDouble(points[0].split(",", 2)[0]);
-        double targetX = Double.parseDouble(points[points.length - 1].split(",", 2)[0]);
-        double trackX = Double.parseDouble(points[1].split(",", 2)[0]);
+        String rawPoints = pointsForSemanticId(pidSvg, signalId);
+        String[] points = rawPoints.split(" ");
+        String context = signalId + " points=\"" + rawPoints + "\"";
+        double sourceX = parseCoordinate(points[0].split(",", 2)[0], context);
+        double targetX = parseCoordinate(points[points.length - 1].split(",", 2)[0], context);
+        double trackX = parseCoordinate(points[1].split(",", 2)[0], context);
         assertTrue(trackX < Math.min(sourceX, targetX) || trackX > Math.max(sourceX, targetX), signalId);
       }
     }
@@ -219,9 +221,19 @@ class EngineeringDiagramDualProfileDeliveryTest {
   }
 
   private static double[] proposalMarkerPoint(String svg, String proposalId) {
-    String[] points = pointsForSemanticId(svg, "pid-proposal:" + proposalId + ":connection").split(" ");
+    String rawPoints = pointsForSemanticId(svg, "pid-proposal:" + proposalId + ":connection");
+    String[] points = rawPoints.split(" ");
     String[] coordinates = points[0].split(",", 2);
-    return new double[] { Double.parseDouble(coordinates[0]), Double.parseDouble(coordinates[1]) };
+    String context = proposalId + " points=\"" + rawPoints + "\"";
+    return new double[] {parseCoordinate(coordinates[0], context), parseCoordinate(coordinates[1], context)};
+  }
+
+  private static double parseCoordinate(String value, String context) {
+    try {
+      return Double.parseDouble(value.trim());
+    } catch (NumberFormatException error) {
+      throw new AssertionError("Non-numeric SVG coordinate '" + value + "' for " + context, error);
+    }
   }
 
   private static String pointsForSemanticId(String svg, String semanticId) {

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDeliveryTest.java
@@ -87,6 +87,7 @@ class EngineeringDiagramDualProfileDeliveryTest {
     assertTrue(registers.getGapCount() > 0);
     int proposalCount = 0;
     Map<String, List<String>> proposalIdsByOwnerAndRegister = new java.util.TreeMap<String, List<String>>();
+    Map<String, String> proposalOwnerById = new java.util.TreeMap<String, String>();
     for (String register : new String[] { "nozzles", "valves", "instruments", "interfaces" }) {
       for (Map<String, Object> row : rows(registers, register)) {
         String id = String.valueOf(row.get("id"));
@@ -98,6 +99,7 @@ class EngineeringDiagramDualProfileDeliveryTest {
           proposalIdsByOwnerAndRegister.put(group, proposalIds);
         }
         proposalIds.add(id);
+        proposalOwnerById.put(id, String.valueOf(row.get("semanticEquipmentId")));
         assertTrue(pidSvg.contains("data-semantic-id=\"pid-proposal:" + id + "\""), id);
         assertTrue(pidSvg.contains(">" + tag + "</text>"), tag);
         proposalCount++;
@@ -105,7 +107,7 @@ class EngineeringDiagramDualProfileDeliveryTest {
     }
     assertTrue(proposalCount > 4);
     assertFalse(pidSvg.contains(" +1</text>"));
-    assertTrue(pidSvg.contains("font-size=\"2.2\""));
+    assertTrue(pidSvg.contains("font-size=\"2.5\""));
     for (Map.Entry<String, List<String>> entry : proposalIdsByOwnerAndRegister.entrySet()) {
       if (entry.getValue().size() < 2) {
         continue;
@@ -115,12 +117,35 @@ class EngineeringDiagramDualProfileDeliveryTest {
         ownerTerminals.add(proposalConnectionTerminal(pidSvg, id));
       }
       assertEquals(entry.getValue().size(), ownerTerminals.size(), entry.getKey());
+      if ((entry.getKey().endsWith("|instruments") || entry.getKey().endsWith("|valves"))
+          && entry.getValue().size() > 4) {
+        Set<String> markerRows = new HashSet<String>();
+        double minimumX = Double.POSITIVE_INFINITY;
+        double maximumX = Double.NEGATIVE_INFINITY;
+        for (String id : entry.getValue()) {
+          double[] marker = proposalMarkerPoint(pidSvg, id);
+          minimumX = Math.min(minimumX, marker[0]);
+          maximumX = Math.max(maximumX, marker[0]);
+          markerRows.add(String.valueOf(marker[1]));
+        }
+        assertTrue(maximumX - minimumX <= 84.0, entry.getKey());
+        assertTrue(markerRows.size() > 1, entry.getKey());
+      }
     }
     List<Map<String, Object>> signals = rows(registers, "controlSignals");
     assertTrue(signals.size() > 1);
     for (Map<String, Object> signal : signals) {
       String signalId = "pid-signal:" + signal.get("sourcePidElementId") + ":" + signal.get("targetPidElementId");
       assertTrue(pidSvg.contains("data-semantic-id=\"" + signalId + "\""), signalId);
+      String sourceId = String.valueOf(signal.get("sourcePidElementId"));
+      String targetId = String.valueOf(signal.get("targetPidElementId"));
+      if (proposalOwnerById.get(sourceId).equals(proposalOwnerById.get(targetId))) {
+        String[] points = pointsForSemanticId(pidSvg, signalId).split(" ");
+        double sourceX = Double.parseDouble(points[0].split(",", 2)[0]);
+        double targetX = Double.parseDouble(points[points.length - 1].split(",", 2)[0]);
+        double trackX = Double.parseDouble(points[1].split(",", 2)[0]);
+        assertTrue(trackX < Math.min(sourceX, targetX) || trackX > Math.max(sourceX, targetX), signalId);
+      }
     }
     assertEquals(signals.size(), signalPaths(pidSvg).size());
     assertTrue(((java.util.List<?>) registers.toMap().get("nozzles")).stream().anyMatch(
@@ -191,5 +216,19 @@ class EngineeringDiagramDualProfileDeliveryTest {
     assertTrue(matcher.find(), proposalId);
     String[] points = matcher.group(1).split(" ");
     return points[points.length - 1];
+  }
+
+  private static double[] proposalMarkerPoint(String svg, String proposalId) {
+    String[] points = pointsForSemanticId(svg, "pid-proposal:" + proposalId + ":connection").split(" ");
+    String[] coordinates = points[0].split(",", 2);
+    return new double[] { Double.parseDouble(coordinates[0]), Double.parseDouble(coordinates[1]) };
+  }
+
+  private static String pointsForSemanticId(String svg, String semanticId) {
+    Pattern pattern = Pattern
+        .compile("<polyline points=\"([^\"]+)\"[^>]+data-semantic-id=\"" + Pattern.quote(semanticId) + "\"");
+    Matcher matcher = pattern.matcher(svg);
+    assertTrue(matcher.find(), semanticId);
+    return matcher.group(1);
   }
 }


### PR DESCRIPTION
Advances #1332 and #2899 within the established shared engineering-diagram lane.

## Frozen increment

- Base: `fce5205e330b9f614a77e6c8eab07b2b8f98a4d0`
- Initial implementation head: `ba59d08f359ad5e169ca1747abfe80173a8dc7f2`
- Review repair: `9e8f7c82a6597bef7ffe6189d074e3f4719ee41e`
- Current exact head after hosted Spotless repair: `b6b90a114502ae46763a9de6ad6fe1a7564e16b1`
- Five ordered tests-first/implementation/documentation/review-repair/formatting commits across three files
- Scope: compact source-linked P&ID proposal racks and collision-resistant same-equipment control routing for the existing `comparesimulations2` reference

Dense instrument and valve groups use deterministic four-column, multi-row racks. Proposal tag size increases from 2.2 to 2.5 drawing millimetres. Same-equipment control and safeguarding relationships alternate through external tracks instead of passing through the owning equipment envelope. Cross-equipment behavior remains on the existing deterministic lane rule.

The canonical plant, production renderer at the review-repair head, PFD bytes, simulation, persistent process layout, stream/H&MB evidence, and native DEXPI 2.0 versus Proteus 4.1 exchange boundaries are unchanged.

## Red-first and validation evidence

The added regression fails on the merged renderer because a dense owner/register group occupies one 120–288 mm row. It requires:

- at most 84 mm horizontal span with multiple rows for instrument/valve groups over four elements;
- every same-owner signal's intermediate track to remain outside its endpoint span;
- full proposal tags at 2.5 mm;
- existing independent semantic identities and distinct perimeter terminals.

The implementation head passed locally:

- `NativeEngineeringDiagramRendererTest`: 10/10
- `EngineeringDiagramDualProfileDeliveryTest`: 4/4
- `Comparesimulations2EngineeringDiagramReferenceTest` with slow tests enabled: 1/1
- direct Spotless, documentation-search, and diff checks

The review repair changes only test diagnostics: coordinate parsing catches `NumberFormatException` and throws a context-rich `AssertionError` containing semantic identity and raw points. The exact hosted Spotless artifact was then applied without semantic change.

At the current exact head, Spotless, pre-commit, PaperLab, and engineering-diagram performance workflows pass. CodeQL, documentation search, and build/test/Javadocs remain active with zero failures. All five review threads are resolved.

## Fresh whole-sheet evidence

Fresh implementation-head execution generated four A1 PFD and four A1 P&ID SVG/PDF pages. Every page was inspected full-sheet and at 200 dpi.

- PFD PDF and every PFD SVG are byte-identical to the merged baseline.
- P&ID callout fans are materially narrower and proposal/control groups are easier to distinguish.
- Both review commits are test-only and cannot alter generated sheets.
- Whole-sheet visual acceptance remains blocked by the sparse overview, canonical route/off-page-label congestion, and the absence of accountable reviewed visual baselines.

## Boundaries

The runnable model remains authoritative and no `24-VB-01` was fabricated. The P&ID remains a review-required teaching proposal with unresolved governed line/nozzle/valve/reducer/instrument/control inputs. This PR makes no ISO/ISA conformance, DEXPI-EV certification, safety, construction, or engineering-approval claim. External interoperability qualification and clean retained-output notebook publication remain outstanding.

Positively identified autonomous implementation occupancy is **6/10**, within the absolute ceiling. Keep this PR draft-only; do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity.

**VALIDATION PENDING EXACT-HEAD CI. WHOLE-SHEET VISUAL ACCEPTANCE BLOCKED.**