### PR TITLE
[AI-Assisted] feat(kinetics): expose segment-mean H2S loss rates

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -220,7 +220,7 @@ split into subsegments, duration-weighted mean rates recover the unsplit reacted
 unsplit mean rate.
 
 This is a time average on a molality basis, not yet a volumetric or molar-flow control-volume
-source. Creating a pipeline source term still requires separately qualified water inventory,
+source. Creating a pipeline source term requires separately qualified water inventory,
 phase transfer, oxygen consumption, reaction products, energy, pressure, and numerical coupling.
 
 ## Piecewise target crossing

--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -192,10 +192,36 @@ factors across unchanged-state segment subdivisions recovers the unsplit retenti
 inventory.
 
 These endpoint rates are differential screening evidence evaluated under the source's
-constant-oxygen assumption. They are not a time-averaged control-volume source, a conversion to
-molar flow, oxygen consumption, or product stoichiometry. Creating a pipeline source term requires
-separate water inventory, phase transfer, reaction products, energy, pressure, and numerical
-coupling evidence.
+constant-oxygen assumption. They are not a conversion to molar flow, oxygen consumption, or
+product stoichiometry.
+
+## Segment-mean loss-rate evidence
+
+For each lower-rate, nominal, and upper-rate path, `SegmentResult` also exposes the analytical
+mean total-sulfide loss rate over the segment. For positive duration,
+
+$
+\overline{r}_{r,i}
+=\frac{c_{r,i,\mathrm{in}}-c_{r,i,\mathrm{out}}}{\Delta t_i}
+=\frac{c_{r,i,\mathrm{reacted}}}{\Delta t_i}.
+$
+
+Its unit is mol total sulfide/(kg water h). Because the differential rate decays monotonically
+within a constant-state segment, the mean is bounded by the endpoint rates:
+
+$
+r_{r,i,\mathrm{out}}\leq\overline{r}_{r,i}\leq r_{r,i,\mathrm{in}}.
+$
+
+Multiplying the mean by segment duration exactly recovers the reacted molality. For a zero-duration
+segment the quotient would be undefined, so the API returns its exact continuous limit
+`k[O2] c_in`; this equals both endpoint rates and remains finite. For an unchanged-state segment
+split into subsegments, duration-weighted mean rates recover the unsplit reacted inventory and
+unsplit mean rate.
+
+This is a time average on a molality basis, not yet a volumetric or molar-flow control-volume
+source. Creating a pipeline source term still requires separately qualified water inventory,
+phase transfer, oxygen consumption, reaction products, energy, pressure, and numerical coupling.
 
 ## Piecewise target crossing
 

--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -192,8 +192,8 @@ factors across unchanged-state segment subdivisions recovers the unsplit retenti
 inventory.
 
 These endpoint rates are differential screening evidence evaluated under the source's
-constant-oxygen assumption. They are not a conversion to molar flow, oxygen consumption, or
-product stoichiometry.
+constant-oxygen assumption. By themselves they are not a time-averaged control-volume source, a
+conversion to molar flow, oxygen consumption, or product stoichiometry.
 
 ## Segment-mean loss-rate evidence
 

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -255,6 +255,37 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.trajectory_test)
 
+    def test_segment_mean_loss_rate_contract_is_documented_and_executable(self):
+        for token in (
+            "Segment-mean loss-rate evidence",
+            "analytical mean total-sulfide loss rate",
+            r"\overline{r}_{r,i}",
+            r"\frac{c_{r,i,\mathrm{in}}-c_{r,i,\mathrm{out}}}{\Delta t_i}",
+            r"r_{r,i,\mathrm{out}}\leq\overline{r}_{r,i}\leq r_{r,i,\mathrm{in}}",
+            "mol total sulfide/(kg water h)",
+            "exact continuous limit",
+            "duration-weighted mean rates",
+            "not yet a volumetric or molar-flow control-volume source",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "getLowerRateMeanLossRateMolalityPerHour()",
+            "getNominalMeanLossRateMolalityPerHour()",
+            "getUpperRateMeanLossRateMolalityPerHour()",
+        ):
+            self.assertIn(token, self.trajectory)
+
+        for token in (
+            "testSegmentMeanLossRatesCloseInventoryAndAreBounded",
+            "testDurationWeightedMeanLossRateIsSplitInvariant",
+            "assertMeanLossRate(",
+            "getLowerRateMeanLossRateMolalityPerHour()",
+            "getNominalMeanLossRateMolalityPerHour()",
+            "getUpperRateMeanLossRateMolalityPerHour()",
+        ):
+            self.assertIn(token, self.trajectory_test)
+
     def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
         for token in (
             "Piecewise target crossing",

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -592,6 +592,22 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
       return lowerPseudoFirstOrderRate * lowerRateOutletTotalSulfideMolality;
     }
 
