### PR TITLE
[AI-Assisted] fix(electrolyte): conserve mixed-brine hydrate inventory

### DIFF
--- a/docs/thermo/ElectrolyteCPAModel.md
+++ b/docs/thermo/ElectrolyteCPAModel.md
@@ -402,6 +402,36 @@ ops.hydrateFormationTemperature();
 System.out.println("Hydrate T: " + fluid.getTemperature("C") + " °C");
 ```
 
+### Component conservation in hydrate-temperature calculations
+
+Non-reactive brines retain the supplied molecular and ionic inventories. The
+multiphase solver temporarily uses a normalized, ion-free molecular feed for
+phase discovery. Stripped ions are excluded from its phase-fraction equations;
+their very small fugacity coefficients must not enter the molecular Newton
+matrix. Restoring the ions transforms both phase fractions and aqueous
+composition back to the full feed basis. Charge balance alone does not establish
+component conservation.
+
+The final ionic gas/aqueous refinement compares Gibbs energies only when the
+reference state conserves the feed. A converged, normalized, conservative
+candidate must not be rejected because a state with a different inventory has
+a lower extensive Gibbs energy.
+
+At every fluid evaluation, the hydrate-temperature operation checks phase and
+composition normalization, each component's recovered inventory against the
+input, and aqueous ion confinement. An invalid non-reactive electrolyte state
+raises `IllegalStateException` with the failed diagnostic instead of returning
+a hydrate temperature. The caller's multiphase-check setting is restored on
+success and failure. Reactive calculations retain their existing species and
+element-balance handling.
+
+Regression coverage includes CO2 with NaCl–CaCl2 and NaCl–KCl mixtures on a
+1 kg water / 10 mol CO2 basis, nearby pressures and salt concentrations, and
+equivalent salt-addition orders and repeated calculations. These are numerical
+conservation checks, not experimental qualification of mixed-salt hydrate
+temperatures. The separate phase-selection and saturated-boundary qualification
+in [issue #3584](https://github.com/equinor/neqsim/issues/3584) remains open.
+
 ## Known Limitations
 
 1. **Divalent anions (SO₄²⁻)**: Higher errors for 1:2 electrolytes like Na₂SO₄ (~20%)

--- a/docs/thermodynamicoperations/hydrate_flash_operations.md
+++ b/docs/thermodynamicoperations/hydrate_flash_operations.md
@@ -149,6 +149,14 @@ System.out.println("Hydrate formation T: " + fluid.getTemperature("C") + " °C")
 System.out.println("At pressure: " + fluid.getPressure("bara") + " bara");
 ```
 
+For non-reactive electrolyte fluids, every fluid evaluation must conserve the
+input component inventory, normalize material phases, and confine ions to the
+aqueous phase. Violations raise `IllegalStateException` with a diagnostic; a
+small hydrate fugacity residual cannot override a failed material balance.
+The original multiphase-check setting is restored even when evaluation fails.
+See [Electrolyte CPA component conservation](../thermo/ElectrolyteCPAModel#component-conservation-in-hydrate-temperature-calculations)
+for the mixed-brine regression scope and remaining phase-selection limitations.
+
 ### Hydrate Formation Pressure
 
 Calculates the pressure at which hydrate first forms at given temperature.

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1183,6 +1183,10 @@ public class TPflash extends Flash {
       }
     }
     double originalGibbsEnergy = system.getGibbsEnergy();
+    // Gibbs energies can only rank states with the same conserved inventory. A
+    // non-conservative reference must not veto a converged, balanced refinement.
+    double originalMaterialResidual = maximumComponentMaterialBalanceResidual(system);
+    boolean originalInventoryValid = Double.isFinite(originalMaterialResidual) && originalMaterialResidual <= 1.0e-10;
     boolean converged = false;
     boolean failed = false;
 
