### PR TITLE
[AI-Assisted] docs(pitzer): fix hydrate guide title contract

### DIFF
--- a/docs/thermo/pitzer_hydrate_equilibrium.md
+++ b/docs/thermo/pitzer_hydrate_equilibrium.md
@@ -3,7 +3,6 @@ title: Pitzer hydrate equilibrium for brines
 description: CO2 and general gas-hydrate onset calculations coupled to Pitzer aqueous activities, with explicit parameter coverage and model limits.
 ---
 
-
 `SystemPitzer` supports incipient hydrate temperature, pressure and equilibrium curves through
 `ThermodynamicOperations`. This couples the existing Pitzer aqueous model and SRK fluid phases to
 van der Waals–Platteeuw hydrate equilibrium. It calculates the onset boundary; it does not calculate

--- a/docs/thermo/pitzer_hydrate_equilibrium.md
+++ b/docs/thermo/pitzer_hydrate_equilibrium.md
@@ -3,7 +3,6 @@ title: Pitzer hydrate equilibrium for brines
 description: CO2 and general gas-hydrate onset calculations coupled to Pitzer aqueous activities, with explicit parameter coverage and model limits.
 ---
 
-# Pitzer hydrate equilibrium for brines
 
 `SystemPitzer` supports incipient hydrate temperature, pressure and equilibrium curves through
 `ThermodynamicOperations`. This couples the existing Pitzer aqueous model and SRK fluid phases to


### PR DESCRIPTION
Repairs the documentation contract failure merged through #3595 and advances #3144 without changing scientific or runtime behavior.

## Capability contract

- **Engineering question:** Does the new Pitzer hydrate guide render under the repository's front-matter contract?
- **Frozen base:** `1d4fcc111b7e80dee49cd0941d8317029b943296`
- **Exact publication head:** `bc1804f171c7bc37fbc6e96ad47b7964d998f921`
- **Observed exact-head failure:** `ThermodynamicDocumentationRenderingContractTest.test_front_matter_title_is_not_repeated_as_h1`
- **Stop boundary:** one documentation file; no Java, parameters, datasets, hydrate equations, defaults, solver behavior, model semantics, or thermodynamic results.

## Change

Removes the redundant Markdown H1 from `docs/thermo/pitzer_hydrate_equilibrium.md`. The front-matter title remains the rendered page title, and all model guidance, equations, provenance, accuracy limits, and warnings remain unchanged.

## Validation

The source change is the direct repair required by the failing contract: the repeated H1 identified in the failure log is absent. The branch differs from the frozen base in one file with two deleted lines.

Local repository tooling was not used; hosted exact-head CI is authoritative.

## Scientific boundary

Pitzer hydrate onset is now implemented through #3595 and the mixed-brine inventory defect was repaired through #3604. The guide still records that mixed-chloride deviations can exceed 1 K and caller-supplied zeta/theta values are unqualified. High-pressure aqueous-density and calcium-sulfate qualification remain fail-closed.

## Coordination

This is the sole active #3144 PR. Positively identified autonomous implementation occupancy will be **6/10** including this draft. All pre-existing exact heads remain untouched.

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon this PR for capacity.