+    /**
+     * Return the segment-mean total-sulfide loss rate for the lower-rate path.
+     *
+     * <p>
+     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit is
+     * the inlet differential rate.
+     * </p>
+     *
+     * @return mean loss rate [mol/(kg water h)]
+     */
+    public double getLowerRateMeanLossRateMolalityPerHour() {
+      double durationHours = segment.getDurationHours();
+      return durationHours == 0.0 ? getLowerRateInletLossRateMolalityPerHour()
+          : lowerRateReactedTotalSulfideMolality / durationHours;
+    }
+
     /** @return local lower-rate retained fraction across this segment. */
     public double getLowerRateRetentionFactor() {
       return Math.exp(-lowerRateExposure);
@@ -607,6 +623,22 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
       return nominalPseudoFirstOrderRate * nominalOutletTotalSulfideMolality;
     }
 
+    /**
+     * Return the segment-mean total-sulfide loss rate for the nominal path.
+     *
+     * <p>
+     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit is
+     * the inlet differential rate.
+     * </p>
+     *
+     * @return mean loss rate [mol/(kg water h)]
+     */
+    public double getNominalMeanLossRateMolalityPerHour() {
+      double durationHours = segment.getDurationHours();
+      return durationHours == 0.0 ? getNominalInletLossRateMolalityPerHour()
+          : nominalReactedTotalSulfideMolality / durationHours;
+    }
+
     /** @return local nominal retained fraction across this segment. */
     public double getNominalRetentionFactor() {
       return Math.exp(-nominalExposure);
@@ -620,6 +652,22 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
     /** @return instantaneous outlet loss rate for the upper-rate path [mol/(kg water h)]. */
     public double getUpperRateOutletLossRateMolalityPerHour() {
       return upperPseudoFirstOrderRate * upperRateOutletTotalSulfideMolality;
+    }
+
+    /**
+     * Return the segment-mean total-sulfide loss rate for the upper-rate path.
+     *
+     * <p>
+     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit is
+     * the inlet differential rate.
+     * </p>
+     *
+     * @return mean loss rate [mol/(kg water h)]
+     */
+    public double getUpperRateMeanLossRateMolalityPerHour() {
+      double durationHours = segment.getDurationHours();
+      return durationHours == 0.0 ? getUpperRateInletLossRateMolalityPerHour()
+          : upperRateReactedTotalSulfideMolality / durationHours;
     }
 
     /** @return local upper-rate retained fraction across this segment. */

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -596,8 +596,8 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
      * Return the segment-mean total-sulfide loss rate for the lower-rate path.
      *
      * <p>
-     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit is
-     * the inlet differential rate.
+     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit
+     * is the inlet differential rate.
      * </p>
      *
      * @return mean loss rate [mol/(kg water h)]
@@ -627,8 +627,8 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
      * Return the segment-mean total-sulfide loss rate for the nominal path.
      *
      * <p>
-     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit is
-     * the inlet differential rate.
+     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit
+     * is the inlet differential rate.
      * </p>
      *
      * @return mean loss rate [mol/(kg water h)]
@@ -658,8 +658,8 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
      * Return the segment-mean total-sulfide loss rate for the upper-rate path.
      *
      * <p>
-     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit is
-     * the inlet differential rate.
+     * For positive duration this is reacted molality divided by duration. At zero duration the exact continuous limit
+     * is the inlet differential rate.
      * </p>
      *
      * @return mean loss rate [mol/(kg water h)]

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -327,8 +327,8 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
         identity.getUpperRateOutletLossRateMolalityPerHour(), 0.0);
     assertEquals(identity.getLowerRateInletLossRateMolalityPerHour(),
         identity.getLowerRateMeanLossRateMolalityPerHour(), 0.0);
