### PR TITLE
[AI-Assisted] feat(diagram): avoid automatic route collisions

### DIFF
--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -100,13 +100,13 @@ the completeness report retains engineering errors and review gaps.
 | Requirement | Current implementation | Automated evidence | Remaining acceptance work |
 | --- | --- | --- | --- |
 | One canonical plant, distinct PFD/P&ID profiles | Dual-profile facade, shared source fingerprint, and P&ID-only proposal overlay | `EngineeringDiagramDualProfileDeliveryTest` and full-model profile assertions | Improve whole-sheet clarity without changing the canonical plant |
-| Reviewable vector and PDF sheets | Native A1 SVG/PDF sheets, process-equipment symbols, fixed-port orthogonal routing, endpoint-aligned separated off-page lanes, collision-scored horizontal route labels, flow arrows, controlled sheet-index regions, compact multi-row P&ID proposal racks, and external same-equipment signal tracks | Renderer label-segment/connector-alignment and non-connectivity sheet-index tests, rack-span/row/track checks, bundle artifact checks, and fresh full-sheet/detail inspection | Resolve any residual process-route congestion and retain accountable reviewed baselines |
+| Reviewable vector and PDF sheets | Native A1 SVG/PDF sheets, process-equipment symbols, obstacle-aware fixed-port orthogonal routing, endpoint-aligned separated off-page lanes, collision-scored horizontal route labels, complete adaptive-size line-terminal identities, flow arrows, controlled sheet-index regions, compact multi-row P&ID proposal racks, and external same-equipment signal tracks | Renderer obstacle-bypass, full-identity, label-segment/connector-alignment, and non-connectivity sheet-index tests; rack-span/row/track checks; bundle artifact checks; and fresh full-sheet/detail inspection | Retain accountable reviewed baselines and resolve any defect visible despite automated diagnostics |
 | Stable regeneration | Deterministic child and bundle manifests plus byte-stable SVG/PDF | Fresh-model repeated-delivery test | Retain accountable reviewed visual baselines |
 | Native PFD exchange | Native DEXPI 2.0 Process artifact | Delivery assessment, bundle labels, and full-model topology assertions | External interoperability qualification |
 | P&ID exchange identity | Companion-only child label plus separate native DEXPI 2.0 Plant and Proteus 4.1 proposal artifacts | Plant assessment, profile labels, artifact and deterministic-regeneration assertions | Qualify the full-model proposal and external interoperability |
 | Stream and H&MB companions | Opt-in governed stream/balance artifacts with exact boundary resolution | Valid, missing-case, unknown-boundary, and repeated-delivery tests | Publish and qualify full-model operating values and boundary assignments |
 | Piping and instrumentation content | Opt-in source-linked proposal registers, sidecars, and per-element P&ID-only SVG/PDF callouts with distributed equipment-boundary attachment points | Register fidelity, immutability, signal classification, full-tag/semantic-ID and distinct attachment-point coverage, unique signal-path, profile-difference, and regeneration tests | Supply governed inputs and materialize reviewed per-element exchange content |
-| Manual layout and routing | Three persistent proposed A1 sheets, serpentine process-order pins, fixed ports, orthogonal routes, and reciprocal continuations | Layout, renderer, full-model topology, and repeated-delivery tests | Accountable route refinement and reviewed visual baselines |
+| Manual layout and routing | Three persistent proposed A1 sheets, serpentine process-order pins, fixed ports, protected-route precedence, deterministic obstacle-aware orthogonal routes, and reciprocal continuations | Layout, obstacle-bypass renderer regression, full-model topology, and repeated-delivery tests | Accountable route refinement and reviewed visual baselines |
 | Standards alignment | Explicit scope and no-conformance boundary | Manifest flags and documentation checks | Licensed clause mapping and accountable review |
 
 ## Engineering and qualification boundary
@@ -148,9 +148,12 @@ export compression. Major model objects have persistent proposed sheet
 assignments and paper-millimetre pins. Sheet 1 indexes those three regions with
 their canonical equipment membership while leaving process connectivity to the
 semantic routes and reciprocal continuations above the index. Fixed-port
