### PR TITLE
[AI-Assisted] feat(optimization): qualify strict separator evidence

### DIFF
--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -213,6 +213,39 @@ a value estimated by the adapter. A line-up or limit change invalidates the old 
 isolated candidate again and build a new snapshot. Through JPype, use the same callback-free builder
 and `toJson()` rather than supplying Python callbacks.
 
+### Qualify separator observations without fallback values
+
+After the complete process candidate has converged, use `PlantSeparatorEvidence` to freeze the
+applicable separator calculations. Configure the vessel and mechanical-design elevations first;
+the strict adapter rejects missing inlet-nozzle diameter, HLL/NLL/NIL, and effective gas/liquid
+length instead of using the convenience estimates in `Separator`.
+
+```java
+PlantSeparatorEvidence separatorEvidence = PlantSeparatorEvidence
+    .builder("Plant", "Separation", calculationId, separator,
+        PlantSeparatorEvidence.Profile.TWO_PHASE_OIL,
+        "approved separator rating revision 4")
+    .maximumLiquidLevelFraction(0.80)
+    .convergenceComplete(fullModelConverged)
+    .build();
+
+if (!separatorEvidence.isComplete() || !separatorEvidence.isFeasible()) {
+  throw new IllegalStateException(separatorEvidence.getDiagnostics().toString());
+}
+String separatorJson = separatorEvidence.toJson();
+```
+
+For a three-phase vessel, select `THREE_PHASE` and also call
+`minimumInterfaceSettlingMinutes(...)`. Two-phase oil and water profiles require only their
+applicable residence observation; a gas scrubber does not create a zero-valued liquid-residence
+row. Missing phases, stale calculation identity, non-finite results, or failed convergence are
+unavailable and fail closed. Through JPype, call the same builder and inspect `toJson()`; unavailable
+numbers are JSON `null`.
+
+The adapter reuses the current public separator calculations. It does not validate or invent
+carry-over/carry-under correlations, slug capacity, relief limits, or operating approval. Register
+those limits only from qualified provider or measured evidence and retain their provenance.
+
 ---
 
 ## Overview

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -176,6 +176,44 @@ but infeasible. Explicitly out-of-service casings qualify only with verified zer
 observed shaft load. Java getters, serialization, `toPlantUtilizationSnapshot()`, and `toJson()`
 expose the same immutable evidence; unavailable JSON numbers are `null`, never zero.
 
+### Strict separator evidence
+
+`PlantSeparatorEvidence` adapts an already solved separator into the same immutable plant registry
+and snapshot model. Select `GAS_SCRUBBER`, `TWO_PHASE_OIL`, `TWO_PHASE_WATER`, or `THREE_PHASE` so
+the required phase observations are explicit. The adapter reads the existing Souders-Brown gas-load,
+K-value, droplet-cut, inlet-momentum, oil/water residence, live liquid-level, and three-phase
+interface-settling calculations. It does not run or retain the separator.
+
+The strict path requires the exact completed calculation ID, full-candidate convergence, vessel
+diameter and length, inlet-nozzle diameter, and every applicable HLL/NLL/NIL and effective-length
+input. This intentionally disables the convenience geometry fallbacks used by interactive
+separator calculations: missing design data becomes unavailable evidence, never zero utilization.
+The liquid-level and three-phase interface-settling limits are caller-owned installed limits.
+
+```java
+PlantSeparatorEvidence separatorEvidence = PlantSeparatorEvidence
+    .builder("Plant", "Separation", calculationId, separator,
+        PlantSeparatorEvidence.Profile.THREE_PHASE,
+        "approved vessel rating revision 4")
+    .maximumLiquidLevelFraction(0.80)
+    .minimumInterfaceSettlingMinutes(1.0)
+    .convergenceComplete(model.isModelConverged())
+    .build();
+
+if (!separatorEvidence.isComplete()) {
+  throw new IllegalStateException(separatorEvidence.getDiagnostics().toString());
+}
+PlantUtilizationSnapshot separatorSnapshot =
+    separatorEvidence.toPlantUtilizationSnapshot();
+```
+
+Java serialization, JPype getters, `toPlantUtilizationSnapshot()`, and `toJson()` preserve the same
+detached values, physical margins, units, bases, and diagnostics. A physical limit violation remains
+complete and is interpreted according to the severity of the corresponding installed separator
+constraint. Carry-over/carry-under and slug handling are not inferred: they remain separate required
+coverage until a qualified provider, measured correlation, or installed slug-volume rating is
+declared and validated.
+
 ## Expected equipment coverage before qualification
 
 `UtilizationCoverageReport` captures evidence for explicitly declared equipment and constraint

--- a/docs/process/optimization/industrial-sm-benchmark.md
+++ b/docs/process/optimization/industrial-sm-benchmark.md
@@ -159,7 +159,8 @@ claim is made. The five-fork wall-time totals were 128.385 s before and 116.614 
 compilation work contributes to those totals. Timing distributions and per-mode execution counts
 remain available in the preserved reports. A later additive evidence-path qualification executes
 the M case's total-shaft-power transition; it does not change or reinterpret these preserved timing
-records. Full large-process qualification and the common-shaft transition remain open roadmap work.
+records. Common-shaft evidence and the strict separator adapter were subsequently added as separate
+immutable post-solve paths. Full large-process qualification remains open roadmap work.
 
 The exact aggregates are stored as deterministic gzip files with an empty filename and `mtime=0`.
 Decompression reproduces the original aggregate bytes, including every fork's raw report and its
