### PR TITLE
[AI-Assisted] test(pitzer): validate acoustic conversion with published water

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -772,6 +772,20 @@ model. Acoustic rows therefore remain inadmissible for volumetric-Pitzer
 calibration until every matched property, uncertainty, source lineage, and
 redistribution right passes the campaign provenance gates.
 
+The SI conversion is checked against the CC BY 4.0 compressed-water results of
+El Hawary and Meier (2023) at 303.15 K and 50 MPa. Their published sound-speed
+correlation and Table 5 density and heat-capacity values give
+$\kappa_T=3.96032\times10^{-10}$ 1/Pa. This agrees within 0.018% with the
+alternative $\kappa_Sc_p/c_v$ identity and within 0.030% with a symmetric
+45/55 MPa density derivative. The benchmark validates units and thermodynamic
+consistency of the conversion. Because the source derived density and heat
+capacity through thermodynamic integration of its acoustic measurements, this
+is not an independent experimental validation. It is pure-water evidence and
+does not qualify CaCl2 acoustic data or any volumetric-Pitzer coefficient.
+
+Reference: El Hawary and Meier (2023),
+[doi:10.1007/s10765-023-03276-1](https://doi.org/10.1007/s10765-023-03276-1).
+
 ### Qualification boundary
 
 - The caller owns coefficient provenance and must keep calibration and

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricAcousticPublishedWaterTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricAcousticPublishedWaterTest.java
@@ -1,0 +1,77 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Published-water validation for the acoustic-to-isothermal compressibility conversion.
+ *
+ * <p>
+ * Source: El Hawary and Meier, International Journal of Thermophysics 44, 180 (2023), doi:10.1007/s10765-023-03276-1,
+ * CC BY 4.0. Sound speed is evaluated from their Table 3 correlation. Density and heat-capacity values, including the
+ * symmetric finite-difference stencils, are from their Table 5.
+ * </p>
+ */
+class PitzerBinaryVolumetricAcousticPublishedWaterTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 303.15;
+  private static final double PRESSURE_MPA = 50.0;
+  private static final double DENSITY_KG_PER_M3 = 1016.787;
+  private static final double SPECIFIC_HEAT_CAPACITY_J_PER_KG_K = 4064.08;
+  private static final double SPECIFIC_ISOCHORIC_HEAT_CAPACITY_J_PER_KG_K = 3976.52;
+
+  // Table 5 symmetric temperature stencil at 50 MPa.
+  private static final double DENSITY_AT_293_15_K_KG_PER_M3 = 1019.924;
+  private static final double DENSITY_AT_313_15_K_KG_PER_M3 = 1013.017;
+
+  // Table 5 symmetric pressure stencil at 303.15 K.
+  private static final double DENSITY_AT_45_MPA_KG_PER_M3 = 1014.763;
+  private static final double DENSITY_AT_55_MPA_KG_PER_M3 = 1018.791;
+
+  private static final double MAXIMUM_RELATIVE_DIFFERENCE = 1.0e-3;
+
+  @Test
+  void agreesWithPublishedHeatCapacityAndDensityReconstructions() {
+    double soundSpeedMPerS = publishedSoundSpeedMPerS(TEMPERATURE_K, PRESSURE_MPA);
+    double thermalExpansionPerK = -(DENSITY_AT_313_15_K_KG_PER_M3 - DENSITY_AT_293_15_K_KG_PER_M3)
+        / (20.0 * DENSITY_KG_PER_M3);
+
+    double isentropicCompressibility = PitzerBinaryVolumetricAcousticConversion
+        .calculateIsentropicCompressibility(DENSITY_KG_PER_M3, soundSpeedMPerS);
+    double convertedIsothermalCompressibility = PitzerBinaryVolumetricAcousticConversion
+        .calculateIsothermalCompressibility(TEMPERATURE_K, DENSITY_KG_PER_M3, soundSpeedMPerS, thermalExpansionPerK,
+            SPECIFIC_HEAT_CAPACITY_J_PER_KG_K);
+
+    double heatCapacityIdentity = isentropicCompressibility * SPECIFIC_HEAT_CAPACITY_J_PER_KG_K
+        / SPECIFIC_ISOCHORIC_HEAT_CAPACITY_J_PER_KG_K;
+    double pressureDerivative = (DENSITY_AT_55_MPA_KG_PER_M3 - DENSITY_AT_45_MPA_KG_PER_M3)
+        / (10.0e6 * DENSITY_KG_PER_M3);
+
+    assertEquals(1592.980718909979, soundSpeedMPerS, 1.0e-9);
+    assertEquals(3.9603194920002513e-10, convertedIsothermalCompressibility, 1.0e-23);
+    assertRelativeAgreement(heatCapacityIdentity, convertedIsothermalCompressibility);
+    assertRelativeAgreement(pressureDerivative, convertedIsothermalCompressibility);
+  }
+
+  private static void assertRelativeAgreement(double expected, double actual) {
+    assertEquals(expected, actual, Math.abs(expected) * MAXIMUM_RELATIVE_DIFFERENCE);
+  }
+
+  private static double publishedSoundSpeedMPerS(double temperatureK, double pressureMpa) {
+    double criticalTemperatureK = 647.096;
+    double criticalPressureMpa = 22.064;
+    double reducedTemperature = temperatureK / criticalTemperatureK;
+    double reducedPressure = pressureMpa / criticalPressureMpa;
+
+    double[] coefficients = { 7.423615233e4, -1.571527759e5, 2.742740269e6, -3.599403339e6, -6.379367333e-4,
+        2.357819770e5, 5.469994955e5, 2.225433179e-1, -2.304269454e5, 3.932184362e-7, -2.621801558e-6, 2.991452743e5 };
+    double[] pressureExponents = { 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0 };
+    double[] temperatureExponents = { -5.0, -4.5, -0.5, 3.5, -19.0, 1.0, 7.0, -12.0, 8.0, -26.0, -24.0, 14.0 };
+
+    double soundSpeedSquared = 0.0;
+    for (int index = 0; index < coefficients.length; index++) {
+      soundSpeedSquared += coefficients[index] * Math.pow(reducedPressure, pressureExponents[index])
+          * Math.pow(reducedTemperature, temperatureExponents[index]);
+    }
+    return Math.sqrt(soundSpeedSquared);
+  }
+}


