### PR TITLE
feat(refinery): qualify Big Hill vacuum screening result

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -141,3 +141,38 @@ This handoff does not identify the screening feed as measured atmospheric bottom
 or pressure correction, or claim vacuum-gas-oil/residue yields, product quality, equipment design, or
 plant agreement. Those remain separate solved-case and public-benchmark gates.
 
+
+## Solved screening-point result
+
+After a caller explicitly runs the configured column,
+`DoeBigHillVacuumFractionationResult.evaluate(model)` provides a fail-closed Java/JPype summary:
+
+```java
+DoeBigHillVacuumFractionationCase model =
+    DoeBigHillVacuumFractionationCase.create("Big Hill vacuum screen", 1000.0, inputs);
+model.getColumn().run();
+
+DoeBigHillVacuumFractionationResult result =
+    DoeBigHillVacuumFractionationResult.evaluate(model);
+double overheadMassFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+double bottomsMassFraction = result.getProduct("Bottoms").getMassFractionOfFeed();
+```
+
+Evaluation accepts only a converged MESH-residual solve without failed or fallback products. The
+external mass closure, column mass balance, column energy balance, maximum tray material balance,
+final MESH residual, and every component molar balance must each satisfy the configured acceptance
+limit. Both overhead and bottoms must have positive material flow, and their mole-weighted mean
+normal boiling points must increase from overhead to bottoms. The result also records iteration
+count, solve time, and convergence diagnostics, and returns defensive product arrays.
+
+The regression executes the explicit 12-tray point shown above twice from independently constructed
+cases. It requires the three exact DOE pseudo-component identities, no more than 5% mass,
+energy, tray, or component closure error, and product flow and mean-boiling-point repeatability
+within 1%.
+
+These gates qualify numerical conservation and separation direction for one transparent engineering
+screening point. No public DOE measurement defines a matching vacuum-column product split, so the
+reported streams are deliberately labeled `Overhead` and `Bottoms`, not validated VGO or vacuum
+residue. The calculation does not establish pressure correction, ASTM D1160 behavior, equipment
+design, a general SRK accuracy envelope, or plant agreement.
+

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
@@ -1,0 +1,302 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import neqsim.process.equipment.stream.StreamInterface;
+
+/**
+ * Immutable engineering summary for a solved {@link DoeBigHillVacuumFractionationCase}.
+ *
+ * <p>
+ * The result qualifies numerical convergence, conservation, and product ordering for an explicit
+ * screening case. It is not a measured DOE vacuum-column material balance or a product-yield
+ * validation.
+ * </p>
+ */
+public final class DoeBigHillVacuumFractionationResult {
+  private static final String[] PRODUCT_LABELS = { "Overhead", "Bottoms" };
+  private static final double MATERIAL_FLOW_FRACTION = 1.0e-8;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  private final ProductResult[] products;
+  private final double feedMassFlowKgPerHour;
+  private final double productMassFlowKgPerHour;
+  private final double massClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double columnMassBalanceError;
+  private final double columnEnergyBalanceError;
+  private final double meshResidualNorm;
+  private final int iterationCount;
+  private final double solveTimeSeconds;
+  private final String convergenceDiagnostics;
+
+  private DoeBigHillVacuumFractionationResult(ProductResult[] products, double feedMassFlowKgPerHour,
+      double productMassFlowKgPerHour, double massClosureRelativeError,
+      double maximumComponentMolarClosureRelativeError, double columnMassBalanceError,
+      double columnEnergyBalanceError, double meshResidualNorm, int iterationCount,
+      double solveTimeSeconds, String convergenceDiagnostics) {
+    this.products = products.clone();
+    this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
+    this.productMassFlowKgPerHour = productMassFlowKgPerHour;
+    this.massClosureRelativeError = massClosureRelativeError;
+    this.maximumComponentMolarClosureRelativeError = maximumComponentMolarClosureRelativeError;
+    this.columnMassBalanceError = columnMassBalanceError;
+    this.columnEnergyBalanceError = columnEnergyBalanceError;
+    this.meshResidualNorm = meshResidualNorm;
+    this.iterationCount = iterationCount;
+    this.solveTimeSeconds = solveTimeSeconds;
+    this.convergenceDiagnostics = convergenceDiagnostics;
+  }
+
+  /**
+   * Evaluate an already solved Big Hill low-pressure screening case.
+   *
+   * @param model solved case to evaluate
+   * @return immutable product and convergence summary
+   * @throws NullPointerException if {@code model} is {@code null}
+   * @throws IllegalStateException if the case is unsolved, used fallback products, is
+   *         non-conservative, or contains invalid or unordered products
+   */
+  public static DoeBigHillVacuumFractionationResult evaluate(
+      DoeBigHillVacuumFractionationCase model) {
+    Objects.requireNonNull(model, "model");
+    DistillationColumn column = model.getColumn();
+    if (!column.solved()) {
+      throw new IllegalStateException("Big Hill vacuum screening column must be solved before evaluation");
+    }
+    if (column.getLastSolverTypeUsed() != DistillationColumn.SolverType.MESH_RESIDUAL) {
+      throw new IllegalStateException("Big Hill vacuum screening column must use the MESH-residual solver");
+    }
+    if (column.getLastSolveStatus() == DistillationColumn.SolveStatus.FALLBACK_PRODUCTS
+        || column.getLastSolveStatus() == DistillationColumn.SolveStatus.FAILED) {
+      throw new IllegalStateException("Fallback or failed column results cannot be evaluated");
+    }
+
+    double massBalanceError = column.getMassBalanceError();
+    double energyBalanceError = column.getEnergyBalanceError();
+    requireFiniteBoundedError(massBalanceError, "Column mass-balance error",
+        BALANCE_TOLERANCE);
+    requireFiniteBoundedError(energyBalanceError, "Column energy-balance error",
+        BALANCE_TOLERANCE);
+    requireFiniteBoundedError(column.getLastTrayMaterialBalanceError(),
+        "Maximum tray material-balance error", column.getTrayMaterialBalanceTolerance());
+    double meshResidual = column.getLastMeshResidualNorm();
+    requireFiniteBoundedError(meshResidual, "MESH residual", column.getMeshResidualTolerance());
+
+    double feedMassFlow = model.getFeedStream().getFlowRate("kg/hr");
+    if (!Double.isFinite(feedMassFlow) || !(feedMassFlow > 0.0)) {
+      throw new IllegalStateException("Feed mass flow must be finite and positive");
+    }
+
+    StreamInterface[] streams = { column.getGasOutStream(), column.getLiquidOutStream() };
+    ProductResult[] productResults = new ProductResult[streams.length];
+    double productMassFlow = 0.0;
+    double previousMeanBoilingPoint = Double.NEGATIVE_INFINITY;
+    for (int i = 0; i < streams.length; i++) {
+      double massFlow = streams[i].getFlowRate("kg/hr");
+      if (!Double.isFinite(massFlow) || !(massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow)) {
+        throw new IllegalStateException("Both vacuum screening products must have material positive flow");
+      }
+      double meanBoilingPoint = meanNormalBoilingPoint(streams[i]);
+      if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
+        throw new IllegalStateException("Products must become heavier from overhead to bottoms");
+      }
+      previousMeanBoilingPoint = meanBoilingPoint;
+      productMassFlow += massFlow;
+      productResults[i] = new ProductResult(PRODUCT_LABELS[i], massFlow,
+          massFlow / feedMassFlow, meanBoilingPoint);
+    }
+
+    double closureError = Math.abs(feedMassFlow - productMassFlow) / feedMassFlow;
+    requireFiniteBoundedError(closureError, "External mass-closure error", BALANCE_TOLERANCE);
+    double maximumComponentError = maximumComponentMolarClosureRelativeError(
+        model.getFeedStream(), streams);
+    requireFiniteBoundedError(maximumComponentError,
+        "Maximum component molar-closure error", BALANCE_TOLERANCE);
+
+    int iterations = column.getLastIterationCount();
+    double solveTime = column.getLastSolveTimeSeconds();
+    if (iterations <= 0 || !Double.isFinite(solveTime) || solveTime < 0.0) {
+      throw new IllegalStateException("Column iteration and solve-time diagnostics must be physical");
+    }
+
+    String diagnostics = column.getConvergenceDiagnostics();
+    return new DoeBigHillVacuumFractionationResult(productResults, feedMassFlow,
+        productMassFlow, closureError, maximumComponentError, massBalanceError,
+        energyBalanceError, meshResidual, iterations, solveTime,
+        diagnostics == null ? "" : diagnostics);
+  }
+
+  /** @return defensive copy of products in overhead-to-bottoms order */
+  public ProductResult[] getProducts() {
+    return products.clone();
+  }
+
+  /**
+   * Return one product by its exact label.
+   *
+   * @param productLabel either {@code Overhead} or {@code Bottoms}
+   * @return matching immutable result
+   * @throws IllegalArgumentException if the label is null or unsupported
+   */
+  public ProductResult getProduct(String productLabel) {
+    if (productLabel != null) {
+      for (ProductResult product : products) {
+        if (product.getProductLabel().equals(productLabel)) {
+          return product;
+        }
+      }
+    }
+    throw new IllegalArgumentException("Unsupported Big Hill vacuum product label: " + productLabel);
+  }
+
+  /** @return evaluated feed mass flow in kg/h */
+  public double getFeedMassFlowKgPerHour() {
+    return feedMassFlowKgPerHour;
+  }
+
+  /** @return sum of evaluated product mass flows in kg/h */
+  public double getProductMassFlowKgPerHour() {
+    return productMassFlowKgPerHour;
+  }
+
+  /** @return absolute feed/product mass-closure error divided by feed mass flow */
+  public double getMassClosureRelativeError() {
+    return massClosureRelativeError;
+  }
+
+  /** @return largest per-component molar-flow closure error divided by feed component flow */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return column-reported relative mass-balance error */
+  public double getColumnMassBalanceError() {
+    return columnMassBalanceError;
+  }
+
+  /** @return column-reported relative energy-balance error */
+  public double getColumnEnergyBalanceError() {
+    return columnEnergyBalanceError;
+  }
+
+  /** @return final MESH residual norm */
+  public double getMeshResidualNorm() {
+    return meshResidualNorm;
+  }
+
+  /** @return iterations used by the qualified solve */
+  public int getIterationCount() {
+    return iterationCount;
+  }
+
+  /** @return reported solve time in seconds */
+  public double getSolveTimeSeconds() {
+    return solveTimeSeconds;
+  }
+
+  /** @return convergence diagnostics captured after the solve */
+  public String getConvergenceDiagnostics() {
+    return convergenceDiagnostics;
+  }
+
+  private static double meanNormalBoilingPoint(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    if (composition.length != boilingPoints.length || composition.length == 0) {
+      throw new IllegalStateException("Product composition and boiling-point arrays must align");
+    }
+
+    double mean = 0.0;
+    double compositionSum = 0.0;
+    for (int i = 0; i < composition.length; i++) {
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0
+          || !Double.isFinite(boilingPoints[i]) || !(boilingPoints[i] > 0.0)) {
+        throw new IllegalStateException("Product composition and boiling points must be physical");
+      }
+      mean += composition[i] * boilingPoints[i];
+      compositionSum += composition[i];
+    }
+    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || !Double.isFinite(mean)) {
+      throw new IllegalStateException("Product mean boiling point is undefined");
+    }
+    return mean / compositionSum;
+  }
+
+  private static double maximumComponentMolarClosureRelativeError(StreamInterface feed,
+      StreamInterface[] products) {
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    double feedMolarFlow = feed.getFlowRate("mol/hr");
+    double maximumError = 0.0;
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      double feedComponentFlow = feedMolarFlow * feedComposition[componentIndex];
+      if (!Double.isFinite(feedComponentFlow) || !(feedComponentFlow > 0.0)) {
+        throw new IllegalStateException("Feed component molar flows must be finite and positive");
+      }
+      double productComponentFlow = 0.0;
+      for (StreamInterface product : products) {
+        double[] productComposition = product.getThermoSystem().getMolarComposition();
+        if (productComposition.length != feedComposition.length) {
+          throw new IllegalStateException("Product composition must align with the feed");
+        }
+        productComponentFlow += product.getFlowRate("mol/hr")
+            * productComposition[componentIndex];
+      }
+      double relativeError = Math.abs(feedComponentFlow - productComponentFlow)
+          / feedComponentFlow;
+      if (!Double.isFinite(relativeError)) {
+        throw new IllegalStateException("Component molar-closure error must be finite");
+      }
+      maximumError = Math.max(maximumError, relativeError);
+    }
+    return maximumError;
+  }
+
+  private static void requireFiniteBoundedError(double value, String label,
+      double tolerance) {
+    if (!Double.isFinite(value) || value < 0.0 || !Double.isFinite(tolerance)
+        || tolerance < 0.0 || value > tolerance) {
+      throw new IllegalStateException(label + " exceeds the qualified tolerance");
+    }
+  }
+
+  /** Immutable calculated vacuum-screening product row. */
+  public static final class ProductResult {
+    private final String productLabel;
+    private final double massFlowKgPerHour;
+    private final double massFractionOfFeed;
+    private final double meanNormalBoilingPointKelvin;
+
+    private ProductResult(String productLabel, double massFlowKgPerHour,
+        double massFractionOfFeed, double meanNormalBoilingPointKelvin) {
+      this.productLabel = productLabel;
+      this.massFlowKgPerHour = massFlowKgPerHour;
+      this.massFractionOfFeed = massFractionOfFeed;
+      this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
+    }
+
+    /** @return product label */
+    public String getProductLabel() {
+      return productLabel;
+    }
+
+    /** @return product mass flow in kg/h */
+    public double getMassFlowKgPerHour() {
+      return massFlowKgPerHour;
+    }
+
+    /** @return product mass flow divided by feed mass flow */
+    public double getMassFractionOfFeed() {
+      return massFractionOfFeed;
+    }
+
+    /** @return mole-weighted mean normal boiling point in kelvin */
+    public double getMeanNormalBoilingPointKelvin() {
+      return meanNormalBoilingPointKelvin;
+    }
+
+    /** @return mole-weighted mean normal boiling point in degrees Celsius */
+    public double getMeanNormalBoilingPointCelsius() {
+      return meanNormalBoilingPointKelvin - 273.15;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
@@ -7,9 +7,8 @@ import neqsim.process.equipment.stream.StreamInterface;
  * Immutable engineering summary for a solved {@link DoeBigHillVacuumFractionationCase}.
  *
  * <p>
- * The result qualifies numerical convergence, conservation, and product ordering for an explicit
- * screening case. It is not a measured DOE vacuum-column material balance or a product-yield
- * validation.
+ * The result qualifies numerical convergence, conservation, and product ordering for an explicit screening case. It is
+ * not a measured DOE vacuum-column material balance or a product-yield validation.
  * </p>
  */
 public final class DoeBigHillVacuumFractionationResult {
@@ -31,9 +30,8 @@ public final class DoeBigHillVacuumFractionationResult {
 
   private DoeBigHillVacuumFractionationResult(ProductResult[] products, double feedMassFlowKgPerHour,
       double productMassFlowKgPerHour, double massClosureRelativeError,
-      double maximumComponentMolarClosureRelativeError, double columnMassBalanceError,
-      double columnEnergyBalanceError, double meshResidualNorm, int iterationCount,
-      double solveTimeSeconds, String convergenceDiagnostics) {
+      double maximumComponentMolarClosureRelativeError, double columnMassBalanceError, double columnEnergyBalanceError,
+      double meshResidualNorm, int iterationCount, double solveTimeSeconds, String convergenceDiagnostics) {
     this.products = products.clone();
     this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
     this.productMassFlowKgPerHour = productMassFlowKgPerHour;
@@ -53,11 +51,10 @@ public final class DoeBigHillVacuumFractionationResult {
    * @param model solved case to evaluate
    * @return immutable product and convergence summary
    * @throws NullPointerException if {@code model} is {@code null}
-   * @throws IllegalStateException if the case is unsolved, used fallback products, is
-   *         non-conservative, or contains invalid or unordered products
+   * @throws IllegalStateException if the case is unsolved, used fallback products, is non-conservative, or contains
+   * invalid or unordered products
    */
-  public static DoeBigHillVacuumFractionationResult evaluate(
-      DoeBigHillVacuumFractionationCase model) {
+  public static DoeBigHillVacuumFractionationResult evaluate(DoeBigHillVacuumFractionationCase model) {
     Objects.requireNonNull(model, "model");
     DistillationColumn column = model.getColumn();
     if (!column.solved()) {
@@ -73,12 +70,10 @@ public final class DoeBigHillVacuumFractionationResult {
 
     double massBalanceError = column.getMassBalanceError();
     double energyBalanceError = column.getEnergyBalanceError();
-    requireFiniteBoundedError(massBalanceError, "Column mass-balance error",
-        BALANCE_TOLERANCE);
-    requireFiniteBoundedError(energyBalanceError, "Column energy-balance error",
-        BALANCE_TOLERANCE);
-    requireFiniteBoundedError(column.getLastTrayMaterialBalanceError(),
-        "Maximum tray material-balance error", column.getTrayMaterialBalanceTolerance());
+    requireFiniteBoundedError(massBalanceError, "Column mass-balance error", BALANCE_TOLERANCE);
+    requireFiniteBoundedError(energyBalanceError, "Column energy-balance error", BALANCE_TOLERANCE);
+    requireFiniteBoundedError(column.getLastTrayMaterialBalanceError(), "Maximum tray material-balance error",
+        column.getTrayMaterialBalanceTolerance());
     double meshResidual = column.getLastMeshResidualNorm();
     requireFiniteBoundedError(meshResidual, "MESH residual", column.getMeshResidualTolerance());
 
@@ -102,16 +97,13 @@ public final class DoeBigHillVacuumFractionationResult {
       }
       previousMeanBoilingPoint = meanBoilingPoint;
       productMassFlow += massFlow;
-      productResults[i] = new ProductResult(PRODUCT_LABELS[i], massFlow,
-          massFlow / feedMassFlow, meanBoilingPoint);
+      productResults[i] = new ProductResult(PRODUCT_LABELS[i], massFlow, massFlow / feedMassFlow, meanBoilingPoint);
     }
 
     double closureError = Math.abs(feedMassFlow - productMassFlow) / feedMassFlow;
     requireFiniteBoundedError(closureError, "External mass-closure error", BALANCE_TOLERANCE);
-    double maximumComponentError = maximumComponentMolarClosureRelativeError(
-        model.getFeedStream(), streams);
-    requireFiniteBoundedError(maximumComponentError,
-        "Maximum component molar-closure error", BALANCE_TOLERANCE);
+    double maximumComponentError = maximumComponentMolarClosureRelativeError(model.getFeedStream(), streams);
+    requireFiniteBoundedError(maximumComponentError, "Maximum component molar-closure error", BALANCE_TOLERANCE);
 
     int iterations = column.getLastIterationCount();
     double solveTime = column.getLastSolveTimeSeconds();
@@ -120,9 +112,8 @@ public final class DoeBigHillVacuumFractionationResult {
     }
 
     String diagnostics = column.getConvergenceDiagnostics();
-    return new DoeBigHillVacuumFractionationResult(productResults, feedMassFlow,
-        productMassFlow, closureError, maximumComponentError, massBalanceError,
-        energyBalanceError, meshResidual, iterations, solveTime,
+    return new DoeBigHillVacuumFractionationResult(productResults, feedMassFlow, productMassFlow, closureError,
+        maximumComponentError, massBalanceError, energyBalanceError, meshResidual, iterations, solveTime,
         diagnostics == null ? "" : diagnostics);
   }
 
@@ -209,8 +200,8 @@ public final class DoeBigHillVacuumFractionationResult {
     double mean = 0.0;
     double compositionSum = 0.0;
     for (int i = 0; i < composition.length; i++) {
-      if (!Double.isFinite(composition[i]) || composition[i] < 0.0
-          || !Double.isFinite(boilingPoints[i]) || !(boilingPoints[i] > 0.0)) {
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
+          || !(boilingPoints[i] > 0.0)) {
         throw new IllegalStateException("Product composition and boiling points must be physical");
       }
       mean += composition[i] * boilingPoints[i];
@@ -222,8 +213,7 @@ public final class DoeBigHillVacuumFractionationResult {
     return mean / compositionSum;
   }
 
-  private static double maximumComponentMolarClosureRelativeError(StreamInterface feed,
-      StreamInterface[] products) {
+  private static double maximumComponentMolarClosureRelativeError(StreamInterface feed, StreamInterface[] products) {
     double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     double feedMolarFlow = feed.getFlowRate("mol/hr");
     double maximumError = 0.0;
@@ -238,11 +228,9 @@ public final class DoeBigHillVacuumFractionationResult {
         if (productComposition.length != feedComposition.length) {
           throw new IllegalStateException("Product composition must align with the feed");
         }
-        productComponentFlow += product.getFlowRate("mol/hr")
-            * productComposition[componentIndex];
+        productComponentFlow += product.getFlowRate("mol/hr") * productComposition[componentIndex];
       }
-      double relativeError = Math.abs(feedComponentFlow - productComponentFlow)
-          / feedComponentFlow;
+      double relativeError = Math.abs(feedComponentFlow - productComponentFlow) / feedComponentFlow;
       if (!Double.isFinite(relativeError)) {
         throw new IllegalStateException("Component molar-closure error must be finite");
       }
@@ -251,10 +239,8 @@ public final class DoeBigHillVacuumFractionationResult {
     return maximumError;
   }
 
-  private static void requireFiniteBoundedError(double value, String label,
-      double tolerance) {
-    if (!Double.isFinite(value) || value < 0.0 || !Double.isFinite(tolerance)
-        || tolerance < 0.0 || value > tolerance) {
+  private static void requireFiniteBoundedError(double value, String label, double tolerance) {
+    if (!Double.isFinite(value) || value < 0.0 || !Double.isFinite(tolerance) || tolerance < 0.0 || value > tolerance) {
       throw new IllegalStateException(label + " exceeds the qualified tolerance");
     }
   }
@@ -266,8 +252,8 @@ public final class DoeBigHillVacuumFractionationResult {
     private final double massFractionOfFeed;
     private final double meanNormalBoilingPointKelvin;
 
-    private ProductResult(String productLabel, double massFlowKgPerHour,
-        double massFractionOfFeed, double meanNormalBoilingPointKelvin) {
+    private ProductResult(String productLabel, double massFlowKgPerHour, double massFractionOfFeed,
+        double meanNormalBoilingPointKelvin) {
       this.productLabel = productLabel;
       this.massFlowKgPerHour = massFlowKgPerHour;
       this.massFractionOfFeed = massFractionOfFeed;

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
@@ -1,0 +1,131 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+import neqsim.process.equipment.stream.StreamInterface;
+
+/** Qualification tests for {@link DoeBigHillVacuumFractionationResult}. */
+public class DoeBigHillVacuumFractionationResultTest {
+  private static final double FEED_MASS_FLOW_KG_PER_HOUR = 1000.0;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+  private static final double REPEAT_TOLERANCE = 1.0e-2;
+
+  /**
+   * Require the explicit screening point to converge, conserve, separate, and repeat.
+   */
+  @Test
+  @Timeout(value = 180, unit = TimeUnit.SECONDS)
+  public void screeningPointProducesConservativeOrderedRepeatableResults() {
+    DoeBigHillVacuumFractionationCase first = createCase("First Big Hill vacuum screen");
+    assertThrows(IllegalStateException.class,
+        () -> DoeBigHillVacuumFractionationResult.evaluate(first));
+
+    first.getColumn().run(UUID.randomUUID());
+    DoeBigHillVacuumFractionationResult firstResult =
+        DoeBigHillVacuumFractionationResult.evaluate(first);
+    assertQualifiedResult(first, firstResult);
+
+    DoeBigHillVacuumFractionationCase second = createCase("Second Big Hill vacuum screen");
+    second.getColumn().run(UUID.randomUUID());
+    DoeBigHillVacuumFractionationResult secondResult =
+        DoeBigHillVacuumFractionationResult.evaluate(second);
+    assertQualifiedResult(second, secondResult);
+
+    ProductResult[] firstProducts = firstResult.getProducts();
+    ProductResult[] secondProducts = secondResult.getProducts();
+    for (int i = 0; i < firstProducts.length; i++) {
+      assertRelativeRepeat(firstProducts[i].getMassFlowKgPerHour(),
+          secondProducts[i].getMassFlowKgPerHour());
+      assertRelativeRepeat(firstProducts[i].getMeanNormalBoilingPointKelvin(),
+          secondProducts[i].getMeanNormalBoilingPointKelvin());
+    }
+  }
+
+  private static DoeBigHillVacuumFractionationCase createCase(String name) {
+    OperatingInputs inputs = new OperatingInputs(12, 4, 640.0, 0.12, 0.08,
+        0.16, 700.0, 0.5);
+    return DoeBigHillVacuumFractionationCase.create(name,
+        FEED_MASS_FLOW_KG_PER_HOUR, inputs);
+  }
+
+  private static void assertQualifiedResult(DoeBigHillVacuumFractionationCase model,
+      DoeBigHillVacuumFractionationResult result) {
+    DistillationColumn column = model.getColumn();
+    String diagnostics = column.getConvergenceDiagnostics();
+    assertTrue(column.solved(), diagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL,
+        column.getLastSolverTypeUsed(), diagnostics);
+    assertTrue(result.getColumnMassBalanceError() <= BALANCE_TOLERANCE, diagnostics);
+    assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE, diagnostics);
+    assertTrue(result.getMeshResidualNorm() <= column.getMeshResidualTolerance(), diagnostics);
+    assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE, diagnostics);
+    assertTrue(result.getMaximumComponentMolarClosureRelativeError()
+        <= BALANCE_TOLERANCE, diagnostics);
+    assertTrue(result.getIterationCount() > 0);
+    assertTrue(Double.isFinite(result.getSolveTimeSeconds())
+        && result.getSolveTimeSeconds() >= 0.0);
+
+    ProductResult[] products = result.getProducts();
+    assertEquals(2, products.length);
+    assertEquals("Overhead", products[0].getProductLabel());
+    assertEquals("Bottoms", products[1].getProductLabel());
+    assertEquals(products[0], result.getProduct("Overhead"));
+    assertEquals(products[1], result.getProduct("Bottoms"));
+    assertThrows(IllegalArgumentException.class, () -> result.getProduct("VGO"));
+    assertNotSame(products, result.getProducts());
+    assertTrue(products[0].getMassFlowKgPerHour() > 0.0);
+    assertTrue(products[1].getMassFlowKgPerHour() > 0.0);
+    assertTrue(products[0].getMeanNormalBoilingPointKelvin()
+        < products[1].getMeanNormalBoilingPointKelvin());
+    assertEquals(1.0, products[0].getMassFractionOfFeed()
+        + products[1].getMassFractionOfFeed(), BALANCE_TOLERANCE);
+    assertEquals(FEED_MASS_FLOW_KG_PER_HOUR, result.getFeedMassFlowKgPerHour(), 1.0e-9);
+    assertEquals(result.getFeedMassFlowKgPerHour(), result.getProductMassFlowKgPerHour(),
+        BALANCE_TOLERANCE * result.getFeedMassFlowKgPerHour());
+
+    assertEquals(3, model.getFeedStream().getThermoSystem().getNumberOfComponents());
+    assertEquals("DOE_BH_650_850_PC",
+        model.getFeedStream().getThermoSystem().getComponent(0).getComponentName());
+    assertEquals("DOE_BH_850_1050_PC",
+        model.getFeedStream().getThermoSystem().getComponent(1).getComponentName());
+    assertEquals("DOE_BH_1050_PLUS_PC",
+        model.getFeedStream().getThermoSystem().getComponent(2).getComponentName());
+    assertIndependentComponentBalance(model);
+  }
+
+  private static void assertIndependentComponentBalance(
+      DoeBigHillVacuumFractionationCase model) {
+    StreamInterface feed = model.getFeedStream();
+    StreamInterface overhead = model.getColumn().getGasOutStream();
+    StreamInterface bottoms = model.getColumn().getLiquidOutStream();
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    double[] overheadComposition = overhead.getThermoSystem().getMolarComposition();
+    double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < feedComposition.length;
+        componentIndex++) {
+      double feedComponentFlow = feed.getFlowRate("mol/hr")
+          * feedComposition[componentIndex];
+      double productComponentFlow = overhead.getFlowRate("mol/hr")
+          * overheadComposition[componentIndex]
+          + bottoms.getFlowRate("mol/hr") * bottomsComposition[componentIndex];
+      assertEquals(feedComponentFlow, productComponentFlow,
+          BALANCE_TOLERANCE * Math.abs(feedComponentFlow));
+    }
+  }
+
+  private static void assertRelativeRepeat(double expected, double actual) {
+    assertTrue(Double.isFinite(expected));
+    assertTrue(Double.isFinite(actual));
+    assertEquals(expected, actual,
+        Math.max(1.0e-8, REPEAT_TOLERANCE * Math.abs(expected)));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
@@ -26,35 +26,29 @@ public class DoeBigHillVacuumFractionationResultTest {
   @Timeout(value = 180, unit = TimeUnit.SECONDS)
   public void screeningPointProducesConservativeOrderedRepeatableResults() {
     DoeBigHillVacuumFractionationCase first = createCase("First Big Hill vacuum screen");
-    assertThrows(IllegalStateException.class,
-        () -> DoeBigHillVacuumFractionationResult.evaluate(first));
+    assertThrows(IllegalStateException.class, () -> DoeBigHillVacuumFractionationResult.evaluate(first));
 
     first.getColumn().run(UUID.randomUUID());
-    DoeBigHillVacuumFractionationResult firstResult =
-        DoeBigHillVacuumFractionationResult.evaluate(first);
+    DoeBigHillVacuumFractionationResult firstResult = DoeBigHillVacuumFractionationResult.evaluate(first);
     assertQualifiedResult(first, firstResult);
 
     DoeBigHillVacuumFractionationCase second = createCase("Second Big Hill vacuum screen");
     second.getColumn().run(UUID.randomUUID());
-    DoeBigHillVacuumFractionationResult secondResult =
-        DoeBigHillVacuumFractionationResult.evaluate(second);
+    DoeBigHillVacuumFractionationResult secondResult = DoeBigHillVacuumFractionationResult.evaluate(second);
     assertQualifiedResult(second, secondResult);
 
     ProductResult[] firstProducts = firstResult.getProducts();
     ProductResult[] secondProducts = secondResult.getProducts();
     for (int i = 0; i < firstProducts.length; i++) {
-      assertRelativeRepeat(firstProducts[i].getMassFlowKgPerHour(),
-          secondProducts[i].getMassFlowKgPerHour());
+      assertRelativeRepeat(firstProducts[i].getMassFlowKgPerHour(), secondProducts[i].getMassFlowKgPerHour());
       assertRelativeRepeat(firstProducts[i].getMeanNormalBoilingPointKelvin(),
           secondProducts[i].getMeanNormalBoilingPointKelvin());
     }
   }
 
   private static DoeBigHillVacuumFractionationCase createCase(String name) {
-    OperatingInputs inputs = new OperatingInputs(12, 4, 640.0, 0.12, 0.08,
-        0.16, 700.0, 0.5);
-    return DoeBigHillVacuumFractionationCase.create(name,
-        FEED_MASS_FLOW_KG_PER_HOUR, inputs);
+    OperatingInputs inputs = new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+    return DoeBigHillVacuumFractionationCase.create(name, FEED_MASS_FLOW_KG_PER_HOUR, inputs);
   }
 
   private static void assertQualifiedResult(DoeBigHillVacuumFractionationCase model,
@@ -62,17 +56,14 @@ public class DoeBigHillVacuumFractionationResultTest {
     DistillationColumn column = model.getColumn();
     String diagnostics = column.getConvergenceDiagnostics();
     assertTrue(column.solved(), diagnostics);
-    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL,
-        column.getLastSolverTypeUsed(), diagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(), diagnostics);
     assertTrue(result.getColumnMassBalanceError() <= BALANCE_TOLERANCE, diagnostics);
     assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE, diagnostics);
     assertTrue(result.getMeshResidualNorm() <= column.getMeshResidualTolerance(), diagnostics);
     assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE, diagnostics);
-    assertTrue(result.getMaximumComponentMolarClosureRelativeError()
-        <= BALANCE_TOLERANCE, diagnostics);
+    assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE, diagnostics);
     assertTrue(result.getIterationCount() > 0);
-    assertTrue(Double.isFinite(result.getSolveTimeSeconds())
-        && result.getSolveTimeSeconds() >= 0.0);
+    assertTrue(Double.isFinite(result.getSolveTimeSeconds()) && result.getSolveTimeSeconds() >= 0.0);
 
     ProductResult[] products = result.getProducts();
     assertEquals(2, products.length);
@@ -84,48 +75,37 @@ public class DoeBigHillVacuumFractionationResultTest {
     assertNotSame(products, result.getProducts());
     assertTrue(products[0].getMassFlowKgPerHour() > 0.0);
     assertTrue(products[1].getMassFlowKgPerHour() > 0.0);
-    assertTrue(products[0].getMeanNormalBoilingPointKelvin()
-        < products[1].getMeanNormalBoilingPointKelvin());
-    assertEquals(1.0, products[0].getMassFractionOfFeed()
-        + products[1].getMassFractionOfFeed(), BALANCE_TOLERANCE);
+    assertTrue(products[0].getMeanNormalBoilingPointKelvin() < products[1].getMeanNormalBoilingPointKelvin());
+    assertEquals(1.0, products[0].getMassFractionOfFeed() + products[1].getMassFractionOfFeed(), BALANCE_TOLERANCE);
     assertEquals(FEED_MASS_FLOW_KG_PER_HOUR, result.getFeedMassFlowKgPerHour(), 1.0e-9);
     assertEquals(result.getFeedMassFlowKgPerHour(), result.getProductMassFlowKgPerHour(),
         BALANCE_TOLERANCE * result.getFeedMassFlowKgPerHour());
 
     assertEquals(3, model.getFeedStream().getThermoSystem().getNumberOfComponents());
-    assertEquals("DOE_BH_650_850_PC",
-        model.getFeedStream().getThermoSystem().getComponent(0).getComponentName());
-    assertEquals("DOE_BH_850_1050_PC",
-        model.getFeedStream().getThermoSystem().getComponent(1).getComponentName());
-    assertEquals("DOE_BH_1050_PLUS_PC",
-        model.getFeedStream().getThermoSystem().getComponent(2).getComponentName());
+    assertEquals("DOE_BH_650_850_PC", model.getFeedStream().getThermoSystem().getComponent(0).getComponentName());
+    assertEquals("DOE_BH_850_1050_PC", model.getFeedStream().getThermoSystem().getComponent(1).getComponentName());
+    assertEquals("DOE_BH_1050_PLUS_PC", model.getFeedStream().getThermoSystem().getComponent(2).getComponentName());
     assertIndependentComponentBalance(model);
   }
 
-  private static void assertIndependentComponentBalance(
-      DoeBigHillVacuumFractionationCase model) {
+  private static void assertIndependentComponentBalance(DoeBigHillVacuumFractionationCase model) {
     StreamInterface feed = model.getFeedStream();
     StreamInterface overhead = model.getColumn().getGasOutStream();
     StreamInterface bottoms = model.getColumn().getLiquidOutStream();
     double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     double[] overheadComposition = overhead.getThermoSystem().getMolarComposition();
     double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition();
-    for (int componentIndex = 0; componentIndex < feedComposition.length;
-        componentIndex++) {
-      double feedComponentFlow = feed.getFlowRate("mol/hr")
-          * feedComposition[componentIndex];
-      double productComponentFlow = overhead.getFlowRate("mol/hr")
-          * overheadComposition[componentIndex]
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      double feedComponentFlow = feed.getFlowRate("mol/hr") * feedComposition[componentIndex];
+      double productComponentFlow = overhead.getFlowRate("mol/hr") * overheadComposition[componentIndex]
           + bottoms.getFlowRate("mol/hr") * bottomsComposition[componentIndex];
-      assertEquals(feedComponentFlow, productComponentFlow,
-          BALANCE_TOLERANCE * Math.abs(feedComponentFlow));
+      assertEquals(feedComponentFlow, productComponentFlow, BALANCE_TOLERANCE * Math.abs(feedComponentFlow));
     }
   }
 
   private static void assertRelativeRepeat(double expected, double actual) {
     assertTrue(Double.isFinite(expected));
     assertTrue(Double.isFinite(actual));
-    assertEquals(expected, actual,
-        Math.max(1.0e-8, REPEAT_TOLERANCE * Math.abs(expected)));
+    assertEquals(expected, actual, Math.max(1.0e-8, REPEAT_TOLERANCE * Math.abs(expected)));
   }
 }


### PR DESCRIPTION
## Summary

Advances #3305 with the next numerical-risk gate after the merged Big Hill low-pressure case handoff.

`DoeBigHillVacuumFractionationResult` evaluates only an already-solved `DoeBigHillVacuumFractionationCase`. It rejects unsolved, failed, fallback, non-MESH, non-conservative, non-finite, or physically unordered outputs and returns an immutable Java/JPype summary of the overhead and bottoms.

## Exact-head contract

- Frozen base: `270a71fb2cb6e13d05f2b87ac5b743fd37a35592`
- Exact published head: `eddeb4a0fe2f52724cbf210664707d8ae5ba47d1`
- Branch: `codex/refinery-big-hill-vacuum-result`
- Five ordered commits, zero behind the frozen base, exactly three intended files
- Sole active #3305 implementation PR
- Positively identified autonomous implementation occupancy after publication: **7/10**

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5603254118

## Engineering and numerical gates

Evaluation requires:

- the rigorous MESH-residual solver to report a converged non-fallback result;
- external mass closure, column mass and energy errors, maximum tray material imbalance, final MESH residual, and every component molar-flow closure to satisfy their configured limits;
- both overhead and bottoms to have positive material flow;
- mole-weighted mean normal boiling point to increase from overhead to bottoms;
- finite positive iteration count and finite non-negative solve time.

The focused regression executes the documented 12-tray low-pressure point twice from independent cases. It checks exact DOE pseudo-component identities, independently reconstructs each component balance, and requires product-flow and mean-boiling-point repeatability within 1%.

## Provenance and scientific boundary

The feed remains derived solely from the public U.S. DOE Strategic Petroleum Reserve [Big Hill Sweet comprehensive assay](https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx), with the provenance and 42.84 mass% whole-crude heavy-cut basis already qualified in #3305. Every column operating value remains an explicit source-unreported engineering assumption.

This is numerical qualification of one transparent screening point. It does not identify the normalized feed as measured atmospheric bottoms, perform ASTM D1160 or pressure correction, fit operating inputs, validate product yields against plant data, claim equipment design, or establish a general SRK vacuum-column accuracy envelope.

## Documentation impact

Updates the Big Hill complete-slate guide with Java/JPype solve/evaluate usage, reported units, every acceptance gate, the two-product naming boundary, repeatability criterion, and the absence of a matching public vacuum-column benchmark.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

The exact hosted Spotless artifact from workflow run `34362502348`, artifact `10108450235`,
digest `sha256:8073f5d58d0527721c95195f14de74d219885c8b879f1b5d79c477c28509b38d`, was audited and
applied to the two new Java files only. It changed formatting and no engineering behavior, tests,
APIs, source values, assumptions, provenance, or acceptance limits. The single formatting-only repair
allowance is consumed; fresh CI on the current head is authoritative.

Connector-side audit passed: exact three-file scope; balanced Java braces and parentheses; Java lines no longer than 108 characters; no tabs, trailing whitespace, or literal `\\n` defects; and zero target drift at publication.

No local Maven, Java, Spotless, pre-commit, or documentation-search execution is claimed. Hosted GitHub Actions on the exact head are authoritative.

Draft-only: do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon for capacity.