### PR TITLE
feat(refinery): expose Big Hill vacuum boiling ranges

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -176,3 +176,32 @@ reported streams are deliberately labeled `Overhead` and `Bottoms`, not validate
 residue. The calculation does not establish pressure correction, ASTM D1160 behavior, equipment
 design, a general SRK accuracy envelope, or plant agreement.
 
+## Discrete product boiling-range diagnostics
+
+Each calculated product also exposes the ascending normal-boiling-point support of its positive
+pseudo-components and the corresponding normalized cumulative product mole fractions:
+
+```java
+ProductResult overhead = result.getProduct("Overhead");
+double overheadT10Kelvin = overhead.getNormalBoilingPointQuantileKelvin(0.10);
+double overheadT50Kelvin = overhead.getNormalBoilingPointQuantileKelvin(0.50);
+double overheadT90Kelvin = overhead.getNormalBoilingPointQuantileKelvin(0.90);
+double[] supportKelvin = overhead.getBoilingPointTemperaturesKelvin();
+double[] cumulativeMoleFractions = overhead.getCumulativeMoleFractions();
+```
+
+For a requested cumulative mole fraction (q) in ((0,1]), the quantile is the first discrete
+pseudo-component normal boiling point whose normalized cumulative product mole fraction reaches
+(q). The support and cumulative arrays are defensive copies, are ordered by increasing normal
+boiling point, and close at a cumulative fraction of one. Invalid or non-finite quantile requests
+fail closed.
+
+The focused regression requires T10 <= T50 <= T90 for both products, an overhead T50 below the
+bottoms T50, and 1% repeatability of all three diagnostics across independently constructed and
+solved cases. These temperatures make the modeled separation direction and broad boiling range
+inspectable on the exact three-pseudo-component DOE basis.
+
+The curve is deliberately discrete and molar-basis. It is not a continuous simulated-distillation
+curve, a TBP curve, an ASTM D86 or ASTM D1160 result, or a pressure-corrected laboratory
+measurement. With only three heavy pseudo-components it must not be used to infer unreported cut
+tails, detailed product quality, or validated VGO/residue yields.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
@@ -99,10 +99,8 @@ public final class DoeBigHillVacuumFractionationResult {
       }
       previousMeanBoilingPoint = meanBoilingPoint;
       productMassFlow += massFlow;
-      productResults[i] =
-          new ProductResult(PRODUCT_LABELS[i], massFlow, massFlow / feedMassFlow, meanBoilingPoint,
-              boilingPointDistribution.boilingPointTemperaturesKelvin,
-              boilingPointDistribution.cumulativeMoleFractions);
+      productResults[i] = new ProductResult(PRODUCT_LABELS[i], massFlow, massFlow / feedMassFlow, meanBoilingPoint,
+          boilingPointDistribution.boilingPointTemperaturesKelvin, boilingPointDistribution.cumulativeMoleFractions);
     }
 
     double closureError = Math.abs(feedMassFlow - productMassFlow) / feedMassFlow;
@@ -362,8 +360,7 @@ public final class DoeBigHillVacuumFractionationResult {
      * Return a discrete pseudo-component normal-boiling-point quantile on cumulative mole basis.
      *
      * <p>
-     * This stepwise diagnostic is not an ASTM D86, ASTM D1160, TBP, or continuous
-     * simulated-distillation temperature.
+     * This stepwise diagnostic is not an ASTM D86, ASTM D1160, TBP, or continuous simulated-distillation temperature.
      * </p>
      *
      * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
@@ -371,8 +368,7 @@ public final class DoeBigHillVacuumFractionationResult {
      * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
      */
     public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
-      if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0)
-          || cumulativeMoleFraction > 1.0) {
+      if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0) || cumulativeMoleFraction > 1.0) {
         throw new IllegalArgumentException("Cumulative mole fraction must be finite and in (0, 1]");
       }
       for (int i = 0; i < cumulativeMoleFractions.length; i++) {

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.distillation;
 
+import java.util.Arrays;
 import java.util.Objects;
 import neqsim.process.equipment.stream.StreamInterface;
 
@@ -92,12 +93,16 @@ public final class DoeBigHillVacuumFractionationResult {
         throw new IllegalStateException("Both vacuum screening products must have material positive flow");
       }
       double meanBoilingPoint = meanNormalBoilingPoint(streams[i]);
+      BoilingPointDistribution boilingPointDistribution = boilingPointDistribution(streams[i]);
       if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
         throw new IllegalStateException("Products must become heavier from overhead to bottoms");
       }
       previousMeanBoilingPoint = meanBoilingPoint;
       productMassFlow += massFlow;