@@ -1263,7 +1267,8 @@ public class TPflash extends Flash {
     double refinedGibbsEnergy = system.getGibbsEnergy();
     double gibbsTolerance = Math.max(1.0e-8, Math.abs(originalGibbsEnergy) * 1.0e-12);
     if (failed || !converged || !isValidIonicGasAqueousEndpoint(gasPhase, aqueousPhase)
-        || !Double.isFinite(refinedGibbsEnergy) || refinedGibbsEnergy > originalGibbsEnergy + gibbsTolerance) {
+        || !Double.isFinite(refinedGibbsEnergy)
+        || (originalInventoryValid && refinedGibbsEnergy > originalGibbsEnergy + gibbsTolerance)) {
       for (int phase = 0; phase < 2; phase++) {
         system.setBeta(phase, originalBeta[phase]);
         for (int component = 0; component < componentCount; component++) {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -125,6 +125,12 @@ public class TPmultiflash extends TPflash {
 
       for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) {
         double overallFraction = getFlashOverallFraction(i);
+        // Stability trials can activate stored phases containing ions stripped from the feed.
+        // Clear them on every molecular-basis update, before normalization dilutes the molecules.
+        if (isIon(i) && overallFraction <= 1.0e-100) {
+          system.getPhase(k).getComponent(i).setx(1.0e-50);
+          continue;
+        }
         if (overallFraction > 1e-100) {
           // Check for ions - ions can only exist in aqueous phases
           // This check must happen regardless of isChemicalSystem() status
@@ -219,6 +225,9 @@ public class TPmultiflash extends TPflash {
 
     for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) {
       double overallFraction = getFlashOverallFraction(i);
+      if (isIon(i) && overallFraction <= 1.0e-100) {
+        overallFraction = 0.0;
+      }
       multTerm[i] = overallFraction / Erow[i];
       multTerm2[i] = overallFraction / (Erow[i] * Erow[i]);
     }
@@ -264,6 +273,16 @@ public class TPmultiflash extends TPflash {
    */
   private void calcEAndCacheFugacityCoefficients() {
     for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      // Removed ions must not enter the molecular beta equations. In particular, the
+      // divalent-ion coefficient can underflow on the ion-free trial and make its
+      // nominally negligible Hessian contribution evaluate as 0 / 0.
+      if (isIon(component) && getFlashOverallFraction(component) <= 1.0e-100) {
+        Erow[component] = 1.0;
+        for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+          fugacityCoefficients[phase][component] = 1.0;
+        }
+        continue;
+      }
       Erow[component] = 0.0;
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
         double fugacityCoefficient = system.getPhase(phase).getComponent(component).getFugacityCoefficient();

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/HydrateFormationTemperatureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/HydrateFormationTemperatureFlash.java
@@ -3,6 +3,8 @@ package neqsim.thermodynamicoperations.flashops.saturationops;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.thermo.component.ComponentHydrate;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -17,6 +19,8 @@ public class HydrateFormationTemperatureFlash extends ConstantDutyTemperatureFla
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(HydrateFormationTemperatureFlash.class);
+  /** Maximum absolute mole-fraction error accepted for a non-reactive electrolyte fluid. */
+  private static final double INVENTORY_TOLERANCE = 1.0e-9;
 
   /**
    * Constructor for HydrateFormationTemperatureFlash.
@@ -34,13 +38,33 @@ public class HydrateFormationTemperatureFlash extends ConstantDutyTemperatureFla
     system = null;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalStateException if a non-reactive electrolyte fluid evaluation fails conservation or phase checks
+   */
   @Override
   public void run() {
     // Enable multi-phase check to properly handle systems with water+MEG+hydrocarbons+electrolytes
     // This ensures proper phase separation (gas, aqueous, hydrocarbon liquid)
     boolean originalMultiPhaseCheck = system.doMultiPhaseCheck();
     system.setMultiPhaseCheck(true);
+    try {
+      runTemperatureIterations();
+    } finally {
+      system.setMultiPhaseCheck(originalMultiPhaseCheck);
+    }
+  }
+
+  /** Iterates hydrate-water fugacity equality while checking the conserved electrolyte feed. */
+  private void runTemperatureIterations() {
+    double[] conservedMoles = null;
+    if (!system.isChemicalSystem() && system.hasIons()) {
+      conservedMoles = new double[system.getPhase(0).getNumberOfComponents()];
+      for (int component = 0; component < conservedMoles.length; component++) {
+        conservedMoles[component] = system.getPhase(0).getComponent(component).getNumberOfmoles();
+      }
+    }
 
     ThermodynamicOperations ops = new ThermodynamicOperations(system);
     system.getPhase(4).getComponent("water").setx(1.0);
@@ -57,10 +81,7 @@ public class HydrateFormationTemperatureFlash extends ConstantDutyTemperatureFla
     double oldOldDiff = 0.0;
 
     // Initial flash to get starting fugacities
-    ops.TPflash();
-    setFug();
-    system.getPhase(4).getComponent("water").fugcoef(system.getPhase(4));
-    system.getPhase(4).getComponent("water").setx(1.0);
+    updateFluidAndHydrate(ops, conservedMoles);
 
     int waterPhaseIndex = findWaterPhaseIndex();
     diff = 1.0 - (system.getPhase(4).getFugacity("water") / system.getPhase(waterPhaseIndex).getFugacity("water"));
@@ -116,10 +137,7 @@ public class HydrateFormationTemperatureFlash extends ConstantDutyTemperatureFla
       system.setTemperature(temp);
 
       // Perform flash and update fugacities
-      ops.TPflash();
-      setFug();
-      system.getPhase(4).getComponent("water").fugcoef(system.getPhase(4));
-      system.getPhase(4).getComponent("water").setx(1.0);
+      updateFluidAndHydrate(ops, conservedMoles);
 
       // Calculate new difference
       waterPhaseIndex = findWaterPhaseIndex();
@@ -130,10 +148,7 @@ public class HydrateFormationTemperatureFlash extends ConstantDutyTemperatureFla
         // Oscillating - take smaller step
         temp = (oldTemp + temp) / 2.0;
         system.setTemperature(temp);
-        ops.TPflash();
-        setFug();
-        system.getPhase(4).getComponent("water").fugcoef(system.getPhase(4));
-        system.getPhase(4).getComponent("water").setx(1.0);
+        updateFluidAndHydrate(ops, conservedMoles);
         waterPhaseIndex = findWaterPhaseIndex();
         diff = 1.0 - (system.getPhase(4).getFugacity("water") / system.getPhase(waterPhaseIndex).getFugacity("water"));
       }
@@ -149,8 +164,76 @@ public class HydrateFormationTemperatureFlash extends ConstantDutyTemperatureFla
           maxIterations, diff);
     }
 
-    // Restore original multi-phase check setting
-    system.setMultiPhaseCheck(originalMultiPhaseCheck);
+  }
+
+  /**
+   * Evaluates the fluid and hydrate reference and rejects an invalid electrolyte inventory.
+   *
+   * @param ops fluid flash operations
+   * @param conservedMoles input component amounts, or null when this operation does not own species conservation
+   */
+  private void updateFluidAndHydrate(ThermodynamicOperations ops, double[] conservedMoles) {
+    ops.TPflash();
+    setFug();
+    system.getPhase(4).getComponent("water").fugcoef(system.getPhase(4));
+    system.getPhase(4).getComponent("water").setx(1.0);
+    if (conservedMoles == null) {
+      return;
+    }
+    double totalMoles = 0.0;
+    for (double moles : conservedMoles) {
+      if (!Double.isFinite(moles) || moles < 0.0) {
+        throw new IllegalStateException("Hydrate fluid inventory has an invalid input component amount");
+      }
+      totalMoles += moles;
+    }
+    if (!(totalMoles > 0.0) || !Double.isFinite(totalMoles) || !Double.isFinite(system.getTotalNumberOfMoles())
+        || Math.abs(system.getTotalNumberOfMoles() / totalMoles - 1.0) > INVENTORY_TOLERANCE) {
+      throw new IllegalStateException("Hydrate fluid inventory failed total-mole conservation");
+    }
+    double betaSum = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      if (!Double.isFinite(beta) || beta < 0.0 || beta > 1.0) {
+        throw new IllegalStateException("Hydrate fluid inventory has an invalid phase fraction: " + beta);
+      }
+      betaSum += beta;
+      double compositionSum = 0.0;
+      for (int component = 0; component < conservedMoles.length; component++) {
+        ComponentInterface species = system.getPhase(phase).getComponent(component);
+        double x = species.getx();
+        if (!Double.isFinite(x) || x < 0.0 || x > 1.0) {
+          throw new IllegalStateException("Hydrate fluid inventory has an invalid composition for "
+              + species.getComponentName() + " in phase " + phase);
+        }
+        compositionSum += x;
+        if ((species.getIonicCharge() != 0 || species.isIsIon())
+            && system.getPhase(phase).getType() != PhaseType.AQUEOUS && x > 1.0e-12) {
+          throw new IllegalStateException(
+              "Hydrate fluid inventory has an ion outside the aqueous phase: " + species.getComponentName());
+        }
+      }
+      if (Math.abs(compositionSum - 1.0) > INVENTORY_TOLERANCE) {
+        throw new IllegalStateException("Hydrate fluid inventory has an unnormalized composition in phase " + phase);
+      }
+    }
+    if (Math.abs(betaSum - 1.0) > INVENTORY_TOLERANCE) {
+      throw new IllegalStateException("Hydrate fluid inventory has unnormalized phase fractions: " + betaSum);
+    }
+    for (int component = 0; component < conservedMoles.length; component++) {
+      double expected = conservedMoles[component] / totalMoles;
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      double overall = system.getPhase(0).getComponent(component).getz();
+      if (!Double.isFinite(overall) || Math.abs(overall - expected) > INVENTORY_TOLERANCE
+          || Math.abs(recovered - expected) > INVENTORY_TOLERANCE) {
+        throw new IllegalStateException(
+            "Hydrate fluid inventory failed for " + system.getPhase(0).getComponent(component).getComponentName()
+                + ": expected=" + expected + ", overall=" + overall + ", recovered=" + recovered);
+      }
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermo/system/ElectrolyteCPAMixedBrineInventoryTest.java
+++ b/src/test/java/neqsim/thermo/system/ElectrolyteCPAMixedBrineInventoryTest.java
@@ -1,0 +1,219 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Method;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.TPflash;
+import neqsim.thermodynamicoperations.flashops.saturationops.HydrateFormationTemperatureFlash;
+
+/** Component conservation regressions for non-reactive mixed brines (issue #3585). */
+class ElectrolyteCPAMixedBrineInventoryTest extends neqsim.NeqSimTest {
+  private static final Logger logger = LogManager.getLogger(ElectrolyteCPAMixedBrineInventoryTest.class);
+
+  @Test
+  void calciumBrineHydratePreservesInventory() throws Exception {
+    SystemInterface fluid = createBrine(50.0, 3.0, 0.6, "Ca++", false);
+    new ThermodynamicOperations(fluid).hydrateFormationTemperature();
+    logger.info("Mixed brine hydrate temperature: {} C", fluid.getTemperature("C"));
+    assertInventory(fluid);
+    assertHydrateResidual(fluid);
+    assertEquals(8.16097, fluid.getTemperature("C"), 1.0e-3,
+        "Numerical regression only, not an experimental temperature benchmark");
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "40, 3, 0.6, Ca++", "60, 3, 0.6, Ca++", "50, 1.5, 0.3, Ca++", "50, 4, 1.2, Ca++", "40, 3, 2, K+",
+      "50, 3, 2, K+", "60, 3, 2, K+" })
+  void nearbyAndMonovalentBrinesConserveInventory(double pressure, double nacl, double secondSalt, String cation)
+      throws Exception {
+    SystemInterface fluid = createBrine(pressure, nacl, secondSalt, cation, false);
+    new ThermodynamicOperations(fluid).hydrateFormationTemperature();
+    assertInventory(fluid);
+    assertHydrateResidual(fluid);
+    logger.info("{} + NaCl at {} bara: {} C", cation, pressure, fluid.getTemperature("C"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "Ca++", "K+" })
+  void additionOrderAndRepeatedRunsMatchFreshFluid(String cation) throws Exception {
+    double secondSalt = "Ca++".equals(cation) ? 0.6 : 2.0;
+    SystemInterface reference = createBrine(50.0, 3.0, secondSalt, cation, false);
+    SystemInterface reordered = createBrine(50.0, 3.0, secondSalt, cation, true);
+    new ThermodynamicOperations(reference).hydrateFormationTemperature();
+    new ThermodynamicOperations(reordered).hydrateFormationTemperature();
+    assertEquivalent(reference, reordered);
+    new ThermodynamicOperations(reordered).hydrateFormationTemperature();
+    assertEquivalent(reference, reordered);
+    reordered.setPressure(40.0);
+    new ThermodynamicOperations(reordered).hydrateFormationTemperature();
+    SystemInterface fresh = createBrine(40.0, 3.0, secondSalt, cation, false);
+    new ThermodynamicOperations(fresh).hydrateFormationTemperature();
+    assertEquivalent(fresh, reordered);
+  }
+
+  @Test
+  void intermediateTpFlashesConserveBothBrines() {
+    for (String cation : new String[] { "Ca++", "K+" }) {
+      SystemInterface fluid = createBrine(50.0, 3.0, "Ca++".equals(cation) ? 0.6 : 2.0, cation, false);
+      ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+      for (double temperature : new double[] { 263.0, 271.0, 281.3, 290.0, 281.3 }) {
+        fluid.setTemperature(temperature);
+        ops.TPflash();
+        assertInventory(fluid);
+      }
+    }
+  }
+
+  @Test
+  void lowerGibbsOfUnbalancedInventoryCannotVetoIonicRefinement() throws Exception {
+    SystemInterface fluid = createBrine(50.0, 3.0, 0.6, "Ca++", false);
+    new ThermodynamicOperations(fluid).hydrateFormationTemperature();
+    SystemInterface reference = fluid.clone();
+    double referenceGibbs = fluid.getGibbsEnergy();
+    double co2 = fluid.getPhase("aqueous").getComponent("CO2").getx();
+    double water = fluid.getPhase("aqueous").getComponent("water").getx();
+    fluid.getPhase("aqueous").getComponent("CO2").setx(co2 - 0.001);
+    fluid.getPhase("aqueous").getComponent("water").setx(water + 0.001);
+    fluid.init(1);
+    assertTrue(fluid.getGibbsEnergy() < referenceGibbs,
+        "The infeasible state reproduces the former lower-Gibbs rejection condition");
+    Method refinement = TPflash.class.getDeclaredMethod("refineIonicGasAqueousEndpoint");
+    refinement.setAccessible(true);
+    refinement.invoke(new TPflash(fluid));
+    assertEquivalent(reference, fluid);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "component", "phase", "normalization", "ion" })
+  void invalidFluidStateThrowsAndRestoresCallerSetting(final String fault) {
+    final SystemInterface fluid = createBrine(50.0, 3.0, 0.6, "Ca++", false);
+    fluid.setMultiPhaseCheck(false);
+    HydrateFormationTemperatureFlash flash = new HydrateFormationTemperatureFlash(fluid) {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public void setFug() {
+        super.setFug();
+        int aqueous = fluid.getPhaseNumberOfPhase("aqueous");
+        if ("phase".equals(fault)) {
+          fluid.setBeta(aqueous, Double.NaN);
+        } else if ("normalization".equals(fault)) {
+          fluid.getPhase(aqueous).getComponent("water").setx(0.5);
+        } else if ("ion".equals(fault)) {
+          int other = aqueous == 0 ? 1 : 0;
+          fluid.getPhase(other).getComponent("Na+").setx(0.001);
+        } else {
+          double co2 = fluid.getPhase(aqueous).getComponent("CO2").getx();
+          double water = fluid.getPhase(aqueous).getComponent("water").getx();
+          fluid.getPhase(aqueous).getComponent("CO2").setx(co2 + 0.001);
+          fluid.getPhase(aqueous).getComponent("water").setx(water - 0.001);
+        }
+      }
+    };
+    IllegalStateException failure = assertThrows(IllegalStateException.class, flash::run);
+    assertTrue(failure.getMessage().startsWith("Hydrate fluid inventory"), failure.getMessage());
+    if ("component".equals(fault)) {
+      assertTrue(failure.getMessage().contains("CO2"), failure.getMessage());
+    }
+    assertFalse(fluid.doMultiPhaseCheck(), "Caller setting must also survive a failed evaluation");
+  }
+
+  private static void assertEquivalent(SystemInterface expected, SystemInterface actual) {
+    assertInventory(expected);
+    assertInventory(actual);
+    assertHydrateResidual(expected);
+    assertHydrateResidual(actual);
+    assertEquals(expected.getTemperature(), actual.getTemperature(), 1.0e-4);
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    for (int phase = 0; phase < expected.getNumberOfPhases(); phase++) {
+      PhaseType type = expected.getPhase(phase).getType();
+      assertTrue(actual.hasPhaseType(type));
+      assertEquals(expected.getPhase(phase).getBeta(), actual.getPhase(type).getBeta(), 1.0e-7);
+      for (int component = 0; component < expected.getPhase(phase).getNumberOfComponents(); component++) {
+        String name = expected.getPhase(phase).getComponent(component).getComponentName();
+        assertEquals(expected.getPhase(phase).getComponent(component).getx(),
+            actual.getPhase(type).getComponent(name).getx(), 1.0e-7, name);
+      }
+    }
+  }
+
+  private static void assertHydrateResidual(SystemInterface fluid) {
+    assertTrue(Double.isFinite(fluid.getTemperature()));
+    double residual = 1.0 - fluid.getPhase(4).getFugacity("water") / fluid.getPhase("aqueous").getFugacity("water");
+    assertEquals(0.0, residual, 1.0e-6, "Hydrate-water fugacity residual");
+    assertTrue(fluid.getNumberOfPhases() > 1, "The regression cases must retain a CO2-rich material phase");
+  }
+
+  private static SystemInterface createBrine(double pressure, double naclWt, double secondSaltWt, String cation,
+      boolean reverseOrder) {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(283.15, pressure);
+    fluid.addComponent("CO2", 10.0);
+    fluid.addComponent("water", 1.0 / 0.01801528);
+    double waterWt = 100.0 - naclWt - secondSaltWt;
+    double nacl = (naclWt / waterWt) / 0.05844277;
+    double secondSalt = (secondSaltWt / waterWt) / ("Ca++".equals(cation) ? 0.11098 : 0.0745513);
+    double chloride = secondSalt * ("Ca++".equals(cation) ? 2.0 : 1.0);
+    if (reverseOrder) {
+      fluid.addComponent("Cl-", chloride);
+      fluid.addComponent(cation, secondSalt);
+      fluid.addComponent("Cl-", nacl);
+      fluid.addComponent("Na+", nacl);
+    } else {
+      fluid.addComponent("Na+", nacl);
+      fluid.addComponent("Cl-", nacl);
+      fluid.addComponent(cation, secondSalt);
+      fluid.addComponent("Cl-", chloride);
+    }
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    fluid.setHydrateCheck(true);
+    return fluid;
+  }
+
+  private static void assertInventory(SystemInterface fluid) {
+    assertTrue(fluid.hasPhaseType(PhaseType.AQUEOUS));
+    assertEquals(10.0, fluid.getPhase(0).getComponent("CO2").getNumberOfmoles(), 1.0e-12);
+    assertEquals(1.0 / 0.01801528, fluid.getPhase(0).getComponent("water").getNumberOfmoles(), 1.0e-12);
+    double betaSum = 0.0;
+    for (int p = 0; p < fluid.getNumberOfPhases(); p++) {
+      double beta = fluid.getBeta(p);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0);
+      betaSum += beta;
+      double xSum = 0.0;
+      double charge = 0.0;
+      for (int i = 0; i < fluid.getPhase(p).getNumberOfComponents(); i++) {
+        double x = fluid.getPhase(p).getComponent(i).getx();
+        assertTrue(Double.isFinite(x) && x >= 0.0 && x <= 1.0);
+        xSum += x;
+        double ionCharge = fluid.getPhase(p).getComponent(i).getIonicCharge();
+        charge += x * ionCharge;
+        if (ionCharge != 0 && fluid.getPhase(p).getType() != PhaseType.AQUEOUS) {
+          assertTrue(x < 1.0e-40, "Ions must remain in the aqueous phase");
+        }
+      }
+      assertEquals(1.0, xSum, 1.0e-9);
+      assertEquals(0.0, charge, 1.0e-10);
+    }
+    assertEquals(1.0, betaSum, 1.0e-12);
+    for (int i = 0; i < fluid.getPhase(0).getNumberOfComponents(); i++) {
+      double recovered = 0.0;
+      for (int p = 0; p < fluid.getNumberOfPhases(); p++) {
+        recovered += fluid.getBeta(p) * fluid.getPhase(p).getComponent(i).getx();
+      }
+      assertEquals(fluid.getPhase(0).getComponent(i).getz(), recovered, 1.0e-9,
+          fluid.getPhase(0).getComponent(i).getComponentName());
+      assertEquals(fluid.getPhase(0).getComponent(i).getNumberOfmoles() / fluid.getTotalNumberOfMoles(), recovered,
+          1.0e-9, "The molecular-basis transformation must preserve the full feed");
+    }
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashStrippedIonTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashStrippedIonTest.java
@@ -1,0 +1,51 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+
+/** The molecular beta solve must exclude stripped ions even if their coefficients underflow. */
+class TPmultiflashStrippedIonTest {
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, 1.0e-200, 1.0e-300 })
+  void strippedIonsCannotPoisonMolecularHessian(double ionCoefficient) {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(281.3, 50.0);
+    fluid.addComponent("CO2", 0.2);
+    fluid.addComponent("water", 0.8);
+    fluid.addComponent("Ca++", 0.01);
+    fluid.addComponent("Cl-", 0.02);
+    fluid.setMixingRule(10);
+    fluid.init(0);
+    fluid.setBeta(0, 0.5);
+    fluid.setBeta(1, 0.5);
+    fluid.init(1);
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      for (int component = 0; component < fluid.getPhase(phase).getNumberOfComponents(); component++) {
+        ComponentInterface species = fluid.getPhase(phase).getComponent(component);
+        boolean ion = species.getIonicCharge() != 0;
+        species.setz(ion ? 1.0e-100 : component == 0 ? 0.2 : 0.8);
+        species.setx(ion ? 0.01 : component == 0 ? 0.2 : 0.8);
+        species.setFugacityCoefficient(ion ? ionCoefficient : 1.0);
+      }
+    }
+    TPmultiflash flash = new TPmultiflash(fluid, false);
+    flash.setDoubleArrays();
+    flash.calcQ();
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      assertEquals(0.0, flash.dQdbeta[phase][0], 1.0e-14);
+      for (int other = 0; other < fluid.getNumberOfPhases(); other++) {
+        assertTrue(Double.isFinite(flash.Qmatrix[phase][other]));
+      }
+    }
+    flash.setXY();
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      assertEquals(0.2, fluid.getPhase(phase).getComponent("CO2").getx(), 1.0e-14);
+      assertEquals(0.8, fluid.getPhase(phase).getComponent("water").getx(), 1.0e-14);
+      assertTrue(fluid.getPhase(phase).getComponent("Ca++").getx() < 1.0e-40);
+    }
+  }
+}