@@ -220,6 +221,8 @@ relative tolerances alongside the measured differences. The participant-sum/sour
 within a single solved state retains its separate `1e-10` tolerance, and the existing convergence,
 mass-balance and bottleneck-transition gates still apply.
 
-That result qualifies the total-power evidence path only. The full ordered piping, compressor,
-separator and export-quality sequence, full L process fixture, and common-shaft case remain open.
-No missing metric or transition is represented as a passed gate.
+That result qualifies the total-power evidence path only. Common-shaft and strict separator evidence
+have separate focused qualification; neither changes the stored S/M timing record. The full ordered
+piping, compressor, separator and export-quality sequence, the full L process fixture, separator
+carry-over/slug evidence, and piping fidelity remain open. No missing metric or transition is
+represented as a passed gate.

--- a/src/main/java/neqsim/process/util/optimizer/PlantSeparatorEvidence.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantSeparatorEvidence.java
@@ -1,0 +1,538 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Immutable, fail-closed separator constraint evidence for one completed plant calculation.
+ *
+ * <p>
+ * This adapter samples the existing separator rating calculations without retaining the mutable separator or its
+ * callbacks. It requires explicit vessel geometry and mechanical-design elevations so that the convenience fallbacks in
+ * {@link Separator} cannot be mistaken for installed design evidence. Missing phases, ratings, geometry, calculation
+ * identity, or convergence are unavailable evidence rather than zero utilization.
+ * </p>
+ *
+ * <p>
+ * The supported profiles cover gas load, K-value at HLL, droplet cut size, inlet momentum, liquid residence,
+ * liquid-level inventory, and (for three-phase vessels) oil-water interface settling. Carry-over/carry-under and
+ * slug-volume qualification require a separately validated provider or measured constraint and are deliberately outside
+ * this adapter.
+ * </p>
+ */
+public final class PlantSeparatorEvidence implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final String SCHEMA_VERSION = "1.0";
+
+  /** Supported separator service profile. */
+  public enum Profile {
+    /** Gas scrubber with gas-capacity and inlet-momentum evidence. */
+    GAS_SCRUBBER,
+    /** Two-phase gas/oil separator. */
+    TWO_PHASE_OIL,
+    /** Two-phase gas/water separator. */
+    TWO_PHASE_WATER,
+    /** Three-phase gas/oil/water separator with interface-settling evidence. */
+    THREE_PHASE
+  }
+
+  /** Overall evidence status. */
+  public enum Status {
+    /** Every profile-required observation is complete for the exact calculation. */
+    AVAILABLE,
+    /** At least one required observation is missing, stale, invalid, or unconverged. */
+    INCOMPLETE
+  }
+
+  private enum Metric {
+    GAS_LOAD("gas-load-factor", "gasLoadFactor", "m/s", "Souders-Brown gas load at design gas area",
+        PlantConstraintDefinition.LimitDirection.MAXIMUM),
+    K_VALUE("k-value-at-hll", "kValue", "m/s", "Souders-Brown K-value at explicit HLL",
+        PlantConstraintDefinition.LimitDirection.MAXIMUM),
+    DROPLET_CUT("droplet-cut-size-at-hll", "dropletCutSize", "µm",
+        "Stokes droplet cut size at explicit HLL and effective gas length",
+        PlantConstraintDefinition.LimitDirection.MAXIMUM),
+    INLET_MOMENTUM("inlet-momentum", "inletMomentum", "Pa", "mixture momentum flux at explicit inlet-nozzle diameter",
+        PlantConstraintDefinition.LimitDirection.MAXIMUM),
+    OIL_RETENTION("oil-retention-time", "oilRetentionTime", "min", "oil residence between explicit NIL and NLL",
+        PlantConstraintDefinition.LimitDirection.MINIMUM),
+    WATER_RETENTION("water-retention-time", "waterRetentionTime", "min", "water residence below explicit NIL",
+        PlantConstraintDefinition.LimitDirection.MINIMUM),
+    LIQUID_LEVEL("liquid-level-inventory", null, "fraction", "live liquid height divided by vessel diameter",
+        PlantConstraintDefinition.LimitDirection.MAXIMUM),
+    INTERFACE_SETTLING("interface-settling-time", null, "min",
+        "150 micrometre water-droplet settling time through the explicit oil layer",
+        PlantConstraintDefinition.LimitDirection.MINIMUM);
+
+    private final String id;
+    private final String equipmentConstraintName;
+    private final String unit;
+    private final String basis;
+    private final PlantConstraintDefinition.LimitDirection direction;
+
+    Metric(String id, String equipmentConstraintName, String unit, String basis,
+        PlantConstraintDefinition.LimitDirection direction) {
+      this.id = id;
+      this.equipmentConstraintName = equipmentConstraintName;
+      this.unit = unit;
+      this.basis = basis;
+      this.direction = direction;
+    }
+  }
+
+  private final String calculationId;
+  private final String separatorName;
+  private final String areaName;
+  private final Profile profile;
+  private final String provenance;
+  private final boolean convergenceComplete;
+  private final Status status;
+  private final List<PlantConstraintDefinition> definitions;
+  private final List<PlantConstraintSample> samples;
+  private final List<String> diagnostics;
+
+  private PlantSeparatorEvidence(Builder builder) {
+    calculationId = PlantConstraintScope.requireText(builder.calculationId, "Calculation id");
+    provenance = PlantConstraintScope.requireText(builder.provenance, "Separator evidence provenance");
+    areaName = PlantConstraintScope.requireText(builder.areaName, "Area name");
+    separatorName = PlantConstraintScope.requireText(builder.separator.getName(), "Separator name");
+    profile = builder.profile;
+    convergenceComplete = builder.convergenceComplete;
+
+    List<String> findings = validateState(builder);
+    List<Metric> metrics = metricsFor(profile);
+    List<PlantConstraintDefinition> capturedDefinitions = new ArrayList<PlantConstraintDefinition>();
+    List<PlantConstraintSample> capturedSamples = new ArrayList<PlantConstraintSample>();
+    PlantConstraintScope scope = PlantConstraintScope.equipment(builder.modelName, areaName, separatorName);
+    Map<String, CapacityConstraint> registered = builder.separator.getCapacityConstraints();
+    boolean stateUsable = findings.isEmpty();
+
+    for (Metric metric : metrics) {
+      CapacityConstraint source = metric.equipmentConstraintName == null ? null
+          : registered.get(metric.equipmentConstraintName);
+      PlantConstraintDefinition definition = definition(metric, scope, source, provenance);
+      capturedDefinitions.add(definition);
+      PlantConstraintSample sample = capture(metric, definition, source, builder, stateUsable);
+      capturedSamples.add(sample);
+      if (sample.getStatus() != PlantConstraintSample.SampleStatus.AVAILABLE) {
+        findings.add(metric.id + "=" + sample.getStatus().name() + diagnosticSuffix(sample.getDiagnostic()));
+      }
+    }
+    Collections.sort(capturedDefinitions);
+    Collections.sort(capturedSamples,
+        (first, second) -> first.getQualifiedConstraintId().compareTo(second.getQualifiedConstraintId()));
+    definitions = Collections.unmodifiableList(capturedDefinitions);
+    samples = Collections.unmodifiableList(capturedSamples);
+    diagnostics = Collections.unmodifiableList(new ArrayList<String>(findings));
+    status = findings.isEmpty() ? Status.AVAILABLE : Status.INCOMPLETE;
+  }
+
+  /**
+   * Starts a callback-free separator evidence builder.
+   *
+   * @param modelName stable process-model name
+   * @param areaName stable process-area name
+   * @param calculationId exact completed process calculation UUID string
+   * @param separator solved separator to sample immediately
+   * @param profile explicit separator service profile
+   * @param provenance source of the installed limits and completed process state
+   * @return new separator evidence builder
+   */
+  public static Builder builder(String modelName, String areaName, String calculationId, Separator separator,
+      Profile profile, String provenance) {
+    return new Builder(modelName, areaName, calculationId, separator, profile, provenance);
+  }
+
+  private static List<String> validateState(Builder builder) {
+    List<String> findings = new ArrayList<String>();
+    Separator separator = builder.separator;
+    if (!builder.convergenceComplete) {
+      findings.add("INCOMPLETE_CONVERGENCE");
+    }
+    if (!separator.solved()) {
+      findings.add("SEPARATOR_NOT_SOLVED");
+    }
+    if (separator.getCalculationIdentifier() == null
+        || !builder.calculationId.equals(separator.getCalculationIdentifier().toString())) {
+      findings.add("STALE_CALCULATION_IDENTITY");
+    }
+    SystemInterface fluid = separator.getThermoSystem();
+    if (fluid == null || !fluid.hasPhaseType("gas")) {
+      findings.add("GAS_PHASE_MISSING");
+    }
+    if (!finitePositive(separator.getInternalDiameter()) || !finitePositive(separator.getSeparatorLength())) {
+      findings.add("EXPLICIT_VESSEL_GEOMETRY_MISSING");
+    }
+    if (!("horizontal".equals(separator.getOrientation()) || "vertical".equals(separator.getOrientation()))) {
+      findings.add("INVALID_SEPARATOR_ORIENTATION");
+    }
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    if (design == null || !finitePositive(design.getInletNozzleID())) {
+      findings.add("EXPLICIT_INLET_NOZZLE_MISSING");
+    }
+    if (profileNeedsHll(builder.profile)
+        && (design == null || !finitePositive(design.getHLL()) || !finitePositive(design.getEffectiveLengthGas()))) {
+      findings.add("EXPLICIT_HLL_OR_GAS_LENGTH_MISSING");
+    }
+    if (profileNeedsLiquidGeometry(builder.profile)
+        && (design == null || !finitePositive(design.getNLL()) || !finitePositive(design.getNIL())
+            || design.getNLL() <= design.getNIL() || !finitePositive(design.getEffectiveLengthLiquid()))) {
+      findings.add("EXPLICIT_LIQUID_LEVEL_GEOMETRY_MISSING");
+    }
+    if (profileNeedsOil(builder.profile) && (fluid == null || !fluid.hasPhaseType("oil"))) {
+      findings.add("OIL_PHASE_MISSING");
+    }
+    if (profileNeedsWater(builder.profile) && (fluid == null || !fluid.hasPhaseType("aqueous"))) {
+      findings.add("WATER_PHASE_MISSING");
+    }
+    if (builder.profile == Profile.THREE_PHASE && !(separator instanceof ThreePhaseSeparator)) {
+      findings.add("THREE_PHASE_SEPARATOR_TYPE_REQUIRED");
+    }
+    if (!Double.isFinite(builder.maximumLiquidLevelFraction) || builder.maximumLiquidLevelFraction <= 0.0
+        || builder.maximumLiquidLevelFraction > 1.0) {
+      findings.add("LIQUID_LEVEL_LIMIT_MISSING");
+    }
+    if (builder.profile == Profile.THREE_PHASE && !finitePositive(builder.minimumInterfaceSettlingMinutes)) {
+      findings.add("INTERFACE_SETTLING_LIMIT_MISSING");
+    }
+    return findings;
+  }
+
+  private static List<Metric> metricsFor(Profile profile) {
+    List<Metric> result = new ArrayList<Metric>();
+    result.add(Metric.GAS_LOAD);
+    result.add(Metric.INLET_MOMENTUM);
+    result.add(Metric.LIQUID_LEVEL);
+    if (profile != Profile.GAS_SCRUBBER) {
+      result.add(Metric.K_VALUE);
+      result.add(Metric.DROPLET_CUT);
+    }
+    if (profileNeedsOil(profile)) {
+      result.add(Metric.OIL_RETENTION);
+    }
+    if (profileNeedsWater(profile)) {
+      result.add(Metric.WATER_RETENTION);
+    }
+    if (profile == Profile.THREE_PHASE) {
+      result.add(Metric.INTERFACE_SETTLING);
+    }
+    return result;
+  }
+
+  private static boolean profileNeedsHll(Profile profile) {
+    return profile != Profile.GAS_SCRUBBER;
+  }
+
+  private static boolean profileNeedsLiquidGeometry(Profile profile) {
+    return profile == Profile.TWO_PHASE_OIL || profile == Profile.TWO_PHASE_WATER || profile == Profile.THREE_PHASE;
+  }
+
+  private static boolean profileNeedsOil(Profile profile) {
+    return profile == Profile.TWO_PHASE_OIL || profile == Profile.THREE_PHASE;
+  }
+
+  private static boolean profileNeedsWater(Profile profile) {
+    return profile == Profile.TWO_PHASE_WATER || profile == Profile.THREE_PHASE;
+  }
+
+  private static PlantConstraintDefinition definition(Metric metric, PlantConstraintScope scope,
+      CapacityConstraint source, String provenance) {
+    ConstraintSeverity severity = source == null ? ConstraintSeverity.HARD : source.getSeverity();
+    return PlantConstraintDefinition.builder(metric.id, scope).limitDirection(metric.direction)
+        .category(PlantConstraintDefinition.Category.DESIGN).severity(severity).unit(metric.unit).basis(metric.basis)
+        .provenance(provenance).owner("separator process and mechanical design")
+        .reference(source == null ? "caller-declared installed limit" : safeText(source.getSourceReference()))
+        .calculationMethod("immutable strict post-solve separator adapter").build();
+  }
+
+  private static PlantConstraintSample capture(Metric metric, PlantConstraintDefinition definition,
+      CapacityConstraint source, Builder builder, boolean stateUsable) {
+    if (!stateUsable) {
+      PlantConstraintSample.SampleStatus status = builder.convergenceComplete ? PlantConstraintSample.SampleStatus.STALE
+          : PlantConstraintSample.SampleStatus.INCOMPLETE_CONVERGENCE;
+      return unavailable(definition, builder.calculationId, status, builder.provenance,
+          "Separator state is not usable for strict evidence");
+    }
+    double limit = limit(metric, source, builder);
+    if (!finitePositive(limit)) {
+      return unavailable(definition, builder.calculationId, PlantConstraintSample.SampleStatus.NOT_CALCULABLE,
+          builder.provenance, "Finite positive installed limit is required");
+    }
+    try {
+      double value = value(metric, builder.separator);
+      if (!Double.isFinite(value) || value < 0.0
+          || metric.direction == PlantConstraintDefinition.LimitDirection.MINIMUM && value <= 0.0) {
+        return unavailable(definition, builder.calculationId, PlantConstraintSample.SampleStatus.NON_FINITE_VALUE,
+            builder.provenance, "Separator observation is unavailable or non-finite");
+      }
+      return sample(definition, builder.calculationId, value, limit, builder.provenance);
+    } catch (RuntimeException exception) {
+      return unavailable(definition, builder.calculationId, PlantConstraintSample.SampleStatus.EXCEPTION,
+          builder.provenance, exception.getClass().getSimpleName() + ": " + safeText(exception.getMessage()));
+    }
+  }
+
+  private static double limit(Metric metric, CapacityConstraint source, Builder builder) {
+    if (metric == Metric.LIQUID_LEVEL) {
+      return builder.maximumLiquidLevelFraction;
+    }
+    if (metric == Metric.INTERFACE_SETTLING) {
+      return builder.minimumInterfaceSettlingMinutes;
+    }
+    if (source == null) {
+      return Double.NaN;
+    }
+    return source.getDisplayDesignValue();
+  }
+
+  private static double value(Metric metric, Separator separator) {
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    switch (metric) {
+    case GAS_LOAD:
+      return separator.getGasLoadFactor();
+    case K_VALUE:
+      return separator.calcKValue(design.getHLL());
+    case DROPLET_CUT:
+      return separator.calcDropletCutSize(design.getEffectiveLengthGas(),
+          separator.getInternalDiameter() - design.getHLL()) * 1.0e6;
+    case INLET_MOMENTUM:
+      return separator.calcInletMomentumFlux(design.getInletNozzleID());
+    case OIL_RETENTION:
+      return separator.calcOilRetentionTime();
+    case WATER_RETENTION:
+      return separator.calcWaterRetentionTime();
+    case LIQUID_LEVEL:
+      return separator.getLiquidLevel();
+    case INTERFACE_SETTLING:
+      return ((ThreePhaseSeparator) separator).calcInterfaceSettlingTime();
+    default:
+      return Double.NaN;
+    }
+  }
+
+  private static PlantConstraintSample sample(PlantConstraintDefinition definition, String calculationId, double value,
+      double limit, String provenance) {
+    boolean minimum = definition.getLimitDirection() == PlantConstraintDefinition.LimitDirection.MINIMUM;
+    double utilization = minimum ? limit / value : value / limit;
+    double margin = minimum ? value - limit : limit - value;
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId).values(value, limit)
+        .normalized(utilization, utilization - 1.0).physical(margin, Math.max(0.0, -margin)).unit(definition.getUnit())
+        .basis(definition.getBasis()).provenance(provenance).build();
+  }
+
+  private static PlantConstraintSample unavailable(PlantConstraintDefinition definition, String calculationId,
+      PlantConstraintSample.SampleStatus status, String provenance, String diagnostic) {
+    return PlantConstraintSample.builder(definition.getQualifiedId(), calculationId).status(status)
+        .unit(definition.getUnit()).basis(definition.getBasis()).provenance(provenance).diagnostic(diagnostic).build();
+  }
+
+  private static boolean finitePositive(double value) {
+    return Double.isFinite(value) && value > 0.0;
+  }
+
+  private static String safeText(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static String diagnosticSuffix(String diagnostic) {
+    return diagnostic == null || diagnostic.isEmpty() ? "" : ":" + diagnostic;
+  }
+
+  /** @return exact completed process calculation identity */
+  public String getCalculationId() {
+    return calculationId;
+  }
+
+  /** @return stable separator equipment name */
+  public String getSeparatorName() {
+    return separatorName;
+  }
+
+  /** @return stable process area name */
+  public String getAreaName() {
+    return areaName;
+  }
+
+  /** @return declared separator service profile */
+  public Profile getProfile() {
+    return profile;
+  }
+
+  /** @return evidence provenance supplied by the caller */
+  public String getProvenance() {
+    return provenance;
+  }
+
+  /** @return overall evidence status */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** @return true only when every profile-required observation is available */
+  public boolean isComplete() {
+    return status == Status.AVAILABLE;
+  }
+
+  /** @return true only when evidence is complete and no hard limit is violated */
+  public boolean isFeasible() {
+    return toPlantUtilizationSnapshot().isFeasible();
+  }
+
+  /** @return immutable deterministic constraint definitions */
+  public List<PlantConstraintDefinition> getDefinitions() {
+    return Collections.unmodifiableList(new ArrayList<PlantConstraintDefinition>(definitions));
+  }
+
+  /** @return immutable deterministic exact-calculation samples */
+  public List<PlantConstraintSample> getSamples() {
+    return Collections.unmodifiableList(new ArrayList<PlantConstraintSample>(samples));
+  }
+
+  /** @return immutable fail-closed diagnostics */
+  public List<String> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<String>(diagnostics));
+  }
+
+  /**
+   * Builds a complete plant utilization snapshot from the frozen separator evidence.
+   *
+   * @return immutable utilization snapshot
+   */
+  public PlantUtilizationSnapshot toPlantUtilizationSnapshot() {
+    PlantConstraintRegistry registry = new PlantConstraintRegistry();
+    for (PlantConstraintDefinition definition : definitions) {
+      registry.register(definition);
+    }
+    PlantUtilizationSnapshot.Builder snapshot = PlantUtilizationSnapshot.builder(registry, calculationId)
+        .convergenceComplete(convergenceComplete);
+    for (PlantConstraintSample sample : samples) {
+      snapshot.sample(sample);
+    }
+    return snapshot.build();
+  }
+
+  /** @return standards-compliant JSON with null for unavailable numbers */
+  public String toJson() {
+    JsonObject root = new JsonObject();
+    root.addProperty("schemaVersion", SCHEMA_VERSION);
+    root.addProperty("calculationId", calculationId);
+    root.addProperty("areaName", areaName);
+    root.addProperty("separatorName", separatorName);
+    root.addProperty("profile", profile.name());
+    root.addProperty("provenance", provenance);
+    root.addProperty("convergenceComplete", convergenceComplete);
+    root.addProperty("status", status.name());
+    JsonArray findingRows = new JsonArray();
+    for (String diagnostic : diagnostics) {
+      findingRows.add(diagnostic);
+    }
+    root.add("diagnostics", findingRows);
+    JsonArray evidenceRows = new JsonArray();
+    for (PlantConstraintEvidence evidence : toPlantUtilizationSnapshot().getEvidence()) {
+      JsonObject row = new JsonObject();
+      row.addProperty("qualifiedConstraintId", evidence.getQualifiedConstraintId());
+      row.addProperty("coverageStatus", evidence.getCoverageStatus().name());
+      row.addProperty("operatingStatus", evidence.getOperatingStatus().name());
+      row.addProperty("unit", evidence.getDefinition().getUnit());
+      row.addProperty("basis", evidence.getDefinition().getBasis());
+      addNumber(row, "sampledValue",
+          evidence.getSample() == null ? Double.NaN : evidence.getSample().getSampledValue());
+      addNumber(row, "applicableLimit",
+          evidence.getSample() == null ? Double.NaN : evidence.getSample().getApplicableLimit());
+      addNumber(row, "normalizedUtilization", evidence.getNormalizedUtilization());
+      addNumber(row, "physicalMargin",
+          evidence.getSample() == null ? Double.NaN : evidence.getSample().getPhysicalMargin());
+      row.addProperty("diagnostic", evidence.getDiagnostic());
+      evidenceRows.add(row);
+    }
+    root.add("evidence", evidenceRows);
+    return root.toString();
+  }
+
+  private static void addNumber(JsonObject target, String name, double value) {
+    if (Double.isFinite(value)) {
+      target.addProperty(name, value);
+    } else {
+      target.add(name, JsonNull.INSTANCE);
+    }
+  }
+
+  /** Callback-free JPype-friendly separator evidence builder. */
+  public static final class Builder {
+    private final String modelName;
+    private final String areaName;
+    private final String calculationId;
+    private final Separator separator;
+    private final Profile profile;
+    private final String provenance;
+    private boolean convergenceComplete;
+    private double maximumLiquidLevelFraction = Double.NaN;
+    private double minimumInterfaceSettlingMinutes = Double.NaN;
+
+    private Builder(String modelName, String areaName, String calculationId, Separator separator, Profile profile,
+        String provenance) {
+      this.modelName = PlantConstraintScope.requireText(modelName, "Model name");
+      this.areaName = PlantConstraintScope.requireText(areaName, "Area name");
+      this.calculationId = PlantConstraintScope.requireText(calculationId, "Calculation id");
+      if (separator == null) {
+        throw new IllegalArgumentException("Separator is required");
+      }
+      if (profile == null) {
+        throw new IllegalArgumentException("Separator profile is required");
+      }
+      this.separator = separator;
+      this.profile = profile;
+      this.provenance = PlantConstraintScope.requireText(provenance, "Separator evidence provenance");
+    }
+
+    /**
+     * Declares the maximum acceptable live liquid-level fraction.
+     *
+     * @param value finite fraction in (0, 1]
+     * @return this builder
+     */
+    public Builder maximumLiquidLevelFraction(double value) {
+      maximumLiquidLevelFraction = value;
+      return this;
+    }
+
+    /**
+     * Declares the minimum acceptable oil-water interface settling time.
+     *
+     * @param value positive time in minutes
+     * @return this builder
+     */
+    public Builder minimumInterfaceSettlingMinutes(double value) {
+      minimumInterfaceSettlingMinutes = value;
+      return this;
+    }
+
+    /**
+     * Declares whether the complete isolated process candidate converged.
+     *
+     * @param value true only after all applicable process convergence checks pass
+     * @return this builder
+     */
+    public Builder convergenceComplete(boolean value) {
+      convergenceComplete = value;
+      return this;
+    }
+
+    /** @return immutable separator evidence */
+    public PlantSeparatorEvidence build() {
+      return new PlantSeparatorEvidence(this);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/PlantSeparatorEvidenceTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PlantSeparatorEvidenceTest.java
@@ -1,0 +1,180 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Engineering acceptance tests for strict immutable separator evidence. */
+class PlantSeparatorEvidenceTest {
+  private static final UUID CALCULATION_ID = UUID.fromString("be5911fe-676e-4d44-b0e4-2c19089a3154");
+
+  @Test
+  void twoPhaseOilProfileUsesExplicitGeometryAndProducesPhysicalMargins() throws Exception {
+    Separator separator = twoPhaseOilSeparator();
+    PlantSeparatorEvidence evidence = evidence(separator, PlantSeparatorEvidence.Profile.TWO_PHASE_OIL,
+        CALCULATION_ID.toString(), true);
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertEquals(6, evidence.getDefinitions().size());
+    assertEquals(6, evidence.getSamples().size());
+    assertTrue(evidence.getSamples().stream().allMatch(sample -> Double.isFinite(sample.getSampledValue())));
+    assertTrue(evidence.getSamples().stream().allMatch(sample -> Double.isFinite(sample.getPhysicalMargin())));
+    assertTrue(evidence.toPlantUtilizationSnapshot().isComplete());
+
+    JsonObject json = JsonParser.parseString(evidence.toJson()).getAsJsonObject();
+    assertEquals("AVAILABLE", json.get("status").getAsString());
+    assertEquals("TWO_PHASE_OIL", json.get("profile").getAsString());
+    assertEquals(6, json.getAsJsonArray("evidence").size());
+
+    PlantSeparatorEvidence restored = roundTrip(evidence);
+    assertNotSame(evidence, restored);
+    assertEquals(evidence.toJson(), restored.toJson());
+  }
+
+  @Test
+  void dryGasScrubberDoesNotInventLiquidResidenceEvidence() {
+    Separator separator = dryGasScrubber();
+    PlantSeparatorEvidence evidence = evidence(separator, PlantSeparatorEvidence.Profile.GAS_SCRUBBER,
+        CALCULATION_ID.toString(), true);
+
+    assertTrue(evidence.isComplete(), evidence.getDiagnostics().toString());
+    assertEquals(3, evidence.getDefinitions().size());
+    assertTrue(evidence.getDefinitions().stream()
+        .noneMatch(definition -> definition.getId().contains("retention") || definition.getId().contains("settling")));
+  }
+
+  @Test
+  void changedInstalledLevelLimitProducesNewEvidenceAndOldSnapshotRemainsImmutable() {
+    Separator separator = twoPhaseOilSeparator();
+    PlantSeparatorEvidence installed = evidence(separator, PlantSeparatorEvidence.Profile.TWO_PHASE_OIL,
+        CALCULATION_ID.toString(), true);
+    String installedJson = installed.toJson();
+
+    PlantSeparatorEvidence tightened = PlantSeparatorEvidence
+        .builder("qualification model", "separation", CALCULATION_ID.toString(), separator,
+            PlantSeparatorEvidence.Profile.TWO_PHASE_OIL, "synthetic installed vessel data")
+        .maximumLiquidLevelFraction(0.10).convergenceComplete(true).build();
+
+    assertTrue(tightened.isComplete(), tightened.getDiagnostics().toString());
+    assertFalse(tightened.isFeasible());
+    assertEquals(installedJson, installed.toJson(), "later evidence construction must not mutate the old snapshot");
+    assertFalse(installedJson.equals(tightened.toJson()));
+
+    PlantSeparatorEvidence restored = evidence(separator, PlantSeparatorEvidence.Profile.TWO_PHASE_OIL,
+        CALCULATION_ID.toString(), true);
+    assertEquals(installedJson, restored.toJson());
+  }
+
+  @Test
+  void staleUnconvergedAndFallbackGeometryPathsFailClosedWithJsonNulls() {
+    Separator separator = twoPhaseOilSeparator();
+    separator.getMechanicalDesign().setInletNozzleID(0.0);
+    separator.getMechanicalDesign().setHLLFraction(0.0);
+
+    PlantSeparatorEvidence evidence = evidence(separator, PlantSeparatorEvidence.Profile.TWO_PHASE_OIL,
+        UUID.randomUUID().toString(), false);
+
+    assertFalse(evidence.isComplete());
+    assertFalse(evidence.isFeasible());
+    assertTrue(evidence.getDiagnostics().contains("INCOMPLETE_CONVERGENCE"));
+    assertTrue(evidence.getDiagnostics().contains("STALE_CALCULATION_IDENTITY"));
+    assertTrue(evidence.getDiagnostics().contains("EXPLICIT_INLET_NOZZLE_MISSING"));
+    assertTrue(evidence.getDiagnostics().contains("EXPLICIT_HLL_OR_GAS_LENGTH_MISSING"));
+    assertTrue(evidence.getSamples().stream()
+        .allMatch(sample -> sample.getStatus() == PlantConstraintSample.SampleStatus.INCOMPLETE_CONVERGENCE));
+    JsonObject json = JsonParser.parseString(evidence.toJson()).getAsJsonObject();
+    assertTrue(json.getAsJsonArray("evidence").get(0).getAsJsonObject().get("sampledValue").isJsonNull());
+  }
+
+  @Test
+  void threePhaseProfileRequiresThreePhaseEquipmentAndInterfaceLimit() {
+    Separator separator = twoPhaseOilSeparator();
+    PlantSeparatorEvidence evidence = PlantSeparatorEvidence
+        .builder("qualification model", "separation", CALCULATION_ID.toString(), separator,
+            PlantSeparatorEvidence.Profile.THREE_PHASE, "synthetic installed vessel data")
+        .maximumLiquidLevelFraction(0.8).convergenceComplete(true).build();
+
+    assertFalse(evidence.isComplete());
+    assertTrue(evidence.getDiagnostics().contains("WATER_PHASE_MISSING"));
+    assertTrue(evidence.getDiagnostics().contains("THREE_PHASE_SEPARATOR_TYPE_REQUIRED"));
+    assertTrue(evidence.getDiagnostics().contains("INTERFACE_SETTLING_LIMIT_MISSING"));
+  }
+
+  private static PlantSeparatorEvidence evidence(Separator separator, PlantSeparatorEvidence.Profile profile,
+      String calculationId, boolean converged) {
+    return PlantSeparatorEvidence
+        .builder("qualification model", "separation", calculationId, separator, profile,
+            "synthetic installed vessel data")
+        .maximumLiquidLevelFraction(0.8).minimumInterfaceSettlingMinutes(1.0).convergenceComplete(converged).build();
+  }
+
+  private static Separator twoPhaseOilSeparator() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 5.0, 35.0);
+    fluid.addComponent("methane", 0.70);
+    fluid.addComponent("ethane", 0.08);
+    fluid.addComponent("propane", 0.07);
+    fluid.addComponent("n-butane", 0.05);
+    fluid.addComponent("n-pentane", 0.04);
+    fluid.addComponent("n-hexane", 0.03);
+    fluid.addComponent("n-heptane", 0.03);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    return runSeparator(fluid, "two-phase oil separator", "horizontal");
+  }
+
+  private static Separator dryGasScrubber() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("ethane", 0.05);
+    fluid.setMixingRule("classic");
+    return runSeparator(fluid, "dry gas scrubber", "vertical");
+  }
+
+  private static Separator runSeparator(SystemInterface fluid, String name, String orientation) {
+    Stream feed = new Stream(name + " feed", fluid);
+    feed.setFlowRate(20000.0, "kg/hr");
+    Separator separator = new Separator(name, feed);
+    separator.setInternalDiameter(2.4);
+    separator.setSeparatorLength(6.0);
+    separator.setOrientation(orientation);
+    separator.setDesignGasLoadFactor(0.12);
+    separator.setLiquidLevel(0.45);
+    separator.getMechanicalDesign().setInletNozzleID(0.25);
+    separator.getMechanicalDesign().setHLLFraction(0.70);
+    separator.getMechanicalDesign().setNLLFraction(0.50);
+    separator.getMechanicalDesign().setNILFraction(0.20);
+    separator.getMechanicalDesign().setEffectiveLengthGas(3.8);
+    separator.getMechanicalDesign().setEffectiveLengthLiquid(4.8);
+    ProcessSystem process = new ProcessSystem(name + " process");
+    process.add(feed);
+    process.add(separator);
+    process.run(CALCULATION_ID);
+    assertTrue(process.solved(), process.getRunStatusJson());
+    return separator;
+  }
+
+  private static PlantSeparatorEvidence roundTrip(PlantSeparatorEvidence evidence) throws Exception {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(buffer)) {
+      output.writeObject(evidence);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      return (PlantSeparatorEvidence) input.readObject();
+    }
+  }
+}