-      productResults[i] = new ProductResult(PRODUCT_LABELS[i], massFlow, massFlow / feedMassFlow, meanBoilingPoint);
+      productResults[i] =
+          new ProductResult(PRODUCT_LABELS[i], massFlow, massFlow / feedMassFlow, meanBoilingPoint,
+              boilingPointDistribution.boilingPointTemperaturesKelvin,
+              boilingPointDistribution.cumulativeMoleFractions);
     }
 
     double closureError = Math.abs(feedMassFlow - productMassFlow) / feedMassFlow;
@@ -213,6 +218,49 @@ public final class DoeBigHillVacuumFractionationResult {
     return mean / compositionSum;
   }
 
+  private static BoilingPointDistribution boilingPointDistribution(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    if (composition.length != boilingPoints.length || composition.length == 0) {
+      throw new IllegalStateException("Product composition and boiling-point arrays must align");
+    }
+
+    double[][] points = new double[composition.length][2];
+    double compositionSum = 0.0;
+    int positiveComponentCount = 0;
+    for (int i = 0; i < composition.length; i++) {
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
+          || !(boilingPoints[i] > 0.0)) {
+        throw new IllegalStateException("Product composition and boiling points must be physical");
+      }
+      points[i][0] = boilingPoints[i];
+      points[i][1] = composition[i];
+      compositionSum += composition[i];
+      if (composition[i] > 0.0) {
+        positiveComponentCount++;
+      }
+    }
+    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || positiveComponentCount == 0) {
+      throw new IllegalStateException("Product boiling-point distribution is undefined");
+    }
+
+    Arrays.sort(points, (left, right) -> Double.compare(left[0], right[0]));
+    double[] temperatures = new double[positiveComponentCount];
+    double[] cumulativeFractions = new double[positiveComponentCount];
+    double cumulativeFraction = 0.0;
+    int resultIndex = 0;
+    for (double[] point : points) {
+      if (point[1] > 0.0) {
+        cumulativeFraction += point[1] / compositionSum;
+        temperatures[resultIndex] = point[0];
+        cumulativeFractions[resultIndex] = cumulativeFraction;
+        resultIndex++;
+      }
+    }
+    cumulativeFractions[cumulativeFractions.length - 1] = 1.0;
+    return new BoilingPointDistribution(temperatures, cumulativeFractions);
+  }
+
   private static double maximumComponentMolarClosureRelativeError(StreamInterface feed, StreamInterface[] products) {
     double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     double feedMolarFlow = feed.getFlowRate("mol/hr");
@@ -245,19 +293,34 @@ public final class DoeBigHillVacuumFractionationResult {
     }
   }
 
