### PR TITLE
[AI-Assisted] Fix rich-gas valve sizing state and pressure units

### DIFF
--- a/docs/process/ValveMechanicalDesign.md
+++ b/docs/process/ValveMechanicalDesign.md
@@ -93,6 +93,26 @@ Engineering context:
   metallic brick stoppers as impact protection and identifies trim capacity and design Cv as key
   selection inputs.
 
+## Consistent sizing and pressure inversion
+
+Run the inlet stream at the design conditions before `valve.autoSize(1.0, 100.0)`.
+With no safety margin and full opening, the resulting Cv must reproduce the
+design flow through `calculateMolarFlow()`, including on a second valve with an
+independent copy of the initialized inlet and the same sizing settings.
+Autosizing retains the flashed phase state; resetting a rich-gas stream's flow
+through an initialization routine can change its density and invalidate the Cv.
+
+The outlet-pressure solver and `getOutletPressure()` return absolute bar.
+Steady and transient valve execution convert that result into the configured
+pressure unit before applying it. Setting a design pressure in `barg` or `kPa`
+therefore gives the same physical result as setting it in `bara`.
+These consistency guarantees do not make pressure unique on a choked-flow
+plateau: when capacity limiting is enabled, an additional downstream boundary
+condition is needed at the limiting flow.
+
+See [Cv, Kv, and valve opening](equipment/valves.md#cv-kv-and-valve-opening)
+for the initialization and unit conventions.
+
 ## Design Standards Reference
 
 | Standard       | Description                                                          |

--- a/docs/process/equipment/valves.md
+++ b/docs/process/equipment/valves.md
@@ -145,6 +145,23 @@ When capacity limiting is enabled and the requested flow reaches the choked
 limit, downstream pressure is no longer uniquely determined by flow and Kv
 alone.
 
+Initialize the inlet at the design conditions (for example, `inlet.run()`)
+before calling `autoSize(safetyFactor, designOpeningPercent)`. Sizing preserves
+the inlet flow, phase split, density, compressibility factor and heat-capacity
+ratio. In particular, it must not reset an already flashed rich-gas inlet while
+restoring an unchanged flow rate. A Cv copied with `setCv(sizedValve.getCv())`
+then reproduces the same forward flow when the initialized inlet, opening,
+sizing method, gas/liquid selection and correction settings are the same.
+
+`calculateOutletPressure(adjustedKv)` and `getOutletPressure()` return **bara**.
+Internally calculated absolute pressures are converted to the configured unit
+before applying them, including when the original setpoint used `barg` or
+`kPa`. This applies to both steady-state and transient calculations and avoids
+adding atmospheric pressure twice. Use `getOutletStream().getPressure(unit)`
+to read the resulting stream pressure in another unit. The one-argument
+`setOutletPressure(value)` continues to use the previously configured unit;
+use the two-argument setter when supplying a value in a different unit.
+
 ## Valve characteristic and mechanical design
 
 The inherent characteristic belongs to `ValveMechanicalDesign`, not directly to

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -19,6 +19,7 @@ import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
+import neqsim.util.unit.PressureUnit;
 
 /**
  * ThrottlingValve class.
@@ -151,10 +152,14 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     return getMechanicalDesign().maxDesignVolumeFlow;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Returns the configured outlet pressure in absolute bar, independently of the unit used to set it.
+   *
+   * @return configured outlet pressure in bara
+   */
   @Override
   public double getOutletPressure() {
-    return this.pressure;
+    return new PressureUnit(pressure, pressureUnit).getValue("bara");
   }
 
   /** {@inheritDoc} */
@@ -229,6 +234,15 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     pressureUnit = unit;
     this.pressure = pressure;
     getOutletStream().getThermoSystem().setPressure(pressure, pressureUnit);
+  }
+
+  /**
+   * Applies a solver pressure without changing the user's configured pressure unit.
+   *
+   * @param pressureBara calculated outlet pressure in absolute bar
+   */
+  private void setCalculatedOutletPressure(double pressureBara) {
+    setOutletPressure(new PressureUnit(pressureBara, "bara").getValue(pressureUnit));
   }
 
   /** {@inheritDoc} */
