### PR TITLE
feat(mcp): qualify bounded multi-server composition

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Run focused bounded-streaming Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.StreamingRunnerTest,neqsim.mcp.runners.McpPrincipalScopingTest test -ntp
 
+      - name: Run focused multi-server composition Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.CompositionRunnerTest test -ntp
+
       - name: Run focused pre-flight validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.ValidatorTest test -ntp
 
@@ -147,6 +150,9 @@ jobs:
 
       - name: Run focused real-MCP bounded-streaming qualification
         run: cd neqsim-mcp-server && python test_streaming_protocol.py
+
+      - name: Run focused real-MCP multi-server composition qualification
+        run: cd neqsim-mcp-server && python test_composition_protocol.py
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py

--- a/neqsim-mcp-server/MCP_CONTRACT.md
+++ b/neqsim-mcp-server/MCP_CONTRACT.md
@@ -126,7 +126,7 @@ domain-specific runners with limited qualification evidence.
 | `runDynamic` | CALCULATION | v1.1 | Dynamic transient simulation with auto-instrumented controllers |
 | `runBioprocess` | CALCULATION | v1.1 | Bioprocessing reactors (AD, fermentation, gasification, pyrolysis) |
 | `streamSimulation` | PLATFORM | v1.2 | Async simulation with incremental polling |
-| `composeMultiServerWorkflow` | PLATFORM | v1.2 | Multi-server orchestration across MCP servers |
+| `composeMultiServerWorkflow` | PLATFORM | v1.2 | Bounded metadata-only planning across MCP servers |
 | `manageSecurity` | PLATFORM | v1.2 | API key management, rate limiting, audit logging |
 | `manageState` | PLATFORM | v1.2 | Persist/restore simulation states across server restarts |
 | `manageValidationProfile` | PLATFORM | v1.2 | Jurisdiction-specific validation profiles (NCS, UKCS, GoM, Brazil) |
@@ -136,6 +136,26 @@ domain-specific runners with limited qualification evidence.
 Execution tools (`solveTask`, `composeWorkflow`, `manageSession`) perform
 multi-step or stateful operations. They are **not part of any governed tier**
 and must not be used for engineering decisions without independent validation.
+
+### Bounded multi-server composition metadata
+
+`composeMultiServerWorkflow` publishes metadata and deterministic host-execution
+plans only. It does not connect to, authenticate with, or execute another
+server. The complete request is limited to 16,384 UTF-8 bytes, a plan task to
+4096 characters, each name to 64 characters, each description to 512
+characters, each tool/format list to 64 unique entries, and the process-local
+custom registry to 32 records. Built-in metadata is immutable. Connection URLs,
+commands, arguments, environment data, headers, credentials, tokens, API keys,
+and secrets are rejected.
+
+The host is responsible for external identity, authorization, transport
+security, schema/unit compatibility, data governance, execution, and
+engineering review. Custom records are not durable, distributed, authenticated,
+encrypted, or tenant-isolated. Suggested steps are not proof of availability,
+feasibility, model fidelity, convergence, conservation, standards
+applicability, safety adequacy, plant authority, certification, or accountable
+engineering approval. See
+[`MULTI_SERVER_COMPOSITION_CONTRACT.md`](docs/evidence/MULTI_SERVER_COMPOSITION_CONTRACT.md).
 
 ## Browsable Resources (Stable)
 

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -266,7 +266,7 @@ Interfaces may change between minor versions.
 | `bridgeTaskWorkflow`         | Convert MCP tool output to task_solve results.json format           |
 | `manageSession`              | Persistent simulation sessions                                      |
 | `streamSimulation`           | Async simulation with incremental polling                           |
-| `composeMultiServerWorkflow` | Multi-server orchestration                                          |
+| `composeMultiServerWorkflow` | Bounded metadata-only multi-server planning                         |
 | `manageSecurity`             | API key management, rate limiting, audit logging                    |
 | `manageState`                | Persist/restore simulation states                                   |
 | `manageValidationProfile`    | Jurisdiction-specific validation profiles                           |
@@ -684,6 +684,18 @@ The `composeMultiServerWorkflow` tool orchestrates across MCP servers:
 
 Pre-registered server types: `cost-estimation`, `plant-historian`, `cad-3d`,
 `document-extraction`, `safety-analysis`.
+
+This is a bounded metadata-only surface. It never opens connections or invokes
+external tools. Requests are capped at 16,384 UTF-8 bytes; plan tasks are
+non-blank and at most 4096 characters; custom metadata is limited to 32 server
+records with bounded, deduplicated tool and format lists. Built-ins are
+protected, and endpoint, command, environment, header, credential, token, API
+key, and secret fields fail closed. The authorized host remains responsible
+for external discovery, authentication, transport security, data governance,
+step execution, semantic compatibility, and independent engineering review.
+Custom records are process-local and are not durable, distributed, or
+tenant-isolated. See
+[the bounded composition contract](docs/evidence/MULTI_SERVER_COMPOSITION_CONTRACT.md).
 
 ---
 

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -16,7 +16,7 @@ manually maintained Java method list.
 | Tool implementations | 71 bindings / 60 classes | `getCapabilities.implementationInventory` | `McpImplementationInventory` |
 | Factory equipment | 207 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