-orthogonal routing remains active for unprotected connections. These records
-are reproducible teaching layout evidence, not checked project layout or
-engineering approval.
+orthogonal routing remains active for unprotected connections and chooses
+deterministic bypass channels before accepting a route through an unrelated
+symbol. Protected manual routes remain authoritative. Full line identities are
+retained in fixed terminal symbols, with adaptive text no smaller than 2.2 mm.
+These records are reproducible teaching layout evidence, not checked project
+layout or engineering approval.
 
 The slow regression test executes two fresh plants and compares manifest,
 source-topology, SVG, and PDF evidence byte-for-byte. It also checks the

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -119,20 +119,26 @@ declared recycle or backward connections receive a deterministic orthogonal retu
 off-page connectors remain the cross-sheet boundary. Their lanes follow the local canonical endpoint
 where space permits and retain deterministic minimum separation when several continuations share one
 sheet edge. Connection labels are selected from horizontal route segments using deterministic
-object- and label-collision scoring instead of being placed on a shared vertical trunk. A reviewed
-protected route remains authoritative and is never replaced by automatic routing. Each fixed-port
+object- and label-collision scoring instead of being placed on a shared vertical trunk. For an
+unprotected connection, automatic routing evaluates the direct orthogonal path and deterministic
+page channels, then selects by fewest non-endpoint object intersections, best achievable label
+collision score, and shortest route, in that order. A reviewed protected route remains authoritative
+and is never replaced by automatic routing. Each fixed-port
 route also carries a deterministic vector arrowhead in SVG and PDF. When the opt-in `LINE_TERMINAL` convention is present,
 each visible off-page label combines the canonical connection designation, directional `TO` or
 `FROM`, and the controlled peer-sheet number. Stable connector and peer-sheet identities remain in
 the document model and SVG semantic attributes without being exposed as reader-facing drawing text.
+Long line-terminal identities remain complete and are reduced only as far as 2.2 mm text to fit
+inside the fixed vector symbol; the renderer never truncates or substitutes a machine identifier.
 Legacy convention/routing profiles retain their previous labels and bytes.
 
 `DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED` reports a malformed endpoint that cannot resolve to an owner.
 A valid peer owner absent from an off-page connection's current sheet is expected and does not create a
-false warning. Connector-lane and route-label placement reduce common congestion but do not suppress
-the renderer's whole-sheet collision diagnostics. Fixed-port routing is deterministic proposal geometry; it is not obstacle-optimal,
-standards-qualified, or drawing-approved. Projects should retain protected routes where accountable
-layout refinement is required.
+false warning. Connector-lane, obstacle-aware route, and route-label placement reduce common
+congestion but do not suppress the renderer's whole-sheet collision diagnostics. Fixed-port routing
+is deterministic proposal geometry; it is not globally obstacle-optimal, standards-qualified, or
+drawing-approved. Projects should retain protected routes where accountable layout refinement is
+required.
 
 `EngineeringDiagramLayoutRegister.SheetOverviewRegion` can place a controlled
 detail-sheet index on another sheet using source-evidenced paper-millimetre

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -605,7 +605,7 @@ public final class NativeEngineeringDiagramRenderer {
             "Rendered object boundary intersects the sheet border, document header, or title-block area", id));
       }
       String label = displayLabel(object);
-      if (estimatedTextWidth(label, 2.8) > OBJECT_WIDTH - 4.0) {
+      if (estimatedTextWidth(label, primaryTextSize(object)) > OBJECT_WIDTH - 4.0) {
         diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_LABEL_OVERFLOW",
             "Primary object label exceeds the available symbol width and requires drawing review", id));
       }
@@ -767,11 +767,89 @@ public final class NativeEngineeringDiagramRenderer {
     return Math.min(contentBottom - PORT_SLOT_MARGIN, Math.max(source.y, target.y) + offset);
   }
 