### PR DESCRIPTION
Advances #3154 roadmap item 5 with a strict, immutable separator evidence adapter built on existing NeqSim separator and mechanical-design calculations.

## Capability contract

- **Engineering question:** Can optimization candidates expose separator capacity evidence from the exact solved calculation without fallback geometry, stale results, or new separator physics?
- **Current → target maturity:** equipment-local separator calculations → deterministic plant constraint definitions, samples, snapshot, diagnostics, and JSON suitable for Java/JPype consumers.
- **Exact baseline:** `fce5205e330b9f614a77e6c8eab07b2b8f98a4d0`.
- **Java authority/views:** `Separator`, `ThreePhaseSeparator`, and `SeparatorMechanicalDesign`; profiles `GAS_SCRUBBER`, `TWO_PHASE_OIL`, `TWO_PHASE_WATER`, and `THREE_PHASE`.
- **Inputs/provenance:** exact calculation ID, convergence state, explicit vessel diameter/length, nozzle diameter, HLL/NLL/NIL, effective phase lengths, installed liquid-level limit, and (for three-phase equipment) installed interface-settling limit.
- **Outputs/units/basis:** immutable constraint definitions and samples for gas load/K-value, droplet cut diameter, inlet momentum, phase residence time, liquid-level inventory, and oil/water interface settling. Units and upper/lower-limit basis are carried in each definition/sample.
- **Validity:** exact calculation-ID coverage and full convergence are mandatory. Missing phases, nonfinite values, fallback geometry, absent installed limits, and non-three-phase equipment selected for the three-phase profile remain unavailable and make the snapshot incomplete.
- **Acceptance:** deterministic physical margins, immutable snapshots/JSON, changed-limit evidence, safe restoration, stale/unconverged rejection, and Java serialization.
- **Compatibility/docs:** additive Java 8 API; no existing separator behavior or physics changed. User guide, capacity framework, and benchmark ledger are updated.
- **Stop boundary:** no new carryover/carryunder correlation, slug physics, piping model, evaluator/scheduler/cache work, or MCP surface.