-| MCP Java test classes | 71 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
+| MCP Java test classes | 72 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | Focused API protocol scenarios | 3 | `getCapabilities.phase0EvidenceInventory` | `test_inspect_api_protocol.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
@@ -87,7 +87,7 @@ does not claim that an external Word/HTML artifact has been generated or enginee
 ## Tests, guides, and known limitations
 
 `getCapabilities.phase0EvidenceInventory` freezes the remaining source-evidence dimensions of the
-Phase 0 inventory. The exact current source contains 71 JUnit test classes under
+Phase 0 inventory. The exact current source contains 72 JUnit test classes under
 `src/test/java/neqsim/mcp`, 94 named scenarios in the primary real-STDIO JSON-RPC harness
 `neqsim-mcp-server/test_mcp_server.py`, and three focused packaged-MCP API-inspection scenarios in
 `neqsim-mcp-server/test_inspect_api_protocol.py`. The primary protocol regression independently

--- a/neqsim-mcp-server/docs/evidence/MULTI_SERVER_COMPOSITION_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/MULTI_SERVER_COMPOSITION_CONTRACT.md
@@ -1,0 +1,106 @@
+# Bounded multi-server composition metadata contract
+
+## Scope
+
+`composeMultiServerWorkflow` is a process-local metadata and planning surface. It
+lists five built-in external-server types, exposes four fixed workflow templates,
+accepts bounded descriptive metadata for custom server types, and returns
+keyword-routed suggestions that an authorized MCP host may choose to execute.
+
+The runner does not open a network connection, launch a command, call an
+external MCP tool, authenticate to another service, persist an endpoint or
+credential, transfer plant data, or execute the suggested steps. Responses mark
+this boundary with `metadataOnly=true`, `executionPerformed=false`, and, for
+plans and the capability manifest, `hostExecutionRequired=true`.
+
+## Qualified actions
+
+| Action | Qualified behavior |
+| --- | --- |
+| `listServers` | Deterministic name-sorted metadata for the five protected built-ins and bounded custom records |
+| `registerServer` | Process-local descriptive metadata with a 64-character name, bounded strings, at most 64 unique tools and formats, and a maximum of 32 custom records |
+| `removeServer` | Removal of a named custom record; built-in records fail closed |
+| `listWorkflows` | Deterministic discovery of the four fixed templates |
+| `getWorkflow` | Exact retrieval of one fixed template or a structured not-found error |
+| `planComposition` | Deterministic keyword routing for one non-blank task of at most 4096 characters, with consecutive step numbers |
+| `describeCapabilities` | Static NeqSim provider/consumer/format metadata and the explicit host-execution boundary |
+
+The complete JSON request is capped at 16,384 UTF-8 bytes. Malformed JSON,
+non-object input, missing actions, invalid names, non-string metadata, oversized
+strings or arrays, unknown actions, and missing records fail closed with
+structured errors. Built-in server metadata cannot be replaced or removed.
+
+Registration accepts metadata only. Endpoint or URL fields, executable commands,
+arguments, environment blocks, headers, credentials, tokens, API keys, and
+secrets are rejected. Tool and data-format entries are trimmed, bounded, and
+deduplicated while preserving caller order.
+
+## Canonical-model and execution boundary
+
+The composition runner contains no thermodynamic or process model. It does not
+replace NeqSim fluids, streams, `ProcessSystem`, `ProcessModel`, runners, or
+result objects. A suggested NeqSim step names an existing canonical tool; only a
+later, separately executed call to that tool can produce an engineering result.
+
+Suggested external server names and tools are descriptive labels, not evidence
+that a server is installed, reachable, authenticated, compatible, licensed, or
+approved. The host application must resolve the actual server and tool, obtain
+authorization, validate schemas and units, control data movement, enforce
+timeouts and resource limits, and preserve result provenance.
+
+## Security, persistence, and tenancy boundary
+
+Custom records live only in the current Java process. They are not durable,
+distributed, encrypted, authenticated, or tenant-scoped. Any deployment that
+shares a process between principals must prevent untrusted callers from using
+the mutation actions or provide isolation outside this runner.
+
+The runner deliberately stores no connection material. It does not establish
+external IAM, TLS, certificate validation, secret management, audit durability,
+network allowlisting, sandboxing, or supply-chain trust. The normal
+`IndustrialProfile` access check remains authoritative at the MCP facade.
+
+The built-in `plant-historian` metadata includes a descriptive `writeTags`
+capability because a host may know such a tool. This runner never calls it and
+grants no plant write-back or control authority.
+
+## Engineering and advisory limitations
+
+Plans are deterministic keyword suggestions, not natural-language
+understanding, dependency resolution, semantic result chaining, topology
+validation, unit reconciliation, feasibility analysis, causal diagnosis,
+optimization, or workflow execution. The fixed templates are examples, not
+validated facility designs, operating procedures, safety studies, or design.
+
+This qualification establishes software input, state, response, and transport
+behavior only. It does not validate EOS or process-model fidelity, convergence,
+mass or energy conservation, equipment design, economic estimates, historian
+quality, document extraction, CAD results, HAZOP/SIL/relief analysis, standards
+applicability, uncertainty, facility completeness, certification, or accountable
+engineering approval.
+
+Every planned step and every result later returned by another server requires
+independent schema, unit, provenance, security, applicability, and engineering
+review before use.
+
+## Evidence
+
+- `src/main/java/neqsim/mcp/runners/CompositionRunner.java`
+- `src/test/java/neqsim/mcp/runners/CompositionRunnerTest.java`
+- `neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java`
+- `neqsim-mcp-server/test_composition_protocol.py`
+- `neqsim-mcp-server/test_mcp_server.py`
+- `neqsim-mcp-server/docs/evidence/MULTI_SERVER_COMPOSITION_CONTRACT.md`
+
+The focused Java suite covers deterministic discovery, fixed workflows,
+sequential planning, bounded metadata lifecycle, rejection of connection and
+credential material, protected built-ins, malformed and oversized inputs, and
+the fixed custom-registry ceiling. The packaged harness repeats the public
+contract over the real STDIO MCP transport and requires standard response
+evidence.
+
+Inventory remains `1.34 / 20 explicit + 34 contract-tested + 17 confirmed
+gaps`. This qualification does not promote
+`composeMultiServerWorkflow`; it remains `CONFIRMED_GAP` until a separate
+post-merge evidence promotion updates the machine-readable inventory and
+authoritative comprehensive protocol accounting atomically.

--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
@@ -1815,18 +1815,20 @@ public class NeqSimTools {
    * @param compositionJson JSON with composition action and parameters
    * @return JSON with workflow plan or server info
    */
-  @Tool(description = "Compose multi-server engineering workflows across MCP servers. "
-      + "Browse external servers (cost estimation, plant historian, CAD, safety), "
-      + "plan cross-domain workflows (digital-twin, feed study, vendor evaluation), "
-      + "and describe NeqSim capabilities. "
-      + "Actions: listServers, registerServer, removeServer, listWorkflows, "
-      + "getWorkflow, planComposition, describeCapabilities.")
+  @Tool(description = "Plan bounded multi-server workflow metadata only; this tool does not connect to "
+      + "or execute external servers. Browse external-server metadata, inspect fixed workflow templates, "
+      + "and create deterministic host-execution plans. Requests are capped at 16384 bytes and reject "
+      + "connection, execution, or credential material. The host remains responsible for identity, "
+      + "authorization, transport security, data handling, execution, step compatibility, "
+      + "and independent engineering review. Actions: listServers, registerServer, removeServer, "
+      + "listWorkflows, getWorkflow, planComposition, describeCapabilities.")
   public String composeMultiServerWorkflow(
-      @ToolArg(description = "JSON with: 'action' (listServers|registerServer|removeServer|"
-          + "listWorkflows|getWorkflow|planComposition|describeCapabilities). "
-          + "For planComposition: 'task' (natural language description). "
-          + "For getWorkflow: 'workflowId' (digital-twin|feed-study|vendor-evaluation|"
-          + "safety-study).") String compositionJson) {
+      @ToolArg(description = "Bounded metadata-only JSON with: 'action' "
+          + "(listServers|registerServer|removeServer|listWorkflows|getWorkflow|planComposition|"
+          + "describeCapabilities). For registerServer: 'name' plus optional description, domain, transport, "
+          + "version, tools, and dataFormats; do not provide endpoints, commands, headers, credentials, or tokens. "
+          + "For planComposition: non-blank 'task' up to 4096 characters. For getWorkflow: 'workflowId' "
+          + "(digital-twin|feed-study|vendor-evaluation|safety-study).") String compositionJson) {
     String policyBlocked = enforceToolAccess("composeMultiServerWorkflow");
     if (policyBlocked != null) {
       return policyBlocked;

--- a/neqsim-mcp-server/test_composition_protocol.py
+++ b/neqsim-mcp-server/test_composition_protocol.py
@@ -1,0 +1,397 @@
+"""Packaged-MCP qualification for bounded multi-server composition metadata.
+
+The scenarios exercise the real STDIO transport, deterministic server and
+workflow discovery, metadata-only planning, bounded custom metadata lifecycle,
+connection/credential rejection, fail-closed inputs, normal access enforcement,
+and standard response evidence. They do not connect to or execute an external
+server, validate suggested engineering calculations, establish external IAM or
+transport security, persist state, isolate tenants, grant plant authority, or
+replace accountable engineering review.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+def require(condition, message, detail=None):
+    if condition:
+        return
+    suffix = "" if detail is None else "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "tool",
+        "code",
+        "errors",
+        "message",
+        "validation",
+        "qualityGate",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+class McpClient:
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-composition-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        require("result" in self.receive(), "MCP initialize did not return a result")
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def request(self, method, params):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": method,
+                "params": params,
+            }
+        )
+        return self.receive()
+
+    def list_tools(self):
+        return self.request("tools/list", {}).get("result", {}).get("tools", [])
+
+    def call_tool(self, name, arguments):
+        response = self.request(
+            "tools/call",
+            {"name": name, "arguments": arguments},
+        )
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        return json.loads(content[0].get("text", ""))
+
+    def call_composition(self, request):
+        return self.call_tool(
+            "composeMultiServerWorkflow",
+            {"compositionJson": json.dumps(request)},
+        )
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def assert_success(response):
+    result = payload(response)
+    require(result.get("status") == "success", "composition request failed", response)
+    require(
+        result.get("tool") == "composeMultiServerWorkflow",
+        "tool identity drifted",
+        response,
+    )
+    require(
+        result.get("validation", {}).get("valid") is True,
+        "standard validation evidence drifted",
+        response,
+    )
+    require(
+        result.get("qualityGate", {}).get("verdict") == "passed",
+        "software gate did not pass",
+        response,
+    )
+    return result
+
+
+def assert_error(response, expected_code):
+    result = payload(response)
+    require(
+        result.get("status") == "error",
+        "composition request did not fail closed",
+        response,
+    )
+    errors = result.get("errors", [])
+    code = result.get("code")
+    if code is None and errors:
+        code = errors[0].get("code")
+    require(code == expected_code, "composition error code drifted", result)
+    return result
+
+
+def test_bounded_discovery(client):
+    tool = next(
+        (
+            item
+            for item in client.list_tools()
+            if item.get("name") == "composeMultiServerWorkflow"
+        ),
+        None,
+    )
+    require(tool is not None, "composeMultiServerWorkflow is missing from tools/list")
+    description = tool.get("description", "")
+    require(
+        "metadata only" in description
+        and "does not connect" in description
+        and "16384 bytes" in description
+        and "independent engineering review" in description,
+        "composition discovery boundary drifted",
+        tool,
+    )
+
+
+def test_server_catalog_is_deterministic_metadata(client):
+    first = assert_success(client.call_composition({"action": "listServers"}))
+    second = assert_success(client.call_composition({"action": "listServers"}))
+    require(first.get("count") == 5, "default server count drifted", first)
+    require(
+        first.get("metadataOnly") is True
+        and first.get("executionPerformed") is False,
+        "server catalog execution boundary drifted",
+        first,
+    )
+    require(first.get("servers") == second.get("servers"), "server order drifted", first)
+    names = [server.get("name") for server in first.get("servers", [])]
+    require(names == sorted(names), "server names are not sorted", names)
+    require(
+        "plant-historian" in names
+        and "endpoint" not in json.dumps(first)
+        and "credentials" not in json.dumps(first),
+        "server metadata boundary drifted",
+        first,
+    )
+
+
+def test_workflow_and_plan_are_host_executed_metadata(client):
+    catalog = assert_success(client.call_composition({"action": "listWorkflows"}))
+    require(catalog.get("count") == 4, "workflow catalog count drifted", catalog)
+
+    workflow = assert_success(
+        client.call_composition(
+            {"action": "getWorkflow", "workflowId": "safety-study"}
+        )
+    )
+    require(
+        workflow.get("id") == "safety-study"
+        and len(workflow.get("steps", [])) == 4,
+        "workflow detail drifted",
+        workflow,
+    )
+
+    plan = assert_success(
+        client.call_composition(
+            {
+                "action": "planComposition",
+                "task": "Compare plant measurements and project cost",
+            }
+        )
+    )
+    steps = plan.get("suggestedSteps", [])
+    require(
+        plan.get("metadataOnly") is True
+        and plan.get("executionPerformed") is False
+        and plan.get("hostExecutionRequired") is True,
+        "plan execution boundary drifted",
+        plan,
+    )
+    require(
+        [step.get("order") for step in steps] == list(range(1, len(steps) + 1)),
+        "plan step order drifted",
+        steps,
+    )
+
+
+def test_custom_metadata_lifecycle(client):
+    name = "phase0-packaged-composition"
+    registered = assert_success(
+        client.call_composition(
+            {
+                "action": "registerServer",
+                "name": name,
+                "description": "Synthetic packaged-test metadata",
+                "domain": "test",
+                "tools": ["inspect", "inspect"],
+                "dataFormats": ["JSON", "JSON"],
+            }
+        )
+    )
+    require(
+        registered.get("metadataOnly") is True
+        and registered.get("executionPerformed") is False,
+        "registration boundary drifted",
+        registered,
+    )
+
+    catalog = assert_success(client.call_composition({"action": "listServers"}))
+    custom = next(
+        (server for server in catalog.get("servers", []) if server.get("name") == name),
+        None,
+    )
+    require(custom is not None, "custom metadata was not listed", catalog)
+    require(
+        custom.get("tools") == ["inspect"]
+        and custom.get("dataFormats") == ["JSON"],
+        "custom metadata was not deduplicated",
+        custom,
+    )
+
+    removed = assert_success(
+        client.call_composition({"action": "removeServer", "name": name})
+    )
+    require(removed.get("removed") is True, "custom metadata was not removed", removed)
+
+
+def test_connection_and_built_in_mutations_fail_closed(client):
+    assert_error(
+        client.call_composition(
+            {
+                "action": "registerServer",
+                "name": "forbidden-endpoint",
+                "endpoint": "https://example.invalid/mcp",
+            }
+        ),
+        "UNSUPPORTED_CONNECTION_DATA",
+    )
+    assert_error(
+        client.call_composition(
+            {
+                "action": "registerServer",
+                "name": "forbidden-token",
+                "token": "do-not-store",
+            }
+        ),
+        "UNSUPPORTED_CONNECTION_DATA",
+    )
+    assert_error(
+        client.call_composition(
+            {"action": "registerServer", "name": "plant-historian"}
+        ),
+        "PROTECTED_SERVER",
+    )
+    assert_error(
+        client.call_composition(
+            {"action": "removeServer", "name": "plant-historian"}
+        ),
+        "PROTECTED_SERVER",
+    )
+
+
+def test_invalid_requests_fail_closed(client):
+    assert_error(client.call_composition({"action": "execute"}), "UNKNOWN_ACTION")
+    assert_error(
+        client.call_composition({"action": "planComposition", "task": "   "}),
+        "INVALID_INPUT",
+    )
+    assert_error(
+        client.call_composition(
+            {"action": "planComposition", "task": "x" * 4097}
+        ),
+        "INVALID_INPUT",
+    )
+    assert_error(
+        client.call_tool(
+            "composeMultiServerWorkflow",
+            {"compositionJson": "{"},
+        ),
+        "INVALID_INPUT",
+    )
+
+
+def test_inventory_remains_a_confirmed_gap(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    require(result.get("status") == "success", "capabilities request failed", result)
+    inventory = result.get("phase0EvidenceInventory", {})
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get(
+        "composeMultiServerWorkflow", {}
+    )
+    require(
+        inventory.get("inventoryVersion") == "1.34"
+        and limitations.get("contractTestedToolCount") == 34
+        and limitations.get("confirmedGapToolCount") == 17
+        and limitations.get("contractPromotionCandidateCount") == 0,
+        "qualification changed inventory accounting",
+        inventory,
+    )
+    require(
+        record.get("coverageStatus") == "CONFIRMED_GAP",
+        "open qualification prematurely promoted composition evidence",
+        record,
+    )
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("bounded discovery", test_bounded_discovery),
+        ("deterministic metadata server catalog", test_server_catalog_is_deterministic_metadata),
+        ("host-executed workflow metadata", test_workflow_and_plan_are_host_executed_metadata),
+        ("custom metadata lifecycle", test_custom_metadata_lifecycle),
+        ("connection and built-in mutations fail closed", test_connection_and_built_in_mutations_fail_closed),
+        ("invalid requests fail closed", test_invalid_requests_fail_closed),
+        ("inventory remains a confirmed gap", test_inventory_remains_a_confirmed_gap),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} composition contract scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1499,8 +1499,8 @@ def test_capabilities():
     tests = evidence.get("tests", {})
     guides = evidence.get("guides", {})
     limitations = evidence.get("knownLimitations", {})
-    check("evidence inventory freezes 71 Java test classes",
-          tests.get("javaTestClassCount") == 71,
+    check("evidence inventory freezes 72 Java test classes",
+          tests.get("javaTestClassCount") == 72,
           str(tests))
     check("evidence inventory freezes 94 protocol scenarios",
           tests.get("protocolScenarioCount") == 94,

--- a/src/main/java/neqsim/mcp/runners/CompositionRunner.java
+++ b/src/main/java/neqsim/mcp/runners/CompositionRunner.java
@@ -151,8 +151,7 @@ public final class CompositionRunner {
   private static synchronized String registerServer(JsonObject input) {
     for (String field : CONNECTION_FIELDS) {
       if (input.has(field)) {
-        return errorJson("UNSUPPORTED_CONNECTION_DATA",
-            "Connection, execution, and credential fields are not accepted",
+        return errorJson("UNSUPPORTED_CONNECTION_DATA", "Connection, execution, and credential fields are not accepted",
             "Register descriptive metadata only; configure connections in the authorized host application");
       }
     }
@@ -562,8 +561,7 @@ public final class CompositionRunner {
   // ═══════════════════════════════════════════════════════════════════════════
 
   private static String requiredString(JsonObject input, String field, int maxLength) {
-    if (!input.has(field) || !input.get(field).isJsonPrimitive()
-        || !input.get(field).getAsJsonPrimitive().isString()) {
+    if (!input.has(field) || !input.get(field).isJsonPrimitive() || !input.get(field).getAsJsonPrimitive().isString()) {
       throw new IllegalArgumentException("Missing string field");
     }
     String value = input.get(field).getAsString().trim();

--- a/src/main/java/neqsim/mcp/runners/CompositionRunner.java
+++ b/src/main/java/neqsim/mcp/runners/CompositionRunner.java
@@ -13,6 +13,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 
 /**
@@ -104,7 +105,7 @@ public final class CompositionRunner {
             "Use: listServers, registerServer, removeServer, listWorkflows, "
                 + "getWorkflow, planComposition, describeCapabilities");
       }
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | JsonParseException e) {
       return errorJson("INVALID_INPUT", "Invalid composition request",
           "Use bounded strings and arrays of strings with the documented fields");
     } catch (Exception e) {

--- a/src/main/java/neqsim/mcp/runners/CompositionRunner.java
+++ b/src/main/java/neqsim/mcp/runners/CompositionRunner.java
@@ -1,8 +1,11 @@
 package neqsim.mcp.runners;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import com.google.gson.Gson;
@@ -17,21 +20,30 @@ import com.google.gson.JsonParser;
  * engineering workflows.
  *
  * <p>
- * Manages a registry of external MCP server endpoints and provides orchestration for multi-server workflows. Each
- * external server can be a cost estimation service, plant historian connector, CAD/3D system, document extraction
- * service, or any MCP-compliant tool provider.
+ * Manages bounded descriptive metadata for external MCP server types and fixed workflow templates. It does not store
+ * connection endpoints or credentials, open a connection, or invoke an external tool. The host application remains
+ * responsible for identity, authorization, transport security, data handling, and execution.
  * </p>
  *
  * <p>
- * Since NeqSim MCP runs over STDIO, external server calls are modeled as registered endpoints that agents can discover
- * and invoke. The actual cross-server communication is handled by the host application (Claude, Copilot, etc.) which
- * has access to all connected MCP servers. This runner provides the composition metadata and workflow templates.
+ * Since NeqSim MCP runs over STDIO, this runner publishes metadata that an authorized host can inspect when planning
+ * cross-server work. Suggested steps are advisory and are not executed or scientifically validated by this runner.
  * </p>
  *
  * @author Even Solbraa
  * @version 1.0
  */
 public final class CompositionRunner {
+
+  private static final int MAX_REQUEST_BYTES = 16384;
+  private static final int MAX_NAME_LENGTH = 64;
+  private static final int MAX_TEXT_LENGTH = 512;
+  private static final int MAX_TASK_LENGTH = 4096;
+  private static final int MAX_COLLECTION_ENTRIES = 64;
+  private static final int MAX_CUSTOM_SERVERS = 32;
+  private static final int DEFAULT_SERVER_COUNT = 5;
+  private static final String[] CONNECTION_FIELDS = { "endpoint", "url", "command", "arguments", "environment",
+      "headers", "credentials", "token", "apiKey", "secret" };
 
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create();
 
@@ -59,9 +71,18 @@ public final class CompositionRunner {
    * @return JSON with results
    */
   public static String run(String json) {
+    if (json == null || json.getBytes(StandardCharsets.UTF_8).length > MAX_REQUEST_BYTES) {
+      return errorJson("INVALID_INPUT", "Composition request is missing or exceeds 16384 bytes",
+          "Provide one bounded JSON object without connection or credential material");
+    }
     try {
-      JsonObject input = JsonParser.parseString(json).getAsJsonObject();
-      String action = input.has("action") ? input.get("action").getAsString() : "";
+      JsonElement parsed = JsonParser.parseString(json);
+      if (!parsed.isJsonObject()) {
+        return errorJson("INVALID_INPUT", "Composition request must be a JSON object",
+            "Provide one JSON object with a supported action");
+      }
+      JsonObject input = parsed.getAsJsonObject();
+      String action = requiredString(input, "action", MAX_NAME_LENGTH);
 
       switch (action) {
       case "listServers":
@@ -83,8 +104,12 @@ public final class CompositionRunner {
             "Use: listServers, registerServer, removeServer, listWorkflows, "
                 + "getWorkflow, planComposition, describeCapabilities");
       }
+    } catch (IllegalArgumentException e) {
+      return errorJson("INVALID_INPUT", "Invalid composition request",
+          "Use bounded strings and arrays of strings with the documented fields");
     } catch (Exception e) {
-      return errorJson("COMPOSITION_ERROR", e.getMessage(), "Check JSON format");
+      return errorJson("COMPOSITION_ERROR", "Composition metadata operation failed",
+          "Retry with a documented action and metadata-only input");
     }
   }
 
@@ -93,16 +118,23 @@ public final class CompositionRunner {
    *
    * @return JSON with server registry
    */
-  private static String listServers() {
+  private static synchronized String listServers() {
     JsonObject response = new JsonObject();
     response.addProperty("status", "success");
     response.addProperty("count", SERVERS.size());
 
     JsonArray servers = new JsonArray();
-    for (ExternalServer server : SERVERS.values()) {
-      servers.add(server.toJson());
+    List<String> names = new ArrayList<String>(SERVERS.keySet());
+    Collections.sort(names);
+    for (String name : names) {
+      ExternalServer server = SERVERS.get(name);
+      if (server != null) {
+        servers.add(server.toJson());
+      }
     }
     response.add("servers", servers);
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
     response.addProperty("note",
         "These are known MCP server types that can compose with NeqSim. "
             + "The host application (Claude, Copilot) handles actual connections. "
@@ -116,37 +148,46 @@ public final class CompositionRunner {
    * @param input JSON with server details
    * @return JSON confirmation
    */
-  private static String registerServer(JsonObject input) {
-    String name = input.has("name") ? input.get("name").getAsString() : "";
-    if (name.isEmpty()) {
-      return errorJson("MISSING_NAME", "Server name is required", "Provide 'name' field");
+  private static synchronized String registerServer(JsonObject input) {
+    for (String field : CONNECTION_FIELDS) {
+      if (input.has(field)) {
+        return errorJson("UNSUPPORTED_CONNECTION_DATA",
+            "Connection, execution, and credential fields are not accepted",
+            "Register descriptive metadata only; configure connections in the authorized host application");
+      }
+    }
+
+    String name = requiredString(input, "name", MAX_NAME_LENGTH);
+    if (!name.matches("[A-Za-z0-9][A-Za-z0-9._-]{0,63}")) {
+      return errorJson("INVALID_NAME", "Server name contains unsupported characters",
+          "Use 1-64 letters, digits, dots, underscores, or hyphens");
+    }
+    if (isBuiltInServer(name)) {
+      return errorJson("PROTECTED_SERVER", "Built-in server metadata cannot be replaced",
+          "Use a distinct custom server name");
+    }
+    if (!SERVERS.containsKey(name) && SERVERS.size() - DEFAULT_SERVER_COUNT >= MAX_CUSTOM_SERVERS) {
+      return errorJson("REGISTRY_LIMIT", "Custom server registry limit reached",
+          "Remove an unused custom metadata record before registering another");
     }
 
     ExternalServer server = new ExternalServer();
     server.name = name;
-    server.description = input.has("description") ? input.get("description").getAsString() : "";
-    server.domain = input.has("domain") ? input.get("domain").getAsString() : "general";
-    server.transport = input.has("transport") ? input.get("transport").getAsString() : "stdio";
-    server.version = input.has("version") ? input.get("version").getAsString() : "1.0";
-
-    if (input.has("tools") && input.get("tools").isJsonArray()) {
-      for (JsonElement t : input.getAsJsonArray("tools")) {
-        server.tools.add(t.getAsString());
-      }
-    }
-
-    if (input.has("dataFormats") && input.get("dataFormats").isJsonArray()) {
-      for (JsonElement f : input.getAsJsonArray("dataFormats")) {
-        server.dataFormats.add(f.getAsString());
-      }
-    }
+    server.description = optionalString(input, "description", "", MAX_TEXT_LENGTH);
+    server.domain = optionalString(input, "domain", "general", MAX_NAME_LENGTH);
+    server.transport = optionalString(input, "transport", "stdio", MAX_NAME_LENGTH);
+    server.version = optionalString(input, "version", "1.0", MAX_NAME_LENGTH);
+    server.tools.addAll(stringArray(input, "tools"));
+    server.dataFormats.addAll(stringArray(input, "dataFormats"));
 
     SERVERS.put(name, server);
 
     JsonObject response = new JsonObject();
     response.addProperty("status", "success");
-    response.addProperty("message", "Server '" + name + "' registered");
+    response.addProperty("message", "Server '" + name + "' metadata registered");
     response.addProperty("totalServers", SERVERS.size());
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
     return GSON.toJson(response);
   }
 
@@ -156,14 +197,24 @@ public final class CompositionRunner {
    * @param input JSON with server name
    * @return JSON confirmation
    */
-  private static String removeServer(JsonObject input) {
-    String name = input.has("name") ? input.get("name").getAsString() : "";
+  private static synchronized String removeServer(JsonObject input) {
+    String name = requiredString(input, "name", MAX_NAME_LENGTH);
+    if (isBuiltInServer(name)) {
+      return errorJson("PROTECTED_SERVER", "Built-in server metadata cannot be removed",
+          "Only custom metadata records may be removed");
+    }
     ExternalServer removed = SERVERS.remove(name);
+    if (removed == null) {
+      return errorJson("NOT_FOUND", "Custom server metadata was not found",
+          "Use listServers to discover registered metadata names");
+    }
 
     JsonObject response = new JsonObject();
     response.addProperty("status", "success");
-    response.addProperty("removed", removed != null);
+    response.addProperty("removed", true);
     response.addProperty("totalServers", SERVERS.size());
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
     return GSON.toJson(response);
   }
 
@@ -193,6 +244,8 @@ public final class CompositionRunner {
       workflows.add(wf);
     }
     response.add("workflows", workflows);
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
     return GSON.toJson(response);
   }
 
@@ -203,7 +256,7 @@ public final class CompositionRunner {
    * @return JSON with full workflow definition
    */
   private static String getWorkflow(JsonObject input) {
-    String id = input.has("workflowId") ? input.get("workflowId").getAsString() : "";
+    String id = requiredString(input, "workflowId", MAX_NAME_LENGTH);
     WorkflowTemplate tmpl = TEMPLATES.get(id);
 
     if (tmpl == null) {
@@ -227,6 +280,9 @@ public final class CompositionRunner {
       servers.add(s);
     }
     response.add("requiredServers", servers);
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
+    response.addProperty("hostExecutionRequired", true);
 
     return GSON.toJson(response);
   }
@@ -238,14 +294,14 @@ public final class CompositionRunner {
    * @return JSON with recommended servers and workflow plan
    */
   private static String planComposition(JsonObject input) {
-    String task = input.has("task") ? input.get("task").getAsString() : "";
+    String task = requiredString(input, "task", MAX_TASK_LENGTH);
 
     JsonObject response = new JsonObject();
     response.addProperty("status", "success");
     response.addProperty("task", task);
 
     // Analyze task keywords to recommend servers and workflows
-    String lower = task.toLowerCase();
+    String lower = task.toLowerCase(Locale.ROOT);
 
     JsonArray recommended = new JsonArray();
     JsonArray steps = new JsonArray();
@@ -258,17 +314,17 @@ public final class CompositionRunner {
         || lower.contains("npv") || lower.contains("budget")) {
       addRecommendation(recommended, "cost-estimation", "CAPEX/OPEX cost estimation and economic analysis",
           "recommended");
-      addStep(steps, 1, "neqsim", "runProcess", "Run process simulation to size equipment");
-      addStep(steps, 2, "cost-estimation", "estimateCosts", "Estimate costs based on sized equipment");
+      addStep(steps, steps.size() + 1, "neqsim", "runProcess", "Run process simulation to size equipment");
+      addStep(steps, steps.size() + 1, "cost-estimation", "estimateCosts", "Estimate costs based on sized equipment");
     }
 
     // Check for plant data keywords
     if (lower.contains("plant") || lower.contains("historian") || lower.contains("pi ") || lower.contains("ip.21")
         || lower.contains("operational") || lower.contains("measured") || lower.contains("digital twin")) {
       addRecommendation(recommended, "plant-historian", "Real-time and historical plant data access", "recommended");
-      addStep(steps, 1, "plant-historian", "readTags", "Read current operating data from historian");
-      addStep(steps, 2, "neqsim", "runProcess", "Run simulation with real operating conditions");
-      addStep(steps, 3, "neqsim", "validateResults", "Compare simulation vs measured values");
+      addStep(steps, steps.size() + 1, "plant-historian", "readTags", "Read current operating data from historian");
+      addStep(steps, steps.size() + 1, "neqsim", "runProcess", "Run simulation with real operating conditions");
+      addStep(steps, steps.size() + 1, "neqsim", "validateResults", "Compare simulation vs measured values");
     }
 
     // Check for document extraction
@@ -292,13 +348,16 @@ public final class CompositionRunner {
 
     // Default: if no specific steps planned, give generic plan
     if (steps.size() == 0) {
-      addStep(steps, 1, "neqsim", "runFlash or runProcess", "Run thermodynamic or process simulation");
-      addStep(steps, 2, "neqsim", "validateResults", "Validate results against design rules");
-      addStep(steps, 3, "neqsim", "generateReport", "Generate engineering report");
+      addStep(steps, steps.size() + 1, "neqsim", "runFlash or runProcess", "Run thermodynamic or process simulation");
+      addStep(steps, steps.size() + 1, "neqsim", "validateResults", "Validate results against design rules");
+      addStep(steps, steps.size() + 1, "neqsim", "generateReport", "Generate engineering report");
     }
 
     response.add("recommendedServers", recommended);
     response.add("suggestedSteps", steps);
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
+    response.addProperty("hostExecutionRequired", true);
     response.addProperty("compositionNote",
         "The host application orchestrates cross-server calls. "
             + "Each step's output feeds into the next step's input. "
@@ -356,6 +415,9 @@ public final class CompositionRunner {
     response.add("provides", provides);
     response.add("consumes", consumes);
     response.add("dataFormats", formats);
+    response.addProperty("metadataOnly", true);
+    response.addProperty("executionPerformed", false);
+    response.addProperty("hostExecutionRequired", true);
 
     return GSON.toJson(response);
   }
@@ -498,6 +560,60 @@ public final class CompositionRunner {
   // ═══════════════════════════════════════════════════════════════════════════
   // Helpers
   // ═══════════════════════════════════════════════════════════════════════════
+
+  private static String requiredString(JsonObject input, String field, int maxLength) {
+    if (!input.has(field) || !input.get(field).isJsonPrimitive()
+        || !input.get(field).getAsJsonPrimitive().isString()) {
+      throw new IllegalArgumentException("Missing string field");
+    }
+    String value = input.get(field).getAsString().trim();
+    if (value.isEmpty() || value.length() > maxLength) {
+      throw new IllegalArgumentException("String field outside bounds");
+    }
+    return value;
+  }
+
+  private static String optionalString(JsonObject input, String field, String defaultValue, int maxLength) {
+    if (!input.has(field)) {
+      return defaultValue;
+    }
+    if (!input.get(field).isJsonPrimitive() || !input.get(field).getAsJsonPrimitive().isString()) {
+      throw new IllegalArgumentException("Optional field must be a string");
+    }
+    String value = input.get(field).getAsString().trim();
+    if (value.length() > maxLength) {
+      throw new IllegalArgumentException("Optional string outside bounds");
+    }
+    return value;
+  }
+
+  private static List<String> stringArray(JsonObject input, String field) {
+    List<String> values = new ArrayList<String>();
+    if (!input.has(field)) {
+      return values;
+    }
+    if (!input.get(field).isJsonArray() || input.getAsJsonArray(field).size() > MAX_COLLECTION_ENTRIES) {
+      throw new IllegalArgumentException("Metadata collection outside bounds");
+    }
+    for (JsonElement element : input.getAsJsonArray(field)) {
+      if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) {
+        throw new IllegalArgumentException("Metadata collection must contain strings");
+      }
+      String value = element.getAsString().trim();
+      if (value.isEmpty() || value.length() > MAX_NAME_LENGTH) {
+        throw new IllegalArgumentException("Metadata item outside bounds");
+      }
+      if (!values.contains(value)) {
+        values.add(value);
+      }
+    }
+    return values;
+  }
+
+  private static boolean isBuiltInServer(String name) {
+    return "cost-estimation".equals(name) || "plant-historian".equals(name) || "cad-3d".equals(name)
+        || "document-extraction".equals(name) || "safety-analysis".equals(name);
+  }
 
   /**
    * Adds a recommendation entry to an array.

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -14,7 +14,7 @@ import com.google.gson.JsonParser;
  */
 public final class McpEvidenceInventory {
 
-  private static final int JAVA_TEST_CLASS_COUNT = 71;
+  private static final int JAVA_TEST_CLASS_COUNT = 72;
   private static final int PROTOCOL_SCENARIO_COUNT = 94;
   private static final int FOCUSED_API_PROTOCOL_SCENARIO_COUNT = 3;
 

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -163,7 +163,7 @@ class CapabilitiesRunnerTest {
     JsonObject inventory = root.getAsJsonObject("phase0EvidenceInventory");
 
     JsonObject tests = inventory.getAsJsonObject("tests");
-    assertEquals(71, tests.get("javaTestClassCount").getAsInt());
+    assertEquals(72, tests.get("javaTestClassCount").getAsInt());
     assertEquals(94, tests.get("protocolScenarioCount").getAsInt());
 
     JsonObject guides = inventory.getAsJsonObject("guides");

--- a/src/test/java/neqsim/mcp/runners/CompositionRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CompositionRunnerTest.java
@@ -1,0 +1,190 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Software-contract tests for bounded metadata-only {@link CompositionRunner} behavior.
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+class CompositionRunnerTest {
+  private static final String CUSTOM_SERVER = "phase0-composition-test";
+
+  @AfterEach
+  void removeCustomMetadata() {
+    CompositionRunner.run("{\"action\":\"removeServer\",\"name\":\"" + CUSTOM_SERVER + "\"}");
+    for (int index = 0; index < 33; index++) {
+      CompositionRunner.run("{\"action\":\"removeServer\",\"name\":\"phase0-capacity-" + index + "\"}");
+    }
+  }
+
+  @Test
+  void defaultServerDiscoveryIsDeterministicAndMetadataOnly() {
+    JsonObject first = run("{\"action\":\"listServers\"}");
+    JsonObject second = run("{\"action\":\"listServers\"}");
+
+    assertEquals("success", first.get("status").getAsString());
+    assertEquals(5, first.get("count").getAsInt());
+    assertTrue(first.get("metadataOnly").getAsBoolean());
+    assertFalse(first.get("executionPerformed").getAsBoolean());
+    assertEquals(first.getAsJsonArray("servers"), second.getAsJsonArray("servers"));
+
+    List<String> names = names(first.getAsJsonArray("servers"));
+    List<String> sortedNames = new ArrayList<String>(names);
+    Collections.sort(sortedNames);
+    assertEquals(sortedNames, names);
+    assertTrue(names.contains("plant-historian"));
+    assertFalse(first.toString().contains("endpoint"));
+    assertFalse(first.toString().contains("credentials"));
+  }
+
+  @Test
+  void fixedWorkflowCatalogAndDetailRemainOrdered() {
+    JsonObject catalog = run("{\"action\":\"listWorkflows\"}");
+    assertEquals("success", catalog.get("status").getAsString());
+    assertEquals(4, catalog.get("count").getAsInt());
+    assertEquals("digital-twin",
+        catalog.getAsJsonArray("workflows").get(0).getAsJsonObject().get("id").getAsString());
+
+    JsonObject workflow = run("{\"action\":\"getWorkflow\",\"workflowId\":\"safety-study\"}");
+    assertEquals("success", workflow.get("status").getAsString());
+    assertEquals("safety-study", workflow.get("id").getAsString());
+    assertEquals(4, workflow.getAsJsonArray("steps").size());
+    assertEquals("neqsim",
+        workflow.getAsJsonArray("steps").get(0).getAsJsonObject().get("server").getAsString());
+  }
+
+  @Test
+  void compositionPlanIsSequentialMetadataAndPerformsNoExecution() {
+    JsonObject result =
+        run("{\"action\":\"planComposition\",\"task\":\"Compare plant measurements and project cost\"}");
+
+    assertEquals("success", result.get("status").getAsString());
+    assertTrue(result.get("metadataOnly").getAsBoolean());
+    assertFalse(result.get("executionPerformed").getAsBoolean());
+    assertTrue(result.get("hostExecutionRequired").getAsBoolean());
+    JsonArray steps = result.getAsJsonArray("suggestedSteps");
+    assertEquals(5, steps.size());
+    for (int index = 0; index < steps.size(); index++) {
+      assertEquals(index + 1, steps.get(index).getAsJsonObject().get("order").getAsInt());
+    }
+  }
+
+  @Test
+  void customMetadataLifecycleDeduplicatesBoundedCollections() {
+    JsonObject registered = run("{\"action\":\"registerServer\",\"name\":\"" + CUSTOM_SERVER
+        + "\",\"description\":\"Synthetic test metadata\",\"domain\":\"test\","
+        + "\"tools\":[\"inspect\",\"inspect\"],\"dataFormats\":[\"JSON\",\"JSON\"]}");
+    assertEquals("success", registered.get("status").getAsString());
+    assertTrue(registered.get("metadataOnly").getAsBoolean());
+    assertFalse(registered.get("executionPerformed").getAsBoolean());
+
+    JsonObject catalog = run("{\"action\":\"listServers\"}");
+    JsonObject custom = server(catalog.getAsJsonArray("servers"), CUSTOM_SERVER);
+    assertEquals(1, custom.getAsJsonArray("tools").size());
+    assertEquals(1, custom.getAsJsonArray("dataFormats").size());
+
+    JsonObject removed =
+        run("{\"action\":\"removeServer\",\"name\":\"" + CUSTOM_SERVER + "\"}");
+    assertEquals("success", removed.get("status").getAsString());
+    assertTrue(removed.get("removed").getAsBoolean());
+  }
+
+  @Test
+  void connectionAndCredentialMaterialFailsClosed() {
+    JsonObject endpoint = run("{\"action\":\"registerServer\",\"name\":\"" + CUSTOM_SERVER
+        + "\",\"endpoint\":\"https://example.invalid/mcp\"}");
+    assertEquals("UNSUPPORTED_CONNECTION_DATA", errorCode(endpoint));
+
+    JsonObject token = run("{\"action\":\"registerServer\",\"name\":\"" + CUSTOM_SERVER
+        + "\",\"token\":\"do-not-store\"}");
+    assertEquals("UNSUPPORTED_CONNECTION_DATA", errorCode(token));
+
+    JsonObject catalog = run("{\"action\":\"listServers\"}");
+    assertFalse(names(catalog.getAsJsonArray("servers")).contains(CUSTOM_SERVER));
+  }
+
+  @Test
+  void builtInMetadataCannotBeReplacedOrRemoved() {
+    JsonObject replace =
+        run("{\"action\":\"registerServer\",\"name\":\"plant-historian\"}");
+    assertEquals("PROTECTED_SERVER", errorCode(replace));
+
+    JsonObject remove =
+        run("{\"action\":\"removeServer\",\"name\":\"plant-historian\"}");
+    assertEquals("PROTECTED_SERVER", errorCode(remove));
+
+    JsonObject catalog = run("{\"action\":\"listServers\"}");
+    assertTrue(names(catalog.getAsJsonArray("servers")).contains("plant-historian"));
+  }
+
+  @Test
+  void malformedBlankAndOversizedRequestsFailClosed() {
+    assertEquals("INVALID_INPUT", errorCode(run("{")));
+    assertEquals("INVALID_INPUT", errorCode(run("{}")));
+    assertEquals("INVALID_INPUT",
+        errorCode(run("{\"action\":\"planComposition\",\"task\":\"   \"}")));
+    assertEquals("INVALID_INPUT",
+        errorCode(run("{\"action\":\"planComposition\",\"task\":\"" + repeat("x", 4097) + "\"}")));
+    assertEquals("INVALID_INPUT", errorCode(run(repeat("x", 16385))));
+    assertEquals("UNKNOWN_ACTION", errorCode(run("{\"action\":\"execute\"}")));
+  }
+
+  @Test
+  void customRegistryHasAFixedCapacity() {
+    for (int index = 0; index < 32; index++) {
+      JsonObject response = run("{\"action\":\"registerServer\",\"name\":\"phase0-capacity-"
+          + index + "\"}");
+      assertEquals("success", response.get("status").getAsString());
+    }
+    JsonObject overflow =
+        run("{\"action\":\"registerServer\",\"name\":\"phase0-capacity-32\"}");
+    assertEquals("REGISTRY_LIMIT", errorCode(overflow));
+  }
+
+  private static JsonObject run(String json) {
+    return JsonParser.parseString(CompositionRunner.run(json)).getAsJsonObject();
+  }
+
+  private static String errorCode(JsonObject response) {
+    assertEquals("error", response.get("status").getAsString());
+    return response.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString();
+  }
+
+  private static List<String> names(JsonArray servers) {
+    List<String> names = new ArrayList<String>();
+    for (int index = 0; index < servers.size(); index++) {
+      names.add(servers.get(index).getAsJsonObject().get("name").getAsString());
+    }
+    return names;
+  }
+
+  private static JsonObject server(JsonArray servers, String name) {
+    for (int index = 0; index < servers.size(); index++) {
+      JsonObject server = servers.get(index).getAsJsonObject();
+      if (name.equals(server.get("name").getAsString())) {
+        return server;
+      }
+    }
+    throw new AssertionError("Missing server metadata: " + name);
+  }
+
+  private static String repeat(String value, int count) {
+    StringBuilder builder = new StringBuilder(count);
+    for (int index = 0; index < count; index++) {
+      builder.append(value);
+    }
+    return builder.toString();
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/CompositionRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CompositionRunnerTest.java
@@ -54,21 +54,19 @@ class CompositionRunnerTest {
     JsonObject catalog = run("{\"action\":\"listWorkflows\"}");
     assertEquals("success", catalog.get("status").getAsString());
     assertEquals(4, catalog.get("count").getAsInt());
-    assertEquals("digital-twin",
-        catalog.getAsJsonArray("workflows").get(0).getAsJsonObject().get("id").getAsString());
+    assertEquals("digital-twin", catalog.getAsJsonArray("workflows").get(0).getAsJsonObject().get("id").getAsString());
 
     JsonObject workflow = run("{\"action\":\"getWorkflow\",\"workflowId\":\"safety-study\"}");
     assertEquals("success", workflow.get("status").getAsString());
     assertEquals("safety-study", workflow.get("id").getAsString());
     assertEquals(4, workflow.getAsJsonArray("steps").size());
-    assertEquals("neqsim",
-        workflow.getAsJsonArray("steps").get(0).getAsJsonObject().get("server").getAsString());
+    assertEquals("neqsim", workflow.getAsJsonArray("steps").get(0).getAsJsonObject().get("server").getAsString());
   }
 
   @Test
   void compositionPlanIsSequentialMetadataAndPerformsNoExecution() {
-    JsonObject result =
-        run("{\"action\":\"planComposition\",\"task\":\"Compare plant measurements and project cost\"}");
+    JsonObject result = run(
+        "{\"action\":\"planComposition\",\"task\":\"Compare plant measurements and project cost\"}");
 
     assertEquals("success", result.get("status").getAsString());
     assertTrue(result.get("metadataOnly").getAsBoolean());
@@ -95,8 +93,7 @@ class CompositionRunnerTest {
     assertEquals(1, custom.getAsJsonArray("tools").size());
     assertEquals(1, custom.getAsJsonArray("dataFormats").size());
 
-    JsonObject removed =
-        run("{\"action\":\"removeServer\",\"name\":\"" + CUSTOM_SERVER + "\"}");
+    JsonObject removed = run("{\"action\":\"removeServer\",\"name\":\"" + CUSTOM_SERVER + "\"}");
     assertEquals("success", removed.get("status").getAsString());
     assertTrue(removed.get("removed").getAsBoolean());
   }
@@ -107,8 +104,8 @@ class CompositionRunnerTest {
         + "\",\"endpoint\":\"https://example.invalid/mcp\"}");
     assertEquals("UNSUPPORTED_CONNECTION_DATA", errorCode(endpoint));
 
-    JsonObject token = run("{\"action\":\"registerServer\",\"name\":\"" + CUSTOM_SERVER
-        + "\",\"token\":\"do-not-store\"}");
+    JsonObject token = run(
+        "{\"action\":\"registerServer\",\"name\":\"" + CUSTOM_SERVER + "\",\"token\":\"do-not-store\"}");
     assertEquals("UNSUPPORTED_CONNECTION_DATA", errorCode(token));
 
     JsonObject catalog = run("{\"action\":\"listServers\"}");
@@ -117,12 +114,10 @@ class CompositionRunnerTest {
 
   @Test
   void builtInMetadataCannotBeReplacedOrRemoved() {
-    JsonObject replace =
-        run("{\"action\":\"registerServer\",\"name\":\"plant-historian\"}");
+    JsonObject replace = run("{\"action\":\"registerServer\",\"name\":\"plant-historian\"}");
     assertEquals("PROTECTED_SERVER", errorCode(replace));
 
-    JsonObject remove =
-        run("{\"action\":\"removeServer\",\"name\":\"plant-historian\"}");
+    JsonObject remove = run("{\"action\":\"removeServer\",\"name\":\"plant-historian\"}");
     assertEquals("PROTECTED_SERVER", errorCode(remove));
 
     JsonObject catalog = run("{\"action\":\"listServers\"}");
@@ -133,8 +128,7 @@ class CompositionRunnerTest {
   void malformedBlankAndOversizedRequestsFailClosed() {
     assertEquals("INVALID_INPUT", errorCode(run("{")));
     assertEquals("INVALID_INPUT", errorCode(run("{}")));
-    assertEquals("INVALID_INPUT",
-        errorCode(run("{\"action\":\"planComposition\",\"task\":\"   \"}")));
+    assertEquals("INVALID_INPUT", errorCode(run("{\"action\":\"planComposition\",\"task\":\"   \"}")));
     assertEquals("INVALID_INPUT",
         errorCode(run("{\"action\":\"planComposition\",\"task\":\"" + repeat("x", 4097) + "\"}")));
     assertEquals("INVALID_INPUT", errorCode(run(repeat("x", 16385))));
@@ -144,12 +138,10 @@ class CompositionRunnerTest {
   @Test
   void customRegistryHasAFixedCapacity() {
     for (int index = 0; index < 32; index++) {
-      JsonObject response = run("{\"action\":\"registerServer\",\"name\":\"phase0-capacity-"
-          + index + "\"}");
+      JsonObject response = run("{\"action\":\"registerServer\",\"name\":\"phase0-capacity-" + index + "\"}");
       assertEquals("success", response.get("status").getAsString());
     }
-    JsonObject overflow =
-        run("{\"action\":\"registerServer\",\"name\":\"phase0-capacity-32\"}");
+    JsonObject overflow = run("{\"action\":\"registerServer\",\"name\":\"phase0-capacity-32\"}");
     assertEquals("REGISTRY_LIMIT", errorCode(overflow));
   }
 


### PR DESCRIPTION
## Summary

Qualify the existing `compositionJson` surface as a bounded, metadata-only multi-server composition planner under #3153.

This increment:

- bounds request size, names, descriptions, tasks, catalogs, workflow steps, and the custom-server registry;
- rejects endpoint, command, environment, header, credential, token, API-key, and secret fields;
- protects built-in server metadata and makes discovery deterministic;
- keeps planning advisory and host-mediated: no server connection, tool invocation, workflow execution, credential access, or process/network side effect occurs;
- adds focused Java coverage, seven packaged-MCP scenarios, CI wiring, and an evidence contract.

## Capability contract

- Issue: #3153
- Exact base: `006727adc7cf0350f172a737024d21fdb581ceef`
- Exact head: `078a4941e35d04f8ead042ca40f919a3ca432d84`
- Scope: bounded metadata discovery and planning only
- Canonical-model rule: canonical NeqSim runners remain authoritative; this layer does not implement thermodynamic or process calculations
- Inventory: unchanged at `1.34 / 20 explicit + 34 contract-tested + 17 confirmed gaps`
- `composeMultiServerWorkflow`: remains `CONFIRMED_GAP` pending a separate evidence promotion
- Autonomous portfolio occupancy after publication: `5/10`
- Overlap: no active pull request touches the eight files in this increment
- Workflow state: draft only; no merge, auto-merge, rebase, synchronization, or ready-for-review transition authorized

## Validation

Status: **VALIDATION PENDING CI**

The draft was published atomically from the frozen base. GitHub's exact-head Spotless artifact was applied as a formatter-only fast-forward repair. The focused Java suite then exposed and drove a narrow fail-closed repair so malformed JSON is classified as `INVALID_INPUT`. Comprehensive MCP subsequently exposed a Java-test source-count omission; the machine inventory, assertions, and surface documentation now consistently freeze 72 classes. No rebase or synchronization occurred. Exact-head validation includes:

- `CompositionRunnerTest`
- packaged `test_composition_protocol.py`
- comprehensive MCP protocol checks
- Java 8/21 fast tests and four slow shards
- Spotless, pre-commit, CodeQL, Javadocs, documentation, PaperLab, and agent validation

Current passing evidence on the exact head: focused Java **8/8**, packaged composition **7/7**, comprehensive MCP **332/332**, pre-commit, Spotless, PaperLab, CodeQL, Javadocs, and agent validation. The Ubuntu/Windows fast tests and four slow shards remain active.

## Files

Twelve files are changed: the composition runner and focused test, MCP tool description, packaged protocol test, CI wiring, README and contracts, plus the machine evidence inventory, its Java/Python assertions, and synchronized surface documentation.