-    assertEquals(identity.getNominalInletLossRateMolalityPerHour(),
-        identity.getNominalMeanLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getNominalInletLossRateMolalityPerHour(), identity.getNominalMeanLossRateMolalityPerHour(),
+        0.0);
     assertEquals(identity.getUpperRateInletLossRateMolalityPerHour(),
         identity.getUpperRateMeanLossRateMolalityPerHour(), 0.0);
   }
@@ -359,9 +359,8 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
     double durationHours = 10.0;
     AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
         .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(durationHours)));
-    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
-        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Arrays.asList(referenceSegment(4.0), referenceSegment(durationHours - 4.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory.advance(
+        INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(durationHours - 4.0)));
 
     AqueousHydrogenSulfideOxidationTrajectory.SegmentResult whole = unsplit.getSegmentResults().get(0);
     AqueousHydrogenSulfideOxidationTrajectory.SegmentResult first = split.getSegmentResults().get(0);

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -269,6 +269,26 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
   }
 
   @Test
+  void testSegmentMeanLossRatesCloseInventoryAndAreBounded() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0),
+            new AqueousHydrogenSulfideOxidationTrajectory.Segment(7.0, 310.15, 7.0, 1.5, 220.0e-6)));
+
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : result.getSegmentResults()) {
+      double durationHours = segment.getSegment().getDurationHours();
+      assertMeanLossRate(segment.getLowerRateReactedTotalSulfideMolality(), durationHours,
+          segment.getLowerRateMeanLossRateMolalityPerHour(), segment.getLowerRateInletLossRateMolalityPerHour(),
+          segment.getLowerRateOutletLossRateMolalityPerHour());
+      assertMeanLossRate(segment.getNominalReactedTotalSulfideMolality(), durationHours,
+          segment.getNominalMeanLossRateMolalityPerHour(), segment.getNominalInletLossRateMolalityPerHour(),
+          segment.getNominalOutletLossRateMolalityPerHour());
+      assertMeanLossRate(segment.getUpperRateReactedTotalSulfideMolality(), durationHours,
+          segment.getUpperRateMeanLossRateMolalityPerHour(), segment.getUpperRateInletLossRateMolalityPerHour(),
+          segment.getUpperRateOutletLossRateMolalityPerHour());
+    }
+  }
+
+  @Test
   void testSegmentRetentionFactorsCloseInventoryUpdate() {
     AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
         .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(3.0),
@@ -305,6 +325,12 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
         0.0);
     assertEquals(identity.getUpperRateInletLossRateMolalityPerHour(),
         identity.getUpperRateOutletLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getLowerRateInletLossRateMolalityPerHour(),
+        identity.getLowerRateMeanLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getNominalInletLossRateMolalityPerHour(),
+        identity.getNominalMeanLossRateMolalityPerHour(), 0.0);
+    assertEquals(identity.getUpperRateInletLossRateMolalityPerHour(),
+        identity.getUpperRateMeanLossRateMolalityPerHour(), 0.0);
   }
 
   @Test
@@ -325,6 +351,34 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
         first.getNominalRetentionFactor() * second.getNominalRetentionFactor(), 1.0e-15);
     assertEquals(whole.getUpperRateRetentionFactor(),
         first.getUpperRateRetentionFactor() * second.getUpperRateRetentionFactor(), 1.0e-15);
+    assertEquals(unsplit.getFinalTotalSulfideMolality(), split.getFinalTotalSulfideMolality(), 1.0e-20);
+  }
+
+  @Test
+  void testDurationWeightedMeanLossRateIsSplitInvariant() {
+    double durationHours = 10.0;
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(durationHours)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Arrays.asList(referenceSegment(4.0), referenceSegment(durationHours - 4.0)));
+
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult whole = unsplit.getSegmentResults().get(0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult first = split.getSegmentResults().get(0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult second = split.getSegmentResults().get(1);
+
+    assertEquals(whole.getLowerRateMeanLossRateMolalityPerHour() * durationHours,
+        first.getLowerRateMeanLossRateMolalityPerHour() * 4.0
+            + second.getLowerRateMeanLossRateMolalityPerHour() * (durationHours - 4.0),
+        1.0e-20);
+    assertEquals(whole.getNominalMeanLossRateMolalityPerHour() * durationHours,
+        first.getNominalMeanLossRateMolalityPerHour() * 4.0
+            + second.getNominalMeanLossRateMolalityPerHour() * (durationHours - 4.0),
+        1.0e-20);
+    assertEquals(whole.getUpperRateMeanLossRateMolalityPerHour() * durationHours,
+        first.getUpperRateMeanLossRateMolalityPerHour() * 4.0
+            + second.getUpperRateMeanLossRateMolalityPerHour() * (durationHours - 4.0),
+        1.0e-20);
     assertEquals(unsplit.getFinalTotalSulfideMolality(), split.getFinalTotalSulfideMolality(), 1.0e-20);
   }
 
@@ -420,6 +474,14 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
         () -> AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(0.5, null));
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
         .timeToRemainingFractionRange(0.5, Collections.<AqueousHydrogenSulfideOxidationTrajectory.Segment>emptyList()));
