### PR TITLE
docs: cover integrated field lifecycle guide

### DIFF
--- a/docs/fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md
+++ b/docs/fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md
@@ -4,8 +4,6 @@ description: Reservoir-to-market oil-field simulation with PVT, wells, SURF, pro
 keywords: field lifecycle, gas injection, oil reservoir, PVT, wells, SURF, flowline, FPSO, NPV, break-even, Norwegian petroleum tax
 ---
 
-# Integrated Field Lifecycle Simulation
-
 The `neqsim.process.fielddevelopment.lifecycle` package connects NeqSim's detailed engineering models on one time
 axis. It is intended for comparing field-development concepts consistently, rather than estimating production and
 economics in disconnected spreadsheets.
@@ -287,6 +285,14 @@ The synthetic reference case represents six subsea producers and three gas injec
 depth. It uses PR-EOS with defined heavy fractions, a gas-cap/oil/water tank, aggregate multiphase tubing and flowline,
 HP/LP separation, oil export pumping, gas export and two-stage gas-injection compression. Well and SURF costs use
 `WellCostEstimator` and `SURFCostEstimator`; topsides and project costs are Class-4 parametric allowances.
+
+The maintained reference assembly is
+[`NorwegianOilFieldCase`](../../src/main/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldCase.java).
+Its focused
+[`NorwegianOilFieldLifecycleTest`](../../src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java)
+executes the reservoir-to-economics workflow and checks production, injection, energy, emissions, economics, reservoir
+pressure, facility sizing, utilization, and product-quality evidence. These regression checks establish executable
+software behavior; they do not qualify the synthetic assumptions for a real asset.
 
 ## Compare concepts
 

--- a/docs/test_engineering_safety_field_documentation.py
+++ b/docs/test_engineering_safety_field_documentation.py
@@ -12,12 +12,20 @@ HOST_TIE_IN_TEST = (
     DOCS.parent
     / "src/test/java/neqsim/process/fielddevelopment/FieldDevelopmentOverviewDocumentationTest.java"
 )
+FIELD_LIFECYCLE_PAGE = DOCS / "fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md"
+FIELD_LIFECYCLE_CASE = DOCS.parent / (
+    "src/main/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldCase.java"
+)
+FIELD_LIFECYCLE_TEST = DOCS.parent / (
+    "src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java"
+)
 SCOPE_PAGES = (
     DOCS / "examples/FieldDevelopmentWorkflow.md",
     DOCS / "fielddevelopment/API_GUIDE.md",
     DOCS / "fielddevelopment/DECISION_ENGINE_WORKFLOWS.md",
     DOCS / "fielddevelopment/DIGITAL_FIELD_TWIN.md",
     DOCS / "fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md",
+    DOCS / "fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md",
     DOCS / "fielddevelopment/HOST_TIE_IN_CAPACITY.md",
     DOCS / "fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md",
     DOCS / "fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md",
@@ -144,7 +152,7 @@ class EngineeringSafetyFieldDocumentationContractTest(unittest.TestCase):
     """Protect the frozen rotation-scope-4 documentation surface."""
 
     def test_frozen_scope_exists(self):
-        self.assertEqual(42, len(SCOPE_PAGES))
+        self.assertEqual(43, len(SCOPE_PAGES))
         for page in SCOPE_PAGES:
             with self.subTest(page=page):
                 self.assertTrue(page.is_file())
@@ -230,6 +238,37 @@ class EngineeringSafetyFieldDocumentationContractTest(unittest.TestCase):
         ):
             with self.subTest(source_contract=source_contract):
                 self.assertIn(source_contract, regression)
+
+    def test_field_lifecycle_reference_case_has_executable_source_evidence(self):
+        page = FIELD_LIFECYCLE_PAGE.read_text(encoding="utf-8")
+        case = FIELD_LIFECYCLE_CASE.read_text(encoding="utf-8")
+        regression = FIELD_LIFECYCLE_TEST.read_text(encoding="utf-8")
+
+        for source_link in (
+            "../../src/main/java/neqsim/process/fielddevelopment/lifecycle/"
+            "NorwegianOilFieldCase.java",
+            "../../src/test/java/neqsim/process/fielddevelopment/lifecycle/"
+            "NorwegianOilFieldLifecycleTest.java",
+        ):
+            with self.subTest(source_link=source_link):
+                self.assertIn(source_link, page)
+
+        for source_contract in (
+            "public static FieldLifecycleConcept createGasInjectionCase()",
+            "public static FieldLifecycleConcept createNaturalDepletionCase()",
+            "public static List<FieldLifecycleConcept> createDevelopmentPortfolio()",
+        ):
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, case)
+
+        for regression_contract in (
+            "void gasInjectionCaseRunsFromReservoirToEconomics()",
+            "assertTrue(result.getCumulativeOilSm3() > 0.0)",
+            "assertTrue(result.getCumulativeGasInjectedSm3() > 0.0)",
+            "assertTrue(Double.isFinite(result.getNpvMusd()))",
+        ):
+            with self.subTest(regression_contract=regression_contract):
+                self.assertIn(regression_contract, regression)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- remove the duplicate body H1 from the integrated field-lifecycle guide so its front-matter title renders once
- add the maintained guide to the frozen engineering/safety/risk/field-development corpus, increasing it from 42 to 43 pages
- link the representative Norwegian lifecycle assembly and focused slow regression
- anchor the documentation contract to the current gas-injection, depletion, portfolio, production, injection, and economics evidence surfaces

## Frozen batch

- Base: `742b525609487aa7c56a5c444d19c476646a14a5`
- Exact head: `bb211bfdc160f2d5be96bb358d6853298107d123`
- Files: exactly 2
- Commits: exactly 2
- Behind base/current master at publication: 0

## Validation

- `python3 -m unittest docs.test_engineering_safety_field_documentation` — pass (8 tests)
- `git diff --check` — pass
- connector-side scope, source-token, route, fence, tab, and trailing-whitespace inspection — pass
- all five hosted exact-head workflows — pass (build/test/Javadocs, pre-commit, Spotless, CodeQL, documentation/search)

## Exact-head status

**READY TO MERGE** at `bb211bfdc160f2d5be96bb358d6853298107d123`. The PR remains draft, mergeable, zero commits behind current `master`, with no reviews or unresolved threads.

## Evidence boundary

This is rendering, navigation, and source/executable-regression documentation evidence only. The synthetic field-lifecycle example was not executed or engineering-qualified in this batch. No production code, numerical assumption, notebook, generated output, DEXPI/PFD/diagram inventory, release, or Huldra artifact is changed.

Campaign: #2499 — D140, rotation scope 4. Keep this PR draft-only; do not mark ready, rebase, synchronize, force-push, close, replace, or merge as an autonomous campaign action.