+  private static final class BoilingPointDistribution {
+    private final double[] boilingPointTemperaturesKelvin;
+    private final double[] cumulativeMoleFractions;
+
+    private BoilingPointDistribution(double[] boilingPointTemperaturesKelvin, double[] cumulativeMoleFractions) {
+      this.boilingPointTemperaturesKelvin = boilingPointTemperaturesKelvin;
+      this.cumulativeMoleFractions = cumulativeMoleFractions;
+    }
+  }
+
   /** Immutable calculated vacuum-screening product row. */
   public static final class ProductResult {
     private final String productLabel;
     private final double massFlowKgPerHour;
     private final double massFractionOfFeed;
     private final double meanNormalBoilingPointKelvin;
+    private final double[] boilingPointTemperaturesKelvin;
+    private final double[] cumulativeMoleFractions;
 
     private ProductResult(String productLabel, double massFlowKgPerHour, double massFractionOfFeed,
-        double meanNormalBoilingPointKelvin) {
+        double meanNormalBoilingPointKelvin, double[] boilingPointTemperaturesKelvin,
+        double[] cumulativeMoleFractions) {
       this.productLabel = productLabel;
       this.massFlowKgPerHour = massFlowKgPerHour;
       this.massFractionOfFeed = massFractionOfFeed;
       this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
+      this.boilingPointTemperaturesKelvin = boilingPointTemperaturesKelvin.clone();
+      this.cumulativeMoleFractions = cumulativeMoleFractions.clone();
     }
 
     /** @return product label */
@@ -283,6 +346,52 @@ public final class DoeBigHillVacuumFractionationResult {
     /** @return mole-weighted mean normal boiling point in degrees Celsius */
     public double getMeanNormalBoilingPointCelsius() {
       return meanNormalBoilingPointKelvin - 273.15;
+    }
+
+    /** @return defensive copy of ascending pseudo-component normal boiling points in kelvin */
+    public double[] getBoilingPointTemperaturesKelvin() {
+      return boilingPointTemperaturesKelvin.clone();
+    }
+
+    /** @return defensive copy of normalized cumulative product mole fractions */
+    public double[] getCumulativeMoleFractions() {
+      return cumulativeMoleFractions.clone();
+    }
+
+    /**
+     * Return a discrete pseudo-component normal-boiling-point quantile on cumulative mole basis.
+     *
+     * <p>
+     * This stepwise diagnostic is not an ASTM D86, ASTM D1160, TBP, or continuous
+     * simulated-distillation temperature.
+     * </p>
+     *
+     * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
+     * @return first normal boiling point whose cumulative mole fraction reaches the request, in kelvin
+     * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
+     */
+    public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0)
+          || cumulativeMoleFraction > 1.0) {
+        throw new IllegalArgumentException("Cumulative mole fraction must be finite and in (0, 1]");
+      }
+      for (int i = 0; i < cumulativeMoleFractions.length; i++) {
+        if (cumulativeMoleFractions[i] >= cumulativeMoleFraction) {
+          return boilingPointTemperaturesKelvin[i];
+        }
+      }
+      return boilingPointTemperaturesKelvin[boilingPointTemperaturesKelvin.length - 1];
+    }
+
+    /**
+     * Return a discrete pseudo-component normal-boiling-point quantile on cumulative mole basis.
+     *
+     * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
+     * @return first normal boiling point whose cumulative mole fraction reaches the request, in degrees Celsius
+     * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
+     */
+    public double getNormalBoilingPointQuantileCelsius(double cumulativeMoleFraction) {
+      return getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction) - 273.15;
     }
   }
 }

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
@@ -82,8 +82,8 @@ public class DoeBigHillVacuumFractionationResultTest {
     assertTrue(products[0].getMeanNormalBoilingPointKelvin() < products[1].getMeanNormalBoilingPointKelvin());
     assertBoilingRange(products[0]);
     assertBoilingRange(products[1]);
-    assertTrue(products[0].getNormalBoilingPointQuantileKelvin(0.5)
-        < products[1].getNormalBoilingPointQuantileKelvin(0.5));
+    assertTrue(
+        products[0].getNormalBoilingPointQuantileKelvin(0.5) < products[1].getNormalBoilingPointQuantileKelvin(0.5));
     assertEquals(1.0, products[0].getMassFractionOfFeed() + products[1].getMassFractionOfFeed(), BALANCE_TOLERANCE);
     assertEquals(FEED_MASS_FLOW_KG_PER_HOUR, result.getFeedMassFlowKgPerHour(), 1.0e-9);
     assertEquals(result.getFeedMassFlowKgPerHour(), result.getProductMassFlowKgPerHour(),

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResultTest.java
@@ -43,6 +43,10 @@ public class DoeBigHillVacuumFractionationResultTest {
       assertRelativeRepeat(firstProducts[i].getMassFlowKgPerHour(), secondProducts[i].getMassFlowKgPerHour());
       assertRelativeRepeat(firstProducts[i].getMeanNormalBoilingPointKelvin(),
           secondProducts[i].getMeanNormalBoilingPointKelvin());
+      for (double quantile : new double[] { 0.1, 0.5, 0.9 }) {
+        assertRelativeRepeat(firstProducts[i].getNormalBoilingPointQuantileKelvin(quantile),
+            secondProducts[i].getNormalBoilingPointQuantileKelvin(quantile));
+      }
     }
   }
 
@@ -76,6 +80,10 @@ public class DoeBigHillVacuumFractionationResultTest {
     assertTrue(products[0].getMassFlowKgPerHour() > 0.0);
     assertTrue(products[1].getMassFlowKgPerHour() > 0.0);
     assertTrue(products[0].getMeanNormalBoilingPointKelvin() < products[1].getMeanNormalBoilingPointKelvin());
+    assertBoilingRange(products[0]);
+    assertBoilingRange(products[1]);
+    assertTrue(products[0].getNormalBoilingPointQuantileKelvin(0.5)
+        < products[1].getNormalBoilingPointQuantileKelvin(0.5));
     assertEquals(1.0, products[0].getMassFractionOfFeed() + products[1].getMassFractionOfFeed(), BALANCE_TOLERANCE);
     assertEquals(FEED_MASS_FLOW_KG_PER_HOUR, result.getFeedMassFlowKgPerHour(), 1.0e-9);
     assertEquals(result.getFeedMassFlowKgPerHour(), result.getProductMassFlowKgPerHour(),
@@ -86,6 +94,41 @@ public class DoeBigHillVacuumFractionationResultTest {
     assertEquals("DOE_BH_850_1050_PC", model.getFeedStream().getThermoSystem().getComponent(1).getComponentName());
     assertEquals("DOE_BH_1050_PLUS_PC", model.getFeedStream().getThermoSystem().getComponent(2).getComponentName());
     assertIndependentComponentBalance(model);
+  }
+
+  private static void assertBoilingRange(ProductResult product) {
+    double[] temperatures = product.getBoilingPointTemperaturesKelvin();
+    double[] cumulativeFractions = product.getCumulativeMoleFractions();
+    assertEquals(temperatures.length, cumulativeFractions.length);
+    assertTrue(temperatures.length > 0);
+    assertNotSame(temperatures, product.getBoilingPointTemperaturesKelvin());
+    assertNotSame(cumulativeFractions, product.getCumulativeMoleFractions());
+
+    for (int i = 0; i < temperatures.length; i++) {
+      assertTrue(Double.isFinite(temperatures[i]) && temperatures[i] > 0.0);
+      assertTrue(Double.isFinite(cumulativeFractions[i]) && cumulativeFractions[i] > 0.0);
+      if (i > 0) {
+        assertTrue(temperatures[i] >= temperatures[i - 1]);
+        assertTrue(cumulativeFractions[i] > cumulativeFractions[i - 1]);
+      }
+    }
+    assertEquals(1.0, cumulativeFractions[cumulativeFractions.length - 1], 1.0e-12);
+
+    double t10 = product.getNormalBoilingPointQuantileKelvin(0.1);
+    double t50 = product.getNormalBoilingPointQuantileKelvin(0.5);
+    double t90 = product.getNormalBoilingPointQuantileKelvin(0.9);
+    assertTrue(t10 <= t50);
+    assertTrue(t50 <= t90);
+    assertEquals(t50 - 273.15, product.getNormalBoilingPointQuantileCelsius(0.5), 1.0e-12);
+    assertThrows(IllegalArgumentException.class, () -> product.getNormalBoilingPointQuantileKelvin(0.0));
+    assertThrows(IllegalArgumentException.class, () -> product.getNormalBoilingPointQuantileKelvin(1.0001));
+    assertThrows(IllegalArgumentException.class, () -> product.getNormalBoilingPointQuantileKelvin(Double.NaN));
+
+    double originalTemperature = product.getBoilingPointTemperaturesKelvin()[0];
+    temperatures[0] = -1.0;
+    cumulativeFractions[0] = -1.0;
+    assertEquals(originalTemperature, product.getBoilingPointTemperaturesKelvin()[0], 0.0);
+    assertTrue(product.getCumulativeMoleFractions()[0] > 0.0);
   }
 
   private static void assertIndependentComponentBalance(DoeBigHillVacuumFractionationCase model) {


### PR DESCRIPTION
## Summary

Advances #3305 with the next Phase 3 acceptance gap after the merged conservative Big Hill vacuum-screening result.

`DoeBigHillVacuumFractionationResult.ProductResult` now exposes each calculated product's ascending discrete pseudo-component normal-boiling-point support, normalized cumulative mole fractions, and fail-closed cumulative-mole-fraction quantiles in kelvin or degrees Celsius.

## Exact-head contract

- Frozen base: `006727adc7cf0350f172a737024d21fdb581ceef`
- Exact publication head: `679ce6cd3f7e576545664748adeebe90a95a505d`
- Branch: `codex/refinery-big-hill-boiling-range`
- Five ordered commits and exactly three intended files
- Sole active #3305 implementation PR
- Positively identified autonomous implementation occupancy after publication: **4/10**

## Engineering acceptance

- Product boiling-point support is sorted in ascending normal boiling point.
- Only positive-composition pseudo-components enter the reported distribution.
- Cumulative product mole fractions are finite, strictly increasing, normalized, and closed to one.
- Quantile requests fail closed unless finite and in `(0, 1]`.
- T10 <= T50 <= T90 for both calculated products.
- Overhead T50 is below bottoms T50.
- T10, T50, and T90 repeat within 1% across independently constructed and solved cases.
- Returned support and cumulative arrays are defensive copies.
- Existing MESH convergence, mass/energy/tray/component closure, two-material-product, mean-boiling-point ordering, exact DOE component identity, and repeatability gates remain in force.

## Provenance and scientific boundary

The calculation uses only the public DOE Big Hill heavy-cut characterization already qualified in #3305. No new empirical parameter or proprietary dataset is introduced.

The reported quantiles are discrete pseudo-component diagnostics on cumulative product mole basis. They are not continuous simulated-distillation curves, TBP temperatures, ASTM D86 or ASTM D1160 results, pressure-corrected laboratory measurements, validated VGO/residue yields, equipment design, or plant agreement.

## Documentation impact

The existing Big Hill guide now documents the Java/JPype accessors, basis, stepwise quantile definition, regression gates, interpretation, and limitations.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

The initial hosted run found only Spotless line wrapping in the two Java files. The exact hosted formatter artifact from run `34440199220` (artifact `10137658419`, archive SHA-256 `ad81f77a9aff610a886c374886d498dc6f40526d0b81041fa3c610c1a30cfda4`) was audited and applied as two sequential formatting-only commits. No behavior, tests, APIs, provenance, assumptions, or acceptance criteria changed. The single formatting-only repair allowance is consumed; fresh hosted GitHub Actions on exact head `679ce6cd3f7e576545664748adeebe90a95a505d` are authoritative.

No merge, auto-merge, rebase, synchronization, force-push, close, replacement, or ready-for-review transition is authorized.