@@ -325,7 +339,7 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
    * Calculates the outlet pressure based on the adjusted Kv value.
    *
    * @param KvAdjusted the adjusted flow coefficient (Kv)
-   * @return the calculated outlet pressure
+   * @return the calculated outlet pressure in bara, independently of the configured pressure unit
    */
   public double calculateOutletPressure(double KvAdjusted) {
     return getMechanicalDesign().getValveSizingMethod().findOutletPressureForFixedKv(KvAdjusted, inStream) / 1.0e5;
@@ -400,11 +414,11 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     // update outlet pressure if required
     if (valveKvSet && isCalcPressure) {
       outPres = calculateOutletPressure(adjustKv(Kv, percentValveOpening));
-      setOutletPressure(outPres);
+      setCalculatedOutletPressure(outPres);
     }
     if (deltaPressure != 0) {
       thermoSystem.setPressure(thermoSystem.getPressure(pressureUnit) - deltaPressure, pressureUnit);
-      setOutletPressure(thermoSystem.getPressure());
+      setCalculatedOutletPressure(thermoSystem.getPressure("bara"));
     }
 
     if ((inStream.getPressure(pressureUnit) - pressure) < 0) {
@@ -418,13 +432,17 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     }
 
     if (getSpecification().equals("out stream")) {
-      thermoSystem.setPressure(outStream.getPressure(), pressureUnit);
+      thermoSystem.setPressure(outStream.getPressure("bara"), "bara");
+    }
+
+    // An unset pressure retains the outlet stream's existing absolute pressure.
+    if (getOutletPressure() == 0.0) {
+      thermoSystem.setPressure(outPres, "bara");
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-    if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
-        || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
-      thermoSystem.setPressure(outPres, pressureUnit);
+    if (isIsoThermal() || Math.abs(thermoSystem.getPressure("bara") - inletPressure) < 1e-6
+        || thermoSystem.getTotalNumberOfMoles() < 1e-12 || thermoSystem.getPressure("bara") == 0) {
       thermoOps.TPflash();
     } else {
       runPHflashWithNaNRetry(thermoOps, enthalpy);
@@ -518,20 +536,20 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     thermoSystem.init(2);
     double enthalpy = thermoSystem.getEnthalpy();
 
-    double outPres = getOutletStream().getThermoSystem().getPressure();
-    pressure = outPres;
+    double outPres = getOutletStream().getPressure("bara");
+    pressure = getOutletStream().getPressure(pressureUnit);
     double deltaP = Math.max(inStream.getPressure() - outPres, 0.0);
 
-    if ((thermoSystem.getPressure(pressureUnit) - outPres) < 0) {
+    if ((thermoSystem.getPressure("bara") - outPres) < 0) {
       if (isAcceptNegativeDP()) {
-        thermoSystem.setPressure(outPres, pressureUnit);
+        thermoSystem.setPressure(outPres, "bara");
       }
     } else {
-      thermoSystem.setPressure(outPres, pressureUnit);
+      thermoSystem.setPressure(outPres, "bara");
     }
 
     if (getSpecification().equals("out stream")) {
-      thermoSystem.setPressure(outStream.getPressure(), pressureUnit);
+      thermoSystem.setPressure(outStream.getPressure("bara"), "bara");
     }
     double adjustKv = adjustKv(Kv, percentValveOpening);
     if (deltaP > 0.0 && !isCalcPressure) {
@@ -546,8 +564,9 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     if (valveKvSet && isCalcPressure) {
       inStream.getFluid().initProperties();
       outPres = calculateOutletPressure(adjustKv);
-      thermoSystem.setPressure(outPres);
-      setOutletPressure(outPres);
+      thermoSystem.setPressure(outPres, "bara");
+      setCalculatedOutletPressure(outPres);
+      deltaP = Math.max(inStream.getPressure("bara") - outPres, 0.0);
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
@@ -1581,7 +1600,8 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   }
 
   /**
-   * Auto-sizes the valve based on current flow conditions with specified design opening.
+   * Auto-sizes the valve based on current flow conditions with specified design opening. The inlet must have been
+   * flashed at the design conditions. Sizing preserves its flow, phase split and initialized thermodynamic state.
    *
    * @param safetyFactor safety factor to apply (e.g., 1.2 for 20% margin)
    * @param designOpeningPercent the target valve opening percentage at design flow (typically 50%)
@@ -1602,13 +1622,16 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     // have established a Cv at a different operating point; running with that stale Cv
     // must not overwrite the new design flow before it is captured for sizing.
     double designFlowRate = getInletStream().getFlowRate("kg/hr");
-    double outletFlowRate = getOutletStream().getFlowRate("kg/hr");
+    double designMolarFlowRate = getInletStream().getFlowRate("mole/sec");
+    double outletMolarFlowRate = getOutletStream().getFlowRate("mole/sec");
 
     // Run the valve first to establish phase type and thermodynamic conditions.
     run();
 
-    getInletStream().setFlowRate(designFlowRate, "kg/hr");
-    getOutletStream().setFlowRate(outletFlowRate, "kg/hr");
+    // setFlowRate() reinitializes the phase state even for an unchanged rate. In
+    // rich gas this can nearly double the density and size a different valve.
+    restoreMolarFlowRate(getInletStream(), designMolarFlowRate);
+    restoreMolarFlowRate(getOutletStream(), outletMolarFlowRate);
 
     // Check if we have meaningful flow
     double flowRate = designFlowRate;
@@ -1678,6 +1701,20 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     initializeCapacityConstraints();
 
     autoSized = true;
+  }
+
+  /**
+   * Restores a sizing flow only when it changed, retaining the stream's phase split and composition.
+   *
+   * @param stream stream whose design flow is to be restored
+   * @param molarFlowRate original molar flow in mol/s
+   */
+  private void restoreMolarFlowRate(StreamInterface stream, double molarFlowRate) {
+    SystemInterface fluid = stream.getFluid();
+    if (fluid.getTotalNumberOfMoles() != molarFlowRate) {
+      fluid.setTotalNumberOfMoles(molarFlowRate);
+      fluid.init(2);
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveSizingStateRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveSizingStateRegressionTest.java
@@ -1,0 +1,116 @@
+package neqsim.process.equipment.valve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for the pressure units and sizing state reported in issue #3446. */
+class ThrottlingValveSizingStateRegressionTest extends neqsim.NeqSimTest {
+  private Stream gasInlet() {
+    SystemSrkEos fluid = new SystemSrkEos(296.25, 1.82925);
+    fluid.addComponent("methane", 0.1);
+    fluid.addComponent("ethane", 0.2);
+    fluid.addComponent("propane", 0.4);
+    fluid.addComponent("n-butane", 0.3);
+    fluid.setMixingRule("classic");
+    Stream inlet = new Stream("inlet", fluid);
+    inlet.setFlowRate(14942.5, "kg/hr");
+    inlet.run();
+    return inlet;
+  }
+
+  private void setDesignPressure(ThrottlingValve valve, String unit) {
+    valve.getOutletStream().setPressure(1.41325, "bara");
+    valve.setOutletPressure(valve.getOutletStream().getPressure(unit), unit);
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "bara, false", "barg, false", "kPa, false", "bara, true", "barg, true", "kPa, true" })
+  void pressureInversionPreservesUnitsAndDesignPoint(String unit, boolean isothermal) {
+    Stream inlet = gasInlet();
+    ThrottlingValve valve = new ThrottlingValve("sized valve", inlet);
+    setDesignPressure(valve, unit);
+    valve.setIsoThermal(isothermal);
+    valve.autoSize(1.0, 100.0);
+    assertEquals(1.41325, valve.getOutletPressure(), 1.0e-6, "Sizing must preserve the specified absolute pressure");
+    assertEquals(1.41325, valve.getOutletStream().getPressure("bara"), 1.0e-6);
+    double cv = valve.getCv();
+    assertEquals(inlet.getFlowRate("mole/sec"), valve.calculateMolarFlow(), 1.0e-6);
+
+    valve.setIsCalcOutPressure(true);
+    ProcessSystem process = new ProcessSystem("pressure inversion");
+    process.add(inlet);
+    process.add(valve);
+    double previousDrop = 0.0;
+    for (double factor : new double[] { 0.95, 1.0, 1.05 }) {
+      inlet.setFlowRate(14942.5 * factor, "kg/hr");
+      process.run();
+      double outletPressure = valve.getOutletStream().getPressure("bara");
+      assertEquals(outletPressure, valve.getOutletPressure(), 1.0e-12);
+      double pressureDrop = inlet.getPressure("bara") - outletPressure;
+      assertTrue(pressureDrop > previousDrop, "Pressure drop must increase continuously with flow");
+      assertTrue(outletPressure > 0.1, "Nearby flows must not hit the pressure floor");
+      assertEquals(inlet.getFlowRate("mole/sec"), valve.calculateMolarFlow(), 2.0e-4);
+      assertEquals(inlet.getFlowRate("kg/hr"), valve.getOutletStream().getFlowRate("kg/hr"), 1.0e-6);
+      assertEquals(cv, valve.getCv(), 0.0);
+      if (factor == 1.0) {
+        assertEquals(1.41325, outletPressure, 1.0e-5);
+      }
+      previousDrop = pressureDrop;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "bara", "barg", "kPa" })
+  void transientPressureInversionPreservesUnits(String unit) {
+    Stream inlet = gasInlet();
+    ThrottlingValve valve = new ThrottlingValve("transient valve", inlet);
+    setDesignPressure(valve, unit);
+    valve.autoSize(1.0, 100.0);
+    valve.setIsCalcOutPressure(true);
+    valve.setCalculateSteadyState(false);
+    valve.runTransient(0.1);
+    assertEquals(1.41325, valve.getOutletPressure(), 1.0e-5);
+    assertEquals(14942.5, inlet.getFlowRate("kg/hr"), 0.1);
+    assertEquals(14942.5, valve.getOutletStream().getFlowRate("kg/hr"), 0.1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  void copiedCvUsesTheSameEquationBeforeFirstRun(boolean richGas) {
+    Stream inlet = gasInlet();
+    if (!richGas) {
+      SystemSrkEos fluid = new SystemSrkEos(296.25, 1.82925);
+      fluid.addComponent("methane", 1.0);
+      fluid.setMixingRule("classic");
+      inlet = new Stream("methane inlet", fluid);
+      inlet.setFlowRate(14942.5, "kg/hr");
+      inlet.run();
+    }
+    // Keep an independent, initialized copy of the design inlet before autoSize.
+    Stream copiedInlet = new Stream("copied inlet", inlet.getFluid().clone());
+    ThrottlingValve sized = new ThrottlingValve("sized", inlet);
+    sized.setOutletPressure(1.41325, "bara");
+    sized.autoSize(1.0, 100.0);
+
+    ThrottlingValve copied = new ThrottlingValve("copied", copiedInlet);
+    copied.setOutletPressure(1.41325, "bara");
+    copied.setCv(sized.getCv());
+    copied.setPercentValveOpening(100.0);
+    double designMolarFlow = inlet.getFlowRate("mole/sec");
+    assertEquals(designMolarFlow, sized.calculateMolarFlow(), 1.0e-5);
+    assertEquals(designMolarFlow, copied.calculateMolarFlow(), 1.0e-5,
+        "An initialized inlet and the same Cv must give the same flow without running or sizing the copy");
+    assertEquals(1.41325, copied.calculateOutletPressure(copied.getKv()), 1.0e-5);
+    assertEquals(sized.isGasValve(), copied.isGasValve());
+    assertEquals(copiedInlet.getFluid().getDensity("kg/m3"), inlet.getFluid().getDensity("kg/m3"), 1.0e-10,
+        "Sizing must preserve the initialized inlet density");
+    assertEquals(copiedInlet.getFluid().getGamma2(), inlet.getFluid().getGamma2(), 1.0e-10);
+    assertEquals(copiedInlet.getFluid().getZ(), inlet.getFluid().getZ(), 1.0e-10);
+  }
+}


### PR DESCRIPTION
Autosizing a prepared rich-gas inlet can change its thermodynamic state, causing a Cv copied to another initialized valve to pass approximately half the design flow. Separately, an outlet pressure calculated in bara can be reapplied as barg or kPa, including a spurious pressure increase.

This follow-up to #3448 addresses the reopened #3446 symptoms.

## Changes

- Preserve inlet and outlet molar flows without calling `setFlowRate()` on unchanged streams. That routine reinitializes the phase state; in the regression, it almost doubles the inlet density. If a flow actually changed, restore it by rescaling moles and refreshing properties while retaining the phase split.
- Convert calculated absolute pressures into the configured pressure unit before applying them in steady and transient execution. Use absolute units consistently in isothermal and outlet-stream pressure paths.
- Return bara from `getOutletPressure()`, consistent with the equipment pressure API. The one-argument pressure setter retains its configured-unit convention.
- Add 11 parameterized regressions covering an independent Cv copy, inlet-property preservation, bara/barg/kPa, isothermal/isenthalpic execution, transient inversion, flow sweeps, and mass conservation.
- Update the valve guide, mechanical-design guide and affected Javadocs.

## Reproduction and results

Named-component synthetic SRK gas: methane/ethane/propane/n-butane = 10/20/40/30 mol%, 296.25 K, 1.82925 bara, 14,942.5 kg/hr, design outlet 1.41325 bara, 100% opening and no sizing margin.

| Quantity | Before | With fix |
| --- | ---: | ---: |
| Inlet density after autosizing, kg/m3 | 6.473610202 | 3.260115912 (unchanged) |
| Sized Cv, US | 352.644399 | 702.896889 |
| Flow through independent Cv copy, mol/s | 48.775226 | 97.219620 |
| Design flow, mol/s | 97.219620 | 97.219620 |
| Reverse outlet with barg configuration, bara | 2.426499538 | 1.413249538 |

The repaired 95%, 100%, 105% flow sweep gives outlet pressures 1.453809788, 1.413249538 and 1.370609276 bara. The design drop is recovered without reaching the pressure floor.

This reproduces both reopening symptoms with public synthetic inputs. The reporter's full E300/TBP model has not been run; confirmation on that model remains appropriate, so this PR does not automatically close the issue.

## Validation

Tested against master `09f335d32f097d4b9ad10549cca61f939edafb42`; published tree matches the validated local tree `491ae1b817f9892748e8c74406197274791ca4b4`.

- `./mvnw -B -ntp test -DskipITs -Djacoco.skip=true "-Dtest=*Valve*Test"` — exit 0; **239 tests, 0 failures, 0 errors**, including the original #3446 regression.
- `java -m jdk.compiler/com.sun.tools.javac.Main --release 8` with the project/test classpath and the changed production/test files — exit 0. Tests executed on Java 17.
- `./mvnw -B -ntp javadoc:javadoc -DjavadocExecutable=/tmp/neqsim-jdk/bin/javadoc` — exit 0; existing repository Javadoc warnings remain.
- `python devtools/run_spotless.py apply` — exit 0, repeated until no further changes.
- `python devtools/run_spotless.py check` — exit 0.
- `python devtools/check_documentation_search.py` — exit 0.
- `python -m pre_commit run --all-files --hook-stage pre-commit` — exit 0.
- `python -m pre_commit run --all-files --hook-stage pre-push` — exit 0.
- `git diff --check` — exit 0.

The configured primary Python interpreter was used for the Python commands. Maven was prepared with the NeqSim skill's environment-only bootstrap.

**VALIDATION PENDING CI** for the full GitHub matrix. Documentation impact: updated user-visible sizing-state and pressure-unit behavior in the same PR.

Related to #3446.