### PR DESCRIPTION
## Problem and fix

Closes #3585.

The reported non-reactive CO2 / 3 wt% NaCl / 0.6 wt% CaCl2 brine returned 8.429344 C at 50 bara while losing 0.0023341526 of the overall CO2 mole fraction and gaining the same water fraction. Charge balance and the hydrate-water residual did not detect it.

The nominally stripped ions still entered the molecular phase-fraction Hessian. Very small calcium fugacity coefficients caused non-finite matrix terms, leaving an unbalanced molecular split. A subsequent ionic gas/aqueous refinement found a conservative solution but rejected it by comparing its extensive Gibbs energy with the different, unbalanced inventory.

This change:
- excludes stripped ionic contributions from the molecular beta equations and clears stale ionic trial compositions before normalization;
- uses the Gibbs comparison only when the reference conserves the feed, while retaining convergence, normalization, confinement, fugacity and finite-Gibbs checks on the candidate;
- checks the original component inventory, total moles, phase fractions, compositions and aqueous ion confinement at every standard non-reactive electrolyte hydrate-temperature evaluation;
- throws an explicit `IllegalStateException` on invalid fluid evidence and restores the caller's multiphase setting through `finally`.

The original brine now returns approximately **8.16097 C**, with component closure at floating-point precision. This is a numerical correction, not an experimental hydrate-temperature benchmark.