### PR DESCRIPTION
Advances #3144 with a published, redistribution-qualified pure-water benchmark for the acoustic-to-isothermal compressibility conversion merged through #3574.

## Capability contract

- **Engineering question:** Does the acoustic conversion reproduce independent thermodynamic reconstructions in SI units at compressed-liquid conditions?
- **Current → target maturity:** synthetic algebraic coverage → published-water unit and thermodynamic-consistency benchmark.
- **Frozen publication base:** `76f14ae079a7b1db1888203d20e11a6433774b4c`
- **Exact publication head:** `918bf358c7c68a1980737a0c18221b7dbe3f5bfb`
- **Recorded contract:** https://github.com/equinor/neqsim/issues/3144#issuecomment-5591166543
- **Stop boundary:** test and density-model documentation only; no datasets, parameters, coefficients, default activation, solver behavior, or thermodynamic production results.

The branch was created only after master advanced through #3580, so the frozen base was updated before publication. No existing autonomous branch or pull-request head was rebased, synchronized, or otherwise changed.

## Scientific source and provenance

El Hawary and Meier (2023), *International Journal of Thermophysics* 44, 180:
https://doi.org/10.1007/s10765-023-03276-1

The article is open access under CC BY 4.0. The test reproduces the paper's Table 3 sound-speed correlation and uses its Table 5 density and heat-capacity values at 303.15 K and 50 MPa, including symmetric temperature and pressure stencils.

## Result

The merged converter gives:

- `kappa_T = 3.960319492e-10 1/Pa`
- 0.0179% relative difference from the alternative `kappa_S * cp / cv` identity
- 0.0298% relative difference from the symmetric 45/55 MPa density derivative
- both below the frozen 0.1% agreement threshold

This validates SI units and thermodynamic consistency of the converter at a published compressed-water state.

## Scientific limitation

The same source derived density and heat capacity through thermodynamic integration of its acoustic measurements. It is therefore not an independent experimental validation lineage. It is also pure-water evidence only: it does not qualify aqueous CaCl2 acoustic data, any volumetric-Pitzer coefficient, high-pressure aqueous density, or calcium-sulfate prediction.

## Validation

Passed locally on the frozen publication base:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 693 Markdown files + 1 standalone HTML file
- `./mvnw -q -DskipITs -Dtest=PitzerBinaryVolumetricAcousticConversionTest,PitzerBinaryVolumetricAcousticPublishedWaterTest test` — 7/7 focused tests
- `git diff --check`

The local environment did not provide the pre-commit executable, so hosted exact-head CI remains authoritative.

## Coordination

This is the sole active #3144 implementation PR. Its two paths do not overlap the four pre-existing autonomous drafts. Including this draft, positively identified autonomous implementation occupancy is **5/10**.

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Keep this PR draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity.