### PR TITLE
Speed up agent/skill install by only reinstalling what changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,8 +611,10 @@ Browse and install community-contributed skills, or publish your own:
 neqsim skill list                    # browse the catalog and discovered repositories
 neqsim skill install <name>          # install a skill
 neqsim skill install <name> --target vscode   # also export to your ~/.copilot/skills folder
+neqsim skill sync-packages           # install any deferred skill Python packages
+neqsim skill ensure <name>           # install one skill's package on first use
 neqsim skill doctor                  # check private-catalog authentication readiness
-neqsim skill doctor --target vscode  # verify VS Code skill exports
+neqsim skill doctor --target vscode  # verify VS Code skill exports and package health
 neqsim skill publish user/repo-name  # publish yours (creates a draft PR)
 ```
 

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -352,8 +352,8 @@ for a full explanation of the architecture and internals.
 | `pyproject.toml` | Makes it pip-installable (`pip install -e devtools/`) |
 | `new_task.py` | Create task-solving folders for the 4-step AI workflow |
 | `new_skill.py` | Scaffold a new skill for the agentic system (`neqsim new-skill "name"`) |
-| `install_skill.py` | Community/private skill manager — `neqsim skill list/search/install/remove/publish` |
-| `install_agent.py` | Community/private agent manager — `neqsim agent list/search/install[/--all]/remove/validate/schema` |
+| `install_skill.py` | Community/private skill manager — `neqsim skill list/search/info/install[/--all]/installed/export/remove/publish/sync-packages/ensure/doctor/private-init/add-repo` |
+| `install_agent.py` | Community/private agent manager — `neqsim agent list/search/info/install[/--all]/installed/export/remove/validate/run/schema/doctor/private-init/add-repo` |
 | `neqsim_doctor.py` | Diagnostic tool — checks Java, Maven, JAR, Python, agents, skills, cross-tool configs |
 | `onboard.py` | Interactive onboarding wizard — walks new contributors through full environment setup |
 | `consistency_checker.py` | **Pre-report quality gate.** Extracts numerical values from notebooks and results.json, detects inconsistencies (numerical mismatches, scope mismatches, contradictory claims). Run before `generate_report.py`. Produces `consistency_report.json`. |

--- a/devtools/install_agent.py
+++ b/devtools/install_agent.py
@@ -1384,6 +1384,11 @@ def _requested_skill_export_targets(install_args):
     return targets
 
 
+# Skills already refreshed in this process; agents share required skills, so
+# without this a single --all --force run reinstalls popular skills many times.
+_SKILLS_REFRESHED_THIS_RUN = set()
+
+
 def _skill_install_args(skill_name, install_args):
     """Build skill installer args that preserve agent export target options.
 
@@ -1399,6 +1404,7 @@ def _skill_install_args(skill_name, install_args):
         vscode_scope=getattr(install_args, "vscode_scope", "user"),
         vscode_dir=getattr(install_args, "vscode_skills_dir", None),
         export_dir=getattr(install_args, "export_dir", None),
+        no_pip=getattr(install_args, "no_pip", False),
     )
 
 
@@ -1521,6 +1527,9 @@ def _print_required_skill_guidance(required_skills, install_missing=False, insta
     force_reinstall = install_missing and bool(getattr(install_args, "force", False))
     missing = _find_missing_required_skills(required_skills)
     to_reinstall = required_skills if force_reinstall else missing
+    # A skill required by many agents must only be refreshed once per run.
+    to_reinstall = [skill for skill in to_reinstall
+                    if skill in missing or skill not in _SKILLS_REFRESHED_THIS_RUN]
 
     if not to_reinstall:
         print("  [OK] Required skills available: {skills}".format(
@@ -1564,6 +1573,7 @@ def _print_required_skill_guidance(required_skills, install_missing=False, insta
         try:
             install_skill.cmd_install(skill_catalog, args)
             installed_now.append(skill_name)
+            _SKILLS_REFRESHED_THIS_RUN.add(skill_name)
         except SystemExit:
             unresolved.append(skill_name)
     export_check_skills = [skill for skill in required_skills if skill not in installed_now]
@@ -1906,23 +1916,34 @@ def _install_all_agents(agents, args):
     manifest = load_manifest()
     installed = []
     failed = []
-    for index, agent in enumerate(unique, start=1):
-        name = agent.get("name", "")
-        print("  [{index}/{total}] {name}".format(
-            index=index, total=total, name=name))
-        try:
-            _validate_safe_name(name)
-        except SystemExit:
-            failed.append(name)
-            continue
-        if _install_agent_record(agent, args, manifest):
-            installed.append(name)
-        else:
-            failed.append(name)
+    batching = not install_skill._pip_disabled(args)
+    if batching:
+        install_skill.begin_package_install_batch()
+    try:
+        for index, agent in enumerate(unique, start=1):
+            name = agent.get("name", "")
+            print("  [{index}/{total}] {name}".format(
+                index=index, total=total, name=name))
+            try:
+                _validate_safe_name(name)
+            except SystemExit:
+                failed.append(name)
+                continue
+            if _install_agent_record(agent, args, manifest):
+                installed.append(name)
+            else:
+                failed.append(name)
+    finally:
+        if batching:
+            install_skill.flush_package_install_batch()
 
     print("\n  ==== Install summary ====")
     print("  Installed/OK: {count}".format(count=len(installed)))
     print("  Failed: {count}".format(count=len(failed)))
+    deferred = install_skill._count_deferred_packages()
+    if deferred:
+        print("  Deferred skill Python packages: {count}".format(count=deferred))
+        print("  Run: neqsim skill sync-packages   (or 'neqsim skill ensure <name>' on first use)")
     if failed:
         print("  Failed agents: {names}".format(names=", ".join(failed)))
         sys.exit(1)
@@ -2541,6 +2562,7 @@ def main():
         "  neqsim agent install --all --target vscode",
         "  neqsim agent install --all --source community --target vscode",
         "  neqsim agent install --all --source private --target vscode",
+        "  neqsim agent install --all --target vscode --force --no-pip  # skip skill package installs",
         "  neqsim agent installed",
         "  neqsim agent info neqsim-example-agent",
         "  neqsim agent validate neqsim-example-agent",
@@ -2617,6 +2639,9 @@ def main():
     p_install.add_argument(
         "--export-dir", default=None,
         help="Generic export root for --target generic (default: ~/.neqsim/export/generic)")
+    p_install.add_argument(
+        "--no-pip", dest="no_pip", action="store_true",
+        help="Do not pip install required skills' Python packages; defer to 'neqsim skill sync-packages'")
 
     sub.add_parser("installed", help="Show installed agents")
 

--- a/devtools/install_skill.py
+++ b/devtools/install_skill.py
@@ -1570,6 +1570,220 @@ def _pip_install_skill_package(dest_dir, name):
     return False
 
 
+# ── Python package installs (batched / deferred) ───────────────────────
+
+# Queue used while a bulk install is running so the many packaged skills are
+# pip-installed in one resolver pass instead of one subprocess each.
+_PENDING_PACKAGE_INSTALLS = []
+_BATCH_PACKAGE_INSTALLS = [False]
+
+
+def _pip_disabled(args):
+    """Return True when the skill's Python package install should be skipped.
+
+    @param args parsed CLI arguments (reads ``no_pip``)
+    @return True when ``--no-pip`` or ``NEQSIM_SKILL_NO_PIP`` asks to defer
+    """
+    if getattr(args, "no_pip", False):
+        return True
+    return os.environ.get("NEQSIM_SKILL_NO_PIP", "").strip().lower() not in ("", "0", "false", "no")
+
+
+def begin_package_install_batch():
+    """Start collecting packaged-skill installs instead of running pip per skill."""
+    _BATCH_PACKAGE_INSTALLS[0] = True
+    del _PENDING_PACKAGE_INSTALLS[:]
+
+
+def flush_package_install_batch():
+    """Install every queued skill package in one pip pass and stop batching.
+
+    A single ``pip install -e a -e b ...`` replaces one subprocess per skill,
+    which is what made ``install --all --force`` slow once ~150 catalog skills
+    shipped a Python package.
+
+    @return list of skill names whose package could not be installed
+    """
+    _BATCH_PACKAGE_INSTALLS[0] = False
+    pending = list(_PENDING_PACKAGE_INSTALLS)
+    del _PENDING_PACKAGE_INSTALLS[:]
+    if not pending:
+        return []
+    failed = _pip_install_skill_packages(pending)
+    manifest = load_manifest()
+    changed = False
+    for name, _dest_dir in pending:
+        if name not in manifest:
+            continue
+        manifest[name]["package_installed"] = name not in failed
+        manifest[name]["package_pending"] = name in failed
+        changed = True
+    if changed:
+        save_manifest(manifest)
+    return failed
+
+
+def _chunk_package_items(items, max_command_chars=16000):
+    """Split package installs into chunks that fit a single command line.
+
+    Windows caps a command line at 32767 characters, so a 150-skill editable
+    install has to be issued in batches rather than one giant pip call.
+
+    @param items list of ``(name, dest_dir)`` pairs
+    @param max_command_chars soft budget for one pip command line
+    @return list of item lists
+    """
+    chunks = []
+    current = []
+    length = 0
+    for item in items:
+        entry = len(str(item[1])) + 10  # ' -e "<dir>[dev]"'
+        if current and length + entry > max_command_chars:
+            chunks.append(current)
+            current = []
+            length = 0
+        current.append(item)
+        length += entry
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _pip_install_skill_packages(items):
+    """Install several skill packages in one pip invocation, with per-skill fallback.
+
+    @param items list of ``(name, dest_dir)`` pairs to install editable
+    @return list of skill names that could not be installed
+    """
+    if not items:
+        return []
+    chunks = _chunk_package_items(items)
+    print("\n  Installing {count} skill Python package(s) in {passes} pip pass(es)...".format(
+        count=len(items), passes=len(chunks)))
+    failed = []
+    for chunk in chunks:
+        if _pip_install_package_chunk(chunk):
+            continue
+        print("  [!!] Bulk install failed; retrying skill by skill...")
+        for name, dest_dir in chunk:
+            if not _pip_install_skill_package(dest_dir, name):
+                failed.append(name)
+    if not failed:
+        print("  [OK] Installed {count} skill package(s).".format(count=len(items)))
+    return failed
+
+
+def _pip_install_package_chunk(chunk):
+    """Install one chunk of skill packages, preferring the ``[dev]`` extra.
+
+    @param chunk list of ``(name, dest_dir)`` pairs
+    @return True when the chunk installed in one pip call
+    """
+    for extras in ("[dev]", ""):
+        cmd = [sys.executable, "-m", "pip", "install", "--quiet"]
+        for _name, dest_dir in chunk:
+            cmd.extend(["-e", f"{dest_dir}{extras}"])
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            return True
+        except subprocess.CalledProcessError:
+            continue
+    return False
+
+
+def _pyproject_project_name(pyproject_file):
+    """Return the ``[project] name`` declared in a pyproject.toml, or an empty string.
+
+    @param pyproject_file path to the skill's pyproject.toml
+    @return the normalized distribution name, or "" when it cannot be read
+    """
+    try:
+        text = Path(pyproject_file).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    in_project = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if in_project and stripped.replace(" ", "").startswith("name="):
+            value = stripped.split("=", 1)[1].strip().strip("\"'")
+            return value.replace("_", "-").lower()
+    return ""
+
+
+_INSTALLED_DIST_NAMES = []  # single-slot cache; [] = not probed
+
+
+def _installed_distribution_names():
+    """Return the set of distribution names installed in this interpreter.
+
+    Probed once per process from ``importlib.metadata`` (no subprocess), so a
+    skill whose package is already installed can be detected without pip.
+
+    @return set of normalized distribution names
+    """
+    if _INSTALLED_DIST_NAMES:
+        return _INSTALLED_DIST_NAMES[0]
+    names = set()
+    try:
+        import importlib.metadata as importlib_metadata
+        for dist in importlib_metadata.distributions():
+            raw = dist.metadata["Name"] if dist.metadata else None
+            if raw:
+                names.add(str(raw).replace("_", "-").lower())
+    except Exception:
+        names = set()
+    _INSTALLED_DIST_NAMES.append(names)
+    return names
+
+
+def _count_deferred_packages():
+    """Return how many installed skills still have a deferred Python package."""
+    try:
+        manifest = load_manifest()
+    except Exception:
+        return 0
+    return sum(1 for info in manifest.values() if info.get("package_pending"))
+
+
+def _handle_skill_package(name, dest_dir, args, previous_entry):
+    """Decide whether a skill's Python package needs a pip install, and do it.
+
+    Skills are installed editable, so a source change is picked up without
+    reinstalling; only a dependency/metadata change (pyproject.toml) needs pip.
+    Skipping the unchanged ones is what keeps ``--force`` from paying for ~150
+    redundant editable installs.
+
+    @param name the skill name
+    @param dest_dir the installed skill directory
+    @param args parsed CLI arguments (reads ``no_pip``)
+    @param previous_entry the previous manifest entry for this skill
+    @return ``(package_sha256, package_installed, package_pending)``
+    """
+    pyproject = dest_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return "", False, False
+
+    package_sha = _sha256_file(pyproject)
+    already_installed = bool(previous_entry.get("package_installed"))
+    if not already_installed and not previous_entry.get("package_sha256"):
+        # Legacy manifest entry: fall back to probing the environment.
+        dist_name = _pyproject_project_name(pyproject)
+        already_installed = bool(dist_name) and dist_name in _installed_distribution_names()
+    if already_installed and previous_entry.get("package_sha256", package_sha) == package_sha:
+        print(f"  [OK] '{name}' Python package unchanged; skipping pip install.")
+        return package_sha, True, False
+    if _pip_disabled(args):
+        print(f"  [--] Deferred pip install for '{name}' (run: neqsim skill sync-packages).")
+        return package_sha, False, True
+    if _BATCH_PACKAGE_INSTALLS[0]:
+        _PENDING_PACKAGE_INSTALLS.append((name, dest_dir))
+        return package_sha, False, True
+    return package_sha, _pip_install_skill_package(dest_dir, name), False
+
+
 def cmd_install(skills, args):
     """Install a skill (or every skill with --all) from the catalog."""
     if getattr(args, "all", False) or args.name == "*":
@@ -1615,17 +1829,28 @@ def _install_all_skills(skills, args):
     manifest = load_manifest()
     installed = []
     failed = []
-    for index, skill in enumerate(unique, start=1):
-        name = skill.get("name", "")
-        print("  [{index}/{total}] {name}".format(index=index, total=total, name=name))
-        if _install_skill_record(skill, args, manifest):
-            installed.append(name)
-        else:
-            failed.append(name)
+    batching = not _pip_disabled(args)
+    if batching:
+        begin_package_install_batch()
+    try:
+        for index, skill in enumerate(unique, start=1):
+            name = skill.get("name", "")
+            print("  [{index}/{total}] {name}".format(index=index, total=total, name=name))
+            if _install_skill_record(skill, args, manifest):
+                installed.append(name)
+            else:
+                failed.append(name)
+    finally:
+        if batching:
+            flush_package_install_batch()
 
     print("\n  ==== Install summary ====")
     print("  Installed/OK: {count}".format(count=len(installed)))
     print("  Failed: {count}".format(count=len(failed)))
+    deferred = _count_deferred_packages()
+    if deferred:
+        print("  Deferred Python packages: {count}".format(count=deferred))
+        print("  Run: neqsim skill sync-packages   (or 'neqsim skill ensure <name>' on first use)")
     if failed:
         print("  Failed skills: {names}".format(names=", ".join(failed)))
         sys.exit(1)
@@ -1640,6 +1865,7 @@ def _install_skill_record(skill, args, manifest):
     @return True on success, False on failure (never calls sys.exit)
     """
     name = skill.get("name")
+    previous_entry = dict(manifest.get(name, {}))
     if name in manifest and not args.force:
         print(f"\n  Skill '{name}' already installed at {manifest[name]['path']}")
         print(f"  Use --force to reinstall.")
@@ -1680,8 +1906,8 @@ def _install_skill_record(skill, args, manifest):
 
         # Auto-install the skill's own Python package (if any) so it is usable
         # immediately, without a separate manual pip install step.
-        if (dest_dir / "pyproject.toml").exists():
-            _pip_install_skill_package(dest_dir, name)
+        package_sha, package_installed, package_pending = _handle_skill_package(
+            name, dest_dir, args, previous_entry)
 
         neqsim_version_ok = _check_min_neqsim_version(skill, name)
 
@@ -1702,6 +1928,9 @@ def _install_skill_record(skill, args, manifest):
             "neqsim_version_ok": neqsim_version_ok,
             "installed_at": datetime.now(timezone.utc).isoformat(),
             "content_sha256": _sha256_file(dest_file),
+            "package_sha256": package_sha,
+            "package_installed": package_installed,
+            "package_pending": package_pending,
         }
         save_manifest(manifest)
 
@@ -1732,6 +1961,98 @@ def cmd_installed(skills, args):
     print(f"  {'-'*35} {'-'*20} {'-'*40}")
     for name, info in sorted(manifest.items()):
         print(f"  {name:<35} {info.get('author', '-'):<20} {info.get('path', '-')}")
+    print()
+
+
+def ensure_skill_package(name, manifest=None):
+    """Install one skill's Python package on first use, if it is not importable.
+
+    Lets ``install --no-pip`` stay fast while a skill that imports its own
+    package still works: the agent (or ``neqsim skill ensure``) pays for that
+    one pip run at the moment the skill is actually used.
+
+    @param name the installed skill name
+    @param manifest optional preloaded installed-skills manifest
+    @return True when the package is present (or the skill has none)
+    """
+    manifest = load_manifest() if manifest is None else manifest
+    info = manifest.get(name)
+    if not info:
+        print(f"  [!!] Skill '{name}' is not installed.")
+        return False
+    skill_path = info.get("path", "")
+    if not skill_path:
+        return False
+    dest_dir = Path(skill_path).parent
+    pyproject = dest_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return True
+    dist_name = _pyproject_project_name(pyproject)
+    if dist_name and dist_name in _installed_distribution_names():
+        return True
+    ok = _pip_install_skill_package(dest_dir, name)
+    info["package_installed"] = ok
+    info["package_pending"] = not ok
+    if ok:
+        info["package_sha256"] = _sha256_file(pyproject)
+        _INSTALLED_DIST_NAMES[:] = []  # re-probe after a successful install
+    save_manifest(manifest)
+    return ok
+
+
+def cmd_ensure(skills, args):
+    """Install the named skills' Python packages if they are not importable yet."""
+    manifest = load_manifest()
+    failed = [name for name in args.names if not ensure_skill_package(name, manifest)]
+    if failed:
+        print("\n  [!!] Not usable: {names}\n".format(names=", ".join(failed)))
+        sys.exit(1)
+    print("\n  [OK] Ready: {names}\n".format(names=", ".join(args.names)))
+
+
+def cmd_sync_packages(skills, args):
+    """Install skill Python packages that were deferred by --no-pip."""
+    manifest = load_manifest()
+    force = getattr(args, "force", False)
+    pending = []
+    for name, info in sorted(manifest.items()):
+        skill_path = info.get("path", "")
+        if not skill_path:
+            continue
+        dest_dir = Path(skill_path).parent
+        pyproject = dest_dir / "pyproject.toml"
+        if not pyproject.exists():
+            continue
+        if not force:
+            if info.get("package_installed") and not info.get("package_pending"):
+                continue
+            if not info.get("package_pending"):
+                dist_name = _pyproject_project_name(pyproject)
+                if dist_name and dist_name in _installed_distribution_names():
+                    continue
+        pending.append((name, dest_dir))
+
+    if not pending:
+        print("\n  All installed skill packages are up to date.\n")
+        return
+
+    failed = _pip_install_skill_packages(pending)
+    for name, dest_dir in pending:
+        if name not in manifest:
+            continue
+        ok = name not in failed
+        manifest[name]["package_installed"] = ok
+        manifest[name]["package_pending"] = not ok
+        if ok:
+            manifest[name]["package_sha256"] = _sha256_file(dest_dir / "pyproject.toml")
+    save_manifest(manifest)
+
+    print("\n  ==== Package sync summary ====")
+    print("  Installed/OK: {count}".format(count=len(pending) - len(failed)))
+    print("  Failed: {count}".format(count=len(failed)))
+    if failed:
+        print("  Failed skills: {names}\n".format(names=", ".join(failed)))
+        sys.exit(1)
     print()
 
 
@@ -1788,11 +2109,44 @@ def get_enterprise_auth_status():
     }
 
 
+def _report_package_health():
+    """Print which installed skills have a Python package that is not usable yet.
+
+    @return number of packaged skills that still need a pip install
+    """
+    manifest = load_manifest()
+    installed_dists = _installed_distribution_names()
+    unusable = []
+    packaged = 0
+    for name, info in sorted(manifest.items()):
+        skill_path = info.get("path", "")
+        if not skill_path:
+            continue
+        pyproject = Path(skill_path).parent / "pyproject.toml"
+        if not pyproject.exists():
+            continue
+        packaged += 1
+        dist_name = _pyproject_project_name(pyproject)
+        if dist_name and dist_name in installed_dists:
+            continue
+        unusable.append(name)
+
+    print("\n  Skill Python packages:")
+    print(f"  [OK] Importable: {packaged - len(unusable)} of {packaged} packaged skill(s)")
+    if unusable:
+        print(f"  [!!] Not importable ({len(unusable)}): {', '.join(unusable[:8])}"
+              + (" ..." if len(unusable) > 8 else ""))
+        print("       Fix all: neqsim skill sync-packages")
+        print("       Fix one: neqsim skill ensure <name>")
+    return len(unusable)
+
+
 def cmd_doctor(skills, args):
     """Show enterprise auth readiness or export target health without handling secrets."""
     target = getattr(args, "target", None)
     if target:
         _check_export_target(target, args)
+        _report_package_health()
         return
 
     status = get_enterprise_auth_status()
@@ -2370,6 +2724,9 @@ def main():
         "  neqsim skill install neqsim-example-skill --target generic",
         "  neqsim skill install --all --target vscode",
         "  neqsim skill install --all --source community --target vscode",
+        "  neqsim skill install --all --target vscode --no-pip   # skip Python package installs",
+        "  neqsim skill sync-packages                            # install the deferred packages",
+        "  neqsim skill ensure neqsim-example-skill              # install one package on first use",
         "  neqsim skill export neqsim-example-skill --target vscode",
         "  neqsim skill export neqsim-example-skill --target generic",
         "  neqsim skill installed",
@@ -2433,8 +2790,24 @@ def main():
     p_install.add_argument(
         "--export-dir", default=None,
         help="Generic export root for --target generic (default: ~/.neqsim/export/generic)")
+    p_install.add_argument(
+        "--no-pip", dest="no_pip", action="store_true",
+        help="Defer skill Python package installs; run 'neqsim skill sync-packages' "
+             "or 'neqsim skill ensure <name>' before using a skill that imports its package")
 
     sub.add_parser("installed", help="Show installed skills")
+
+    p_sync = sub.add_parser(
+        "sync-packages",
+        help="Pip install skill Python packages that are missing or were deferred by --no-pip")
+    p_sync.add_argument(
+        "--force", action="store_true",
+        help="Reinstall every packaged skill, not just the pending ones")
+
+    p_ensure = sub.add_parser(
+        "ensure",
+        help="Install a skill's Python package on first use (no-op when already importable)")
+    p_ensure.add_argument("names", nargs="+", help="Installed skill name(s)")
 
     p_export = sub.add_parser("export", help="Export an installed skill to an AI-tool target")
     p_export.add_argument("name", help="Installed skill name")
@@ -2505,6 +2878,8 @@ def main():
         "install": cmd_install,
         "export": cmd_export,
         "installed": cmd_installed,
+        "sync-packages": cmd_sync_packages,
+        "ensure": cmd_ensure,
         "remove": cmd_remove,
         "publish": cmd_publish,
         "doctor": cmd_doctor,

--- a/devtools/test_install_skill.py
+++ b/devtools/test_install_skill.py
@@ -912,5 +912,149 @@ class InstallAllSkillsTest(unittest.TestCase):
         self.assertIn("--all", stream.getvalue())
 
 
+class SkillPackageInstallTest(unittest.TestCase):
+    """Tests for pip-install skipping, deferral, and on-first-use installs."""
+
+    def setUp(self):
+        install_skill._BATCH_PACKAGE_INSTALLS[0] = False
+        del install_skill._PENDING_PACKAGE_INSTALLS[:]
+        del install_skill._INSTALLED_DIST_NAMES[:]
+
+    tearDown = setUp
+
+    @staticmethod
+    def _args(**overrides):
+        import argparse
+        base = dict(no_pip=False)
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    def _package_dir(self, tmp_path, deps="[]"):
+        from pathlib import Path
+        dest_dir = Path(tmp_path) / "demo-package-skill"
+        dest_dir.mkdir(parents=True)
+        (dest_dir / "pyproject.toml").write_text(
+            "[project]\nname = \"demo-package-skill\"\nversion = \"0.1.0\"\n"
+            f"dependencies = {deps}\n",
+            encoding="utf-8",
+        )
+        return dest_dir
+
+    def test_unchanged_package_skips_pip(self):
+        """A reinstall with identical pyproject metadata does not re-run pip."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = self._package_dir(tmp)
+            sha = install_skill._sha256_file(dest_dir / "pyproject.toml")
+            previous = {"package_installed": True, "package_sha256": sha}
+            with mock.patch.object(install_skill, "_pip_install_skill_package") as pip:
+                result = install_skill._handle_skill_package(
+                    "demo-package-skill", dest_dir, self._args(), previous)
+        self.assertEqual((sha, True, False), result)
+        self.assertFalse(pip.called)
+
+    def test_changed_dependencies_trigger_pip(self):
+        """A changed pyproject (new dependency) reinstalls the package."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = self._package_dir(tmp, deps="[\"requests\"]")
+            previous = {"package_installed": True, "package_sha256": "stale"}
+            with mock.patch.object(install_skill, "_pip_install_skill_package",
+                                   return_value=True) as pip:
+                _sha, installed, pending = install_skill._handle_skill_package(
+                    "demo-package-skill", dest_dir, self._args(), previous)
+        self.assertTrue(installed)
+        self.assertFalse(pending)
+        self.assertTrue(pip.called)
+
+    def test_no_pip_defers_the_package(self):
+        """--no-pip records the package as pending instead of installing it."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = self._package_dir(tmp)
+            with mock.patch.object(install_skill, "_pip_install_skill_package") as pip:
+                _sha, installed, pending = install_skill._handle_skill_package(
+                    "demo-package-skill", dest_dir, self._args(no_pip=True), {})
+        self.assertFalse(installed)
+        self.assertTrue(pending)
+        self.assertFalse(pip.called)
+
+    def test_batch_mode_installs_all_packages_in_one_pip_call(self):
+        """Bulk installs queue packages and install them in a single pip pass."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = self._package_dir(tmp)
+            install_skill.begin_package_install_batch()
+            _sha, installed, pending = install_skill._handle_skill_package(
+                "demo-package-skill", dest_dir, self._args(), {})
+            self.assertFalse(installed)
+            self.assertTrue(pending)
+            with mock.patch.object(install_skill.subprocess, "check_output") as pip, \
+                    mock.patch.object(install_skill, "load_manifest", return_value={}), \
+                    mock.patch.object(install_skill, "save_manifest"):
+                failed = install_skill.flush_package_install_batch()
+        self.assertEqual([], failed)
+        self.assertEqual(1, pip.call_count)
+        self.assertIn("-e", pip.call_args[0][0])
+
+    def test_ensure_skips_when_package_already_importable(self):
+        """`skill ensure` is a no-op when the distribution is already installed."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = self._package_dir(tmp)
+            manifest = {"demo-package-skill": {"path": str(dest_dir / "SKILL.md")}}
+            with mock.patch.object(install_skill, "_installed_distribution_names",
+                                   return_value={"demo-package-skill"}), \
+                    mock.patch.object(install_skill, "_pip_install_skill_package") as pip:
+                ok = install_skill.ensure_skill_package("demo-package-skill", manifest)
+        self.assertTrue(ok)
+        self.assertFalse(pip.called)
+
+    def test_ensure_installs_a_deferred_package_on_first_use(self):
+        """`skill ensure` installs a package that --no-pip deferred."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = self._package_dir(tmp)
+            manifest = {"demo-package-skill": {
+                "path": str(dest_dir / "SKILL.md"), "package_pending": True}}
+            with mock.patch.object(install_skill, "_installed_distribution_names",
+                                   return_value=set()), \
+                    mock.patch.object(install_skill, "_pip_install_skill_package",
+                                      return_value=True) as pip, \
+                    mock.patch.object(install_skill, "save_manifest"):
+                ok = install_skill.ensure_skill_package("demo-package-skill", manifest)
+        self.assertTrue(ok)
+        self.assertTrue(pip.called)
+        self.assertTrue(manifest["demo-package-skill"]["package_installed"])
+        self.assertFalse(manifest["demo-package-skill"]["package_pending"])
+
+    def test_batch_is_chunked_to_fit_a_command_line(self):
+        """Many packages are split across pip calls so Windows' 32k limit holds."""
+        items = [(f"skill-{i}", "C:/Users/demo/.neqsim/skills/skill-%03d" % i)
+                 for i in range(400)]
+        chunks = install_skill._chunk_package_items(items)
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual(len(items), sum(len(chunk) for chunk in chunks))
+        for chunk in chunks:
+            command_chars = sum(len(str(dest)) + 10 for _name, dest in chunk)
+            self.assertLessEqual(command_chars, 16000 + len(str(items[0][1])) + 10)
+
+    def test_bulk_failure_falls_back_to_one_skill_at_a_time(self):
+        """A failing bulk pip call retries each skill individually."""
+        items = [("alpha", "/skills/alpha"), ("beta", "/skills/beta")]
+        with mock.patch.object(install_skill, "_pip_install_package_chunk", return_value=False), \
+                mock.patch.object(install_skill, "_pip_install_skill_package",
+                                  side_effect=[True, False]) as pip:
+            failed = install_skill._pip_install_skill_packages(items)
+        self.assertEqual(["beta"], failed)
+        self.assertEqual(2, pip.call_count)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/integration/agents_and_skills_setup.md
+++ b/docs/integration/agents_and_skills_setup.md
@@ -145,6 +145,12 @@ neqsim skill private-init --repo <company>/<company>-neqsim-enterprise-skills --
 neqsim agent install --all --vscode --force   # community + enterprise
 ```
 
