### PR TITLE
[AI-Assisted] feat(mcp): qualify bounded streaming simulations

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Run focused task-solver and composed-workflow Java contracts
         run: mvn -B -Dtest=neqsim.mcp.runners.TaskSolverRunnerTest test -ntp
 
+      - name: Run focused bounded-streaming Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.StreamingRunnerTest,neqsim.mcp.runners.McpPrincipalScopingTest test -ntp
+
       - name: Run focused pre-flight validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.ValidatorTest test -ntp
 
@@ -141,6 +144,9 @@ jobs:
 
       - name: Run focused real-MCP task-solver qualification
         run: cd neqsim-mcp-server && python test_solve_task_protocol.py
+
+      - name: Run focused real-MCP bounded-streaming qualification
+        run: cd neqsim-mcp-server && python test_streaming_protocol.py
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py

--- a/neqsim-mcp-server/MCP_CONTRACT.md
+++ b/neqsim-mcp-server/MCP_CONTRACT.md
@@ -443,6 +443,18 @@ An operation exceeding its timeout is cancelled and reported with status
 error rather than queueing. Active limits are reported by `getCapabilities`
 under `modelLifecycle.executionPolicy` and by `streamSimulation(action='list')`.
 
+`streamSimulation` also applies fixed request bounds: 1–1000 parametric
+points, 1–10,000 dynamic time steps, 1–1000 Monte Carlo iterations, a 256 KiB
+dynamic process definition, and at most 100 result records per poll. Invalid
+variables, units, ranges, distributions, compositions, process definitions,
+timings, and negative poll cursors fail closed before background work is
+registered. Retained terminal results do not consume the 20-operation global
+active-work allowance. Operations and results are in-process and
+principal-scoped; they are not durable or distributed. Cancellation and timeout
+remain cooperative, not hard process isolation. The detailed evidence and
+advisory boundary are recorded in
+`docs/evidence/STREAMING_SIMULATION_CONTRACT.md`.
+
 `runCapability(action='invoke')` has a separate five-second in-process worker budget for bounded
 static calculations. It rejects MCP runners and dispatchers, raw generic containers, requests over
 64 KiB, argument arrays over 4096 elements, and results over 256 KiB. Conversion and serialization

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -599,6 +599,21 @@ The `streamSimulation` tool runs long simulations in the background with increme
 | `cancel` / `cancelOperation`             | Cancel a running operation                                   |
 | `list` / `listOperations`                | List all active operations                                   |
 
+Starts fail closed unless work is explicitly bounded: 1–1000 sweep points,
+1–10,000 dynamic steps, or 1–1000 Monte Carlo iterations. Poll cursors must be
+non-negative and each poll returns at most 100 records, with
+`nextPollIndex` and `hasMoreResults` for continuation. Standard response
+`status` remains `success` or `error`; asynchronous lifecycle state is
+reported separately as `operationStatus`. `listOperations`
+reports these fixed request limits together with the shared execution policy.
+
+Operations are visible only to their initiating principal, retained only in the
+current server process, and removed 30 minutes after terminal activity. A
+restart loses them; cancellation and timeout are cooperative rather than hard
+process isolation. Streaming results preserve the underlying NeqSim model
+behavior and require independent engineering review. See
+[the bounded streaming contract](docs/evidence/STREAMING_SIMULATION_CONTRACT.md).
+
 ---
 
 ## Inline Visualization

--- a/neqsim-mcp-server/docs/evidence/STREAMING_SIMULATION_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/STREAMING_SIMULATION_CONTRACT.md
@@ -1,0 +1,81 @@
+# Bounded streaming-simulation contract evidence
+
+## Scope
+
+The `streamSimulation` MCP tool starts bounded in-process parametric,
+transient, and Monte Carlo operations using existing NeqSim runners. A caller
+receives an opaque operation identifier, polls paginated results, may request
+cooperative cancellation, and can list only that caller's operations.
+
+This qualification keeps Phase 0 inventory at `1.33 / 20+33+18`.
+`streamSimulation` remains `CONFIRMED_GAP` until a separate post-merge
+promotion atomically records this direct evidence.
+
+## Contract-tested implementation boundary
+
+`NeqSimTools.streamSimulation` applies normal Tier 3 access enforcement and
+the standard MCP response envelope before delegating to
+`StreamingRunner`. The runner accepts only documented actions and applies
+fixed bounds before registering background work:
+
+- 1–1000 parametric sweep points;
+- 1–10,000 dynamic time steps;
+- 1–1000 Monte Carlo iterations;
+- a dynamic process definition no larger than 256 KiB; and
+- at most 100 result records per poll.
+
+Sweeps require a non-empty, finite, non-negative component map with a positive
+total, an explicit temperature or pressure variable, documented units, finite
+conditions, temperature above absolute zero, and positive absolute pressure.
+Monte Carlo requests apply the same composition rules and require finite
+distribution parameters with non-negative standard deviations. Dynamic
+requests require a nested process object or non-blank JSON string plus finite
+positive timing and a bounded derived step count. Poll cursors are
+non-negative; continuation uses `nextPollIndex` and `hasMoreResults`.
+Transport responses keep the standard top-level `status` contract
+(`success` or `error`) and expose asynchronous lifecycle state separately
+as `operationStatus`.
+
+Retained terminal results do not count against the 20-operation global
+active-work allowance. Per-principal concurrency is still enforced by
+`McpExecutionPolicy`. Every terminal path releases its acquired slot exactly once, including a
+dynamic process-build failure. A timeout outcome cannot be overwritten by a
+later worker exit, and cancellation cannot overwrite an existing terminal
+outcome. Timeouts and caller cancellation remain cooperative.
+
+Operation identifiers use 144 bits of secure randomness. Poll, cancel, and
+list resolve only operations owned by the current principal. Unknown and
+out-of-scope identifiers return the same non-disclosing response.
+
+## Direct evidence
+
+The focused Java contract in
+`src/test/java/neqsim/mcp/runners/StreamingRunnerTest.java` covers fixed-limit
+discovery, malformed and unknown actions, missing or invalid compositions,
+non-positive and oversized work, invalid variables, units, physical ranges,
+distributions and timing, negative cursors, unknown cancellation, and a real
+two-point SRK sweep lifecycle. Existing
+`McpPrincipalScopingTest` independently verifies that one principal cannot
+poll, cancel, or list another principal's operation.
+
+The packaged `neqsim-mcp-server/test_streaming_protocol.py` harness starts
+the shaded server over STDIO and repeats seven transport-level scenarios. It
+checks discovery language, standard response evidence, fixed limit reporting,
+fail-closed requests, a canonical two-point NeqSim sweep, pagination metadata,
+and non-disclosing cancellation. The comprehensive MCP regression remains the
+authoritative 71-tool surface check.
+
+## Evidence and advisory boundary
+
+The contract proves bounded request admission, in-process lifecycle
+accounting, principal-scoped lookup, canonical runner delegation, structured
+errors, standard MCP envelopes, and packaged transport. It does not establish
+EOS or process-model numerical accuracy, convergence for arbitrary inputs,
+statistical or uncertainty validity, completeness of sampled distributions,
+real-time deadlines, durability, recovery after restart, multi-instance
+coordination, distributed execution, external queues, hard process isolation,
+cooperative interruption of every numerical kernel, external IAM or transport
+security, tenant isolation beyond the request context, plant control or
+write-back, standards compliance, certification, or accountable engineering
+approval. Each result retains the applicability and validation boundary of the
+underlying NeqSim model and must be independently reviewed.