+  }
+
+  private static void assertMeanLossRate(double reactedMolality, double durationHours, double meanLossRate,
+      double inletLossRate, double outletLossRate) {
+    assertEquals(reactedMolality / durationHours, meanLossRate, 0.0);
+    assertEquals(reactedMolality, meanLossRate * durationHours, 1.0e-20);
+    assertTrue(meanLossRate <= inletLossRate);
+    assertTrue(meanLossRate >= outletLossRate);
   }
 
   private static double exposureAtTime(List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments,


### PR DESCRIPTION
## Summary

Advances #3318 with analytical segment-mean total-sulfide loss-rate evidence for the existing qualified aqueous H₂S/O₂ trajectory.

For each lower-rate, nominal, and upper-rate Millero fit-scatter path, `SegmentResult` now exposes:

`r_mean = (c_in - c_out) / Δt` for positive duration.

At zero duration the exact continuous limit is the existing inlet differential rate `k[O2]c_in`. Units are mol total sulfide/(kg water h). Values derive from existing immutable segment state; no coefficient, empirical threshold, constructor field, or serialized state is added.

Scientific source and domain remain unchanged: Millero et al. (1987), https://doi.org/10.1021/es00159a003

Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5591739650

## Exact-head contract

- Exact branch point: `76f14ae079a7b1db1888203d20e11a6433774b4c`
- Exact published head: `aa37cc38b3ba381641b9c25fd7d66316afa7ddcf`
- Branch: `codex/3318-h2s-segment-mean-loss-rate`
- Eight ordered commits, zero behind the recorded base, and exactly four intended files.
- Sole active #3318 implementation PR.
- Portfolio occupancy after publication: **6/10**.

## Numerical gates and reference audit

Focused tests require:

- positive-duration mean rates to reproduce reacted molality divided by duration;
- mean rates to remain between analytical outlet and inlet differential rates;
- mean rate times duration to close each segment inventory;
- zero-duration means to be finite and equal the exact differential limit;
- duration-weighted unchanged-state subdivisions to recover the unsplit mean and final inventory.

Independent nominal 10 h reference at 298.15 K, pH 8, I=0.723 mol/kg water, O₂=250 µmol/kg water, and initial total sulfide 25 µmol/kg water:

- pseudo-first-order rate: `0.030904384181529014 h^-1`;
- retention: `0.7341485829141302`;
- outlet: `18.353714572853256 µmol/kg water`;
- reacted: `6.646285427146745 µmol/kg water`;
- mean loss rate: `0.6646285427146745 µmol/(kg water h)`;
- inlet/outlet differential rates: `0.7726096045382254` / `0.5672102463175847 µmol/(kg water h)`.

The mean is bounded by the endpoints and its 10 h integral exactly reproduces reacted molality.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Connector-side audit passed; hosted CI exposed and repaired two stale documentation-boundary tokens plus exact Spotless wrapping. Current audit: exact four-file scope; balanced Java braces; no tabs or trailing whitespace; three new accessors, focused Java gates, guide section, and executable documentation contract present.

No local Maven, Java, Spotless, pre-commit, or Python execution is claimed. Hosted GitHub Actions on this exact head are authoritative.

## Documentation and stop boundary

Updated Javadocs, focused Java tests, the H₂S/O₂ guide, and its executable documentation contract.

This remains constant-O2 atmospheric aqueous screening on a molality basis. It is not a volumetric or molar-flow control-volume source and does not calculate water holdup, O₂ depletion, sulfur products, reaction heat, pressure, phase transfer, corrosion, S8 precipitation, wall inventory, pipeline/transient mutation, R1–R8 binding, or MCP exposure.