## Regression coverage and validation

Base: `09f335d32f097d4b9ad10549cca61f939edafb42`.
Published head: `b5d6338b760d742c4061b0e30723ed88023a2d74`.
NeqSim 3.20.0, Java 17 runtime; separate Java 8 compatibility compile.

**125 tests passed; zero failures, errors or skips**, including **19 new regression cases**:
- reported calcium brine, NaCl–KCl control, 40/50/60 bara and adjacent concentrations, all with component residuals below 1e-9;
- intermediate TP evaluations, charge balance, ion confinement, phase normalization and unchanged molecular inputs;
- reversed salt-addition order, repeated calculation and changed-pressure comparison with fresh fluids;
- a conservative refinement challenged by a lower-Gibbs, unbalanced reference;
- underflowing/zero stripped-ion coefficients and injected component, phase-fraction, normalization and confinement failures;
- existing reactive/non-reactive electrolyte hydrate, MEG-brine, electrolyte CPA variants, phase-boundary, ionic flash, aqueous material-balance and cubic-root suites.

Commands and results:
- `./mvnw -q -DskipTests compile` — exit 0.
- `./mvnw -q -Dtest=ElectrolyteCPAMixedBrineInventoryTest,TPmultiflashStrippedIonTest,TPflashIonicGasAqueousConsistencyTest,ElectrolyteCPAHydrateEquilibriumTest,HydrateFormationTemperatureFlashTest,SystemElectrolyteCPATest,SystemElectrolyteCPAMMTest,SystemElectrolyteCPAAdvancedTest,ElectrolytePhaseBoundaryFlashTest,TPflashAqueousMaterialBalanceRefinementTest,TPflashCubicRootSelectionTest -DexcludedTestGroups=benchmark test` — exit 0, 125 tests.
- `javac --release 8` on all five changed Java files against the test classpath — exit 0.
- `python devtools/run_spotless.py apply` and `check` — exit 0; final tree unchanged.
- `python devtools/check_documentation_search.py` — exit 0; 693 Markdown pages and one standalone HTML page.
- `pre-commit run --all-files --hook-stage pre-commit` and `pre-push` — exit 0.
- `./mvnw -q checkstyle:check` — completed with the repository's existing warning-only findings.
- `./mvnw -q -DskipTests javadoc:javadoc` — exit 0.
- `git diff --check` — exit 0.

The original reproducer failed before the fix with the exact reported CO2 residual. The full repository test suite was not run.

## Documentation and coordination

Updated the Electrolyte CPA guide, hydrate-flash guide and operation Javadoc with conservation behavior, exceptions and qualification limits. Existing reaction handling and thermodynamic parameters remain in use.

Related ownership: #3144 and #2937. **#3584 remains unresolved**: its 10 wt% NaCl probes at 40 and 200 bara now stop on explicit intermediate CO2-inventory diagnostics rather than returning an unqualified temperature. Removing calcium Hessian contamination does not resolve that separate phase-selection path.

PR #3595 overlaps the hydrate `run()` entry and guide to add Pitzer dispatch. Its Pitzer early return should remain before the existing CPA iteration path when the two changes are combined.

AI-assisted implementation. **Draft pending exact-head CI and the independent domain review required by GOVERNANCE.md.** The closing keyword resolves #3585 after merge into master.