### PR TITLE
feat(refinery): summarize solved Sarir fractionation

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -284,6 +284,27 @@ are not configured. In particular, the factory does not tune either side-draw fr
 published plant or HYSYS yields, and creating or solving the case is not evidence of product-yield
 or D86 agreement.
 
+## Solved-case product and balance summary
+
+After the caller runs the configured column, `SarirAtmosphericFractionationResult.evaluate(case)`
+creates an immutable Java/JPype summary of the rigorous result. The four rows remain in the
+established top-to-bottom comparison order: Total Naphtha, Kerosene, Diesel, and Residual. Each row
+reports calculated mass flow in kg/h, mass fraction of feed, mole-weighted mean normal boiling point,
+the independently published plant rate, and the absolute relative rate difference.
+
+The evaluator requires a solved non-fallback MESH-residual column. It rejects non-finite or negative
+flows, mass or energy errors above the qualified five-percent integration tolerance, feed/product
+mass-closure error above that tolerance, fewer than two material products, and material products
+whose mean normal boiling points do not increase from overhead to bottoms. Product arrays are
+defensive copies, and exact-label lookup fails closed for unsupported labels.
+
+The calculated mass fractions and mean normal boiling points depend on the caller-supplied cut
+properties and unreported column controls. They are model outputs, not source measurements, ASTM
+D86 curves, or evidence that NeqSim reproduces the plant. The plant rates remain read-only
+comparators: no calculated-versus-plant error is used as a solver control, tuning target, or pass
+threshold. Java callers use the same evaluator directly; Python callers access the factory,
+`getColumn().run(...)`, and evaluator through the existing JPype bridge.
+
 ## Scientific boundary
 
 The source-derived volumes, boiling boundaries, and product-specification rows are reproducible,

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCase.java
@@ -38,10 +38,13 @@ public final class SarirAtmosphericFractionationCase {
 
   private final Stream feedStream;
   private final DistillationColumn column;
+  private final OperatingInputs operatingInputs;
 
-  private SarirAtmosphericFractionationCase(Stream feedStream, DistillationColumn column) {
+  private SarirAtmosphericFractionationCase(Stream feedStream, DistillationColumn column,
+      OperatingInputs operatingInputs) {
     this.feedStream = feedStream;
     this.column = column;
+    this.operatingInputs = operatingInputs;
   }
 
   /**
@@ -107,7 +110,7 @@ public final class SarirAtmosphericFractionationCase {
     configuredColumn.setEnthalpyBalanceTolerance(ENTHALPY_BALANCE_TOLERANCE);
     configuredColumn.setEnforceEnergyBalanceTolerance(true);
 
-    return new SarirAtmosphericFractionationCase(feed, configuredColumn);
+    return new SarirAtmosphericFractionationCase(feed, configuredColumn, operatingInputs);
   }
 
   /**
@@ -126,6 +129,15 @@ public final class SarirAtmosphericFractionationCase {
    */
   public DistillationColumn getColumn() {
     return column;
+  }
+
+  /**
+   * Return the immutable engineering inputs used to configure this case.
+   *
+   * @return source-unreported operating inputs supplied by the caller
+   */
+  public OperatingInputs getOperatingInputs() {
+    return operatingInputs;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
@@ -10,13 +10,12 @@ import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldRefe
  * Immutable engineering summary for a solved {@link SarirAtmosphericFractionationCase}.
  *
  * <p>
- * Published plant rates are retained as read-only comparison evidence. They are not solver controls,
- * tuning targets, or acceptance thresholds.
+ * Published plant rates are retained as read-only comparison evidence. They are not solver controls, tuning targets, or
+ * acceptance thresholds.
  * </p>
  */
 public final class SarirAtmosphericFractionationResult {
-  private static final String[] PRODUCT_LABELS = { "Total Naphtha", "Kerosene", "Diesel",
-      "Residual" };
+  private static final String[] PRODUCT_LABELS = { "Total Naphtha", "Kerosene", "Diesel", "Residual" };
   private static final double MATERIAL_FLOW_FRACTION = 1.0e-8;
   private static final double BALANCE_TOLERANCE = 5.0e-2;
 
@@ -29,9 +28,8 @@ public final class SarirAtmosphericFractionationResult {
   private final int iterationCount;
   private final String convergenceDiagnostics;
 
-  private SarirAtmosphericFractionationResult(ProductResult[] products,
-      double feedMassFlowKgPerHour, double productMassFlowKgPerHour,
-      double massClosureRelativeError, double columnMassBalanceError,
+  private SarirAtmosphericFractionationResult(ProductResult[] products, double feedMassFlowKgPerHour,
+      double productMassFlowKgPerHour, double massClosureRelativeError, double columnMassBalanceError,
       double columnEnergyBalanceError, int iterationCount, String convergenceDiagnostics) {
     this.products = products.clone();
     this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
@@ -49,11 +47,10 @@ public final class SarirAtmosphericFractionationResult {
    * @param model solved case to evaluate
    * @return immutable calculated-product and convergence summary
    * @throws NullPointerException if {@code model} is {@code null}
-   * @throws IllegalStateException if the case is unsolved, used fallback products, is
-   *         non-conservative, or contains invalid or unordered material-product results
+   * @throws IllegalStateException if the case is unsolved, used fallback products, is non-conservative, or contains
+   * invalid or unordered material-product results
    */
-  public static SarirAtmosphericFractionationResult evaluate(
-      SarirAtmosphericFractionationCase model) {
+  public static SarirAtmosphericFractionationResult evaluate(SarirAtmosphericFractionationCase model) {
     Objects.requireNonNull(model, "model");
     DistillationColumn column = model.getColumn();
     if (!column.solved()) {
@@ -78,12 +75,9 @@ public final class SarirAtmosphericFractionationResult {
     }
 
     OperatingInputs inputs = model.getOperatingInputs();
-    StreamInterface[] streams = {
-        column.getGasOutStream(),
-        column.getSideDrawStream(inputs.getKeroseneSideDrawTray(),
-            DistillationColumn.SideDrawPhase.LIQUID),
-        column.getSideDrawStream(inputs.getDieselSideDrawTray(),
-            DistillationColumn.SideDrawPhase.LIQUID),
+    StreamInterface[] streams = { column.getGasOutStream(),
+        column.getSideDrawStream(inputs.getKeroseneSideDrawTray(), DistillationColumn.SideDrawPhase.LIQUID),
+        column.getSideDrawStream(inputs.getDieselSideDrawTray(), DistillationColumn.SideDrawPhase.LIQUID),
         column.getLiquidOutStream() };
 
     ProductResult[] productResults = new ProductResult[streams.length];
@@ -101,17 +95,15 @@ public final class SarirAtmosphericFractionationResult {
       if (massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow) {
         meanBoilingPoint = meanNormalBoilingPoint(streams[i]);
         if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
-          throw new IllegalStateException(
-              "Material products must become heavier from the column top to the bottoms");
+          throw new IllegalStateException("Material products must become heavier from the column top to the bottoms");
         }
         previousMeanBoilingPoint = meanBoilingPoint;
         materialProductCount++;
       }
 
-      ProductYieldReference reference =
-          SarirAtmosphericReference.getProductYield(PRODUCT_LABELS[i]);
-      productResults[i] = new ProductResult(reference.getName(), massFlow,
-          massFlow / feedMassFlow, meanBoilingPoint, reference.getPlantMassFlowRateKgPerHour(),
+      ProductYieldReference reference = SarirAtmosphericReference.getProductYield(PRODUCT_LABELS[i]);
+      productResults[i] = new ProductResult(reference.getName(), massFlow, massFlow / feedMassFlow, meanBoilingPoint,
+          reference.getPlantMassFlowRateKgPerHour(),
           reference.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(massFlow));
     }
     if (materialProductCount < 2) {
@@ -124,9 +116,8 @@ public final class SarirAtmosphericFractionationResult {
     }
 
     String diagnostics = column.getConvergenceDiagnostics();
-    return new SarirAtmosphericFractionationResult(productResults, feedMassFlow,
-        productMassFlow, closureError, massBalanceError, energyBalanceError,
-        column.getLastIterationCount(), diagnostics == null ? "" : diagnostics);
+    return new SarirAtmosphericFractionationResult(productResults, feedMassFlow, productMassFlow, closureError,
+        massBalanceError, energyBalanceError, column.getLastIterationCount(), diagnostics == null ? "" : diagnostics);
   }
 
   /** @return defensive copy of calculated product rows in top-to-bottom order */
@@ -189,8 +180,7 @@ public final class SarirAtmosphericFractionationResult {
 
   private static double meanNormalBoilingPoint(StreamInterface stream) {
     double[] composition = stream.getThermoSystem().getMolarComposition();
-    double[] boilingPoints =
-        stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
     if (composition.length != boilingPoints.length || composition.length == 0) {
       throw new IllegalStateException("Product composition and boiling-point arrays must align");
     }
@@ -198,15 +188,14 @@ public final class SarirAtmosphericFractionationResult {
     double mean = 0.0;
     double compositionSum = 0.0;
     for (int i = 0; i < composition.length; i++) {
-      if (!Double.isFinite(composition[i]) || composition[i] < 0.0
-          || !Double.isFinite(boilingPoints[i]) || !(boilingPoints[i] > 0.0)) {
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
+          || !(boilingPoints[i] > 0.0)) {
         throw new IllegalStateException("Product composition and boiling points must be physical");
       }
       mean += composition[i] * boilingPoints[i];
       compositionSum += composition[i];
     }
-    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0)
-        || !Double.isFinite(mean)) {
+    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || !Double.isFinite(mean)) {
       throw new IllegalStateException("Product mean boiling point is undefined");
     }
     return mean / compositionSum;
@@ -227,16 +216,15 @@ public final class SarirAtmosphericFractionationResult {
     private final double plantMassFlowKgPerHour;
     private final double absoluteRelativeErrorPercentAgainstPlant;
 
-    private ProductResult(String productLabel, double calculatedMassFlowKgPerHour,
-        double calculatedMassFractionOfFeed, double meanNormalBoilingPointKelvin,
-        double plantMassFlowKgPerHour, double absoluteRelativeErrorPercentAgainstPlant) {
+    private ProductResult(String productLabel, double calculatedMassFlowKgPerHour, double calculatedMassFractionOfFeed,
+        double meanNormalBoilingPointKelvin, double plantMassFlowKgPerHour,
+        double absoluteRelativeErrorPercentAgainstPlant) {
       this.productLabel = productLabel;
       this.calculatedMassFlowKgPerHour = calculatedMassFlowKgPerHour;
       this.calculatedMassFractionOfFeed = calculatedMassFractionOfFeed;
       this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
       this.plantMassFlowKgPerHour = plantMassFlowKgPerHour;
-      this.absoluteRelativeErrorPercentAgainstPlant =
-          absoluteRelativeErrorPercentAgainstPlant;
+      this.absoluteRelativeErrorPercentAgainstPlant = absoluteRelativeErrorPercentAgainstPlant;
     }
 
     /** @return exact source-table product label */
@@ -269,8 +257,7 @@ public final class SarirAtmosphericFractionationResult {
      * @return mean normal boiling point in degrees Celsius, or NaN for a non-material product
      */
     public double getMeanNormalBoilingPointCelsius() {
-      return Double.isFinite(meanNormalBoilingPointKelvin)
-          ? meanNormalBoilingPointKelvin - 273.15 : Double.NaN;
+      return Double.isFinite(meanNormalBoilingPointKelvin) ? meanNormalBoilingPointKelvin - 273.15 : Double.NaN;
     }
 
     /** @return measured plant product rate in kg/h */

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
@@ -1,0 +1,290 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import neqsim.process.equipment.distillation.SarirAtmosphericFractionationCase.OperatingInputs;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
+
+/**
+ * Immutable engineering summary for a solved {@link SarirAtmosphericFractionationCase}.
+ *
+ * <p>
+ * Published plant rates are retained as read-only comparison evidence. They are not solver controls,
+ * tuning targets, or acceptance thresholds.
+ * </p>
+ */
+public final class SarirAtmosphericFractionationResult {
+  private static final String[] PRODUCT_LABELS = { "Total Naphtha", "Kerosene", "Diesel",
+      "Residual" };
+  private static final double MATERIAL_FLOW_FRACTION = 1.0e-8;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  private final ProductResult[] products;
+  private final double feedMassFlowKgPerHour;
+  private final double productMassFlowKgPerHour;
+  private final double massClosureRelativeError;
+  private final double columnMassBalanceError;
+  private final double columnEnergyBalanceError;
+  private final int iterationCount;
+  private final String convergenceDiagnostics;
+
+  private SarirAtmosphericFractionationResult(ProductResult[] products,
+      double feedMassFlowKgPerHour, double productMassFlowKgPerHour,
+      double massClosureRelativeError, double columnMassBalanceError,
+      double columnEnergyBalanceError, int iterationCount, String convergenceDiagnostics) {
+    this.products = products.clone();
+    this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
+    this.productMassFlowKgPerHour = productMassFlowKgPerHour;
+    this.massClosureRelativeError = massClosureRelativeError;
+    this.columnMassBalanceError = columnMassBalanceError;
+    this.columnEnergyBalanceError = columnEnergyBalanceError;
+    this.iterationCount = iterationCount;
+    this.convergenceDiagnostics = convergenceDiagnostics;
+  }
+
+  /**
+   * Evaluate an already solved Sarir atmospheric-fractionation case.
+   *
+   * @param model solved case to evaluate
+   * @return immutable calculated-product and convergence summary
+   * @throws NullPointerException if {@code model} is {@code null}
+   * @throws IllegalStateException if the case is unsolved, used fallback products, is
+   *         non-conservative, or contains invalid or unordered material-product results
+   */
+  public static SarirAtmosphericFractionationResult evaluate(
+      SarirAtmosphericFractionationCase model) {
+    Objects.requireNonNull(model, "model");
+    DistillationColumn column = model.getColumn();
+    if (!column.solved()) {
+      throw new IllegalStateException("Sarir atmospheric column must be solved before evaluation");
+    }
+    if (column.getLastSolverTypeUsed() != DistillationColumn.SolverType.MESH_RESIDUAL) {
+      throw new IllegalStateException("Sarir atmospheric column must use the MESH-residual solver");
+    }
+    if (column.getLastSolveStatus() == DistillationColumn.SolveStatus.FALLBACK_PRODUCTS
+        || column.getLastSolveStatus() == DistillationColumn.SolveStatus.FAILED) {
+      throw new IllegalStateException("Fallback or failed column results cannot be evaluated");
+    }
+
+    double massBalanceError = column.getMassBalanceError();
+    double energyBalanceError = column.getEnergyBalanceError();
+    requireFiniteBoundedError(massBalanceError, "Column mass-balance error");
+    requireFiniteBoundedError(energyBalanceError, "Column energy-balance error");
+
+    double feedMassFlow = model.getFeedStream().getFlowRate("kg/hr");
+    if (!Double.isFinite(feedMassFlow) || !(feedMassFlow > 0.0)) {
+      throw new IllegalStateException("Feed mass flow must be finite and positive");
+    }
+
+    OperatingInputs inputs = model.getOperatingInputs();
+    StreamInterface[] streams = {
+        column.getGasOutStream(),
+        column.getSideDrawStream(inputs.getKeroseneSideDrawTray(),
+            DistillationColumn.SideDrawPhase.LIQUID),
+        column.getSideDrawStream(inputs.getDieselSideDrawTray(),
+            DistillationColumn.SideDrawPhase.LIQUID),
+        column.getLiquidOutStream() };
+
+    ProductResult[] productResults = new ProductResult[streams.length];
+    double productMassFlow = 0.0;
+    double previousMeanBoilingPoint = Double.NEGATIVE_INFINITY;
+    int materialProductCount = 0;
+    for (int i = 0; i < streams.length; i++) {
+      double massFlow = streams[i].getFlowRate("kg/hr");
+      if (!Double.isFinite(massFlow) || massFlow < 0.0) {
+        throw new IllegalStateException("Product mass flow must be finite and non-negative");
+      }
+      productMassFlow += massFlow;
+
+      double meanBoilingPoint = Double.NaN;
+      if (massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow) {
+        meanBoilingPoint = meanNormalBoilingPoint(streams[i]);
+        if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
+          throw new IllegalStateException(
+              "Material products must become heavier from the column top to the bottoms");
+        }
+        previousMeanBoilingPoint = meanBoilingPoint;
+        materialProductCount++;
+      }
+
+      ProductYieldReference reference =
+          SarirAtmosphericReference.getProductYield(PRODUCT_LABELS[i]);
+      productResults[i] = new ProductResult(reference.getName(), massFlow,
+          massFlow / feedMassFlow, meanBoilingPoint, reference.getPlantMassFlowRateKgPerHour(),
+          reference.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(massFlow));
+    }
+    if (materialProductCount < 2) {
+      throw new IllegalStateException("At least two ordered material products are required");
+    }
+
+    double closureError = Math.abs(feedMassFlow - productMassFlow) / feedMassFlow;
+    if (!Double.isFinite(closureError) || closureError > BALANCE_TOLERANCE) {
+      throw new IllegalStateException("Calculated product mass flow does not close against feed");
+    }
+
+    String diagnostics = column.getConvergenceDiagnostics();
+    return new SarirAtmosphericFractionationResult(productResults, feedMassFlow,
+        productMassFlow, closureError, massBalanceError, energyBalanceError,
+        column.getLastIterationCount(), diagnostics == null ? "" : diagnostics);
+  }
+
+  /** @return defensive copy of calculated product rows in top-to-bottom order */
+  public ProductResult[] getProducts() {
+    return products.clone();
+  }
+
+  /**
+   * Return one calculated product row by its exact source-table label.
+   *
+   * @param productLabel exact label
+   * @return matching immutable row
+   * @throws IllegalArgumentException if the label is null or unsupported
+   */
+  public ProductResult getProduct(String productLabel) {
+    if (productLabel != null) {
+      for (ProductResult product : products) {
+        if (product.getProductLabel().equals(productLabel)) {
+          return product;
+        }
+      }
+    }
+    throw new IllegalArgumentException("Unsupported Sarir product label: " + productLabel);
+  }
+
+  /** @return evaluated feed mass flow in kg/h */
+  public double getFeedMassFlowKgPerHour() {
+    return feedMassFlowKgPerHour;
+  }
+
+  /** @return sum of evaluated product mass flows in kg/h */
+  public double getProductMassFlowKgPerHour() {
+    return productMassFlowKgPerHour;
+  }
+
+  /** @return absolute feed/product mass-closure error divided by feed flow */
+  public double getMassClosureRelativeError() {
+    return massClosureRelativeError;
+  }
+
+  /** @return column-reported relative mass-balance error */
+  public double getColumnMassBalanceError() {
+    return columnMassBalanceError;
+  }
+
+  /** @return column-reported relative energy-balance error */
+  public double getColumnEnergyBalanceError() {
+    return columnEnergyBalanceError;
+  }
+
+  /** @return iterations used by the qualified column solve */
+  public int getIterationCount() {
+    return iterationCount;
+  }
+
+  /** @return convergence diagnostics captured after the solve */
+  public String getConvergenceDiagnostics() {
+    return convergenceDiagnostics;
+  }
+
+  private static double meanNormalBoilingPoint(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] boilingPoints =
+        stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    if (composition.length != boilingPoints.length || composition.length == 0) {
+      throw new IllegalStateException("Product composition and boiling-point arrays must align");
+    }
+
+    double mean = 0.0;
+    double compositionSum = 0.0;
+    for (int i = 0; i < composition.length; i++) {
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0
+          || !Double.isFinite(boilingPoints[i]) || !(boilingPoints[i] > 0.0)) {
+        throw new IllegalStateException("Product composition and boiling points must be physical");
+      }
+      mean += composition[i] * boilingPoints[i];
+      compositionSum += composition[i];
+    }
+    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0)
+        || !Double.isFinite(mean)) {
+      throw new IllegalStateException("Product mean boiling point is undefined");
+    }
+    return mean / compositionSum;
+  }
+
+  private static void requireFiniteBoundedError(double value, String label) {
+    if (!Double.isFinite(value) || value < 0.0 || value > BALANCE_TOLERANCE) {
+      throw new IllegalStateException(label + " exceeds the qualified tolerance");
+    }
+  }
+
+  /** Immutable calculated product row with read-only plant comparison evidence. */
+  public static final class ProductResult {
+    private final String productLabel;
+    private final double calculatedMassFlowKgPerHour;
+    private final double calculatedMassFractionOfFeed;
+    private final double meanNormalBoilingPointKelvin;
+    private final double plantMassFlowKgPerHour;
+    private final double absoluteRelativeErrorPercentAgainstPlant;
+
+    private ProductResult(String productLabel, double calculatedMassFlowKgPerHour,
+        double calculatedMassFractionOfFeed, double meanNormalBoilingPointKelvin,
+        double plantMassFlowKgPerHour, double absoluteRelativeErrorPercentAgainstPlant) {
+      this.productLabel = productLabel;
+      this.calculatedMassFlowKgPerHour = calculatedMassFlowKgPerHour;
+      this.calculatedMassFractionOfFeed = calculatedMassFractionOfFeed;
+      this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
+      this.plantMassFlowKgPerHour = plantMassFlowKgPerHour;
+      this.absoluteRelativeErrorPercentAgainstPlant =
+          absoluteRelativeErrorPercentAgainstPlant;
+    }
+
+    /** @return exact source-table product label */
+    public String getProductLabel() {
+      return productLabel;
+    }
+
+    /** @return calculated product mass flow in kg/h */
+    public double getCalculatedMassFlowKgPerHour() {
+      return calculatedMassFlowKgPerHour;
+    }
+
+    /** @return calculated product mass flow divided by evaluated feed mass flow */
+    public double getCalculatedMassFractionOfFeed() {
+      return calculatedMassFractionOfFeed;
+    }
+
+    /**
+     * Return the calculated mole-weighted mean normal boiling point.
+     *
+     * @return mean normal boiling point in kelvin, or NaN for a non-material product
+     */
+    public double getMeanNormalBoilingPointKelvin() {
+      return meanNormalBoilingPointKelvin;
+    }
+
+    /**
+     * Return the calculated mole-weighted mean normal boiling point.
+     *
+     * @return mean normal boiling point in degrees Celsius, or NaN for a non-material product
+     */
+    public double getMeanNormalBoilingPointCelsius() {
+      return Double.isFinite(meanNormalBoilingPointKelvin)
+          ? meanNormalBoilingPointKelvin - 273.15 : Double.NaN;
+    }
+
+    /** @return measured plant product rate in kg/h */
+    public double getPlantMassFlowKgPerHour() {
+      return plantMassFlowKgPerHour;
+    }
+
+    /**
+     * Return the absolute calculated-rate difference from the plant rate.
+     *
+     * @return absolute relative error in percent; this is evidence, not an acceptance threshold
+     */
+    public double getAbsoluteRelativeErrorPercentAgainstPlant() {
+      return absoluteRelativeErrorPercentAgainstPlant;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
@@ -50,8 +50,7 @@ public class SarirAtmosphericFractionationCaseTest {
     assertEquals(15, inputs.getDieselSideDrawTray());
     assertEquals(0.15, inputs.getDieselSideDrawFraction(), 0.0);
     assertTrue(inputs == model.getOperatingInputs());
-    assertThrows(IllegalStateException.class,
-        () -> SarirAtmosphericFractionationResult.evaluate(model));
+    assertThrows(IllegalStateException.class, () -> SarirAtmosphericFractionationResult.evaluate(model));
 
     column.run(UUID.randomUUID());
 
@@ -68,8 +67,7 @@ public class SarirAtmosphericFractionationCaseTest {
         column.getLiquidOutStream() };
     assertBalancesAndBoilingOrder(column, feed, products);
 
-    SarirAtmosphericFractionationResult result =
-        SarirAtmosphericFractionationResult.evaluate(model);
+    SarirAtmosphericFractionationResult result = SarirAtmosphericFractionationResult.evaluate(model);
     assertEquals(feed.getFlowRate("kg/hr"), result.getFeedMassFlowKgPerHour(), 1.0e-8);
     assertEquals(column.getLastIterationCount(), result.getIterationCount());
     assertEquals(column.getMassBalanceError(), result.getColumnMassBalanceError(), 0.0);
@@ -95,8 +93,8 @@ public class SarirAtmosphericFractionationCaseTest {
       calculatedFraction += rows[i].getCalculatedMassFractionOfFeed();
       if (Double.isFinite(rows[i].getMeanNormalBoilingPointKelvin())) {
         assertTrue(rows[i].getMeanNormalBoilingPointKelvin() > previousBoilingPoint);
-        assertEquals(rows[i].getMeanNormalBoilingPointKelvin() - 273.15,
-            rows[i].getMeanNormalBoilingPointCelsius(), 1.0e-12);
+        assertEquals(rows[i].getMeanNormalBoilingPointKelvin() - 273.15, rows[i].getMeanNormalBoilingPointCelsius(),
+            1.0e-12);
         previousBoilingPoint = rows[i].getMeanNormalBoilingPointKelvin();
       }
     }
@@ -111,8 +109,7 @@ public class SarirAtmosphericFractionationCaseTest {
   /** Require unreported operating controls and profiles to fail closed. */
   @Test
   public void invalidEngineeringInputsAreRejectedBeforeCaseCreation() {
-    assertThrows(NullPointerException.class,
-        () -> SarirAtmosphericFractionationResult.evaluate(null));
+    assertThrows(NullPointerException.class, () -> SarirAtmosphericFractionationResult.evaluate(null));
     assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(2.5, 2.0, 700.0, 1.0, 24, 0.08, 15, 0.15));
     assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 15, 0.08, 24, 0.15));
     assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 24, 1.0, 15, 0.15));

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
@@ -49,6 +49,9 @@ public class SarirAtmosphericFractionationCaseTest {
     assertEquals(0.08, inputs.getKeroseneSideDrawFraction(), 0.0);
     assertEquals(15, inputs.getDieselSideDrawTray());
     assertEquals(0.15, inputs.getDieselSideDrawFraction(), 0.0);
+    assertTrue(inputs == model.getOperatingInputs());
+    assertThrows(IllegalStateException.class,
+        () -> SarirAtmosphericFractionationResult.evaluate(model));
 
     column.run(UUID.randomUUID());
 
@@ -64,11 +67,52 @@ public class SarirAtmosphericFractionationCaseTest {
         column.getSideDrawStream(inputs.getDieselSideDrawTray(), DistillationColumn.SideDrawPhase.LIQUID),
         column.getLiquidOutStream() };
     assertBalancesAndBoilingOrder(column, feed, products);
+
+    SarirAtmosphericFractionationResult result =
+        SarirAtmosphericFractionationResult.evaluate(model);
+    assertEquals(feed.getFlowRate("kg/hr"), result.getFeedMassFlowKgPerHour(), 1.0e-8);
+    assertEquals(column.getLastIterationCount(), result.getIterationCount());
+    assertEquals(column.getMassBalanceError(), result.getColumnMassBalanceError(), 0.0);
+    assertEquals(column.getEnergyBalanceError(), result.getColumnEnergyBalanceError(), 0.0);
+    assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+    assertTrue(!result.getConvergenceDiagnostics().isEmpty());
+
+    String[] expectedLabels = { "Total Naphtha", "Kerosene", "Diesel", "Residual" };
+    SarirAtmosphericFractionationResult.ProductResult[] rows = result.getProducts();
+    assertEquals(expectedLabels.length, rows.length);
+    double calculatedMassFlow = 0.0;
+    double calculatedFraction = 0.0;
+    double previousBoilingPoint = Double.NEGATIVE_INFINITY;
+    for (int i = 0; i < rows.length; i++) {
+      assertEquals(expectedLabels[i], rows[i].getProductLabel());
+      assertEquals(rows[i], result.getProduct(expectedLabels[i]));
+      assertTrue(Double.isFinite(rows[i].getCalculatedMassFlowKgPerHour()));
+      assertTrue(rows[i].getCalculatedMassFlowKgPerHour() >= 0.0);
+      assertTrue(Double.isFinite(rows[i].getCalculatedMassFractionOfFeed()));
+      assertTrue(Double.isFinite(rows[i].getPlantMassFlowKgPerHour()));
+      assertTrue(Double.isFinite(rows[i].getAbsoluteRelativeErrorPercentAgainstPlant()));
+      calculatedMassFlow += rows[i].getCalculatedMassFlowKgPerHour();
+      calculatedFraction += rows[i].getCalculatedMassFractionOfFeed();
+      if (Double.isFinite(rows[i].getMeanNormalBoilingPointKelvin())) {
+        assertTrue(rows[i].getMeanNormalBoilingPointKelvin() > previousBoilingPoint);
+        assertEquals(rows[i].getMeanNormalBoilingPointKelvin() - 273.15,
+            rows[i].getMeanNormalBoilingPointCelsius(), 1.0e-12);
+        previousBoilingPoint = rows[i].getMeanNormalBoilingPointKelvin();
+      }
+    }
+    assertEquals(result.getProductMassFlowKgPerHour(), calculatedMassFlow, 1.0e-8);
+    assertEquals(calculatedMassFlow / feed.getFlowRate("kg/hr"), calculatedFraction, 1.0e-12);
+    rows[0] = null;
+    assertTrue(result.getProducts()[0] != null);
+    assertThrows(IllegalArgumentException.class, () -> result.getProduct(null));
+    assertThrows(IllegalArgumentException.class, () -> result.getProduct("Naphtha"));
   }
 
   /** Require unreported operating controls and profiles to fail closed. */
   @Test
   public void invalidEngineeringInputsAreRejectedBeforeCaseCreation() {
+    assertThrows(NullPointerException.class,
+        () -> SarirAtmosphericFractionationResult.evaluate(null));
     assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(2.5, 2.0, 700.0, 1.0, 24, 0.08, 15, 0.15));
     assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 15, 0.08, 24, 0.15));
     assertThrows(IllegalArgumentException.class, () -> new OperatingInputs(1.2, 2.33, 700.0, 1.0, 24, 1.0, 15, 0.15));


### PR DESCRIPTION
## Summary

- retain the explicit Sarir column operating inputs on the reusable case
- add an immutable Java/JPype summary for a rigorously solved atmospheric case
- report four ordered product rates, mass yields, mean normal boiling points, convergence and balance evidence
- retain published plant rates only as read-only calculated-rate comparisons
- fail closed for unsolved, fallback, non-conservative, invalid, or unordered results
- document the calculation and evidence boundary

## Capability contract

This increment evaluates the four established outputs in top-to-bottom order: Total Naphtha, Kerosene, Diesel, and Residual. It exposes calculated kg/h, feed mass fractions, mole-weighted mean normal boiling points, aggregate mass closure, column mass/energy errors, iterations, diagnostics, plant kg/h, and absolute calculated-versus-plant rate differences.

The evaluator requires an already solved MESH-residual case and rejects fallback/failed status, non-finite or negative flows, balance errors above the qualified integration tolerance, non-closing totals, fewer than two material products, and non-increasing material-product boiling points. Returned product arrays are defensive.

## Provenance and scientific boundary

Source: Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, published 2022-03-31, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), CC BY 4.0.

Calculated yields and mean normal boiling points depend on caller-supplied, source-unreported cut properties and operating controls. They are model outputs, not source measurements, ASTM D86 curves, or evidence of plant agreement. Published plant rates remain read-only comparators and are never controls, tuning targets, or pass thresholds. Steam, pump-arounds, side strippers, efficiencies, and missing source controls remain excluded.

## Validation

- [ ] focused solved/unsolved and defensive-result regression
- [ ] rigorous non-fallback mass/energy-conservative solve
- [ ] ordered material-product boiling descriptors
- [ ] Spotless and pre-commit
- [ ] documentation search and Javadocs
- [ ] CodeQL, PaperLab, and agent-skill checks
- [ ] exact-head Java matrix and slow shards
- [ ] no review findings or unresolved threads

Exact base: `a2e1f6a26b3cde5b98740e5090d70eeb74b22512`.

Campaign: #3305

This PR is intentionally draft-only. Do not merge, rebase, synchronize, enable auto-merge, or mark ready for review as part of the campaign automation.