### PR TITLE
feat(refinery): derive Big Hill vacuum screening feed

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -58,6 +58,32 @@ petroleum pseudo-components), reconstructed component mass closure within `1e-10
 0.40867518 mass%, and nitrogen 0.1095129 mass%. A second construction must produce the identical
 resolved mass vector.
 
+## 650 degF+ vacuum-screening feed
+
+`DoeBigHillSweetAssay.createVacuumScreeningFeed(...)` returns a three-cut heavy feed assembled
+only from the 650-850 degF, 850-1050 degF, and one-sided 1050 degF+ source rows. Those rows account
+for 42.84 mass% of whole crude. The factory preserves their relative masses and normalizes them to
+the screening-feed basis:
+
+$$w_i^{screen}=\frac{w_i^{whole\ crude}}{42.84\%}$$
+
+| Source cut | Whole-crude mass % | Screening-feed mass % |
+| --- | ---: | ---: |
+| 650-850 degF | 18.44 | 43.0438842204 |
+| 850-1050 degF | 12.84 | 29.9719887955 |
+| 1050 degF+ | 11.56 | 26.9841269841 |
+
+The source-weight accessor returns a defensive copy, while the factory preserves the source
+specific gravities, sulfur, nitrogen, finite cut boundaries, and the residue's one-sided lower
+boundary and Watson factor. The normalized feed reconstructs 0.815211951447 sulfur mass% and
+0.249229691877 nitrogen mass%.
+
+This feed is a transparent characterization and numerical-screening basis. It is not a measured
+atmospheric-column bottoms stream: DOE does not report tower entrainment, cut-point overlap, light-tail
+carryover, operating pressure, or a matching atmospheric-column material balance. The factory
+therefore does not infer any of those quantities and does not perform pressure correction or ASTM
+D1160 conversion.
+
 ## Evidence and validity boundary
 
 This class is a source-specific reproducible reference composition. It does not mix the older 1998
@@ -66,6 +92,7 @@ generated critical properties, acentric factors, vapor-liquid equilibrium, atmos
 or conversion-unit performance. DOE publishes the workbook for information purposes with no warranty
 of accuracy or completeness; users remain responsible for its application.
 
-The next validation gate is to run this complete slate through the atmospheric-column workflow and
-compare product yields and boiling ranges against independent public evidence before advancing to
-vacuum fractionation.
+The complete slate has separately passed atmospheric-column integration and the public Sarir case
+now provides the campaign's operating-case fractionation evidence. The normalized 650 degF+ slice is
+the characterization handoff for a later low-pressure column benchmark; it does not itself validate
+vacuum fractionation or product yields.

--- a/src/main/java/neqsim/thermo/characterization/DoeBigHillSweetAssay.java
+++ b/src/main/java/neqsim/thermo/characterization/DoeBigHillSweetAssay.java
@@ -108,9 +108,9 @@ public final class DoeBigHillSweetAssay {
    * Configure the normalized DOE Big Hill Sweet 650 degF+ vacuum-screening feed on a one-kilogram basis.
    *
    * <p>
-   * The three retained source rows account for 42.84 mass% of whole crude. Their source mass percentages are
-   * normalized to the returned feed basis. This is a reproducible heavy-assay slice, not a measured atmospheric-column
-   * bottoms composition.
+   * The three retained source rows account for 42.84 mass% of whole crude. Their source mass percentages are normalized
+   * to the returned feed basis. This is a reproducible heavy-assay slice, not a measured atmospheric-column bottoms
+   * composition.
    * </p>
    *
    * @param system empty or caller-owned thermodynamic system
@@ -144,14 +144,14 @@ public final class DoeBigHillSweetAssay {
   }
 
   private static void addVacuumScreeningCuts(OilAssayCharacterisation assay, double weightScale) {
-    addBoundedCut(assay, "DOE_BH_650_850", VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[0] * weightScale, 0.9039,
-        650.0, 850.0, 0.534, 0.102);
-    addBoundedCut(assay, "DOE_BH_850_1050", VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[1] * weightScale, 0.9336,
-        850.0, 1050.0, 0.752, 0.234);
-    assay.addCut(new AssayCut("DOE_BH_1050_PLUS")
-        .withWeightPercent(VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[2] * weightScale).withSpecificGravity(1.0089)
-        .withLowerBoilingPointFahrenheit(1050.0).withWatsonCharacterizationFactor(11.7).withSulfurMassPercent(1.334)
-        .withNitrogenMassPercent(0.501));
+    addBoundedCut(assay, "DOE_BH_650_850", VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[0] * weightScale, 0.9039, 650.0,
+        850.0, 0.534, 0.102);
+    addBoundedCut(assay, "DOE_BH_850_1050", VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[1] * weightScale, 0.9336, 850.0,
+        1050.0, 0.752, 0.234);
+    assay.addCut(
+        new AssayCut("DOE_BH_1050_PLUS").withWeightPercent(VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[2] * weightScale)
+            .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(1050.0).withWatsonCharacterizationFactor(11.7)
+            .withSulfurMassPercent(1.334).withNitrogenMassPercent(0.501));
   }
 
   private static void addModeledGasCut(OilAssayCharacterisation assay) {

--- a/src/main/java/neqsim/thermo/characterization/DoeBigHillSweetAssay.java
+++ b/src/main/java/neqsim/thermo/characterization/DoeBigHillSweetAssay.java
@@ -40,6 +40,8 @@ public final class DoeBigHillSweetAssay {
   private static final double[] GAS_COMPONENT_WEIGHT_PERCENT = { 0.09, 10.38, 10.21, 45.95 };
   private static final double GAS_SUBSET_WEIGHT_PERCENT = 66.63;
   private static final double C5_175_MOLAR_MASS_KG_PER_MOL = 0.07915383665629189;
+  private static final double[] VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT = { 18.44, 12.84, 11.56 };
+  private static final double VACUUM_SCREENING_WHOLE_CRUDE_MASS_PERCENT = 42.84;
 
   private DoeBigHillSweetAssay() {
   }
@@ -80,13 +82,76 @@ public final class DoeBigHillSweetAssay {
     addBoundedCut(assay, "DOE_BH_250_375", 12.55, 0.7817, 250.0, 375.0, 0.019, 0.0);
     addBoundedCut(assay, "DOE_BH_375_530", 16.19, 0.8297, 375.0, 530.0, 0.096, 0.0018);
     addBoundedCut(assay, "DOE_BH_530_650", 13.18, 0.8604, 530.0, 650.0, 0.313, 0.0186);
-    addBoundedCut(assay, "DOE_BH_650_850", 18.44, 0.9039, 650.0, 850.0, 0.534, 0.102);
-    addBoundedCut(assay, "DOE_BH_850_1050", 12.84, 0.9336, 850.0, 1050.0, 0.752, 0.234);
+    addVacuumScreeningCuts(assay, 1.0);
+    return assay;
+  }
 
-    assay.addCut(new AssayCut("DOE_BH_1050_PLUS").withWeightPercent(11.56).withSpecificGravity(1.0089)
+  /**
+   * Return the source mass represented by the 650 degF+ vacuum-screening slice.
+   *
+   * @return source slice mass in percent of whole crude
+   */
+  public static double getVacuumScreeningWholeCrudeMassPercent() {
+    return VACUUM_SCREENING_WHOLE_CRUDE_MASS_PERCENT;
+  }
+
+  /**
+   * Return the three source mass percentages retained by the vacuum-screening slice.
+   *
+   * @return defensive copy ordered as 650-850 degF, 850-1050 degF, and 1050 degF+
+   */
+  public static double[] getVacuumScreeningSourceWeightPercent() {
+    return VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT.clone();
+  }
+
+  /**
+   * Configure the normalized DOE Big Hill Sweet 650 degF+ vacuum-screening feed on a one-kilogram basis.
+   *
+   * <p>
+   * The three retained source rows account for 42.84 mass% of whole crude. Their source mass percentages are
+   * normalized to the returned feed basis. This is a reproducible heavy-assay slice, not a measured atmospheric-column
+   * bottoms composition.
+   * </p>
+   *
+   * @param system empty or caller-owned thermodynamic system
+   * @return configured three-cut assay; no component has been added to {@code system}
+   * @throws NullPointerException if {@code system} is {@code null}
+   */
+  public static OilAssayCharacterisation createVacuumScreeningFeed(SystemInterface system) {
+    return createVacuumScreeningFeed(system, 1.0);
+  }
+
+  /**
+   * Configure the normalized DOE Big Hill Sweet 650 degF+ vacuum-screening feed.
+   *
+   * @param system empty or caller-owned thermodynamic system
+   * @param totalAssayMassKg positive screening-feed mass in kg
+   * @return configured three-cut assay; no component has been added to {@code system}
+   * @throws NullPointerException if {@code system} is {@code null}
+   * @throws IllegalArgumentException if {@code totalAssayMassKg} is non-finite or not positive
+   */
+  public static OilAssayCharacterisation createVacuumScreeningFeed(SystemInterface system, double totalAssayMassKg) {
+    Objects.requireNonNull(system, "system");
+    if (!Double.isFinite(totalAssayMassKg) || !(totalAssayMassKg > 0.0)) {
+      throw new IllegalArgumentException("Total assay mass must be finite and positive");
+    }
+
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.clearCuts();
+    assay.setTotalAssayMass(totalAssayMassKg);
+    addVacuumScreeningCuts(assay, 100.0 / VACUUM_SCREENING_WHOLE_CRUDE_MASS_PERCENT);
+    return assay;
+  }
+
+  private static void addVacuumScreeningCuts(OilAssayCharacterisation assay, double weightScale) {
+    addBoundedCut(assay, "DOE_BH_650_850", VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[0] * weightScale, 0.9039,
+        650.0, 850.0, 0.534, 0.102);
+    addBoundedCut(assay, "DOE_BH_850_1050", VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[1] * weightScale, 0.9336,
+        850.0, 1050.0, 0.752, 0.234);
+    assay.addCut(new AssayCut("DOE_BH_1050_PLUS")
+        .withWeightPercent(VACUUM_SCREENING_SOURCE_WEIGHT_PERCENT[2] * weightScale).withSpecificGravity(1.0089)
         .withLowerBoilingPointFahrenheit(1050.0).withWatsonCharacterizationFactor(11.7).withSulfurMassPercent(1.334)
         .withNitrogenMassPercent(0.501));
-    return assay;
   }
 
   private static void addModeledGasCut(OilAssayCharacterisation assay) {

--- a/src/test/java/neqsim/thermo/characterization/DoeBigHillSweetAssayTest.java
+++ b/src/test/java/neqsim/thermo/characterization/DoeBigHillSweetAssayTest.java
@@ -87,8 +87,8 @@ public class DoeBigHillSweetAssayTest {
     sourceWeightPercent[0] = 0.0;
     assertEquals(18.44, DoeBigHillSweetAssay.getVacuumScreeningSourceWeightPercent()[0], 0.0);
 
-    assertArrayEquals(new double[] { 18.44 / 42.84, 12.84 / 42.84, 11.56 / 42.84 },
-        assay.getResolvedMassFractions(), 1.0e-12);
+    assertArrayEquals(new double[] { 18.44 / 42.84, 12.84 / 42.84, 11.56 / 42.84 }, assay.getResolvedMassFractions(),
+        1.0e-12);
     assertEquals(1.0, sum(assay.getResolvedMassFractions()), 1.0e-12);
     assertEquals(0.8152119514472456, assay.getBulkSulfurMassPercent(), 1.0e-12);
     assertEquals(0.24922969187675068, assay.getBulkNitrogenMassPercent(), 1.0e-12);

--- a/src/test/java/neqsim/thermo/characterization/DoeBigHillSweetAssayTest.java
+++ b/src/test/java/neqsim/thermo/characterization/DoeBigHillSweetAssayTest.java
@@ -72,6 +72,51 @@ public class DoeBigHillSweetAssayTest {
   }
 
   @Test
+  public void vacuumScreeningFeedNormalizesQualifiedHeavyCutsWithoutInventingBoundaries() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = DoeBigHillSweetAssay.createVacuumScreeningFeed(system, 4.2);
+
+    assertEquals(0, system.getNumberOfComponents());
+    assertEquals(3, assay.getCuts().size());
+    assertEquals(4.2, assay.getTotalAssayMass(), 0.0);
+    assertEquals(42.84, DoeBigHillSweetAssay.getVacuumScreeningWholeCrudeMassPercent(), 0.0);
+
+    double[] sourceWeightPercent = DoeBigHillSweetAssay.getVacuumScreeningSourceWeightPercent();
+    assertArrayEquals(new double[] { 18.44, 12.84, 11.56 }, sourceWeightPercent, 0.0);
+    assertEquals(42.84, sum(sourceWeightPercent), 1.0e-12);
+    sourceWeightPercent[0] = 0.0;
+    assertEquals(18.44, DoeBigHillSweetAssay.getVacuumScreeningSourceWeightPercent()[0], 0.0);
+
+    assertArrayEquals(new double[] { 18.44 / 42.84, 12.84 / 42.84, 11.56 / 42.84 },
+        assay.getResolvedMassFractions(), 1.0e-12);
+    assertEquals(1.0, sum(assay.getResolvedMassFractions()), 1.0e-12);
+    assertEquals(0.8152119514472456, assay.getBulkSulfurMassPercent(), 1.0e-12);
+    assertEquals(0.24922969187675068, assay.getBulkNitrogenMassPercent(), 1.0e-12);
+
+    AssayCut firstDistillate = assay.getCuts().get(0);
+    AssayCut secondDistillate = assay.getCuts().get(1);
+    AssayCut residue = assay.getCuts().get(2);
+    assertEquals("DOE_BH_650_850", firstDistillate.getName());
+    assertEquals("DOE_BH_850_1050", secondDistillate.getName());
+    assertEquals("DOE_BH_1050_PLUS", residue.getName());
+    assertTrue(firstDistillate.hasLowerBoilingPoint());
+    assertTrue(firstDistillate.hasUpperBoilingPoint());
+    assertTrue(secondDistillate.hasLowerBoilingPoint());
+    assertTrue(secondDistillate.hasUpperBoilingPoint());
+    assertTrue(residue.hasLowerBoilingPoint());
+    assertFalse(residue.hasUpperBoilingPoint());
+    assertTrue(residue.hasWatsonCharacterizationFactor());
+
+    assay.apply();
+
+    assertEquals(3, system.getNumberOfComponents());
+    assertPositiveFiniteComponent(system.getComponent("DOE_BH_650_850_PC"));
+    assertPositiveFiniteComponent(system.getComponent("DOE_BH_850_1050_PC"));
+    assertPositiveFiniteComponent(system.getComponent("DOE_BH_1050_PLUS_PC"));
+    assertEquals(4.2, reconstructedMassKg(system), 1.0e-10);
+  }
+
+  @Test
   public void invalidMassFailsBeforeChangingExistingAssayOrSystem() {
     SystemInterface system = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation existing = system.getOilAssayCharacterisation();
@@ -81,6 +126,10 @@ public class DoeBigHillSweetAssayTest {
 
     assertThrows(IllegalArgumentException.class, () -> DoeBigHillSweetAssay.create(system, Double.NaN));
     assertThrows(IllegalArgumentException.class, () -> DoeBigHillSweetAssay.create(system, 0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillSweetAssay.createVacuumScreeningFeed(system, Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillSweetAssay.createVacuumScreeningFeed(system, 0.0));
+    assertThrows(NullPointerException.class, () -> DoeBigHillSweetAssay.createVacuumScreeningFeed(null));
     assertEquals(1, existing.getCuts().size());
     assertEquals("Existing", existing.getCuts().get(0).getName());
     assertEquals(0, system.getNumberOfComponents());


### PR DESCRIPTION
## Summary

Adds a reusable DOE Big Hill Sweet 650 degF+ vacuum-screening feed to `DoeBigHillSweetAssay`.

- retains the public 650–850 degF, 850–1050 degF, and one-sided 1050 degF+ rows;
- exposes the source weights defensively and their 42.84 mass% whole-crude basis;
- normalizes those three rows to a caller-selected screening-feed mass;
- preserves source SG, sulfur, nitrogen, finite boundaries, and residue Watson factor;
- qualifies source and normalized closure, reconstructed bulk properties, defensive access, fail-closed inputs, pseudo-component creation, and exact applied mass;
- documents the normalization equation, units, provenance, and scientific boundary.

## Engineering boundary

This is a reproducible heavy-assay slice for low-pressure numerical screening. It is not a measured atmospheric bottoms composition and does not infer cut-point overlap, entrainment, light-tail carryover, pressure correction, ASTM D1160 behavior, vacuum-column yields, or plant agreement.

## Public provenance

- DOE SPR Big Hill Sweet comprehensive assay workbook, reported 24 September 2021: https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx
- DOE SPR Crude Oil Assay Manual, 5th edition, 1 August 2024: https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf

These public U.S. government sources were already transcribed and independently qualified by #3305. No proprietary simulator data or standards procedure text is included.

## Validation

- Exact frozen base: `32600dc09e38ababc41c9dfb24da0752ddffba80`.
- Exact publication head: `87f135e5521a25aa079248e7bbc1d7d05b18acc0`.
- Connector-side audit: 3 commits, 3 intended files, 0 commits behind base, balanced Java braces, no tabs/trailing whitespace/literal `\\n` defects, and compact Colab-safe display math.
- Independent arithmetic: source mass closes to 42.84%; normalized weights close to 100%; sulfur reconstructs to 0.815211951447 mass%; nitrogen to 0.249229691877 mass%.
- GitHub CI is authoritative for Java 8/21 compilation, focused and repository tests, Spotless, pre-commit, documentation, CodeQL, PaperLab, and Javadocs.

Status: **VALIDATION PENDING EXACT-HEAD CI**.

## Documentation impact

Updated `refinery_big_hill_complete_slate.md` with the new API, normalization equation, table, reconstructed properties, provenance, and explicit handoff to a later vacuum-column benchmark.

Campaign: #3305