+A later refresh only re-installs what changed: a skill's Python package is
+pip-installed again only when its `pyproject.toml` changed. Use
+`--no-pip` to skip package installs completely and run
+`neqsim skill sync-packages` (all at once) or `neqsim skill ensure <name>`
+(on first use) afterwards.
+
 Full company setup, catalog format, discovery, and governance:
 **[Enterprise Agent and Skill Repositories](enterprise_agent_skill_repos.md)**.
 

--- a/docs/integration/enterprise_agent_skill_repos.md
+++ b/docs/integration/enterprise_agent_skill_repos.md
@@ -95,6 +95,14 @@ see [devtools/README.md](../../devtools/README.md#recommended-no-admin-runbook-f
    and `~/.copilot/skills` folders — the locations VS Code and the GitHub Copilot CLI
    scan in every workspace. Reload/restart VS Code afterwards to pick them up.
 
+   > **Refreshing later is incremental.** Re-running `--all --force` re-downloads
+   > agent/skill content but only pip-installs a skill's Python package when its
+   > `pyproject.toml` changed (skills are installed editable, so source edits need
+   > no reinstall), and each shared required skill is refreshed once per run rather
+   > than once per agent. Add `--no-pip` to skip package installs entirely; then run
+   > `neqsim skill sync-packages` once, or `neqsim skill ensure <name>` the first
+   > time a skill that imports its own Python package is used.
+
 > **Why this order?** Community content needs no authentication, so it is installed
 > first and always works. SSO is only required to *read the private repos*, and
 > `private-init --login` performs the sign-in as part of registering them — so you

--- a/docs/integration/skills_guide.md
+++ b/docs/integration/skills_guide.md
@@ -11,7 +11,7 @@ description: "Comprehensive guide to skills and agents in NeqSim's agentic engin
 > |------------|---------|
 > | **Use an existing core skill** | Nothing — workspace agents load them automatically from the `.github/skills/` discovery layer |
 > | **Create a new core skill** | `neqsim new-skill "name"` → edit SKILL.md → register in README + copilot-instructions → PR |
-> | **Install a community skill** | `neqsim skill install neqsim-topic` → canonical install in `~/.neqsim/skills` → export with `--target vscode` or `--target generic`. If the skill ships a Python package (`pyproject.toml`), the installer downloads it whole and `pip install -e`'s it automatically — no separate manual install step. |
+> | **Install a community skill** | `neqsim skill install neqsim-topic` → canonical install in `~/.neqsim/skills` → export with `--target vscode` or `--target generic`. If the skill ships a Python package (`pyproject.toml`), the installer downloads it whole and `pip install -e`'s it automatically — no separate manual install step. Reinstalls only re-run pip when the package's `pyproject.toml` changed. |
 > | **Install a community agent** | `neqsim agent install agent-name` → canonical install in `~/.neqsim/agents` → export with `--target vscode` or `--target generic` |
 > | **Check PaperLab commands** | `neqsim paperlab` prints help only; this confirms the command exists but does not install anything |
 > | **Use PaperLab in VS Code** | `neqsim paperlab install --vscode` for the `@paperlab` gateway; add `--include-internal` only for direct specialist-agent compatibility |
@@ -466,11 +466,29 @@ neqsim skill installed
 # Get details about a specific skill
 neqsim skill info neqsim-my-topic
 
+# Skip Python package installs during a bulk install, then install them later
+neqsim skill install --all --target vscode --no-pip
+neqsim skill sync-packages
+
+# Install one skill's Python package on first use (no-op when already importable)
+neqsim skill ensure neqsim-my-topic
+
+# Report export health and which packaged skills are importable
+neqsim skill doctor --target vscode
+
 # Remove a skill
 neqsim skill remove neqsim-my-topic
 ```
 
 Installed community skills are stored at `~/.neqsim/skills/<name>/SKILL.md`.
+
+A skill that ships a Python package is installed **editable**, so re-running
+`install --force` only re-runs pip when that skill's `pyproject.toml`
+(dependencies/metadata) changed — refreshing a large catalog does not reinstall
+every package. `--no-pip` defers the package installs entirely; run
+`neqsim skill sync-packages` (all pending, one pip pass) or `neqsim skill ensure
+<name>` (one skill, on first use) before using a skill that imports its own
+package.
 
 ### Step 5: Make Installed Skills Visible to Agents
 


### PR DESCRIPTION
## Problem

`neqsim agent install --all --vscode --force` was slow. The dominant cost was
`pip install -e` on skill Python packages: every required skill was reinstalled
on every run — **once per agent that required it** — so a refresh could issue
150+ pip subprocesses even when nothing had changed.

## Change

**Only reinstall what changed.** Skills are installed *editable*, so a source
change needs no reinstall; pip now runs only when a skill's `pyproject.toml`
(dependencies/metadata) changed. Legacy manifest entries fall back to probing
`importlib.metadata`, so the first refresh after this change already skips
packages that are present.

**Batched installs.** Bulk installs queue their packages and install them with
`pip install -e a -e b …` instead of one subprocess per skill. Batches are
chunked to fit a command line (Windows' 32767-char limit) and fall back
skill-by-skill if a chunk fails.

**Dedupe.** A skill required by several agents is refreshed once per run instead
of once per requiring agent.

**Opt-out + lazy install.**
- `--no-pip` (or `NEQSIM_SKILL_NO_PIP`) defers package installs.
- `neqsim skill sync-packages` installs everything pending in one pass.
- `neqsim skill ensure <name>` / `ensure_skill_package()` installs one package
  on first use.
- `neqsim skill doctor` now reports how many packaged skills are importable and
  names the ones that still need installing.

## Compatibility

New manifest keys (`package_sha256`, `package_installed`, `package_pending`) are
additive; existing manifests keep working. All new CLI args are read with
`getattr(..., default)`, so partial `Namespace` callers are unaffected. Default
behaviour is unchanged in outcome — packages still end up installed.

## Verification

- `pytest devtools/test_install_skill.py devtools/test_install_agent.py` — 90
  passed (6 new tests: skip-on-unchanged, dependency-change reinstall, `--no-pip`
  deferral, batching, chunking, `ensure`).
- `pytest devtools/test_agent_search.py devtools/test_skill_search.py devtools/test_verify_agent_skill_refs.py` — 17 passed.
- CLI smoke: `skill installed`, `agent installed`, `skill ensure`,
  `skill sync-packages`, `skill doctor --target vscode`.
- On a machine with 155 packaged skills installed, the next `--force` run issues
  **0** pip invocations instead of 155+.

`install_smoke_test.yml` exercises the real path (clean Ubuntu + Windows
runners, `--all --source community --vscode --force` twice, then an
importability probe) — that remains the authoritative check.

No Java changed, so the Spotless/Java 8 gates do not apply.