## Implementation

- Adds `PlantSeparatorEvidence` as a serializable, immutable adapter.
- Uses the live separator/mechanical-design values already calculated by NeqSim; it does not derive convenience geometry or invent missing capacity.
- Emits deterministic `PlantConstraintDefinition`, `PlantConstraintSample`, `PlantUtilizationSnapshot`, and JSON views from the same authoritative evidence.
- Supports direct installed liquid-level and interface limits, with fail-closed changed-limit and restoration behavior.
- Documents the supported profiles, required inputs, provenance, and explicit limitations.

## Validation

Run locally from the exact branch head:

- `./mvnw -q -DskipTests compile` — passed.
- Focused `PlantSeparatorEvidenceTest` — 5 tests, 0 failures/errors, 2.279 s.
- Adjacent `SeparatorTest` — 15 tests, 0 failures/errors, 5.725 s.
- `python devtools/run_spotless.py apply` — passed and stable.
- `python devtools/run_spotless.py check` — passed.
- `python devtools/check_documentation_search.py` — passed (693 Markdown + 1 standalone HTML).
- `./mvnw -q -DskipTests javadoc:javadoc` — passed.
- `git diff --check` — passed.

The runtime exposed Java 17 modules but not the `javac`/`javadoc` launchers, so validation used environment-only wrappers under `/tmp`; no repository build configuration was changed. Local `pre-commit` was unavailable and package installation was blocked, so that gate is **VALIDATION PENDING CI**.

## Deliberate limitations

- Existing public seven-stage carryover/carryunder behavior remains excluded because it is documented as unvalidated/default-assumption physics.
- Slug capacity and piping fidelity remain separate owned work.
- The full >=150-unit / >=6-area acceptance fixture and its wall-time, memory, and result-size budgets remain an explicit campaign gate; this PR makes no large-scale performance claim.
- The three-phase profile is fail-closed for missing water/interface evidence; a broader operating workflow remains future qualification.

This PR is intentionally a draft pending exact-head hosted CI and owner/domain review.