### PR TITLE
docs: restore reaction-model audit navigation

### DIFF
--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -175,6 +175,7 @@ NeqSim is distributed under the Apache-2.0 license and can be used via:
 | Thermo Operations   | [docs/thermo/thermodynamic_operations.md](thermo/thermodynamic_operations.md)                     | Thermodynamic operations        |
 | TP Flash Algorithm  | [docs/thermodynamicoperations/TPflash_algorithm.md](thermodynamicoperations/TPflash_algorithm.md) | TP flash algorithm details      |
 | Reactive Flash      | [docs/thermo/reactive_flash.md](thermo/reactive_flash.md)                                        | Simultaneous chemical and phase equilibrium (Modified RAND method) |
+| Reaction Model Audit | [docs/thermo/reaction_model_audit.md](thermo/reaction_model_audit.md)                             | Read-only reaction-source, basis, parameter, and validation-status comparison |
 | Reactive PH Flash   | [examples/notebooks/reactive_ph_flash_examples.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/reactive_ph_flash_examples.ipynb) | Isenthalpic/isentropic reactive flash examples (PH, PS flash) |
 | Reactive Distillation | [docs/process/reactive_distillation.md](process/reactive_distillation.md)                        | Reactive distillation column with equilibrium-based reactive flash on each tray |
 | Phase Envelope Algorithm | [docs/thermodynamicoperations/phase_envelope_algorithm.md](thermodynamicoperations/phase_envelope_algorithm.md) | Michelsen continuation method, cricondenbar/cricondentherm Newton refinement, critical point detection |

--- a/docs/test_thermodynamic_documentation_rendering.py
+++ b/docs/test_thermodynamic_documentation_rendering.py
@@ -15,6 +15,14 @@ SCOPE_DIRECTORIES = (
 )
 EXCLUDED_FILE = DOCS / "thermodynamicoperations/TPflash_algorithm.md"
 EXCLUDED_DIRECTORY = DOCS / "thermo/characterization"
+THERMO_OVERVIEW = DOCS / "thermo/README.md"
+REFERENCE_MANUAL = DOCS / "REFERENCE_MANUAL_INDEX.md"
+REACTION_MODEL_AUDIT = DOCS / "thermo/reaction_model_audit.md"
+REACTION_MODEL_AUDIT_SOURCE = (
+    DOCS.parent
+    / "src/main/java/neqsim/chemicalreactions/chemicalreaction"
+    / "ChemicalReactionModelAudit.java"
+)
 
 
 def scoped_pages():
@@ -100,6 +108,24 @@ class ThermodynamicDocumentationRenderingContractTest(unittest.TestCase):
 
     def test_scope_remains_substantial(self):
         self.assertGreaterEqual(len(self.pages), 66)
+
+    def test_reaction_model_audit_routes_resolve_to_source_backed_guide(self):
+        routes = (
+            (THERMO_OVERVIEW, "reaction_model_audit"),
+            (REFERENCE_MANUAL, "thermo/reaction_model_audit.md"),
+        )
+        for source, target in routes:
+            visible = remove_fenced_code(source.read_text(encoding="utf-8"))
+            with self.subTest(source=source.name, target=target):
+                self.assertEqual(1, visible.count(f"]({target})"))
+                candidates = target_candidates(source, target)
+                self.assertIn(REACTION_MODEL_AUDIT, candidates)
+                self.assertTrue(any(candidate.exists() for candidate in candidates))
+
+        guide = REACTION_MODEL_AUDIT.read_text(encoding="utf-8")
+        source = REACTION_MODEL_AUDIT_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("ChemicalReactionModelAudit.compare(cpa, pitzer)", guide)
+        self.assertIn("public final class ChemicalReactionModelAudit", source)
 
     def test_pages_have_searchable_front_matter(self):
         for page in self.pages:

--- a/docs/thermo/README.md
+++ b/docs/thermo/README.md
@@ -44,6 +44,7 @@ thermo/
 - [Mixing Rules Guide](mixing_rules_guide): **Detailed documentation** on mixing rules, including mathematical formulations, binary interaction parameters, and usage examples for different applications.
 - [Flash Calculations Guide](flash_calculations_guide): **Comprehensive documentation** of flash calculations available via ThermodynamicOperations, including TP, PH, PS, VU flashes, saturation calculations, and hydrate equilibria.
 - [Reactive Flash](reactive_flash): **Simultaneous chemical and phase equilibrium** using the Modified RAND method. Covers reactive TP and PH flash for systems with gas-phase reactions, ionic equilibria, and multiphase reactive systems.
+- [Reaction Model Audit](reaction_model_audit): **Read-only provenance and compatibility diagnostics** for active reaction sets, concentration bases, stored parameters, and model-specific validation declarations.
 - [Hydrate Models Guide](hydrate_models): **Comprehensive documentation** of gas hydrate thermodynamic models, including van der Waals-Platteeuw theory, Structure I/II hydrates, CPA and PVTsim implementations, and inhibitor modeling.
 - [Electrolyte CPA Model](ElectrolyteCPAModel): **Detailed documentation** of the electrolyte CPA model, including Fürst electrostatic contributions, validation data, and usage examples.
 - [Pitzer Parameter Provenance and Coverage](pitzer_parameter_provenance): **Dataset and safety reference** for Pitzer equation conventions, source/licensing comparisons, mixed-ion coverage diagnostics, and parameter-adoption gates.


### PR DESCRIPTION
## Summary

- restore discoverability of the maintained reaction-model audit guide from the thermo documentation set
- add the same guide to the thermodynamics chapter of the reference-manual index
- add a source-linked regression requiring both routes to resolve to the canonical guide

## D138 frozen batch

Rotation scope 2: thermo, fluids, phase equilibrium, and physical properties.

The bounded audit covered 66 maintained Markdown pages under `docs/fluidmechanics/**`, `docs/physical_properties/**`, `docs/thermo/**`, and `docs/thermodynamicoperations/**`, excluding the separately owned characterization corpus and active TP-flash page, plus their maintained section/reference indexes.

Confirmed defect: `docs/thermo/reaction_model_audit.md` was the only non-index page in that corpus with no incoming maintained documentation route. The guide documents the current `ChemicalReactionModelAudit` source and executable test surface, but neither maintained index exposed it.

Exact base: `32600dc09e38ababc41c9dfb24da0752ddffba80`  
Exact published head: `33ce6eb7d91237daa2df23fa460a1fafe0d6dbaa`

Exactly three frozen files and three ordered commits:

- `docs/thermo/README.md`
- `docs/REFERENCE_MANUAL_INDEX.md`
- `docs/test_thermodynamic_documentation_rendering.py`

## Validation

Prepublication connector-side checks confirm:

- exactly the three frozen files changed, with 28 additions and no deletions
- one published relative route from each maintained index
- both routes resolve to `docs/thermo/reaction_model_audit.md`
- the regression anchors the guide to the current `ChemicalReactionModelAudit` source
- balanced Markdown fences, no tabs, and no trailing whitespace
- branch is three commits ahead and zero behind its exact base

No local checkout was available, so no local Python, Jekyll, pre-commit, or documentation-search result is claimed. Hosted validation on the exact head is authoritative:

- thermodynamic documentation source contracts, including the new two-route resolution and source anchor: pass
- Jekyll build, generated search coverage, and search JavaScript syntax: pass
- pre-commit and Spotless: pass
- CodeQL: pass
- build/agent-skill checks: pass; Java and Javadoc jobs were correctly skipped because no Java or XML changed

**READY TO MERGE**

## Evidence and stop boundaries

This is navigation and source-contract evidence only. D138 does not execute, requalify, or alter reaction initialization, reaction parameters, equilibrium constants, activity conventions, flash calculations, or chemical/process performance.

No production code, reaction data, thermodynamic or physical-property model, executable example, notebook, generated output, refinery, MCP, release, DEXPI/PFD, kinetics, or Huldra surface changed.

This is the sole active #2499 implementation PR. Its paths do not overlap the four pre-existing autonomous drafts. Autonomous implementation occupancy after publication is **5 / 10**.

Next rotation after independent merge and current-`master` verification: scope 3, process equipment and process simulation.

This PR is intentionally draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, close, replace, or abandon it for capacity.

Campaign: #2499