--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
@@ -1746,16 +1746,19 @@ public class NeqSimTools {
    * @param streamJson JSON with streaming action and parameters
    * @return JSON with operation ID or polled results
    */
-  @Tool(description = "Run simulations with incremental streaming results. "
-      + "Starts async operations (parametric sweeps, dynamic sims, Monte Carlo) "
-      + "and polls for new results as they become available. "
-      + "Actions: startParametricSweep, startDynamicStreaming, startMonteCarlo, "
-      + "pollResults, cancelOperation, listOperations.")
+  @Tool(description = "Run bounded in-process simulations with incremental polling. "
+      + "Starts canonical NeqSim parametric sweeps, dynamic simulations, or deterministic "
+      + "Monte Carlo studies. Requests are capped at 1000 sweep points, 10000 dynamic "
+      + "steps, or 1000 iterations; polls return at most 100 records. Operations are "
+      + "principal-scoped, retained in process for 30 minutes, and not durable or distributed. "
+      + "Results require independent engineering review. Actions: startParametricSweep, "
+      + "startDynamicStreaming, startMonteCarlo, pollResults, cancelOperation, listOperations.")
   public String streamSimulation(
-      @ToolArg(description = "JSON with: 'action' (startParametricSweep|startDynamicStreaming|"
-          + "startMonteCarlo|pollResults|cancelOperation|listOperations). "
-          + "For start actions: simulation parameters. "
-          + "For pollResults: 'operationId' and 'lastIndex'.") String streamJson) {
+      @ToolArg(description = "JSON with action. Sweep: components, sweepVariable "
+          + "(temperature|pressure), from, to, points and documented units. Dynamic: processJson, "
+          + "totalTime and timeStep. Monte Carlo: components, iterations and distribution "
+          + "parameters. Poll: operationId and non-negative lastIndex. List reports active "
+          + "execution and fixed request limits.") String streamJson) {
     String policyBlocked = enforceToolAccess("streamSimulation");
     if (policyBlocked != null) {
       return policyBlocked;

--- a/neqsim-mcp-server/test_streaming_protocol.py
+++ b/neqsim-mcp-server/test_streaming_protocol.py
@@ -1,0 +1,300 @@
+"""Packaged-MCP qualification for the bounded streamSimulation contract.
+
+The scenarios exercise real STDIO transport, discovery, fixed request limits,
+fail-closed malformed and oversized work, a canonical NeqSim sweep, incremental
+polling, cancellation, and in-process state reporting. They do not establish
+numerical accuracy, uncertainty validity, durability, distributed execution,
+hard process isolation, plant authority, certification, or engineering
+approval.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+def require(condition, message, detail=None):
+    if condition:
+        return
+    suffix = "" if detail is None else "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in ("status", "tool", "code", "errors", "message", "validation", "qualityGate"):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+class McpClient:
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "neqsim-streaming-contract-test", "version": "1.0"},
+            },
+        })
+        require("result" in self.receive(), "MCP initialize did not return a result")
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def request(self, method, params):
+        self.send({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": method,
+            "params": params,
+        })
+        return self.receive()
+
+    def list_tools(self):
+        return self.request("tools/list", {}).get("result", {}).get("tools", [])
+
+    def call_stream(self, request):
+        response = self.request("tools/call", {
+            "name": "streamSimulation",
+            "arguments": {"streamJson": json.dumps(request)},
+        })
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        return json.loads(content[0].get("text", ""))
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def assert_success(response):
+    result = payload(response)
+    require(result.get("status") == "success", "stream request failed", response)
+    require(result.get("tool") == "streamSimulation", "tool identity drifted", response)
+    require(result.get("validation", {}).get("valid") is True,
+            "standard validation evidence drifted", response)
+    require(result.get("qualityGate", {}).get("verdict") == "passed",
+            "software gate did not pass", response)
+    return result
+
+
+def assert_error(response, expected_code):
+    result = payload(response)
+    require(result.get("status") == "error", "stream request did not fail closed", response)
+    errors = result.get("errors", [])
+    code = result.get("code")
+    if code is None and errors:
+        code = errors[0].get("code")
+    require(code == expected_code, "stream error code drifted", result)
+    return result
+
+
+def test_bounded_discovery(client):
+    tool = next((item for item in client.list_tools()
+                 if item.get("name") == "streamSimulation"), None)
+    require(tool is not None, "streamSimulation is missing from tools/list")
+    description = tool.get("description", "")
+    require("1000 sweep points" in description
+            and "10000 dynamic steps" in description
+            and "100 records" in description
+            and "not durable or distributed" in description
+            and "independent engineering review" in description,
+            "streaming discovery boundary drifted", tool)
+
+
+def test_list_reports_limits(client):
+    result = assert_success(client.call_stream({"action": "listOperations"}))
+    limits = result.get("requestLimits", {})
+    require(limits.get("maxSweepPoints") == 1000
+            and limits.get("maxDynamicSteps") == 10000
+            and limits.get("maxMonteCarloIterations") == 1000
+            and limits.get("maxResultsPerPoll") == 100
+            and limits.get("maxProcessJsonBytes") == 262144,
+            "fixed request limits drifted", result)
+    require("executionPolicy" in result and isinstance(result.get("operations"), list),
+            "execution policy or operation list missing", result)
+
+
+def test_fail_closed_actions_and_work_sizes(client):
+    assert_error(client.call_stream({"action": "erase"}), "UNKNOWN_ACTION")
+    assert_error(client.call_stream({
+        "action": "startSweep",
+        "components": {"methane": 1.0},
+        "points": 0,
+    }), "INVALID_POINTS")
+    assert_error(client.call_stream({
+        "action": "startSweep",
+        "components": {"methane": 1.0},
+        "points": 1001,
+    }), "INVALID_POINTS")
+    assert_error(client.call_stream({
+        "action": "startMonteCarlo",
+        "components": {"methane": 1.0},
+        "iterations": 1001,
+    }), "INVALID_ITERATIONS")
+
+
+def test_fail_closed_sweep_semantics(client):
+    assert_error(client.call_stream({
+        "action": "startSweep",
+        "components": {"methane": 1.0},
+        "sweepVariable": "enthalpy",
+        "points": 2,
+    }), "INVALID_SWEEP_VARIABLE")
+    assert_error(client.call_stream({
+        "action": "startSweep",
+        "components": {"methane": 1.0},
+        "sweepVariable": "temperature",
+        "unit": "rankine",
+        "points": 2,
+    }), "INVALID_UNIT")
+    assert_error(client.call_stream({
+        "action": "startSweep",
+        "components": {},
+        "points": 2,
+    }), "MISSING_COMPONENTS")
+
+
+def test_fail_closed_dynamic_timing(client):
+    assert_error(client.call_stream({"action": "startDynamic"}), "MISSING_PROCESS")
+    assert_error(client.call_stream({
+        "action": "startDynamic",
+        "processJson": {},
+        "totalTime": 1,
+        "timeStep": 0,
+    }), "INVALID_TIME_RANGE")
+    assert_error(client.call_stream({
+        "action": "startDynamic",
+        "processJson": {},
+        "totalTime": 10001,
+        "timeStep": 1,
+    }), "INVALID_STEP_COUNT")
+
+
+def test_canonical_sweep_lifecycle(client):
+    started = assert_success(client.call_stream({
+        "action": "startParametricSweep",
+        "components": {"methane": 1.0},
+        "model": "SRK",
+        "sweepVariable": "temperature",
+        "from": 20.0,
+        "to": 21.0,
+        "points": 2,
+        "unit": "C",
+        "fixedPressure": 10.0,
+        "fixedPressureUnit": "bara",
+    }))
+    require(started.get("operationStatus") == "started" and started.get("totalPoints") == 2,
+            "bounded sweep did not start", started)
+    operation_id = started.get("operationId")
+
+    result = None
+    for _ in range(200):
+        result = assert_success(client.call_stream({
+            "action": "pollResults",
+            "operationId": operation_id,
+            "lastIndex": 0,
+        }))
+        if result.get("operationStatus") == "completed":
+            break
+        time.sleep(0.05)
+
+    require(result.get("operationStatus") == "completed"
+            and result.get("completedSteps") == 2
+            and result.get("totalResultCount") == 2,
+            "canonical sweep did not complete", result)
+    require(result.get("maxResultsPerPoll") == 100
+            and result.get("hasMoreResults") is False
+            and result.get("nextPollIndex") == 2,
+            "poll continuation metadata drifted", result)
+    points = result.get("newResults", [])
+    require(len(points) == 2
+            and all(point.get("pressure_bara") == 10.0 for point in points)
+            and all(point.get("numberOfPhases", 0) >= 1 for point in points),
+            "canonical NeqSim sweep evidence drifted", points)
+
+    assert_error(client.call_stream({
+        "action": "poll",
+        "operationId": operation_id,
+        "lastIndex": -1,
+    }), "INVALID_CURSOR")
+
+
+def test_unknown_cancel_is_non_disclosing(client):
+    result = assert_error(client.call_stream({
+        "action": "cancelOperation",
+        "operationId": "sweep-not-owned-or-absent",
+    }), "NOT_FOUND")
+    require("operationId" not in result,
+            "unknown cancellation disclosed state", result)
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("bounded discovery", test_bounded_discovery),
+        ("list reports limits", test_list_reports_limits),
+        ("fail-closed actions and work sizes", test_fail_closed_actions_and_work_sizes),
+        ("fail-closed sweep semantics", test_fail_closed_sweep_semantics),
+        ("fail-closed dynamic timing", test_fail_closed_dynamic_timing),
+        ("canonical sweep lifecycle", test_canonical_sweep_lifecycle),
+        ("unknown cancel is non-disclosing", test_unknown_cancel_is_non_disclosing),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} bounded-streaming scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/src/main/java/neqsim/mcp/runners/StreamingRunner.java
+++ b/src/main/java/neqsim/mcp/runners/StreamingRunner.java
@@ -123,7 +123,8 @@ public final class StreamingRunner {
 
     // Parse sweep parameters
     JsonObject components = input.has("components") && input.get("components").isJsonObject()
-        ? input.getAsJsonObject("components") : null;
+        ? input.getAsJsonObject("components")
+        : null;
     String model = input.has("model") ? input.get("model").getAsString() : "SRK";
     String sweepVar = input.has("sweepVariable") ? input.get("sweepVariable").getAsString() : "temperature";
     double from = input.has("from") ? input.get("from").getAsDouble() : 0;
@@ -156,8 +157,7 @@ public final class StreamingRunner {
           "Use C, K or F for temperature and bara, bar, psi, kPa, MPa or atm for pressure");
     }
     if (!isFinite(from) || !isFinite(to) || !isFinite(fixedTemp) || !isFinite(fixedPressure)
-        || convertToKelvin(fixedTemp, fixedTempUnit) <= 0.0
-        || convertToBara(fixedPressure, fixedPressureUnit) <= 0.0
+        || convertToKelvin(fixedTemp, fixedTempUnit) <= 0.0 || convertToBara(fixedPressure, fixedPressureUnit) <= 0.0
         || ("temperature".equalsIgnoreCase(sweepVar)
             && (convertToKelvin(from, unit) <= 0.0 || convertToKelvin(to, unit) <= 0.0))
         || ("pressure".equalsIgnoreCase(sweepVar)
@@ -276,8 +276,9 @@ public final class StreamingRunner {
 
     double stepCount = Math.floor(totalTime / timeStep);
     if (stepCount < 1.0 || stepCount > MAX_DYNAMIC_STEPS) {
-      return errorJson("INVALID_STEP_COUNT", "Dynamic operation must contain between 1 and " + MAX_DYNAMIC_STEPS
-          + " time steps", "Increase timeStep or reduce totalTime");
+      return errorJson("INVALID_STEP_COUNT",
+          "Dynamic operation must contain between 1 and " + MAX_DYNAMIC_STEPS + " time steps",
+          "Increase timeStep or reduce totalTime");
     }
     int steps = (int) stepCount;
     op.totalSteps = steps;
@@ -344,7 +345,8 @@ public final class StreamingRunner {
     StreamingOperation op = new StreamingOperation(opId, "monte_carlo");
 
     JsonObject baseComponents = input.has("components") && input.get("components").isJsonObject()
-        ? input.getAsJsonObject("components") : null;
+        ? input.getAsJsonObject("components")
+        : null;
     String model = input.has("model") ? input.get("model").getAsString() : "SRK";
     int iterations = input.has("iterations") ? input.get("iterations").getAsInt() : 100;
 
@@ -359,14 +361,14 @@ public final class StreamingRunner {
       return componentError;
     }
     if (iterations < 1 || iterations > MAX_MONTE_CARLO_ITERATIONS) {
-      return errorJson("INVALID_ITERATIONS",
-          "iterations must be between 1 and " + MAX_MONTE_CARLO_ITERATIONS,
+      return errorJson("INVALID_ITERATIONS", "iterations must be between 1 and " + MAX_MONTE_CARLO_ITERATIONS,
           "Choose a bounded positive Monte Carlo size");
     }
-    if (!isFinite(tempMean) || !isFinite(tempStd) || !isFinite(presMean) || !isFinite(presStd)
-        || tempStd < 0.0 || presStd < 0.0 || convertToKelvin(tempMean, "C") <= 0.0 || presMean <= 0.0) {
-      return errorJson("INVALID_DISTRIBUTION", "Monte Carlo parameters must be finite, with non-negative "
-          + "standard deviations, temperature above absolute zero, and positive mean pressure",
+    if (!isFinite(tempMean) || !isFinite(tempStd) || !isFinite(presMean) || !isFinite(presStd) || tempStd < 0.0
+        || presStd < 0.0 || convertToKelvin(tempMean, "C") <= 0.0 || presMean <= 0.0) {
+      return errorJson("INVALID_DISTRIBUTION",
+          "Monte Carlo parameters must be finite, with non-negative "
+              + "standard deviations, temperature above absolute zero, and positive mean pressure",
           "Correct the requested distribution");
     }
 
@@ -515,8 +517,7 @@ public final class StreamingRunner {
     StreamingOperation op = ownedOperation(opId);
 
     if (op == null) {
-      return errorJson("NOT_FOUND", "Operation not found: " + opId,
-          "Use action 'list' to see active operations");
+      return errorJson("NOT_FOUND", "Operation not found: " + opId, "Use action 'list' to see active operations");
     }
     String operationStatus = op.requestCancellation();
     JsonObject response = new JsonObject();

--- a/src/main/java/neqsim/mcp/runners/StreamingRunner.java
+++ b/src/main/java/neqsim/mcp/runners/StreamingRunner.java
@@ -44,6 +44,21 @@ public final class StreamingRunner {
   /** Max concurrent streaming operations. */
   private static final int MAX_OPERATIONS = 20;
 
+  /** Maximum points accepted for a parametric sweep. */
+  static final int MAX_SWEEP_POINTS = 1000;
+
+  /** Maximum time steps accepted for one dynamic operation. */
+  static final int MAX_DYNAMIC_STEPS = 10000;
+
+  /** Maximum iterations accepted for one Monte Carlo operation. */
+  static final int MAX_MONTE_CARLO_ITERATIONS = 1000;
+
+  /** Maximum result records returned by one poll. */
+  static final int MAX_RESULTS_PER_POLL = 100;
+
+  /** Maximum accepted serialized process definition size. */
+  private static final int MAX_PROCESS_JSON_BYTES = 256 * 1024;
+
   /** Retention time for completed streaming operations. */
   private static final long OPERATION_RETENTION_MS = 30L * 60L * 1000L;
 
@@ -103,15 +118,12 @@ public final class StreamingRunner {
    */
   private static String startParametricSweep(JsonObject input) {
     cleanupOperations();
-    if (OPERATIONS.size() >= MAX_OPERATIONS) {
-      return errorJson("LIMIT_REACHED", "Max streaming operations reached", "Cancel some first");
-    }
-
     String opId = newOperationId("sweep");
     StreamingOperation op = new StreamingOperation(opId, "parametric_sweep");
 
     // Parse sweep parameters
-    JsonObject components = input.has("components") ? input.getAsJsonObject("components") : new JsonObject();
+    JsonObject components = input.has("components") && input.get("components").isJsonObject()
+        ? input.getAsJsonObject("components") : null;
     String model = input.has("model") ? input.get("model").getAsString() : "SRK";
     String sweepVar = input.has("sweepVariable") ? input.get("sweepVariable").getAsString() : "temperature";
     double from = input.has("from") ? input.get("from").getAsDouble() : 0;
@@ -124,6 +136,35 @@ public final class StreamingRunner {
     String fixedTempUnit = input.has("fixedTemperatureUnit") ? input.get("fixedTemperatureUnit").getAsString() : "C";
     double fixedPressure = input.has("fixedPressure") ? input.get("fixedPressure").getAsDouble() : 1.0;
     String fixedPressureUnit = input.has("fixedPressureUnit") ? input.get("fixedPressureUnit").getAsString() : "bara";
+
+    String componentError = validateComponents(components);
+    if (componentError != null) {
+      return componentError;
+    }
+    if (points < 1 || points > MAX_SWEEP_POINTS) {
+      return errorJson("INVALID_POINTS", "points must be between 1 and " + MAX_SWEEP_POINTS,
+          "Choose a bounded positive sweep size");
+    }
+    if (!"temperature".equalsIgnoreCase(sweepVar) && !"pressure".equalsIgnoreCase(sweepVar)) {
+      return errorJson("INVALID_SWEEP_VARIABLE", "sweepVariable must be temperature or pressure",
+          "Use one of the documented sweep variables");
+    }
+    if (!isTemperatureUnit(fixedTempUnit) || !isPressureUnit(fixedPressureUnit)
+        || ("temperature".equalsIgnoreCase(sweepVar) && !isTemperatureUnit(unit))
+        || ("pressure".equalsIgnoreCase(sweepVar) && !isPressureUnit(unit))) {
+      return errorJson("INVALID_UNIT", "Unsupported sweep or fixed-condition unit",
+          "Use C, K or F for temperature and bara, bar, psi, kPa, MPa or atm for pressure");
+    }
+    if (!isFinite(from) || !isFinite(to) || !isFinite(fixedTemp) || !isFinite(fixedPressure)
+        || convertToKelvin(fixedTemp, fixedTempUnit) <= 0.0
+        || convertToBara(fixedPressure, fixedPressureUnit) <= 0.0
+        || ("temperature".equalsIgnoreCase(sweepVar)
+            && (convertToKelvin(from, unit) <= 0.0 || convertToKelvin(to, unit) <= 0.0))
+        || ("pressure".equalsIgnoreCase(sweepVar)
+            && (convertToBara(from, unit) <= 0.0 || convertToBara(to, unit) <= 0.0))) {
+      return errorJson("INVALID_RANGE", "Sweep and fixed conditions must be finite and physically positive",
+          "Use temperatures above absolute zero and positive absolute pressures");
+    }
 
     op.totalSteps = points;
     String limited = registerOperation(op);
@@ -188,7 +229,8 @@ public final class StreamingRunner {
     });
 
     JsonObject response = new JsonObject();
-    response.addProperty("status", "started");
+    response.addProperty("status", "success");
+    response.addProperty("operationStatus", "started");
     response.addProperty("operationId", opId);
     response.addProperty("type", "parametric_sweep");
     response.addProperty("totalPoints", points);
@@ -204,18 +246,40 @@ public final class StreamingRunner {
    */
   private static String startDynamicStreaming(JsonObject input) {
     cleanupOperations();
-    if (OPERATIONS.size() >= MAX_OPERATIONS) {
-      return errorJson("LIMIT_REACHED", "Max streaming operations reached", "Cancel some first");
-    }
-
     String opId = newOperationId("dynamic");
     StreamingOperation op = new StreamingOperation(opId, "dynamic_simulation");
 
-    String processJson = input.has("processJson") ? GSON.toJson(input.get("processJson")) : "{}";
+    if (!input.has("processJson") || input.get("processJson").isJsonNull()) {
+      return errorJson("MISSING_PROCESS", "processJson is required for dynamic streaming",
+          "Provide a nested process definition or a JSON string");
+    }
+    JsonElement processElement = input.get("processJson");
+    if (!processElement.isJsonObject()
+        && (!processElement.isJsonPrimitive() || !processElement.getAsJsonPrimitive().isString())) {
+      return errorJson("INVALID_PROCESS", "processJson must be an object or JSON string",
+          "Provide a ProcessSystem JSON definition");
+    }
+    String processJson = processElement.isJsonObject() ? GSON.toJson(processElement) : processElement.getAsString();
+    if (processJson.trim().isEmpty()) {
+      return errorJson("INVALID_PROCESS", "processJson must not be blank", "Provide a ProcessSystem JSON definition");
+    }
+    if (processJson.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > MAX_PROCESS_JSON_BYTES) {
+      return errorJson("REQUEST_TOO_LARGE", "processJson exceeds " + MAX_PROCESS_JSON_BYTES + " bytes",
+          "Reduce the process definition before starting the operation");
+    }
     double totalTime = input.has("totalTime") ? input.get("totalTime").getAsDouble() : 3600.0;
     double timeStep = input.has("timeStep") ? input.get("timeStep").getAsDouble() : 1.0;
+    if (!isFinite(totalTime) || !isFinite(timeStep) || totalTime <= 0.0 || timeStep <= 0.0) {
+      return errorJson("INVALID_TIME_RANGE", "totalTime and timeStep must be finite and positive",
+          "Provide positive durations in seconds");
+    }
 
-    int steps = (int) (totalTime / timeStep);
+    double stepCount = Math.floor(totalTime / timeStep);
+    if (stepCount < 1.0 || stepCount > MAX_DYNAMIC_STEPS) {
+      return errorJson("INVALID_STEP_COUNT", "Dynamic operation must contain between 1 and " + MAX_DYNAMIC_STEPS
+          + " time steps", "Increase timeStep or reduce totalTime");
+    }
+    int steps = (int) stepCount;
     op.totalSteps = steps;
     String limited = registerOperation(op);
     if (limited != null) {
@@ -225,9 +289,9 @@ public final class StreamingRunner {
     EXECUTOR.submit(() -> {
       try {
         SimulationResult buildResult = ProcessSystem.fromJsonAndRun(processJson);
-        if (buildResult.isError()) {
-          op.status = "failed";
+        if (buildResult.isError() || buildResult.getProcessSystem() == null) {
           op.errorMessage = "Failed to build process";
+          op.markFinished("failed");
           return;
         }
 
@@ -259,7 +323,8 @@ public final class StreamingRunner {
     });
 
     JsonObject response = new JsonObject();
-    response.addProperty("status", "started");
+    response.addProperty("status", "success");
+    response.addProperty("operationStatus", "started");
     response.addProperty("operationId", opId);
     response.addProperty("type", "dynamic_simulation");
     response.addProperty("totalSteps", steps);
@@ -275,14 +340,11 @@ public final class StreamingRunner {
    */
   private static String startMonteCarlo(JsonObject input) {
     cleanupOperations();
-    if (OPERATIONS.size() >= MAX_OPERATIONS) {
-      return errorJson("LIMIT_REACHED", "Max streaming operations reached", "Cancel some first");
-    }
-
     String opId = newOperationId("mc");
     StreamingOperation op = new StreamingOperation(opId, "monte_carlo");
 
-    JsonObject baseComponents = input.has("components") ? input.getAsJsonObject("components") : new JsonObject();
+    JsonObject baseComponents = input.has("components") && input.get("components").isJsonObject()
+        ? input.getAsJsonObject("components") : null;
     String model = input.has("model") ? input.get("model").getAsString() : "SRK";
     int iterations = input.has("iterations") ? input.get("iterations").getAsInt() : 100;
 
@@ -291,6 +353,22 @@ public final class StreamingRunner {
     double tempStd = input.has("temperatureStd") ? input.get("temperatureStd").getAsDouble() : 5.0;
     double presMean = input.has("pressureMean") ? input.get("pressureMean").getAsDouble() : 50.0;
     double presStd = input.has("pressureStd") ? input.get("pressureStd").getAsDouble() : 10.0;
+
+    String componentError = validateComponents(baseComponents);
+    if (componentError != null) {
+      return componentError;
+    }
+    if (iterations < 1 || iterations > MAX_MONTE_CARLO_ITERATIONS) {
+      return errorJson("INVALID_ITERATIONS",
+          "iterations must be between 1 and " + MAX_MONTE_CARLO_ITERATIONS,
+          "Choose a bounded positive Monte Carlo size");
+    }
+    if (!isFinite(tempMean) || !isFinite(tempStd) || !isFinite(presMean) || !isFinite(presStd)
+        || tempStd < 0.0 || presStd < 0.0 || convertToKelvin(tempMean, "C") <= 0.0 || presMean <= 0.0) {
+      return errorJson("INVALID_DISTRIBUTION", "Monte Carlo parameters must be finite, with non-negative "
+          + "standard deviations, temperature above absolute zero, and positive mean pressure",
+          "Correct the requested distribution");
+    }
 
     op.totalSteps = iterations;
     String limited = registerOperation(op);
@@ -367,7 +445,8 @@ public final class StreamingRunner {
     });
 
     JsonObject response = new JsonObject();
-    response.addProperty("status", "started");
+    response.addProperty("status", "success");
+    response.addProperty("operationStatus", "started");
     response.addProperty("operationId", opId);
     response.addProperty("type", "monte_carlo");
     response.addProperty("iterations", iterations);
@@ -391,11 +470,16 @@ public final class StreamingRunner {
     op.touch();
 
     int lastIndex = input.has("lastIndex") ? input.get("lastIndex").getAsInt() : 0;
+    if (lastIndex < 0) {
+      return errorJson("INVALID_CURSOR", "lastIndex must be zero or greater",
+          "Use nextPollIndex from the previous response");
+    }
 
     JsonObject response = new JsonObject();
     response.addProperty("operationId", opId);
     response.addProperty("type", op.type);
-    response.addProperty("status", op.status);
+    response.addProperty("status", "success");
+    response.addProperty("operationStatus", op.status);
     response.addProperty("completedSteps", op.completedSteps);
     response.addProperty("totalSteps", op.totalSteps);
     response.addProperty("progressPercent", op.totalSteps > 0 ? (100.0 * op.completedSteps / op.totalSteps) : 0);
@@ -405,7 +489,7 @@ public final class StreamingRunner {
     }
 
     // Get new results since lastIndex
-    List<JsonObject> newResults = op.getResultsSince(lastIndex);
+    List<JsonObject> newResults = op.getResultsSince(lastIndex, MAX_RESULTS_PER_POLL);
     JsonArray results = new JsonArray();
     for (JsonObject r : newResults) {
       results.add(r);
@@ -414,6 +498,8 @@ public final class StreamingRunner {
     response.addProperty("newResultCount", newResults.size());
     response.addProperty("totalResultCount", op.getResultCount());
     response.addProperty("nextPollIndex", lastIndex + newResults.size());
+    response.addProperty("maxResultsPerPoll", MAX_RESULTS_PER_POLL);
+    response.addProperty("hasMoreResults", lastIndex + newResults.size() < op.getResultCount());
 
     return GSON.toJson(response);
   }
@@ -428,17 +514,15 @@ public final class StreamingRunner {
     String opId = input.has("operationId") ? input.get("operationId").getAsString() : "";
     StreamingOperation op = ownedOperation(opId);
 
-    JsonObject response = new JsonObject();
-    if (op != null) {
-      op.cancelled = true;
-      op.status = "cancelling";
-      op.touch();
-      response.addProperty("status", "cancelling");
-      response.addProperty("operationId", opId);
-    } else {
-      response.addProperty("status", "not_found");
-      response.addProperty("operationId", opId);
+    if (op == null) {
+      return errorJson("NOT_FOUND", "Operation not found: " + opId,
+          "Use action 'list' to see active operations");
     }
+    String operationStatus = op.requestCancellation();
+    JsonObject response = new JsonObject();
+    response.addProperty("status", "success");
+    response.addProperty("operationStatus", operationStatus);
+    response.addProperty("operationId", opId);
     return GSON.toJson(response);
   }
 
@@ -451,6 +535,7 @@ public final class StreamingRunner {
     cleanupOperations();
     String owner = McpRequestContext.currentSubject();
     JsonObject response = new JsonObject();
+    response.addProperty("status", "success");
 
     JsonArray ops = new JsonArray();
     for (Map.Entry<String, StreamingOperation> entry : OPERATIONS.entrySet()) {
@@ -472,6 +557,7 @@ public final class StreamingRunner {
     response.addProperty("count", ops.size());
     response.add("operations", ops);
     response.add("executionPolicy", McpExecutionPolicy.describe());
+    response.add("requestLimits", describeRequestLimits());
     response.addProperty("activeForCaller", McpExecutionPolicy.activeOperations(owner));
     return GSON.toJson(response);
   }
@@ -496,7 +582,10 @@ public final class StreamingRunner {
    * @param op the operation to register
    * @return null when registration succeeded, otherwise an error response
    */
-  private static String registerOperation(StreamingOperation op) {
+  private static synchronized String registerOperation(StreamingOperation op) {
+    if (activeOperationCount() >= MAX_OPERATIONS) {
+      return errorJson("LIMIT_REACHED", "Max streaming operations reached", "Wait for active work to finish");
+    }
     if (!McpExecutionPolicy.tryAcquireSlot()) {
       return errorJson("CONCURRENCY_LIMIT",
           "This caller already has " + McpExecutionPolicy.getMaxOperationsPerPrincipal() + " operations running",
@@ -510,6 +599,105 @@ public final class StreamingRunner {
   // ═══════════════════════════════════════════════════════════════════════════
   // Helpers
   // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Counts active operations without treating retained terminal results as active work.
+   *
+   * @return number of non-terminal operations
+   */
+  private static int activeOperationCount() {
+    int active = 0;
+    for (StreamingOperation op : OPERATIONS.values()) {
+      if (!op.isTerminal()) {
+        active++;
+      }
+    }
+    return active;
+  }
+
+  /**
+   * Validates a non-empty, finite and non-negative composition with positive total amount.
+   *
+   * @param components component amount map
+   * @return null when valid, otherwise a structured error response
+   */
+  private static String validateComponents(JsonObject components) {
+    if (components == null || components.size() == 0) {
+      return errorJson("MISSING_COMPONENTS", "components must contain at least one component",
+          "Provide a component-to-amount map");
+    }
+    double total = 0.0;
+    try {
+      for (Map.Entry<String, JsonElement> entry : components.entrySet()) {
+        JsonElement element = entry.getValue();
+        if (entry.getKey().trim().isEmpty() || element == null || !element.isJsonPrimitive()
+            || !element.getAsJsonPrimitive().isNumber()) {
+          return errorJson("INVALID_COMPONENTS", "Component names and amounts must be numeric",
+              "Provide non-blank names and finite non-negative amounts");
+        }
+        double amount = element.getAsDouble();
+        if (!isFinite(amount) || amount < 0.0) {
+          return errorJson("INVALID_COMPONENTS", "Component amounts must be finite and non-negative",
+              "Correct the component map");
+        }
+        total += amount;
+      }
+    } catch (RuntimeException e) {
+      return errorJson("INVALID_COMPONENTS", "Component amounts must be numeric",
+          "Provide finite non-negative amounts");
+    }
+    if (!isFinite(total) || total <= 0.0) {
+      return errorJson("INVALID_COMPONENTS", "At least one component amount must be positive",
+          "Correct the component map");
+    }
+    return null;
+  }
+
+  /**
+   * Reports fixed streaming request bounds.
+   *
+   * @return request-limit object
+   */
+  private static JsonObject describeRequestLimits() {
+    JsonObject limits = new JsonObject();
+    limits.addProperty("maxSweepPoints", MAX_SWEEP_POINTS);
+    limits.addProperty("maxDynamicSteps", MAX_DYNAMIC_STEPS);
+    limits.addProperty("maxMonteCarloIterations", MAX_MONTE_CARLO_ITERATIONS);
+    limits.addProperty("maxResultsPerPoll", MAX_RESULTS_PER_POLL);
+    limits.addProperty("maxProcessJsonBytes", MAX_PROCESS_JSON_BYTES);
+    return limits;
+  }
+
+  /**
+   * Checks whether a value is finite.
+   *
+   * @param value value to check
+   * @return true only for finite values
+   */
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  /**
+   * Checks a documented temperature unit.
+   *
+   * @param unit unit token
+   * @return true for C, K or F
+   */
+  private static boolean isTemperatureUnit(String unit) {
+    return "C".equalsIgnoreCase(unit) || "K".equalsIgnoreCase(unit) || "F".equalsIgnoreCase(unit);
+  }
+
+  /**
+   * Checks a documented pressure unit.
+   *
+   * @param unit unit token
+   * @return true for bara, bar, psi, kPa, MPa or atm
+   */
+  private static boolean isPressureUnit(String unit) {
+    return "bara".equalsIgnoreCase(unit) || "bar".equalsIgnoreCase(unit) || "psi".equalsIgnoreCase(unit)
+        || "kPa".equalsIgnoreCase(unit) || "MPa".equalsIgnoreCase(unit) || "atm".equalsIgnoreCase(unit);
+  }
 
   /**
    * Converts temperature to Kelvin.
@@ -756,16 +944,32 @@ public final class StreamingRunner {
      *
      * @param finalStatus final status value
      */
-    void markFinished(String finalStatus) {
+    synchronized void markFinished(String finalStatus) {
+      if (!finished.compareAndSet(false, true)) {
+        return;
+      }
       status = finalStatus;
       touch();
-      if (finished.compareAndSet(false, true)) {
-        java.util.concurrent.ScheduledFuture<?> handle = timeoutHandle;
-        if (handle != null) {
-          handle.cancel(false);
-        }
-        McpExecutionPolicy.releaseSlot(owner);
+      java.util.concurrent.ScheduledFuture<?> handle = timeoutHandle;
+      if (handle != null) {
+        handle.cancel(false);
       }
+      McpExecutionPolicy.releaseSlot(owner);
+    }
+
+    /**
+     * Requests cooperative cancellation without overwriting a terminal outcome.
+     *
+     * @return the resulting operation status
+     */
+    synchronized String requestCancellation() {
+      if (isTerminal()) {
+        return status;
+      }
+      cancelled = true;
+      status = "cancelling";
+      touch();
+      return status;
     }
 
     /**
@@ -784,12 +988,13 @@ public final class StreamingRunner {
      * @param fromIndex the start index
      * @return new results
      */
-    List<JsonObject> getResultsSince(int fromIndex) {
+    List<JsonObject> getResultsSince(int fromIndex, int limit) {
       synchronized (results) {
         if (fromIndex >= results.size()) {
           return new ArrayList<JsonObject>();
         }
-        return new ArrayList<JsonObject>(results.subList(fromIndex, results.size()));
+        int toIndex = Math.min(results.size(), fromIndex + limit);
+        return new ArrayList<JsonObject>(results.subList(fromIndex, toIndex));
       }
     }
 

--- a/src/main/java/neqsim/mcp/runners/StreamingRunner.java
+++ b/src/main/java/neqsim/mcp/runners/StreamingRunner.java
@@ -517,7 +517,11 @@ public final class StreamingRunner {
     StreamingOperation op = ownedOperation(opId);
 
     if (op == null) {
-      return errorJson("NOT_FOUND", "Operation not found: " + opId, "Use action 'list' to see active operations");
+      String notFound = errorJson("NOT_FOUND", "Operation not found: " + opId,
+          "Use action 'list' to see active operations");
+      JsonObject response = JsonParser.parseString(notFound).getAsJsonObject();
+      response.addProperty("operationStatus", "not_found");
+      return GSON.toJson(response);
     }
     String operationStatus = op.requestCancellation();
     JsonObject response = new JsonObject();

--- a/src/test/java/neqsim/mcp/runners/StreamingRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/StreamingRunnerTest.java
@@ -1,52 +1,148 @@
 package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 /**
- * Tests for {@link StreamingRunner}.
+ * Contract tests for {@link StreamingRunner}.
  *
  * @author Even Solbraa
- * @version 1.0
+ * @version 1.1
  */
 class StreamingRunnerTest {
 
-  @Test
-  void testListOperations() {
-    String json = "{\"action\": \"list\"}";
-    String result = StreamingRunner.run(json);
-    assertNotNull(result);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    // list action returns count + operations, no top-level status
-    assertTrue(obj.has("operations"), "Should list operations: " + result);
+  private JsonObject run(String json) {
+    return JsonParser.parseString(StreamingRunner.run(json)).getAsJsonObject();
+  }
+
+  private String errorCode(JsonObject response) {
+    JsonArray errors = response.getAsJsonArray("errors");
+    return errors.get(0).getAsJsonObject().get("code").getAsString();
   }
 
   @Test
-  void testPollNonexistent() {
-    String json = "{\"action\": \"poll\", \"operationId\": \"nonexistent-id\"," + "\"lastIndex\": 0}";
-    String result = StreamingRunner.run(json);
-    assertNotNull(result);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("error", obj.get("status").getAsString());
+  void testListOperationsReportsBounds() {
+    JsonObject result = run("{\"action\": \"list\"}");
+    assertTrue(result.has("operations"), result.toString());
+    JsonObject limits = result.getAsJsonObject("requestLimits");
+    assertEquals(StreamingRunner.MAX_SWEEP_POINTS, limits.get("maxSweepPoints").getAsInt());
+    assertEquals(StreamingRunner.MAX_DYNAMIC_STEPS, limits.get("maxDynamicSteps").getAsInt());
+    assertEquals(StreamingRunner.MAX_MONTE_CARLO_ITERATIONS,
+        limits.get("maxMonteCarloIterations").getAsInt());
+    assertEquals(StreamingRunner.MAX_RESULTS_PER_POLL, limits.get("maxResultsPerPoll").getAsInt());
   }
 
   @Test
-  void testCancelNonexistent() {
-    String json = "{\"action\": \"cancel\", \"operationId\": \"nonexistent-id\"}";
-    String result = StreamingRunner.run(json);
-    assertNotNull(result);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("not_found", obj.get("status").getAsString());
+  void testPollAndCancelNonexistentOperation() {
+    JsonObject poll = run("{\"action\": \"poll\", \"operationId\": \"nonexistent-id\","
+        + " \"lastIndex\": 0}");
+    assertEquals("error", poll.get("status").getAsString());
+    assertEquals("NOT_FOUND", errorCode(poll));
+
+    JsonObject cancel = run("{\"action\": \"cancel\", \"operationId\": \"nonexistent-id\"}");
+    assertEquals("error", cancel.get("status").getAsString());
+    assertEquals("NOT_FOUND", errorCode(cancel));
   }
 
   @Test
-  void testNullInput() {
-    String result = StreamingRunner.run(null);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("error", obj.get("status").getAsString());
+  void testNullMalformedAndUnknownInputFailClosed() {
+    assertEquals("STREAMING_ERROR", errorCode(run(null)));
+    assertEquals("STREAMING_ERROR", errorCode(run("{")));
+    assertEquals("UNKNOWN_ACTION", errorCode(run("{\"action\": \"deleteEverything\"}")));
+  }
+
+  @Test
+  void testSweepRequiresBoundedPointsAndComposition() {
+    JsonObject missing = run("{\"action\": \"startSweep\", \"points\": 2}");
+    assertEquals("MISSING_COMPONENTS", errorCode(missing));
+
+    String prefix = "{\"action\":\"startSweep\",\"components\":{\"methane\":1.0},";
+    assertEquals("INVALID_POINTS", errorCode(run(prefix + "\"points\":0}")));
+    assertEquals("INVALID_POINTS",
+        errorCode(run(prefix + "\"points\":" + (StreamingRunner.MAX_SWEEP_POINTS + 1) + "}")));
+  }
+
+  @Test
+  void testSweepRejectsAmbiguousVariableUnitAndRange() {
+    String prefix = "{\"action\":\"startSweep\",\"components\":{\"methane\":1.0},";
+    assertEquals("INVALID_SWEEP_VARIABLE",
+        errorCode(run(prefix + "\"sweepVariable\":\"enthalpy\",\"points\":2}")));
+    assertEquals("INVALID_UNIT",
+        errorCode(run(prefix + "\"sweepVariable\":\"temperature\",\"unit\":\"rankine\","
+            + "\"points\":2}")));
+    assertEquals("INVALID_RANGE",
+        errorCode(run(prefix + "\"sweepVariable\":\"pressure\",\"unit\":\"bara\","
+            + "\"from\":0,\"to\":10,\"points\":2}")));
+  }
+
+  @Test
+  void testMonteCarloRequiresBoundedFiniteDistribution() {
+    String prefix = "{\"action\":\"startMonteCarlo\",\"components\":{\"methane\":1.0},";
+    assertEquals("INVALID_ITERATIONS", errorCode(run(prefix + "\"iterations\":0}")));
+    assertEquals("INVALID_ITERATIONS",
+        errorCode(run(prefix + "\"iterations\":" + (StreamingRunner.MAX_MONTE_CARLO_ITERATIONS + 1) + "}")));
+    assertEquals("INVALID_DISTRIBUTION",
+        errorCode(run(prefix + "\"iterations\":1,\"temperatureStd\":-1}")));
+  }
+
+  @Test
+  void testDynamicRequiresProcessAndBoundedTiming() {
+    assertEquals("MISSING_PROCESS", errorCode(run("{\"action\":\"startDynamic\"}")));
+    String prefix = "{\"action\":\"startDynamic\",\"processJson\":{},";
+    assertEquals("INVALID_TIME_RANGE", errorCode(run(prefix + "\"totalTime\":1,\"timeStep\":0}")));
+    assertEquals("INVALID_STEP_COUNT",
+        errorCode(run(prefix + "\"totalTime\":" + (StreamingRunner.MAX_DYNAMIC_STEPS + 1)
+            + ",\"timeStep\":1}")));
+  }
+
+  @Test
+  void testNegativePollCursorFailsClosed() {
+    JsonObject started = run("{\"action\":\"startSweep\",\"components\":{\"methane\":1.0},"
+        + "\"sweepVariable\":\"temperature\",\"from\":20,\"to\":20,\"points\":1}");
+    assertEquals("success", started.get("status").getAsString(), started.toString());
+    assertEquals("started", started.get("operationStatus").getAsString(), started.toString());
+    String operationId = started.get("operationId").getAsString();
+    JsonObject poll = run("{\"action\":\"poll\",\"operationId\":\"" + operationId
+        + "\",\"lastIndex\":-1}");
+    assertEquals("INVALID_CURSOR", errorCode(poll));
+    run("{\"action\":\"cancel\",\"operationId\":\"" + operationId + "\"}");
+  }
+
+  @Test
+  void testBoundedSweepLifecycleAndPollMetadata() throws InterruptedException {
+    JsonObject started = run("{\"action\":\"startSweep\",\"components\":{\"methane\":1.0},"
+        + "\"sweepVariable\":\"temperature\",\"from\":20,\"to\":21,\"points\":2}");
+    assertEquals("success", started.get("status").getAsString(), started.toString());
+    assertEquals("started", started.get("operationStatus").getAsString(), started.toString());
+    String operationId = started.get("operationId").getAsString();
+
+    JsonObject poll = null;
+    for (int attempt = 0; attempt < 200; attempt++) {
+      poll = run("{\"action\":\"poll\",\"operationId\":\"" + operationId
+          + "\",\"lastIndex\":0}");
+      if ("completed".equals(poll.get("operationStatus").getAsString())) {
+        break;
+      }
+      Thread.sleep(25L);
+    }
+
+    assertNotNull(poll);
+    assertEquals("success", poll.get("status").getAsString(), poll.toString());
+    assertEquals("completed", poll.get("operationStatus").getAsString(), poll.toString());
+    assertEquals(2, poll.get("completedSteps").getAsInt());
+    assertEquals(2, poll.get("totalResultCount").getAsInt());
+    assertEquals(StreamingRunner.MAX_RESULTS_PER_POLL, poll.get("maxResultsPerPoll").getAsInt());
+    assertFalse(poll.get("hasMoreResults").getAsBoolean());
+
+    JsonObject cancelledAfterCompletion = run("{\"action\":\"cancel\",\"operationId\":\""
+        + operationId + "\"}");
+    assertEquals("completed", cancelledAfterCompletion.get("operationStatus").getAsString(),
+        "Cancellation must not overwrite a terminal outcome");
   }
 }

--- a/src/test/java/neqsim/mcp/runners/StreamingRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/StreamingRunnerTest.java
@@ -33,15 +33,13 @@ class StreamingRunnerTest {
     JsonObject limits = result.getAsJsonObject("requestLimits");
     assertEquals(StreamingRunner.MAX_SWEEP_POINTS, limits.get("maxSweepPoints").getAsInt());
     assertEquals(StreamingRunner.MAX_DYNAMIC_STEPS, limits.get("maxDynamicSteps").getAsInt());
-    assertEquals(StreamingRunner.MAX_MONTE_CARLO_ITERATIONS,
-        limits.get("maxMonteCarloIterations").getAsInt());
+    assertEquals(StreamingRunner.MAX_MONTE_CARLO_ITERATIONS, limits.get("maxMonteCarloIterations").getAsInt());
     assertEquals(StreamingRunner.MAX_RESULTS_PER_POLL, limits.get("maxResultsPerPoll").getAsInt());
   }
 
   @Test
   void testPollAndCancelNonexistentOperation() {
-    JsonObject poll = run("{\"action\": \"poll\", \"operationId\": \"nonexistent-id\","
-        + " \"lastIndex\": 0}");
+    JsonObject poll = run("{\"action\": \"poll\", \"operationId\": \"nonexistent-id\"," + " \"lastIndex\": 0}");
     assertEquals("error", poll.get("status").getAsString());
     assertEquals("NOT_FOUND", errorCode(poll));
 
@@ -71,14 +69,11 @@ class StreamingRunnerTest {
   @Test
   void testSweepRejectsAmbiguousVariableUnitAndRange() {
     String prefix = "{\"action\":\"startSweep\",\"components\":{\"methane\":1.0},";
-    assertEquals("INVALID_SWEEP_VARIABLE",
-        errorCode(run(prefix + "\"sweepVariable\":\"enthalpy\",\"points\":2}")));
+    assertEquals("INVALID_SWEEP_VARIABLE", errorCode(run(prefix + "\"sweepVariable\":\"enthalpy\",\"points\":2}")));
     assertEquals("INVALID_UNIT",
-        errorCode(run(prefix + "\"sweepVariable\":\"temperature\",\"unit\":\"rankine\","
-            + "\"points\":2}")));
-    assertEquals("INVALID_RANGE",
-        errorCode(run(prefix + "\"sweepVariable\":\"pressure\",\"unit\":\"bara\","
-            + "\"from\":0,\"to\":10,\"points\":2}")));
+        errorCode(run(prefix + "\"sweepVariable\":\"temperature\",\"unit\":\"rankine\"," + "\"points\":2}")));
+    assertEquals("INVALID_RANGE", errorCode(
+        run(prefix + "\"sweepVariable\":\"pressure\",\"unit\":\"bara\"," + "\"from\":0,\"to\":10,\"points\":2}")));
   }
 
   @Test
@@ -87,8 +82,7 @@ class StreamingRunnerTest {
     assertEquals("INVALID_ITERATIONS", errorCode(run(prefix + "\"iterations\":0}")));
     assertEquals("INVALID_ITERATIONS",
         errorCode(run(prefix + "\"iterations\":" + (StreamingRunner.MAX_MONTE_CARLO_ITERATIONS + 1) + "}")));
-    assertEquals("INVALID_DISTRIBUTION",
-        errorCode(run(prefix + "\"iterations\":1,\"temperatureStd\":-1}")));
+    assertEquals("INVALID_DISTRIBUTION", errorCode(run(prefix + "\"iterations\":1,\"temperatureStd\":-1}")));
   }
 
   @Test
@@ -97,8 +91,7 @@ class StreamingRunnerTest {
     String prefix = "{\"action\":\"startDynamic\",\"processJson\":{},";
     assertEquals("INVALID_TIME_RANGE", errorCode(run(prefix + "\"totalTime\":1,\"timeStep\":0}")));
     assertEquals("INVALID_STEP_COUNT",
-        errorCode(run(prefix + "\"totalTime\":" + (StreamingRunner.MAX_DYNAMIC_STEPS + 1)
-            + ",\"timeStep\":1}")));
+        errorCode(run(prefix + "\"totalTime\":" + (StreamingRunner.MAX_DYNAMIC_STEPS + 1) + ",\"timeStep\":1}")));
   }
 
   @Test
@@ -108,8 +101,7 @@ class StreamingRunnerTest {
     assertEquals("success", started.get("status").getAsString(), started.toString());
     assertEquals("started", started.get("operationStatus").getAsString(), started.toString());
     String operationId = started.get("operationId").getAsString();
-    JsonObject poll = run("{\"action\":\"poll\",\"operationId\":\"" + operationId
-        + "\",\"lastIndex\":-1}");
+    JsonObject poll = run("{\"action\":\"poll\",\"operationId\":\"" + operationId + "\",\"lastIndex\":-1}");
     assertEquals("INVALID_CURSOR", errorCode(poll));
     run("{\"action\":\"cancel\",\"operationId\":\"" + operationId + "\"}");
   }
@@ -124,8 +116,7 @@ class StreamingRunnerTest {
 
     JsonObject poll = null;
     for (int attempt = 0; attempt < 200; attempt++) {
-      poll = run("{\"action\":\"poll\",\"operationId\":\"" + operationId
-          + "\",\"lastIndex\":0}");
+      poll = run("{\"action\":\"poll\",\"operationId\":\"" + operationId + "\",\"lastIndex\":0}");
       if ("completed".equals(poll.get("operationStatus").getAsString())) {
         break;
       }
@@ -140,8 +131,7 @@ class StreamingRunnerTest {
     assertEquals(StreamingRunner.MAX_RESULTS_PER_POLL, poll.get("maxResultsPerPoll").getAsInt());
     assertFalse(poll.get("hasMoreResults").getAsBoolean());
 
-    JsonObject cancelledAfterCompletion = run("{\"action\":\"cancel\",\"operationId\":\""
-        + operationId + "\"}");
+    JsonObject cancelledAfterCompletion = run("{\"action\":\"cancel\",\"operationId\":\"" + operationId + "\"}");
     assertEquals("completed", cancelledAfterCompletion.get("operationStatus").getAsString(),
         "Cancellation must not overwrite a terminal outcome");
   }


### PR DESCRIPTION
## Summary

Advances #3153 with a direct qualification increment for `streamSimulation`.

The existing runner accepted unbounded or non-positive work sizes, silently treated unknown sweep variables and units as other meanings, allowed negative poll cursors to fail internally, mixed asynchronous lifecycle values into the standard MCP `status` field, and could retain a caller concurrency slot after a dynamic process-build failure. This draft repairs those contract gaps while preserving the existing canonical NeqSim calculation routes.

### Contract repair

- bounds parametric sweeps to 1–1000 points, dynamic work to 1–10,000 time steps, Monte Carlo work to 1–1000 iterations, and process definitions to 256 KiB;
- caps each poll at 100 records with `nextPollIndex` and `hasMoreResults`;
- rejects missing/invalid compositions, unsupported sweep variables or units, non-physical ranges, invalid distributions/timing, malformed process definitions, and negative cursors before registration;
- makes global admission atomic and excludes retained terminal results from active-work accounting;
- releases per-principal slots on dynamic build failure and preserves the first terminal outcome across timeout/cancel/worker races;
- retains secure opaque IDs and principal-scoped poll/cancel/list behavior;
- separates standard `status: success|error` from asynchronous `operationStatus`;
- documents in-process, cooperative-cancellation, advisory, numerical, durability, and distributed-execution boundaries.

### Evidence

- focused Java bounded-streaming and principal-scoping contract: **16/16**
- packaged-STDIO bounded-streaming contract: **7/7**
- comprehensive 71-tool MCP regression: **331/331**
- Java 8/21 fast tests on Ubuntu and Windows
- all four Java 21 slow-test shards on Ubuntu
- Javadocs, CodeQL, pre-commit, Spotless, PaperLab, documentation, and agent validation

### Canonical-model and inventory continuity

No EOS, flash, process, dynamic, or uncertainty model is replaced. Existing NeqSim runners remain authoritative and all numerical outputs retain their own applicability boundaries.

Phase 0 remains `1.33 / 20+33+18`; `streamSimulation` remains `CONFIRMED_GAP` pending a separate promotion after this qualification merges.

## Coordination

Exact base: `a2e1f6a26b3cde5b98740e5090d70eeb74b22512`  
Exact head: `cc84db1f7bdebab71d8ca32d967d42621cc598a2`

Current `master` is `32600dc09e38ababc41c9dfb24da0752ddffba80`, four commits ahead. Those commits change H2S kinetics, engineering diagrams, refinery fractionation, compressor documentation, and their tests; none overlaps the frozen eight-file #3589 scope. No synchronization is required.

Open autonomous implementation PRs are #3577, #3582, #3589, #3590, #3591, #3593, #3594, #3595, #3596, and #3597. Portfolio occupancy is **10/10**, the absolute global ceiling.

## Validation

All applicable exact-head gates pass:

- [x] focused Java bounded-streaming and principal isolation **16/16**
- [x] packaged bounded-streaming MCP **7/7**
- [x] comprehensive MCP **331/331**
- [x] Java 8/21 fast tests on Ubuntu and Windows
- [x] all four Java 21 slow-test shards on Ubuntu
- [x] pre-commit and documentation checks
- [x] Spotless
- [x] PaperLab
- [x] CodeQL
- [x] Javadocs
- [x] agent-skill cross-reference validation

Classification: **READY TO MERGE**

The initial head failed only Spotless and was repaired with the exact hosted formatter output. The formatted head then exposed one legacy principal-scoping expectation for lowercase `not_found`; the current head preserves that non-disclosing marker as `operationStatus: not_found` while retaining top-level `status: error` and code `NOT_FOUND`.

There are no reviews or unresolved review threads. The PR is open, draft, and mergeable.

## Documentation impact

Updated MCP discovery text, README usage and lifecycle boundaries, the server contract, and dedicated streaming evidence documentation. The documented API now matches the bounded runtime behavior and standard response envelope.

## Safety

Draft only. No rebase, synchronization, merge, auto-merge, or ready-for-review transition is requested. Results require independent engineering review.