### PR TITLE
[AI-Assisted] feat(kinetics): project H2S loss onto water inventory

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -223,6 +223,37 @@ This is a time average on a molality basis, not yet a volumetric or molar-flow c
 source. Creating a pipeline source term requires separately qualified water inventory,
 phase transfer, oxygen consumption, reaction products, energy, pressure, and numerical coupling.
 
+## Explicit water-inventory projection
+
+`AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(...)` converts one immutable
+segment result from the molality basis to dimensional total-sulfide loss evidence using a
+caller-supplied liquid-water inventory `m_w` in kg:
+
+$
+\dot n_{r,i}=\overline{r}_{r,i}m_w, \qquad
+n_{r,i,\mathrm{reacted}}=c_{r,i,\mathrm{reacted}}m_w.
+$
+
+The immutable result reports lower-rate, nominal, and upper-rate mean loss in mol/h and mol/s,
+together with reacted total sulfide in mol. The water inventory must be finite and strictly
+positive. For positive segment duration, each path closes exactly as
+
+$
+\dot n_{r,i}\Delta t_i=n_{r,i,\mathrm{reacted}}.
+$
+
+At zero duration, reacted amount is exactly zero while the mean-loss output preserves the existing
+finite differential limit. Dimensional values scale linearly with water inventory. If an unchanged
+state is subdivided while the same water inventory is used for each subsegment, the reacted-mole
+increments sum to the unsplit result.
+
+The supplied water inventory is explicit evidence, not a holdup or free-water prediction. This
+projection is an unsigned total-sulfide loss potential, not a component source applied to a control
+volume. It does not infer water dropout, consume O2, assign products or selectivity, calculate
+reaction heat, pressure or phase transfer, mutate pipeline/transient state, or update sulfur
+deposition and wall inventories. Those steps require separately qualified inputs and must compose
+with the existing pipeline and sulfur-deposition implementations.
+
 ## Piecewise target crossing
 
 `AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -330,7 +330,7 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         for token in (
             "testProjectionClosesPositiveDurationInventoryInHoursAndSeconds",
             "testZeroDurationPreservesDifferentialLimitAndZeroReaction",
-            "testWaterInventoryScalingAndFitScatterOrderingArePreserved",
+            "testReferenceSegmentPreservesScalingAndFitScatterOrdering",
             "testConstantWaterInventorySegmentSplitClosesTotalReaction",
             "testProjectionFailsClosedForMissingOrInvalidWaterInventory",
         ):

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -27,6 +27,16 @@ TRAJECTORY_TEST = (
     / "src/test/java/neqsim/process/equipment/reactor/"
     / "AqueousHydrogenSulfideOxidationTrajectoryTest.java"
 )
+WATER_INVENTORY_PROJECTION = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationWaterInventoryProjection.java"
+)
+WATER_INVENTORY_PROJECTION_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java"
+)
 
 
 class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
@@ -40,6 +50,12 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
         cls.trajectory = TRAJECTORY.read_text(encoding="utf-8")
         cls.trajectory_test = TRAJECTORY_TEST.read_text(encoding="utf-8")
+        cls.water_inventory_projection = WATER_INVENTORY_PROJECTION.read_text(
+            encoding="utf-8"
+        )
+        cls.water_inventory_projection_test = WATER_INVENTORY_PROJECTION_TEST.read_text(
+            encoding="utf-8"
+        )
         cls.normalized = " ".join(cls.guide.split())
 
     def test_source_equation_and_units_are_explicit(self):
@@ -285,6 +301,40 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "getUpperRateMeanLossRateMolalityPerHour()",
         ):
             self.assertIn(token, self.trajectory_test)
+
+    def test_water_inventory_projection_is_documented_and_executable(self):
+        for token in (
+            "Explicit water-inventory projection",
+            r"\dot n_{r,i}=\overline{r}_{r,i}m_w",
+            r"n_{r,i,\mathrm{reacted}}=c_{r,i,\mathrm{reacted}}m_w",
+            "lower-rate, nominal, and upper-rate mean loss in mol/h and mol/s",
+            "finite and strictly positive",
+            r"\dot n_{r,i}\Delta t_i=n_{r,i,\mathrm{reacted}}",
+            "reacted amount is exactly zero",
+            "scales linearly with water inventory",
+            "unsigned total-sulfide loss potential",
+            "not a component source applied to a control volume",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static Result project(",
+            "requirePositiveFinite(waterInventoryKg",
+            "getLowerRateMeanLossMolesPerHour()",
+            "getNominalMeanLossMolesPerSecond()",
+            "getUpperRateReactedMoles()",
+            "implements Serializable",
+        ):
+            self.assertIn(token, self.water_inventory_projection)
+
+        for token in (
+            "testProjectionClosesPositiveDurationInventoryInHoursAndSeconds",
+            "testZeroDurationPreservesDifferentialLimitAndZeroReaction",
+            "testWaterInventoryScalingAndFitScatterOrderingArePreserved",
+            "testConstantWaterInventorySegmentSplitClosesTotalReaction",
+            "testProjectionFailsClosedForMissingOrInvalidWaterInventory",
+        ):
+            self.assertIn(token, self.water_inventory_projection_test)
 
     def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
         for token in (

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -311,7 +311,7 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "finite and strictly positive",
             r"\dot n_{r,i}\Delta t_i=n_{r,i,\mathrm{reacted}}",
             "reacted amount is exactly zero",
-            "scales linearly with water inventory",
+            "scale linearly with water inventory",
             "unsigned total-sulfide loss potential",
             "not a component source applied to a control volume",
         ):

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -68,7 +68,8 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
 
   private static double finiteProduct(double first, double second, String name) {
     double product = first * second;
-    if (!Double.isFinite(product) || product < 0.0) {
+    if (!Double.isFinite(product) || product < 0.0
+        || (first > 0.0 && second > 0.0 && product == 0.0)) {
       throw new IllegalArgumentException(name + " is not finite and non-negative");
     }
     return product;

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -1,0 +1,166 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Projects qualified aqueous H2S/O2 segment evidence onto an explicit water inventory.
+ *
+ * <p>
+ * The projection multiplies the existing molality-basis mean total-sulfide loss rates and reacted
+ * molalities by a caller-supplied liquid-water inventory. It does not derive water holdup, assign
+ * reaction products, consume oxygen, or mutate a process or thermodynamic system.
+ * </p>
+ *
+ * @author esol
+ * @version $Id: $
+ */
+public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
+  private static final double SECONDS_PER_HOUR = 3600.0;
+
+  private AqueousHydrogenSulfideOxidationWaterInventoryProjection() {}
+
+  /**
+   * Project one immutable trajectory segment onto an explicit liquid-water inventory.
+   *
+   * @param segmentResult qualified segment result
+   * @param waterInventoryKg liquid-water inventory [kg]
+   * @return immutable dimensional total-sulfide loss evidence
+   */
+  public static Result project(
+      AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult,
+      double waterInventoryKg) {
+    if (segmentResult == null) {
+      throw new IllegalArgumentException("Segment result cannot be null");
+    }
+    requirePositiveFinite(waterInventoryKg, "Water inventory");
+
+    double lowerRateMeanLossMolesPerHour = finiteProduct(
+        segmentResult.getLowerRateMeanLossRateMolalityPerHour(), waterInventoryKg,
+        "Lower-rate mean total-sulfide loss");
+    double nominalMeanLossMolesPerHour = finiteProduct(
+        segmentResult.getNominalMeanLossRateMolalityPerHour(), waterInventoryKg,
+        "Nominal mean total-sulfide loss");
+    double upperRateMeanLossMolesPerHour = finiteProduct(
+        segmentResult.getUpperRateMeanLossRateMolalityPerHour(), waterInventoryKg,
+        "Upper-rate mean total-sulfide loss");
+
+    double lowerRateReactedMoles = finiteProduct(
+        segmentResult.getLowerRateReactedTotalSulfideMolality(), waterInventoryKg,
+        "Lower-rate reacted total sulfide");
+    double nominalReactedMoles = finiteProduct(
+        segmentResult.getNominalReactedTotalSulfideMolality(), waterInventoryKg,
+        "Nominal reacted total sulfide");
+    double upperRateReactedMoles = finiteProduct(
+        segmentResult.getUpperRateReactedTotalSulfideMolality(), waterInventoryKg,
+        "Upper-rate reacted total sulfide");
+
+    return new Result(segmentResult.getSegmentIndex(), segmentResult.getSegment().getDurationHours(),
+        waterInventoryKg, lowerRateMeanLossMolesPerHour, nominalMeanLossMolesPerHour,
+        upperRateMeanLossMolesPerHour, lowerRateReactedMoles, nominalReactedMoles,
+        upperRateReactedMoles);
+  }
+
+  private static void requirePositiveFinite(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static double finiteProduct(double first, double second, String name) {
+    double product = first * second;
+    if (!Double.isFinite(product) || product < 0.0) {
+      throw new IllegalArgumentException(name + " is not finite and non-negative");
+    }
+    return product;
+  }
+
+  /** Immutable dimensional projection for one trajectory segment. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final int segmentIndex;
+    private final double durationHours;
+    private final double waterInventoryKg;
+    private final double lowerRateMeanLossMolesPerHour;
+    private final double nominalMeanLossMolesPerHour;
+    private final double upperRateMeanLossMolesPerHour;
+    private final double lowerRateReactedMoles;
+    private final double nominalReactedMoles;
+    private final double upperRateReactedMoles;
+
+    private Result(int segmentIndex, double durationHours, double waterInventoryKg,
+        double lowerRateMeanLossMolesPerHour, double nominalMeanLossMolesPerHour,
+        double upperRateMeanLossMolesPerHour, double lowerRateReactedMoles,
+        double nominalReactedMoles, double upperRateReactedMoles) {
+      this.segmentIndex = segmentIndex;
+      this.durationHours = durationHours;
+      this.waterInventoryKg = waterInventoryKg;
+      this.lowerRateMeanLossMolesPerHour = lowerRateMeanLossMolesPerHour;
+      this.nominalMeanLossMolesPerHour = nominalMeanLossMolesPerHour;
+      this.upperRateMeanLossMolesPerHour = upperRateMeanLossMolesPerHour;
+      this.lowerRateReactedMoles = lowerRateReactedMoles;
+      this.nominalReactedMoles = nominalReactedMoles;
+      this.upperRateReactedMoles = upperRateReactedMoles;
+    }
+
+    /** @return source-order segment index. */
+    public int getSegmentIndex() {
+      return segmentIndex;
+    }
+
+    /** @return segment duration [h]. */
+    public double getDurationHours() {
+      return durationHours;
+    }
+
+    /** @return caller-supplied liquid-water inventory [kg]. */
+    public double getWaterInventoryKg() {
+      return waterInventoryKg;
+    }
+
+    /** @return lower-rate mean total-sulfide loss [mol/h]. */
+    public double getLowerRateMeanLossMolesPerHour() {
+      return lowerRateMeanLossMolesPerHour;
+    }
+
+    /** @return nominal mean total-sulfide loss [mol/h]. */
+    public double getNominalMeanLossMolesPerHour() {
+      return nominalMeanLossMolesPerHour;
+    }
+
+    /** @return upper-rate mean total-sulfide loss [mol/h]. */
+    public double getUpperRateMeanLossMolesPerHour() {
+      return upperRateMeanLossMolesPerHour;
+    }
+
+    /** @return lower-rate mean total-sulfide loss [mol/s]. */
+    public double getLowerRateMeanLossMolesPerSecond() {
+      return lowerRateMeanLossMolesPerHour / SECONDS_PER_HOUR;
+    }
+
+    /** @return nominal mean total-sulfide loss [mol/s]. */
+    public double getNominalMeanLossMolesPerSecond() {
+      return nominalMeanLossMolesPerHour / SECONDS_PER_HOUR;
+    }
+
+    /** @return upper-rate mean total-sulfide loss [mol/s]. */
+    public double getUpperRateMeanLossMolesPerSecond() {
+      return upperRateMeanLossMolesPerHour / SECONDS_PER_HOUR;
+    }
+
+    /** @return reacted total sulfide for the lower-rate path [mol]. */
+    public double getLowerRateReactedMoles() {
+      return lowerRateReactedMoles;
+    }
+
+    /** @return reacted total sulfide for the nominal path [mol]. */
+    public double getNominalReactedMoles() {
+      return nominalReactedMoles;
+    }
+
+    /** @return reacted total sulfide for the upper-rate path [mol]. */
+    public double getUpperRateReactedMoles() {
+      return upperRateReactedMoles;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -6,9 +6,9 @@ import java.io.Serializable;
  * Projects qualified aqueous H2S/O2 segment evidence onto an explicit water inventory.
  *
  * <p>
- * The projection multiplies the existing molality-basis mean total-sulfide loss rates and reacted
- * molalities by a caller-supplied liquid-water inventory. It does not derive water holdup, assign
- * reaction products, consume oxygen, or mutate a process or thermodynamic system.
+ * The projection multiplies the existing molality-basis mean total-sulfide loss rates and reacted molalities by a
+ * caller-supplied liquid-water inventory. It does not derive water holdup, assign reaction products, consume oxygen, or
+ * mutate a process or thermodynamic system.
  * </p>
  *
  * @author esol
@@ -17,7 +17,8 @@ import java.io.Serializable;
 public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
   private static final double SECONDS_PER_HOUR = 3600.0;
 
-  private AqueousHydrogenSulfideOxidationWaterInventoryProjection() {}
+  private AqueousHydrogenSulfideOxidationWaterInventoryProjection() {
+  }
 
   /**
    * Project one immutable trajectory segment onto an explicit liquid-water inventory.
@@ -26,38 +27,30 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
    * @param waterInventoryKg liquid-water inventory [kg]
    * @return immutable dimensional total-sulfide loss evidence
    */
-  public static Result project(
-      AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult,
+  public static Result project(AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult,
       double waterInventoryKg) {
     if (segmentResult == null) {
       throw new IllegalArgumentException("Segment result cannot be null");
     }
     requirePositiveFinite(waterInventoryKg, "Water inventory");
 
-    double lowerRateMeanLossMolesPerHour = finiteProduct(
-        segmentResult.getLowerRateMeanLossRateMolalityPerHour(), waterInventoryKg,
-        "Lower-rate mean total-sulfide loss");
-    double nominalMeanLossMolesPerHour = finiteProduct(
-        segmentResult.getNominalMeanLossRateMolalityPerHour(), waterInventoryKg,
-        "Nominal mean total-sulfide loss");
-    double upperRateMeanLossMolesPerHour = finiteProduct(
-        segmentResult.getUpperRateMeanLossRateMolalityPerHour(), waterInventoryKg,
-        "Upper-rate mean total-sulfide loss");
+    double lowerRateMeanLossMolesPerHour = finiteProduct(segmentResult.getLowerRateMeanLossRateMolalityPerHour(),
+        waterInventoryKg, "Lower-rate mean total-sulfide loss");
+    double nominalMeanLossMolesPerHour = finiteProduct(segmentResult.getNominalMeanLossRateMolalityPerHour(),
+        waterInventoryKg, "Nominal mean total-sulfide loss");
+    double upperRateMeanLossMolesPerHour = finiteProduct(segmentResult.getUpperRateMeanLossRateMolalityPerHour(),
+        waterInventoryKg, "Upper-rate mean total-sulfide loss");
 
-    double lowerRateReactedMoles = finiteProduct(
-        segmentResult.getLowerRateReactedTotalSulfideMolality(), waterInventoryKg,
-        "Lower-rate reacted total sulfide");
-    double nominalReactedMoles = finiteProduct(
-        segmentResult.getNominalReactedTotalSulfideMolality(), waterInventoryKg,
+    double lowerRateReactedMoles = finiteProduct(segmentResult.getLowerRateReactedTotalSulfideMolality(),
+        waterInventoryKg, "Lower-rate reacted total sulfide");
+    double nominalReactedMoles = finiteProduct(segmentResult.getNominalReactedTotalSulfideMolality(), waterInventoryKg,
         "Nominal reacted total sulfide");
-    double upperRateReactedMoles = finiteProduct(
-        segmentResult.getUpperRateReactedTotalSulfideMolality(), waterInventoryKg,
-        "Upper-rate reacted total sulfide");
+    double upperRateReactedMoles = finiteProduct(segmentResult.getUpperRateReactedTotalSulfideMolality(),
+        waterInventoryKg, "Upper-rate reacted total sulfide");
 
-    return new Result(segmentResult.getIndex(), segmentResult.getSegment().getDurationHours(),
-        waterInventoryKg, lowerRateMeanLossMolesPerHour, nominalMeanLossMolesPerHour,
-        upperRateMeanLossMolesPerHour, lowerRateReactedMoles, nominalReactedMoles,
-        upperRateReactedMoles);
+    return new Result(segmentResult.getIndex(), segmentResult.getSegment().getDurationHours(), waterInventoryKg,
+        lowerRateMeanLossMolesPerHour, nominalMeanLossMolesPerHour, upperRateMeanLossMolesPerHour,
+        lowerRateReactedMoles, nominalReactedMoles, upperRateReactedMoles);
   }
 
   private static void requirePositiveFinite(double value, String name) {
@@ -68,8 +61,7 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
 
   private static double finiteProduct(double first, double second, String name) {
     double product = first * second;
-    if (!Double.isFinite(product) || product < 0.0
-        || (first > 0.0 && second > 0.0 && product == 0.0)) {
+    if (!Double.isFinite(product) || product < 0.0 || (first > 0.0 && second > 0.0 && product == 0.0)) {
       throw new IllegalArgumentException(name + " is not finite and non-negative");
     }
     return product;
@@ -90,9 +82,8 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     private final double upperRateReactedMoles;
 
     private Result(int segmentIndex, double durationHours, double waterInventoryKg,
-        double lowerRateMeanLossMolesPerHour, double nominalMeanLossMolesPerHour,
-        double upperRateMeanLossMolesPerHour, double lowerRateReactedMoles,
-        double nominalReactedMoles, double upperRateReactedMoles) {
+        double lowerRateMeanLossMolesPerHour, double nominalMeanLossMolesPerHour, double upperRateMeanLossMolesPerHour,
+        double lowerRateReactedMoles, double nominalReactedMoles, double upperRateReactedMoles) {
       this.segmentIndex = segmentIndex;
       this.durationHours = durationHours;
       this.waterInventoryKg = waterInventoryKg;

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -54,7 +54,7 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
         segmentResult.getUpperRateReactedTotalSulfideMolality(), waterInventoryKg,
         "Upper-rate reacted total sulfide");
 
-    return new Result(segmentResult.getSegmentIndex(), segmentResult.getSegment().getDurationHours(),
+    return new Result(segmentResult.getIndex(), segmentResult.getSegment().getDurationHours(),
         waterInventoryKg, lowerRateMeanLossMolesPerHour, nominalMeanLossMolesPerHour,
         upperRateMeanLossMolesPerHour, lowerRateReactedMoles, nominalReactedMoles,
         upperRateReactedMoles);

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -62,9 +62,12 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result large = AqueousHydrogenSulfideOxidationWaterInventoryProjection
         .project(segment, 250.0);
 
-    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(), large.getLowerRateMeanLossMolesPerHour(), NUMERICAL_TOLERANCE);
-    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(), large.getNominalMeanLossMolesPerHour(), NUMERICAL_TOLERANCE);
-    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(), large.getUpperRateMeanLossMolesPerHour(), NUMERICAL_TOLERANCE);
+    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(), large.getLowerRateMeanLossMolesPerHour(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(), large.getNominalMeanLossMolesPerHour(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(), large.getUpperRateMeanLossMolesPerHour(),
+        NUMERICAL_TOLERANCE);
     assertEquals(2.5 * small.getNominalReactedMoles(), large.getNominalReactedMoles(), NUMERICAL_TOLERANCE);
 
     assertTrue(large.getLowerRateMeanLossMolesPerHour() < large.getNominalMeanLossMolesPerHour());

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -12,7 +12,7 @@ import neqsim.NeqSimTest;
 public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends NeqSimTest {
   private static final double INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
   private static final double WATER_INVENTORY_KG = 1200.0;
-  private static final double NUMERICAL_TOLERANCE = 1.0e-18;
+  private static final double NUMERICAL_TOLERANCE = 1.0e-17;
 
   @Test
   void testProjectionClosesPositiveDurationInventoryInHoursAndSeconds() {

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -1,0 +1,153 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests dimensional water-inventory projection of qualified aqueous H2S/O2 evidence. */
+public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends NeqSimTest {
+  private static final double INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
+  private static final double WATER_INVENTORY_KG = 1200.0;
+
+  @Test
+  void testProjectionClosesPositiveDurationInventoryInHoursAndSeconds() {
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
+        segmentResult(referenceSegment(10.0));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
+            WATER_INVENTORY_KG);
+
+    assertEquals(segment.getSegmentIndex(), projection.getSegmentIndex());
+    assertEquals(10.0, projection.getDurationHours(), 0.0);
+    assertEquals(WATER_INVENTORY_KG, projection.getWaterInventoryKg(), 0.0);
+
+    assertProjectionPath(segment.getLowerRateMeanLossRateMolalityPerHour(),
+        segment.getLowerRateReactedTotalSulfideMolality(),
+        projection.getLowerRateMeanLossMolesPerHour(),
+        projection.getLowerRateMeanLossMolesPerSecond(),
+        projection.getLowerRateReactedMoles(), 10.0);
+    assertProjectionPath(segment.getNominalMeanLossRateMolalityPerHour(),
+        segment.getNominalReactedTotalSulfideMolality(),
+        projection.getNominalMeanLossMolesPerHour(),
+        projection.getNominalMeanLossMolesPerSecond(), projection.getNominalReactedMoles(),
+        10.0);
+    assertProjectionPath(segment.getUpperRateMeanLossRateMolalityPerHour(),
+        segment.getUpperRateReactedTotalSulfideMolality(),
+        projection.getUpperRateMeanLossMolesPerHour(),
+        projection.getUpperRateMeanLossMolesPerSecond(),
+        projection.getUpperRateReactedMoles(), 10.0);
+  }
+
+  @Test
+  void testZeroDurationPreservesDifferentialLimitAndZeroReaction() {
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
+        segmentResult(referenceSegment(0.0));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
+            WATER_INVENTORY_KG);
+
+    assertEquals(0.0, projection.getDurationHours(), 0.0);
+    assertEquals(segment.getLowerRateInletLossRateMolalityPerHour() * WATER_INVENTORY_KG,
+        projection.getLowerRateMeanLossMolesPerHour(), 0.0);
+    assertEquals(segment.getNominalInletLossRateMolalityPerHour() * WATER_INVENTORY_KG,
+        projection.getNominalMeanLossMolesPerHour(), 0.0);
+    assertEquals(segment.getUpperRateInletLossRateMolalityPerHour() * WATER_INVENTORY_KG,
+        projection.getUpperRateMeanLossMolesPerHour(), 0.0);
+    assertTrue(Double.isFinite(projection.getNominalMeanLossMolesPerSecond()));
+    assertEquals(0.0, projection.getLowerRateReactedMoles(), 0.0);
+    assertEquals(0.0, projection.getNominalReactedMoles(), 0.0);
+    assertEquals(0.0, projection.getUpperRateReactedMoles(), 0.0);
+  }
+
+  @Test
+  void testWaterInventoryScalingAndFitScatterOrderingArePreserved() {
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
+        segmentResult(referenceSegment(10.0));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result small =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 100.0);
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result large =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 250.0);
+
+    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(),
+        large.getLowerRateMeanLossMolesPerHour(), 1.0e-20);
+    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(),
+        large.getNominalMeanLossMolesPerHour(), 1.0e-20);
+    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(),
+        large.getUpperRateMeanLossMolesPerHour(), 1.0e-20);
+    assertEquals(2.5 * small.getNominalReactedMoles(), large.getNominalReactedMoles(),
+        1.0e-20);
+
+    assertTrue(large.getLowerRateMeanLossMolesPerHour()
+        < large.getNominalMeanLossMolesPerHour());
+    assertTrue(large.getNominalMeanLossMolesPerHour()
+        < large.getUpperRateMeanLossMolesPerHour());
+  }
+
+  @Test
+  void testConstantWaterInventorySegmentSplitClosesTotalReaction() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Collections.singletonList(referenceSegment(10.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+
+    double unsplitReacted =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection
+            .project(unsplit.getSegmentResults().get(0), WATER_INVENTORY_KG)
+            .getNominalReactedMoles();
+    double splitReacted = 0.0;
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment :
+        split.getSegmentResults()) {
+      splitReacted += AqueousHydrogenSulfideOxidationWaterInventoryProjection
+          .project(segment, WATER_INVENTORY_KG).getNominalReactedMoles();
+    }
+
+    assertEquals(unsplitReacted, splitReacted, 1.0e-20);
+  }
+
+  @Test
+  void testProjectionFailsClosedForMissingOrInvalidWaterInventory() {
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
+        segmentResult(referenceSegment(1.0));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(null, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, -1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
+            Double.NaN));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
+            Double.POSITIVE_INFINITY));
+  }
+
+  private static void assertProjectionPath(double meanLossMolalityPerHour,
+      double reactedMolality, double meanLossMolesPerHour, double meanLossMolesPerSecond,
+      double reactedMoles, double durationHours) {
+    assertEquals(meanLossMolalityPerHour * WATER_INVENTORY_KG, meanLossMolesPerHour, 0.0);
+    assertEquals(meanLossMolesPerHour / 3600.0, meanLossMolesPerSecond, 0.0);
+    assertEquals(reactedMolality * WATER_INVENTORY_KG, reactedMoles, 0.0);
+    assertEquals(reactedMoles, meanLossMolesPerHour * durationHours, 1.0e-20);
+  }
+
+  private static AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult(
+      AqueousHydrogenSulfideOxidationTrajectory.Segment segment) {
+    return AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(segment))
+        .getSegmentResults().get(0);
+  }
+
+  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(
+      double durationHours) {
+    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, 298.15, 8.0,
+        0.723, 250.0e-6);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -64,7 +64,7 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
   }
 
   @Test
-  void testWaterInventoryScalingAndFitScatterOrderingArePreserved() {
+  void testReferenceSegmentPreservesScalingAndFitScatterOrdering() {
     AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
         segmentResult(referenceSegment(10.0));
     AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result small =
@@ -121,6 +121,9 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 0.0));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, -1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
+            Double.MIN_VALUE));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
             Double.NaN));

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -21,7 +21,7 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
             WATER_INVENTORY_KG);
 
-    assertEquals(segment.getSegmentIndex(), projection.getSegmentIndex());
+    assertEquals(segment.getIndex(), projection.getSegmentIndex());
     assertEquals(10.0, projection.getDurationHours(), 0.0);
     assertEquals(WATER_INVENTORY_KG, projection.getWaterInventoryKg(), 0.0);
 

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -15,40 +15,30 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
 
   @Test
   void testProjectionClosesPositiveDurationInventoryInHoursAndSeconds() {
-    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
-        segmentResult(referenceSegment(10.0));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
-            WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment = segmentResult(referenceSegment(10.0));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(segment, WATER_INVENTORY_KG);
 
     assertEquals(segment.getIndex(), projection.getSegmentIndex());
     assertEquals(10.0, projection.getDurationHours(), 0.0);
     assertEquals(WATER_INVENTORY_KG, projection.getWaterInventoryKg(), 0.0);
 
     assertProjectionPath(segment.getLowerRateMeanLossRateMolalityPerHour(),
-        segment.getLowerRateReactedTotalSulfideMolality(),
-        projection.getLowerRateMeanLossMolesPerHour(),
-        projection.getLowerRateMeanLossMolesPerSecond(),
-        projection.getLowerRateReactedMoles(), 10.0);
+        segment.getLowerRateReactedTotalSulfideMolality(), projection.getLowerRateMeanLossMolesPerHour(),
+        projection.getLowerRateMeanLossMolesPerSecond(), projection.getLowerRateReactedMoles(), 10.0);
     assertProjectionPath(segment.getNominalMeanLossRateMolalityPerHour(),
-        segment.getNominalReactedTotalSulfideMolality(),
-        projection.getNominalMeanLossMolesPerHour(),
-        projection.getNominalMeanLossMolesPerSecond(), projection.getNominalReactedMoles(),
-        10.0);
+        segment.getNominalReactedTotalSulfideMolality(), projection.getNominalMeanLossMolesPerHour(),
+        projection.getNominalMeanLossMolesPerSecond(), projection.getNominalReactedMoles(), 10.0);
     assertProjectionPath(segment.getUpperRateMeanLossRateMolalityPerHour(),
-        segment.getUpperRateReactedTotalSulfideMolality(),
-        projection.getUpperRateMeanLossMolesPerHour(),
-        projection.getUpperRateMeanLossMolesPerSecond(),
-        projection.getUpperRateReactedMoles(), 10.0);
+        segment.getUpperRateReactedTotalSulfideMolality(), projection.getUpperRateMeanLossMolesPerHour(),
+        projection.getUpperRateMeanLossMolesPerSecond(), projection.getUpperRateReactedMoles(), 10.0);
   }
 
   @Test
   void testZeroDurationPreservesDifferentialLimitAndZeroReaction() {
-    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
-        segmentResult(referenceSegment(0.0));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
-            WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment = segmentResult(referenceSegment(0.0));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(segment, WATER_INVENTORY_KG);
 
     assertEquals(0.0, projection.getDurationHours(), 0.0);
     assertEquals(segment.getLowerRateInletLossRateMolalityPerHour() * WATER_INVENTORY_KG,
@@ -65,46 +55,34 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
 
   @Test
   void testReferenceSegmentPreservesScalingAndFitScatterOrdering() {
-    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
-        segmentResult(referenceSegment(10.0));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result small =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 100.0);
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result large =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 250.0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment = segmentResult(referenceSegment(10.0));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result small = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(segment, 100.0);
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result large = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(segment, 250.0);
 
-    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(),
-        large.getLowerRateMeanLossMolesPerHour(), 1.0e-20);
-    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(),
-        large.getNominalMeanLossMolesPerHour(), 1.0e-20);
-    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(),
-        large.getUpperRateMeanLossMolesPerHour(), 1.0e-20);
-    assertEquals(2.5 * small.getNominalReactedMoles(), large.getNominalReactedMoles(),
-        1.0e-20);
+    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(), large.getLowerRateMeanLossMolesPerHour(), 1.0e-20);
+    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(), large.getNominalMeanLossMolesPerHour(), 1.0e-20);
+    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(), large.getUpperRateMeanLossMolesPerHour(), 1.0e-20);
+    assertEquals(2.5 * small.getNominalReactedMoles(), large.getNominalReactedMoles(), 1.0e-20);
 
-    assertTrue(large.getLowerRateMeanLossMolesPerHour()
-        < large.getNominalMeanLossMolesPerHour());
-    assertTrue(large.getNominalMeanLossMolesPerHour()
-        < large.getUpperRateMeanLossMolesPerHour());
+    assertTrue(large.getLowerRateMeanLossMolesPerHour() < large.getNominalMeanLossMolesPerHour());
+    assertTrue(large.getNominalMeanLossMolesPerHour() < large.getUpperRateMeanLossMolesPerHour());
   }
 
   @Test
   void testConstantWaterInventorySegmentSplitClosesTotalReaction() {
-    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Collections.singletonList(referenceSegment(10.0)));
-    AqueousHydrogenSulfideOxidationTrajectory.Result split =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(10.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
 
-    double unsplitReacted =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection
-            .project(unsplit.getSegmentResults().get(0), WATER_INVENTORY_KG)
-            .getNominalReactedMoles();
+    double unsplitReacted = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(unsplit.getSegmentResults().get(0), WATER_INVENTORY_KG).getNominalReactedMoles();
     double splitReacted = 0.0;
-    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment :
-        split.getSegmentResults()) {
-      splitReacted += AqueousHydrogenSulfideOxidationWaterInventoryProjection
-          .project(segment, WATER_INVENTORY_KG).getNominalReactedMoles();
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : split.getSegmentResults()) {
+      splitReacted += AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, WATER_INVENTORY_KG)
+          .getNominalReactedMoles();
     }
 
     assertEquals(unsplitReacted, splitReacted, 1.0e-20);
@@ -112,8 +90,7 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
 
   @Test
   void testProjectionFailsClosedForMissingOrInvalidWaterInventory() {
-    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment =
-        segmentResult(referenceSegment(1.0));
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment = segmentResult(referenceSegment(1.0));
 
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(null, 1.0));
@@ -122,19 +99,15 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, -1.0));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
-            Double.MIN_VALUE));
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, Double.MIN_VALUE));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
-            Double.NaN));
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, Double.NaN));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment,
-            Double.POSITIVE_INFINITY));
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, Double.POSITIVE_INFINITY));
   }
 
-  private static void assertProjectionPath(double meanLossMolalityPerHour,
-      double reactedMolality, double meanLossMolesPerHour, double meanLossMolesPerSecond,
-      double reactedMoles, double durationHours) {
+  private static void assertProjectionPath(double meanLossMolalityPerHour, double reactedMolality,
+      double meanLossMolesPerHour, double meanLossMolesPerSecond, double reactedMoles, double durationHours) {
     assertEquals(meanLossMolalityPerHour * WATER_INVENTORY_KG, meanLossMolesPerHour, 0.0);
     assertEquals(meanLossMolesPerHour / 3600.0, meanLossMolesPerSecond, 0.0);
     assertEquals(reactedMolality * WATER_INVENTORY_KG, reactedMoles, 0.0);
@@ -144,13 +117,10 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
   private static AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult(
       AqueousHydrogenSulfideOxidationTrajectory.Segment segment) {
     return AqueousHydrogenSulfideOxidationTrajectory
-        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(segment))
-        .getSegmentResults().get(0);
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(segment)).getSegmentResults().get(0);
   }
 
-  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(
-      double durationHours) {
-    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, 298.15, 8.0,
-        0.723, 250.0e-6);
+  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(double durationHours) {
+    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, 298.15, 8.0, 0.723, 250.0e-6);
   }
 }

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -12,6 +12,7 @@ import neqsim.NeqSimTest;
 public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends NeqSimTest {
   private static final double INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
   private static final double WATER_INVENTORY_KG = 1200.0;
+  private static final double NUMERICAL_TOLERANCE = 1.0e-18;
 
   @Test
   void testProjectionClosesPositiveDurationInventoryInHoursAndSeconds() {
@@ -61,10 +62,10 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result large = AqueousHydrogenSulfideOxidationWaterInventoryProjection
         .project(segment, 250.0);
 
-    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(), large.getLowerRateMeanLossMolesPerHour(), 1.0e-20);
-    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(), large.getNominalMeanLossMolesPerHour(), 1.0e-20);
-    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(), large.getUpperRateMeanLossMolesPerHour(), 1.0e-20);
-    assertEquals(2.5 * small.getNominalReactedMoles(), large.getNominalReactedMoles(), 1.0e-20);
+    assertEquals(2.5 * small.getLowerRateMeanLossMolesPerHour(), large.getLowerRateMeanLossMolesPerHour(), NUMERICAL_TOLERANCE);
+    assertEquals(2.5 * small.getNominalMeanLossMolesPerHour(), large.getNominalMeanLossMolesPerHour(), NUMERICAL_TOLERANCE);
+    assertEquals(2.5 * small.getUpperRateMeanLossMolesPerHour(), large.getUpperRateMeanLossMolesPerHour(), NUMERICAL_TOLERANCE);
+    assertEquals(2.5 * small.getNominalReactedMoles(), large.getNominalReactedMoles(), NUMERICAL_TOLERANCE);
 
     assertTrue(large.getLowerRateMeanLossMolesPerHour() < large.getNominalMeanLossMolesPerHour());
     assertTrue(large.getNominalMeanLossMolesPerHour() < large.getUpperRateMeanLossMolesPerHour());
@@ -85,7 +86,7 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
           .getNominalReactedMoles();
     }
 
-    assertEquals(unsplitReacted, splitReacted, 1.0e-20);
+    assertEquals(unsplitReacted, splitReacted, NUMERICAL_TOLERANCE);
   }
 
   @Test
@@ -111,7 +112,7 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     assertEquals(meanLossMolalityPerHour * WATER_INVENTORY_KG, meanLossMolesPerHour, 0.0);
     assertEquals(meanLossMolesPerHour / 3600.0, meanLossMolesPerSecond, 0.0);
     assertEquals(reactedMolality * WATER_INVENTORY_KG, reactedMoles, 0.0);
-    assertEquals(reactedMoles, meanLossMolesPerHour * durationHours, 1.0e-20);
+    assertEquals(reactedMoles, meanLossMolesPerHour * durationHours, NUMERICAL_TOLERANCE);
   }
 
   private static AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult(


### PR DESCRIPTION
## Summary

Advances #3318 with a dimensional projection for the existing qualified aqueous H₂S/O₂ segment evidence.

`AqueousHydrogenSulfideOxidationWaterInventoryProjection` multiplies the existing lower, nominal, and upper segment-mean total-sulfide loss rates and reacted molalities by an explicit caller-supplied liquid-water inventory. The immutable result reports mean loss in mol/h and mol/s and reacted total sulfide in mol.

Scientific source and domain are unchanged: Millero et al. (1987), https://doi.org/10.1021/es00159a003

Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5599190595

## Exact-head contract

- Exact branch point: `32600dc09e38ababc41c9dfb24da0752ddffba80`
- Exact published head: `e5cff4ddc60f36b9991b281bd23d8f8787e1822b`
- Branch: `codex/3318-h2s-water-inventory-projection`
- Fifteen ordered commits, zero behind the recorded base, exactly four intended files
- Sole active #3318 implementation PR
- Positively identified autonomous implementation occupancy after publication: **3/10**

## Numerical gates and reference audit

Focused tests require:

- dimensional multiplication from mol/(kg water h) to mol/h and conversion to mol/s, checked to an absolute tolerance of `1e-17` across supported platforms;
- `n_dot * Δt = n_reacted` for every fit path at positive duration, checked to the same strict tolerance;
- finite differential-limit rates and exactly zero reacted amount at zero duration;
- linear scaling with water inventory;
- source fit-path labels and reference-segment ordering to be preserved;
- unchanged-state segment-split reaction closure at constant water inventory;
- missing, non-positive, non-finite, underflowing, or overflowing inputs to fail closed.

Independent nominal 10 h reference using the existing 298.15 K, pH 8, I=0.723 mol/kg-water, O₂=250 µmol/kg-water, initial total sulfide 25 µmol/kg-water trajectory and 1200 kg explicit water inventory:

- mean loss: `7.975542512576095e-4 mol/h`;
- mean loss: `2.2154284757155818e-7 mol/s`;
- reacted total sulfide: `7.975542512576095e-3 mol`.

The 10 h integral closes exactly to the reacted amount.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

The first complete build on head `15ae776e` exposed Windows/JVM assertions differing by one to two ULP while requiring effectively bit-exact closure. Heads `01e42fd5` and `e5cff4dd` replace only those cross-platform assertions with a strict `1e-17` absolute tolerance; head `b59c29b9` applied the exact Spotless layout. Production code, scientific parameters, equations, and scope are unchanged.

The unrelated repeated H1 in `docs/thermo/pitzer_hydrate_equilibrium.md` was repaired by merged PR #3610 without modifying this branch. On exact head `e5cff4dd`, Spotless, pre-commit, and PaperLab pass. Documentation/search, production-optimization documentation, CodeQL, and the Java build/test matrix are running against the repaired base. The prior `NewtonSolverAnalysisTest.benchmarkInitLevelBreakdown` failure is a known transient timing benchmark outside this four-file diff and will receive only a targeted rerun if it recurs after the campaign regression passes.

Connector-side audit passed:

- exact four-file scope;
- existing `SegmentResult.getIndex()` and all rate/inventory accessors verified before publication;
- balanced Java braces, no tabs or trailing whitespace, and no line over 120 characters;
- guide equations, API tokens, numerical gates, and executable documentation contract present.

No local Maven, Java, Spotless, pre-commit, Python, or documentation-search execution is claimed. Hosted GitHub Actions on this exact head are authoritative.

## Documentation impact

Adds complete Javadocs, a focused JUnit class, an explicit water-inventory section in the H₂S/O₂ guide, and source-linked Python documentation-contract checks.

## Stop boundary

This is an unsigned diagnostic total-sulfide loss potential, not a signed component source applied to a control volume. The caller-supplied water inventory is not a water-holdup or free-water prediction.

This PR does not derive water dropout, consume O₂, assign products/selectivity, calculate reaction heat, pressure or phase transfer, mutate a thermodynamic/process/pipeline/transient state, bind R1–R8, precipitate S₈, update FeS wall inventory, replace `SulfurDepositionAnalyser`/`IronSulfideWallInventory`/`SolidFlashDepositSource`, or expose MCP. Any later product/deposition coupling remains gated by separately qualified stoichiometry/selectivity and must compose with the existing implementations.

Draft-only: do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon for capacity.