+  private static List<Point> obstacleAwareOrthogonalRoute(Point source, Point target, boolean recycle,
+      double laneOffset, Map<String, Point> positions, String sourceOwnerId, String targetOwnerId, double contentBottom,
+      String label, List<RouteView> routes, double pageWidth) {
+    List<List<Point>> candidates = new ArrayList<List<Point>>();
+    if (recycle) {
+      double returnY = recycleReturnY(source, target, contentBottom, laneOffset);
+      double sourceTurnX = source.x + 10.0 + Math.abs(laneOffset);
+      double targetTurnX = target.x - 10.0 - Math.abs(laneOffset);
+      candidates.add(Arrays.asList(source, new Point(sourceTurnX, source.y), new Point(sourceTurnX, returnY),
+          new Point(targetTurnX, returnY), new Point(targetTurnX, target.y), target));
+    } else {
+      double middleX = (source.x + target.x) / 2.0 + laneOffset;
+      candidates.add(Arrays.asList(source, new Point(middleX, source.y), new Point(middleX, target.y), target));
+    }
+
+    double direction = target.x >= source.x ? 1.0 : -1.0;
+    double lower = CONTENT_TOP + OBJECT_HEIGHT;
+    double upper = contentBottom - OBJECT_HEIGHT;
+    for (int offsetIndex = 0; offsetIndex <= 5; offsetIndex++) {
+      double turnOffset = offsetIndex == 0 ? 0.0 : 10.0 + Math.abs(laneOffset) + (offsetIndex - 1) * 12.0;
+      double sourceTurnX = source.x + direction * turnOffset + laneOffset;
+      double targetTurnX = target.x - direction * turnOffset + laneOffset;
+      for (double channelY = lower; channelY <= upper + 0.0000001; channelY += 12.0) {
+        candidates.add(Arrays.asList(source, new Point(sourceTurnX, source.y), new Point(sourceTurnX, channelY),
+            new Point(targetTurnX, channelY), new Point(targetTurnX, target.y), target));
+      }
+    }
+
+    List<Point> best = candidates.get(0);
+    int bestScore = routeObjectIntersectionCount(best, positions, sourceOwnerId, targetOwnerId);
+    int bestLabelScore = bestRouteLabelCollisionScore(best, label, positions, routes, pageWidth, contentBottom);
+    double bestLength = routeLength(best);
+    for (int index = 1; index < candidates.size(); index++) {
+      List<Point> candidate = candidates.get(index);
+      int score = routeObjectIntersectionCount(candidate, positions, sourceOwnerId, targetOwnerId);
+      int labelScore = bestRouteLabelCollisionScore(candidate, label, positions, routes, pageWidth, contentBottom);
+      double length = routeLength(candidate);
+      if (score < bestScore || score == bestScore && labelScore < bestLabelScore
+          || score == bestScore && labelScore == bestLabelScore && length < bestLength) {
+        best = candidate;
+        bestScore = score;
+        bestLabelScore = labelScore;
+        bestLength = length;
+      }
+    }
+    return best;
+  }
+
+  private static int bestRouteLabelCollisionScore(List<Point> points, String label, Map<String, Point> positions,
+      List<RouteView> routes, double pageWidth, double contentBottom) {
+    if (label == null || label.trim().isEmpty()) {
+      return 0;
+    }
+    Point labelPoint = collisionAwareRouteLabelPoint(points, label, positions, routes, pageWidth, contentBottom);
+    return routeLabelCollisionScore(label, labelPoint, positions, routes, pageWidth, contentBottom);
+  }
+
+  private static int routeObjectIntersectionCount(List<Point> points, Map<String, Point> positions,
+      String sourceOwnerId, String targetOwnerId) {
+    int count = 0;
+    for (Map.Entry<String, Point> entry : positions.entrySet()) {
+      if (!entry.getKey().equals(sourceOwnerId) && !entry.getKey().equals(targetOwnerId)
+          && polylineIntersectsObject(points, entry.getValue())) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static double routeLength(List<Point> points) {
+    double result = 0.0;
+    for (int index = 1; index < points.size(); index++) {
+      result += distance(points.get(index - 1), points.get(index));
+    }
+    return result;
+  }
+
   private void addConnection(Page page, SemanticObject connection, Map<String, Point> positions,
       Map<String, Point> endpointAnchors, OffPageConnector connector, ProtectedRoute protectedRoute,
       Map<String, SemanticObject> objects, Map<String, Point> connectorPoints, double contentBottom, double laneOffset,
       List<Diagnostic> diagnostics) {
     List<Point> points = new ArrayList<Point>();
+    String routeLabel = displayLabel(connection);
     boolean protectedGeometry = protectedRoute != null;
     if (protectedGeometry) {
       for (Waypoint waypoint : protectedRoute.getWaypoints()) {
@@ -787,22 +865,14 @@ public final class NativeEngineeringDiagramRenderer {
         source = offPage;
       }
       if (source != null && target != null) {
-        points.add(source);
-        if (routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
-            && (Boolean.TRUE.equals(connection.getProperties().get("recycle")) || source.x >= target.x)) {
-          double returnY = recycleReturnY(source, target, contentBottom, laneOffset);
-          double sourceTurnX = source.x + 10.0 + Math.abs(laneOffset);
-          double targetTurnX = target.x - 10.0 - Math.abs(laneOffset);
-          points.add(new Point(sourceTurnX, source.y));
-          points.add(new Point(sourceTurnX, returnY));
-          points.add(new Point(targetTurnX, returnY));
-          points.add(new Point(targetTurnX, target.y));
-        } else {
-          double middleX = (source.x + target.x) / 2.0 + laneOffset;
-          points.add(new Point(middleX, source.y));
-          points.add(new Point(middleX, target.y));
-        }
-        points.add(target);
+        boolean recycle = Boolean.TRUE.equals(connection.getProperties().get("recycle")) || source.x >= target.x;
+        points.addAll(
+            routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
+                ? obstacleAwareOrthogonalRoute(source, target, recycle, laneOffset, positions,
+                    endpointOwnerId(connection, "sourceEndpointId", objects),
+                    endpointOwnerId(connection, "targetEndpointId", objects), contentBottom, routeLabel, page.routes,
+                    page.width)
+                : Arrays.asList(source, target));
       } else {
         diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_CONNECTION_ENDPOINT_OMITTED",
             "Connection endpoints cannot both be placed on this sheet; the semantic connection remains in the source document",
@@ -824,7 +894,7 @@ public final class NativeEngineeringDiagramRenderer {
     if (routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL) {
       addFlowArrow(page, points, color, connection.getId());
     }
-    String label = displayLabel(connection);
+    String label = routeLabel;
     if (label == null || label.trim().isEmpty()) {
       diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_CONNECTION_LABEL_MISSING",
           "Rendered connection has no primary label and requires drawing review", connection.getId()));
@@ -913,7 +983,8 @@ public final class NativeEngineeringDiagramRenderer {
       page.commands.add(symbolCommand(shape, position, stroke, fill, object.getId()));
     }
     String primary = displayLabel(object);
-    page.commands.add(Command.text(position.x, position.y - 0.8, 2.8, primary, "#111827", object.getId(), "middle"));
+    page.commands.add(Command.text(position.x, position.y - 0.8, primaryTextSize(object), primary, "#111827",
+        object.getId(), "middle"));
     String secondary = shape == SymbolShape.PROCESS_EQUIPMENT ? equipmentFamily(object) : object.getKind().name();
     page.commands.add(Command.text(position.x, position.y + 4.0, 2.0, secondary, "#4b5563", object.getId(), "middle"));
   }
@@ -1686,6 +1757,20 @@ public final class NativeEngineeringDiagramRenderer {
 
   private static double estimatedTextWidth(String value, double fontSize) {
     return value.length() * fontSize * 0.52;
+  }
+
+  private static double primaryTextSize(SemanticObject object) {
+    double standardSize = 2.8;
+    if (object.getKind() != EngineeringNode.Kind.LINE) {
+      return standardSize;
+    }
+    String label = displayLabel(object);
+    double availableWidth = OBJECT_WIDTH - 4.0;
+    double estimatedWidth = estimatedTextWidth(label, standardSize);
+    if (estimatedWidth <= availableWidth) {
+      return standardSize;
+    }
+    return Math.max(2.2, standardSize * (availableWidth - 1.0) / estimatedWidth);
   }
 
   private static boolean insideAll(List<Waypoint> waypoints, double width, double contentBottom) {

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -392,6 +392,61 @@ class NativeEngineeringDiagramRendererTest {
   }
 
   @Test
+  void routesUnprotectedFixedPortConnectionsAroundPinnedEquipment() {
+    EngineeringGraph graph = new EngineeringGraph("OBSTACLE-AWARE-ROUTING", "A");
+    graph.addNode(new EngineeringNode("equipment:a", EngineeringNode.Kind.EQUIPMENT, "a", "Equipment A")
+        .putProperty("equipmentName", "A"));
+    graph.addNode(new EngineeringNode("equipment:obstacle", EngineeringNode.Kind.EQUIPMENT, "obstacle", "Obstacle")
+        .putProperty("equipmentName", "OBSTACLE"));
+    graph.addNode(new EngineeringNode("equipment:b", EngineeringNode.Kind.EQUIPMENT, "b", "Equipment B")
+        .putProperty("equipmentName", "B"));
+    graph.addNode(endpointNode("nozzle:a-out", "equipment:a", "OUTLET"));
+    graph.addNode(endpointNode("nozzle:b-in", "equipment:b", "INLET"));
+    graph.addNode(connectionNode("connection:around-obstacle", "nozzle:a-out", "nozzle:b-in", "A", "B", false));
+    EngineeringDiagramDocumentSet baseline = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-NATIVE-012",
+        "Obstacle-aware route reference", ContentProfile.PFD);
+    String sheetKey = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition("equipment:a", sheetKey, 80.0, 80.0))
+        .withPinnedPosition(reviewedPosition("equipment:obstacle", sheetKey, 165.0, 80.0))
+        .withPinnedPosition(reviewedPosition("equipment:b", sheetKey, 250.0, 80.0));
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-NATIVE-012",
+        "Obstacle-aware route reference", ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String svg = result.getSvgBySheetId().values().iterator().next();
+    String route = pointsForSemanticId(svg, "connection:around-obstacle");
+
+    assertTrue(route.split(" ").length >= 6, route);
+    assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_OBJECT_INTERSECTION"));
+    assertEquals(result.getSvgBySheetId(), new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render().getSvgBySheetId());
+    assertTrue(result.isComplete());
+  }
+
+  @Test
+  void keepsLongLineTerminalIdentityInsideItsSymbol() {
+    EngineeringGraph graph = new EngineeringGraph("LINE-TERMINAL-LABEL", "A");
+    graph.addNode(new EngineeringNode("line:reflux", EngineeringNode.Kind.LINE, "reflux", "dew point liquid reflux 1"));
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-NATIVE-LINE-LABEL",
+        "Line-terminal label reference", ContentProfile.PFD);
+    EngineeringDiagramConventionRegister conventions = new EngineeringDiagramConventionRegister()
+        .withConvention(new SymbolConvention(EngineeringNode.Kind.LINE, SymbolShape.LINE_TERMINAL, "#1f2937", "#eff6ff",
+            "project-line-profile:v1", EngineeringDiagramConventionRegister.EvidenceState.PROPOSED, "", "",
+            "2026-09-09T00:00:00Z", "A"));
+
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.SheetFormat.A1_LANDSCAPE, conventions,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String svg = result.getSvgBySheetId().values().iterator().next();
+
+    assertTrue(svg.contains(">dew point liquid reflux 1</text>"));
+    assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_LABEL_OVERFLOW"));
+    assertTrue(result.isComplete());
+  }
+
+  @Test
   void alignsSingleOffPageConnectorsWithTheirLocalEndpoints() {
     EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessModel(
         EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(), "DEXPI-REF-MULTI-AREA", "A",


### PR DESCRIPTION
## Summary

This successor to #3593 advances the #1332/#2899 comparesimulations2 PFD/P&ID visual milestone with deterministic obstacle-aware routing for unprotected automatic connections.

- Evaluate the direct orthogonal route and deterministic page channels.
- Select by fewest non-endpoint object intersections, best achievable route-label collision score, then shortest route.
- Preserve protected manual routes as authoritative and retain stable fixed-port, parallel-lane, recycle, off-page, arrow, and canonical topology behavior.
- Keep complete reader-facing line identities, reducing line-terminal text only as far as 2.2 mm instead of truncating or exposing internal IDs.
- Keep whole-sheet collision diagnostics fail-visible.

The PFD, P&ID proposal, model topology, P&ID registers, native DEXPI 2.0 Plant/Process artifacts, and separately labelled Proteus 4.1 companion are otherwise unchanged. The unmodelled illustrated vessel `24-VB-01` remains absent.

## Frozen scope and exact head

- Base: `742b525609487aa7c56a5c444d19c476646a14a5`
- Exact head: `98b515928dc8e209022e9c0303fdc745924c295c`
- Branch: `codex/pid-obstacle-aware-routing`
- Four ordered commits and exactly four intended files
- Zero commits behind the publication base
- Sole active #1332/#2899 implementation PR
- Current autonomous implementation portfolio: **6/10**

## Tests-first and validation

The new obstacle regression failed on the previous renderer because the route crossed a pinned equipment symbol. A broader run then exposed and repaired parallel routes selecting the same bypass turn.

- `NativeEngineeringDiagramRendererTest`, `EngineeringDiagramDualProfileDeliveryTest`, and `EngineeringDiagramDualProfileCompanionDeliveryTest`: **23/23 pass**
- Full notebook-equivalent `Comparesimulations2EngineeringDiagramReferenceTest`: **1/1 pass**
- Spotless apply/check: pass and stable
- Documentation search audit: pass, 693 Markdown pages and one standalone HTML page
- `git diff --check`: pass
- Two independently constructed full-model deliveries: byte-identical files and manifests

Fresh evidence hashes:

- PFD A1 PDF: `0d8ff5974674e691c218ec151eb449d2318783657d859736035db8aef0656b89`
- P&ID A1 PDF: `d8252b831942df46e78835b311c2efe7ba5094b07ccbd2d9cf3996951316374f`
- Dual-profile manifest: `10a571e38b168fb97502d02d4e497b06927cd45c044f01af12e3baa0459d7bc7`

## Whole-sheet evidence and acceptance boundary

Fresh generation produced four PFD and four distinct P&ID A1 landscape sheets. Every page was rendered and inspected at full-sheet scale and 200 dpi. The prior full-model result reported 77 route/object intersections, four route-label/object collisions, seven connection-label/label collisions, and two label overflows per profile. This head reports **zero WARNING and zero ERROR renderer diagnostics** for both profiles; each retains 43 INFO records for proposal-only content and proposed symbol conventions.

The full-resolution sheets are unclipped, complete, and materially clearer. The overview remains intentionally sparse and the P&ID proposal racks remain information-dense, so automated zero-warning output is not a reviewed visual baseline or accountable drawing approval.

## Engineering and standards boundary

This remains a source-linked teaching proposal, not a completed safety design. It does not claim ISO 10628 or ANSI/ISA-5.1 conformance, certification, construction fitness, safety credit, or engineering approval. The public standards metadata does not replace licensed-text review. Project metadata, completed/reviewed piping-nozzle-valve-reducer-instrument-control registers, and isolation/drain/vent/relief decisions still require accountable project input.

Remaining milestone gates:

- accountable project metadata and reviewed visual baselines;
- external native DEXPI 2.0 and separately labelled Proteus 4.1 interoperability qualification;
- clean retained-output publication of the existing comparesimulations2 notebook without disturbing its comparison/optimization content or historical output.

**DRAFT — VALIDATION PENDING EXACT-HEAD CI: JAVA 8 UBUNTU/WINDOWS ACTIVE; PROJECT/INTEROPERABILITY/NOTEBOOK GATES OPEN.**

Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon this PR as an autonomous campaign action.