### PR TITLE
feat(refinery): share product boiling-range diagnostics

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -305,6 +305,43 @@ comparators: no calculated-versus-plant error is used as a solver control, tunin
 threshold. Java callers use the same evaluator directly; Python callers access the factory,
 `getColumn().run(...)`, and evaluator through the existing JPype bridge.
 
+## Shared discrete product boiling-range diagnostics
+
+Material products returned by `SarirAtmosphericFractionationResult` expose the same immutable
+`ProductBoilingPointDistribution` used by the qualified Big Hill vacuum result. This shared
+implementation avoids separate atmospheric and vacuum quantile algorithms. It derives an ascending
+normal-boiling-point support from positive-composition pseudo-components, normalizes their
+cumulative product mole fractions to one, and reports the mole-weighted mean normal boiling point.
+
+Java and Python/JPype callers can inspect a material row as follows:
+
+```java
+SarirAtmosphericFractionationResult.ProductResult diesel =
+    result.getProduct("Diesel");
+boolean distributionAvailable = diesel.hasBoilingPointDistribution();
+double dieselT10Kelvin = diesel.getNormalBoilingPointQuantileKelvin(0.10);
+double dieselT50Celsius = diesel.getNormalBoilingPointQuantileCelsius(0.50);
+double dieselT90Kelvin = diesel.getNormalBoilingPointQuantileKelvin(0.90);
+double[] supportKelvin = diesel.getBoilingPointTemperaturesKelvin();
+double[] cumulativeMoleFractions = diesel.getCumulativeMoleFractions();
+```
+
+The support and cumulative arrays are defensive copies. Requests fail closed unless the cumulative
+mole fraction is finite and in `(0, 1]`. A source-table row whose calculated stream is below the
+qualified material-flow threshold reports `hasBoilingPointDistribution() == false`; attempting to
+read its distribution or quantiles fails closed instead of presenting an undefined curve.
+
+The focused 34-tray integration requires finite positive support temperatures, strictly increasing
+normalized cumulative fractions, exact cumulative closure to one, and T10 <= T50 <= T90 for every
+material product. Existing convergence, conservation, product-ordering, and read-only plant-rate
+comparisons remain unchanged.
+
+These values are discrete cumulative-mole pseudo-component diagnostics. They are not continuous
+simulated-distillation or TBP curves, ASTM D86/D1160 temperatures, pressure-corrected laboratory
+measurements, specification-compliance results, or evidence that NeqSim reproduces the Sarir plant
+yields. The cut density and molar-mass profiles and unreported column controls remain explicit
+engineering inputs.
+
 ## Scientific boundary
 
 The source-derived volumes, boiling boundaries, and product-specification rows are reproducible,

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
@@ -1,6 +1,5 @@
 package neqsim.process.equipment.distillation;
 
-import java.util.Arrays;
 import java.util.Objects;
 import neqsim.process.equipment.stream.StreamInterface;
 
@@ -92,15 +91,16 @@ public final class DoeBigHillVacuumFractionationResult {
       if (!Double.isFinite(massFlow) || !(massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow)) {
         throw new IllegalStateException("Both vacuum screening products must have material positive flow");
       }
-      double meanBoilingPoint = meanNormalBoilingPoint(streams[i]);
-      BoilingPointDistribution boilingPointDistribution = boilingPointDistribution(streams[i]);
+      ProductBoilingPointDistribution boilingPointDistribution =
+          ProductBoilingPointDistribution.from(streams[i]);
+      double meanBoilingPoint = boilingPointDistribution.getMeanNormalBoilingPointKelvin();
       if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
         throw new IllegalStateException("Products must become heavier from overhead to bottoms");
       }
       previousMeanBoilingPoint = meanBoilingPoint;
       productMassFlow += massFlow;
       productResults[i] = new ProductResult(PRODUCT_LABELS[i], massFlow, massFlow / feedMassFlow, meanBoilingPoint,
-          boilingPointDistribution.boilingPointTemperaturesKelvin, boilingPointDistribution.cumulativeMoleFractions);
+          boilingPointDistribution);
     }
 
     double closureError = Math.abs(feedMassFlow - productMassFlow) / feedMassFlow;
@@ -193,72 +193,6 @@ public final class DoeBigHillVacuumFractionationResult {
     return convergenceDiagnostics;
   }
 
-  private static double meanNormalBoilingPoint(StreamInterface stream) {
-    double[] composition = stream.getThermoSystem().getMolarComposition();
-    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
-    if (composition.length != boilingPoints.length || composition.length == 0) {
-      throw new IllegalStateException("Product composition and boiling-point arrays must align");
-    }
-
-    double mean = 0.0;
-    double compositionSum = 0.0;
-    for (int i = 0; i < composition.length; i++) {
-      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
-          || !(boilingPoints[i] > 0.0)) {
-        throw new IllegalStateException("Product composition and boiling points must be physical");
-      }
-      mean += composition[i] * boilingPoints[i];
-      compositionSum += composition[i];
-    }
-    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || !Double.isFinite(mean)) {
-      throw new IllegalStateException("Product mean boiling point is undefined");
-    }
-    return mean / compositionSum;
-  }
-
-  private static BoilingPointDistribution boilingPointDistribution(StreamInterface stream) {
-    double[] composition = stream.getThermoSystem().getMolarComposition();
-    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
-    if (composition.length != boilingPoints.length || composition.length == 0) {
-      throw new IllegalStateException("Product composition and boiling-point arrays must align");
-    }
-
-    double[][] points = new double[composition.length][2];
-    double compositionSum = 0.0;
-    int positiveComponentCount = 0;
-    for (int i = 0; i < composition.length; i++) {
-      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
-          || !(boilingPoints[i] > 0.0)) {
-        throw new IllegalStateException("Product composition and boiling points must be physical");
-      }
-      points[i][0] = boilingPoints[i];
-      points[i][1] = composition[i];
-      compositionSum += composition[i];
-      if (composition[i] > 0.0) {
-        positiveComponentCount++;
-      }
-    }
-    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || positiveComponentCount == 0) {
-      throw new IllegalStateException("Product boiling-point distribution is undefined");
-    }
-
-    Arrays.sort(points, (left, right) -> Double.compare(left[0], right[0]));
-    double[] temperatures = new double[positiveComponentCount];
-    double[] cumulativeFractions = new double[positiveComponentCount];
-    double cumulativeFraction = 0.0;
-    int resultIndex = 0;
-    for (double[] point : points) {
-      if (point[1] > 0.0) {
-        cumulativeFraction += point[1] / compositionSum;
-        temperatures[resultIndex] = point[0];
-        cumulativeFractions[resultIndex] = cumulativeFraction;
-        resultIndex++;
-      }
-    }
-    cumulativeFractions[cumulativeFractions.length - 1] = 1.0;
-    return new BoilingPointDistribution(temperatures, cumulativeFractions);
-  }
-
   private static double maximumComponentMolarClosureRelativeError(StreamInterface feed, StreamInterface[] products) {
     double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     double feedMolarFlow = feed.getFlowRate("mol/hr");
@@ -291,34 +225,22 @@ public final class DoeBigHillVacuumFractionationResult {
     }
   }
 
-  private static final class BoilingPointDistribution {
-    private final double[] boilingPointTemperaturesKelvin;
-    private final double[] cumulativeMoleFractions;
-
-    private BoilingPointDistribution(double[] boilingPointTemperaturesKelvin, double[] cumulativeMoleFractions) {
-      this.boilingPointTemperaturesKelvin = boilingPointTemperaturesKelvin;
-      this.cumulativeMoleFractions = cumulativeMoleFractions;
-    }
-  }
-
   /** Immutable calculated vacuum-screening product row. */
   public static final class ProductResult {
     private final String productLabel;
     private final double massFlowKgPerHour;
     private final double massFractionOfFeed;
     private final double meanNormalBoilingPointKelvin;
-    private final double[] boilingPointTemperaturesKelvin;
-    private final double[] cumulativeMoleFractions;
+    private final ProductBoilingPointDistribution boilingPointDistribution;
 
     private ProductResult(String productLabel, double massFlowKgPerHour, double massFractionOfFeed,
-        double meanNormalBoilingPointKelvin, double[] boilingPointTemperaturesKelvin,
-        double[] cumulativeMoleFractions) {
+        double meanNormalBoilingPointKelvin, ProductBoilingPointDistribution boilingPointDistribution) {
       this.productLabel = productLabel;
       this.massFlowKgPerHour = massFlowKgPerHour;
       this.massFractionOfFeed = massFractionOfFeed;
       this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
-      this.boilingPointTemperaturesKelvin = boilingPointTemperaturesKelvin.clone();
-      this.cumulativeMoleFractions = cumulativeMoleFractions.clone();
+      this.boilingPointDistribution = Objects.requireNonNull(boilingPointDistribution,
+          "boilingPointDistribution");
     }
 
     /** @return product label */
@@ -348,12 +270,12 @@ public final class DoeBigHillVacuumFractionationResult {
 
     /** @return defensive copy of ascending pseudo-component normal boiling points in kelvin */
     public double[] getBoilingPointTemperaturesKelvin() {
-      return boilingPointTemperaturesKelvin.clone();
+      return boilingPointDistribution.getBoilingPointTemperaturesKelvin();
     }
 
     /** @return defensive copy of normalized cumulative product mole fractions */
     public double[] getCumulativeMoleFractions() {
-      return cumulativeMoleFractions.clone();
+      return boilingPointDistribution.getCumulativeMoleFractions();
     }
 
     /**
@@ -368,15 +290,7 @@ public final class DoeBigHillVacuumFractionationResult {
      * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
      */
     public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
-      if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0) || cumulativeMoleFraction > 1.0) {
-        throw new IllegalArgumentException("Cumulative mole fraction must be finite and in (0, 1]");
-      }
-      for (int i = 0; i < cumulativeMoleFractions.length; i++) {
-        if (cumulativeMoleFractions[i] >= cumulativeMoleFraction) {
-          return boilingPointTemperaturesKelvin[i];
-        }
-      }
-      return boilingPointTemperaturesKelvin[boilingPointTemperaturesKelvin.length - 1];
+      return boilingPointDistribution.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
     }
 
     /**
@@ -387,7 +301,7 @@ public final class DoeBigHillVacuumFractionationResult {
      * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
      */
     public double getNormalBoilingPointQuantileCelsius(double cumulativeMoleFraction) {
-      return getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction) - 273.15;
+      return boilingPointDistribution.getNormalBoilingPointQuantileCelsius(cumulativeMoleFraction);
     }
   }
 }

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFractionationResult.java
@@ -91,8 +91,7 @@ public final class DoeBigHillVacuumFractionationResult {
       if (!Double.isFinite(massFlow) || !(massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow)) {
         throw new IllegalStateException("Both vacuum screening products must have material positive flow");
       }
-      ProductBoilingPointDistribution boilingPointDistribution =
-          ProductBoilingPointDistribution.from(streams[i]);
+      ProductBoilingPointDistribution boilingPointDistribution = ProductBoilingPointDistribution.from(streams[i]);
       double meanBoilingPoint = boilingPointDistribution.getMeanNormalBoilingPointKelvin();
       if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
         throw new IllegalStateException("Products must become heavier from overhead to bottoms");
@@ -239,8 +238,7 @@ public final class DoeBigHillVacuumFractionationResult {
       this.massFlowKgPerHour = massFlowKgPerHour;
       this.massFractionOfFeed = massFractionOfFeed;
       this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
-      this.boilingPointDistribution = Objects.requireNonNull(boilingPointDistribution,
-          "boilingPointDistribution");
+      this.boilingPointDistribution = Objects.requireNonNull(boilingPointDistribution, "boilingPointDistribution");
     }
 
     /** @return product label */

--- a/src/main/java/neqsim/process/equipment/distillation/ProductBoilingPointDistribution.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ProductBoilingPointDistribution.java
@@ -64,6 +64,11 @@ public final class ProductBoilingPointDistribution {
       throw new IllegalStateException("Product boiling-point distribution is undefined");
     }
 
+    double meanBoilingPoint = weightedBoilingPoint / compositionSum;
+    if (!Double.isFinite(meanBoilingPoint) || !(meanBoilingPoint > 0.0)) {
+      throw new IllegalStateException("Product mean boiling point is undefined");
+    }
+
     Arrays.sort(points, (left, right) -> Double.compare(left[0], right[0]));
     double[] temperatures = new double[positiveComponentCount];
     double[] cumulativeFractions = new double[positiveComponentCount];
@@ -71,7 +76,13 @@ public final class ProductBoilingPointDistribution {
     int resultIndex = 0;
     for (double[] point : points) {
       if (point[1] > 0.0) {
-        cumulativeFraction += point[1] / compositionSum;
+        double nextCumulativeFraction = cumulativeFraction + point[1] / compositionSum;
+        if (!Double.isFinite(nextCumulativeFraction)
+            || !(nextCumulativeFraction > cumulativeFraction)) {
+          throw new IllegalStateException(
+              "Positive product components must increase cumulative mole fraction");
+        }
+        cumulativeFraction = nextCumulativeFraction;
         temperatures[resultIndex] = point[0];
         cumulativeFractions[resultIndex] = cumulativeFraction;
         resultIndex++;
@@ -79,7 +90,7 @@ public final class ProductBoilingPointDistribution {
     }
     cumulativeFractions[cumulativeFractions.length - 1] = 1.0;
     return new ProductBoilingPointDistribution(temperatures, cumulativeFractions,
-        weightedBoilingPoint / compositionSum);
+        meanBoilingPoint);
   }
 
   /** @return defensive copy of ascending pseudo-component normal boiling points in kelvin */

--- a/src/main/java/neqsim/process/equipment/distillation/ProductBoilingPointDistribution.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ProductBoilingPointDistribution.java
@@ -8,8 +8,8 @@ import neqsim.process.equipment.stream.StreamInterface;
  * Immutable discrete normal-boiling-point distribution for a material process product.
  *
  * <p>
- * The distribution uses positive pseudo-component mole fractions from a NeqSim stream. It is a
- * model diagnostic, not an ASTM D86, ASTM D1160, TBP, or continuous simulated-distillation curve.
+ * The distribution uses positive pseudo-component mole fractions from a NeqSim stream. It is a model diagnostic, not an
+ * ASTM D86, ASTM D1160, TBP, or continuous simulated-distillation curve.
  * </p>
  */
 public final class ProductBoilingPointDistribution {
@@ -17,8 +17,8 @@ public final class ProductBoilingPointDistribution {
   private final double[] cumulativeMoleFractions;
   private final double meanNormalBoilingPointKelvin;
 
-  private ProductBoilingPointDistribution(double[] boilingPointTemperaturesKelvin,
-      double[] cumulativeMoleFractions, double meanNormalBoilingPointKelvin) {
+  private ProductBoilingPointDistribution(double[] boilingPointTemperaturesKelvin, double[] cumulativeMoleFractions,
+      double meanNormalBoilingPointKelvin) {
     this.boilingPointTemperaturesKelvin = boilingPointTemperaturesKelvin.clone();
     this.cumulativeMoleFractions = cumulativeMoleFractions.clone();
     this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
@@ -30,8 +30,7 @@ public final class ProductBoilingPointDistribution {
    * @param stream material product stream
    * @return immutable distribution on cumulative product mole basis
    * @throws NullPointerException if {@code stream} is {@code null}
-   * @throws IllegalStateException if composition and boiling-point data are missing, unaligned, or
-   *         non-physical
+   * @throws IllegalStateException if composition and boiling-point data are missing, unaligned, or non-physical
    */
   public static ProductBoilingPointDistribution from(StreamInterface stream) {
     Objects.requireNonNull(stream, "stream");
@@ -46,10 +45,9 @@ public final class ProductBoilingPointDistribution {
     double weightedBoilingPoint = 0.0;
     int positiveComponentCount = 0;
     for (int i = 0; i < composition.length; i++) {
-      if (!Double.isFinite(composition[i]) || composition[i] < 0.0
-          || !Double.isFinite(boilingPoints[i]) || !(boilingPoints[i] > 0.0)) {
-        throw new IllegalStateException(
-            "Product composition and boiling points must be physical");
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
+          || !(boilingPoints[i] > 0.0)) {
+        throw new IllegalStateException("Product composition and boiling points must be physical");
       }
       points[i][0] = boilingPoints[i];
       points[i][1] = composition[i];
@@ -59,8 +57,8 @@ public final class ProductBoilingPointDistribution {
         positiveComponentCount++;
       }
     }
-    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0)
-        || !Double.isFinite(weightedBoilingPoint) || positiveComponentCount == 0) {
+    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || !Double.isFinite(weightedBoilingPoint)
+        || positiveComponentCount == 0) {
       throw new IllegalStateException("Product boiling-point distribution is undefined");
     }
 
@@ -77,10 +75,8 @@ public final class ProductBoilingPointDistribution {
     for (double[] point : points) {
       if (point[1] > 0.0) {
         double nextCumulativeFraction = cumulativeFraction + point[1] / compositionSum;
-        if (!Double.isFinite(nextCumulativeFraction)
-            || !(nextCumulativeFraction > cumulativeFraction)) {
-          throw new IllegalStateException(
-              "Positive product components must increase cumulative mole fraction");
+        if (!Double.isFinite(nextCumulativeFraction) || !(nextCumulativeFraction > cumulativeFraction)) {
+          throw new IllegalStateException("Positive product components must increase cumulative mole fraction");
         }
         cumulativeFraction = nextCumulativeFraction;
         temperatures[resultIndex] = point[0];
@@ -89,8 +85,7 @@ public final class ProductBoilingPointDistribution {
       }
     }
     cumulativeFractions[cumulativeFractions.length - 1] = 1.0;
-    return new ProductBoilingPointDistribution(temperatures, cumulativeFractions,
-        meanBoilingPoint);
+    return new ProductBoilingPointDistribution(temperatures, cumulativeFractions, meanBoilingPoint);
   }
 
   /** @return defensive copy of ascending pseudo-component normal boiling points in kelvin */
@@ -121,10 +116,8 @@ public final class ProductBoilingPointDistribution {
    * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
    */
   public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
-    if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0)
-        || cumulativeMoleFraction > 1.0) {
-      throw new IllegalArgumentException(
-          "Cumulative mole fraction must be finite and in (0, 1]");
+    if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0) || cumulativeMoleFraction > 1.0) {
+      throw new IllegalArgumentException("Cumulative mole fraction must be finite and in (0, 1]");
     }
     for (int i = 0; i < cumulativeMoleFractions.length; i++) {
       if (cumulativeMoleFractions[i] >= cumulativeMoleFraction) {

--- a/src/main/java/neqsim/process/equipment/distillation/ProductBoilingPointDistribution.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ProductBoilingPointDistribution.java
@@ -1,0 +1,136 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Arrays;
+import java.util.Objects;
+import neqsim.process.equipment.stream.StreamInterface;
+
+/**
+ * Immutable discrete normal-boiling-point distribution for a material process product.
+ *
+ * <p>
+ * The distribution uses positive pseudo-component mole fractions from a NeqSim stream. It is a
+ * model diagnostic, not an ASTM D86, ASTM D1160, TBP, or continuous simulated-distillation curve.
+ * </p>
+ */
+public final class ProductBoilingPointDistribution {
+  private final double[] boilingPointTemperaturesKelvin;
+  private final double[] cumulativeMoleFractions;
+  private final double meanNormalBoilingPointKelvin;
+
+  private ProductBoilingPointDistribution(double[] boilingPointTemperaturesKelvin,
+      double[] cumulativeMoleFractions, double meanNormalBoilingPointKelvin) {
+    this.boilingPointTemperaturesKelvin = boilingPointTemperaturesKelvin.clone();
+    this.cumulativeMoleFractions = cumulativeMoleFractions.clone();
+    this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
+  }
+
+  /**
+   * Build a discrete product distribution from stream pseudo-components.
+   *
+   * @param stream material product stream
+   * @return immutable distribution on cumulative product mole basis
+   * @throws NullPointerException if {@code stream} is {@code null}
+   * @throws IllegalStateException if composition and boiling-point data are missing, unaligned, or
+   *         non-physical
+   */
+  public static ProductBoilingPointDistribution from(StreamInterface stream) {
+    Objects.requireNonNull(stream, "stream");
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    if (composition.length != boilingPoints.length || composition.length == 0) {
+      throw new IllegalStateException("Product composition and boiling-point arrays must align");
+    }
+
+    double[][] points = new double[composition.length][2];
+    double compositionSum = 0.0;
+    double weightedBoilingPoint = 0.0;
+    int positiveComponentCount = 0;
+    for (int i = 0; i < composition.length; i++) {
+      if (!Double.isFinite(composition[i]) || composition[i] < 0.0
+          || !Double.isFinite(boilingPoints[i]) || !(boilingPoints[i] > 0.0)) {
+        throw new IllegalStateException(
+            "Product composition and boiling points must be physical");
+      }
+      points[i][0] = boilingPoints[i];
+      points[i][1] = composition[i];
+      compositionSum += composition[i];
+      weightedBoilingPoint += composition[i] * boilingPoints[i];
+      if (composition[i] > 0.0) {
+        positiveComponentCount++;
+      }
+    }
+    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0)
+        || !Double.isFinite(weightedBoilingPoint) || positiveComponentCount == 0) {
+      throw new IllegalStateException("Product boiling-point distribution is undefined");
+    }
+
+    Arrays.sort(points, (left, right) -> Double.compare(left[0], right[0]));
+    double[] temperatures = new double[positiveComponentCount];
+    double[] cumulativeFractions = new double[positiveComponentCount];
+    double cumulativeFraction = 0.0;
+    int resultIndex = 0;
+    for (double[] point : points) {
+      if (point[1] > 0.0) {
+        cumulativeFraction += point[1] / compositionSum;
+        temperatures[resultIndex] = point[0];
+        cumulativeFractions[resultIndex] = cumulativeFraction;
+        resultIndex++;
+      }
+    }
+    cumulativeFractions[cumulativeFractions.length - 1] = 1.0;
+    return new ProductBoilingPointDistribution(temperatures, cumulativeFractions,
+        weightedBoilingPoint / compositionSum);
+  }
+
+  /** @return defensive copy of ascending pseudo-component normal boiling points in kelvin */
+  public double[] getBoilingPointTemperaturesKelvin() {
+    return boilingPointTemperaturesKelvin.clone();
+  }
+
+  /** @return defensive copy of normalized cumulative product mole fractions */
+  public double[] getCumulativeMoleFractions() {
+    return cumulativeMoleFractions.clone();
+  }
+
+  /** @return mole-weighted mean normal boiling point in kelvin */
+  public double getMeanNormalBoilingPointKelvin() {
+    return meanNormalBoilingPointKelvin;
+  }
+
+  /** @return mole-weighted mean normal boiling point in degrees Celsius */
+  public double getMeanNormalBoilingPointCelsius() {
+    return meanNormalBoilingPointKelvin - 273.15;
+  }
+
+  /**
+   * Return the first support temperature whose cumulative mole fraction reaches the request.
+   *
+   * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
+   * @return discrete normal boiling point in kelvin
+   * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
+   */
+  public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+    if (!Double.isFinite(cumulativeMoleFraction) || !(cumulativeMoleFraction > 0.0)
+        || cumulativeMoleFraction > 1.0) {
+      throw new IllegalArgumentException(
+          "Cumulative mole fraction must be finite and in (0, 1]");
+    }
+    for (int i = 0; i < cumulativeMoleFractions.length; i++) {
+      if (cumulativeMoleFractions[i] >= cumulativeMoleFraction) {
+        return boilingPointTemperaturesKelvin[i];
+      }
+    }
+    return boilingPointTemperaturesKelvin[boilingPointTemperaturesKelvin.length - 1];
+  }
+
+  /**
+   * Return the first support temperature whose cumulative mole fraction reaches the request.
+   *
+   * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
+   * @return discrete normal boiling point in degrees Celsius
+   * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
+   */
+  public double getNormalBoilingPointQuantileCelsius(double cumulativeMoleFraction) {
+    return getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction) - 273.15;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
@@ -279,8 +279,7 @@ public final class SarirAtmosphericFractionationResult {
      * @throws IllegalStateException if this is a non-material product
      */
     public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
-      return requireBoilingPointDistribution()
-          .getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+      return requireBoilingPointDistribution().getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
     }
 
     /**
@@ -292,14 +291,12 @@ public final class SarirAtmosphericFractionationResult {
      * @throws IllegalStateException if this is a non-material product
      */
     public double getNormalBoilingPointQuantileCelsius(double cumulativeMoleFraction) {
-      return requireBoilingPointDistribution()
-          .getNormalBoilingPointQuantileCelsius(cumulativeMoleFraction);
+      return requireBoilingPointDistribution().getNormalBoilingPointQuantileCelsius(cumulativeMoleFraction);
     }
 
     private ProductBoilingPointDistribution requireBoilingPointDistribution() {
       if (boilingPointDistribution == null) {
-        throw new IllegalStateException(
-            "Boiling-point distribution is unavailable for a non-material product");
+        throw new IllegalStateException("Boiling-point distribution is unavailable for a non-material product");
       }
       return boilingPointDistribution;
     }

--- a/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationResult.java
@@ -92,8 +92,10 @@ public final class SarirAtmosphericFractionationResult {
       productMassFlow += massFlow;
 
       double meanBoilingPoint = Double.NaN;
+      ProductBoilingPointDistribution boilingPointDistribution = null;
       if (massFlow > MATERIAL_FLOW_FRACTION * feedMassFlow) {
-        meanBoilingPoint = meanNormalBoilingPoint(streams[i]);
+        boilingPointDistribution = ProductBoilingPointDistribution.from(streams[i]);
+        meanBoilingPoint = boilingPointDistribution.getMeanNormalBoilingPointKelvin();
         if (!(meanBoilingPoint > previousMeanBoilingPoint)) {
           throw new IllegalStateException("Material products must become heavier from the column top to the bottoms");
         }
@@ -103,7 +105,7 @@ public final class SarirAtmosphericFractionationResult {
 
       ProductYieldReference reference = SarirAtmosphericReference.getProductYield(PRODUCT_LABELS[i]);
       productResults[i] = new ProductResult(reference.getName(), massFlow, massFlow / feedMassFlow, meanBoilingPoint,
-          reference.getPlantMassFlowRateKgPerHour(),
+          boilingPointDistribution, reference.getPlantMassFlowRateKgPerHour(),
           reference.calculateAbsoluteRelativeErrorPercentForMassFlowKgPerHour(massFlow));
     }
     if (materialProductCount < 2) {
@@ -178,29 +180,6 @@ public final class SarirAtmosphericFractionationResult {
     return convergenceDiagnostics;
   }
 
-  private static double meanNormalBoilingPoint(StreamInterface stream) {
-    double[] composition = stream.getThermoSystem().getMolarComposition();
-    double[] boilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
-    if (composition.length != boilingPoints.length || composition.length == 0) {
-      throw new IllegalStateException("Product composition and boiling-point arrays must align");
-    }
-
-    double mean = 0.0;
-    double compositionSum = 0.0;
-    for (int i = 0; i < composition.length; i++) {
-      if (!Double.isFinite(composition[i]) || composition[i] < 0.0 || !Double.isFinite(boilingPoints[i])
-          || !(boilingPoints[i] > 0.0)) {
-        throw new IllegalStateException("Product composition and boiling points must be physical");
-      }
-      mean += composition[i] * boilingPoints[i];
-      compositionSum += composition[i];
-    }
-    if (!Double.isFinite(compositionSum) || !(compositionSum > 0.0) || !Double.isFinite(mean)) {
-      throw new IllegalStateException("Product mean boiling point is undefined");
-    }
-    return mean / compositionSum;
-  }
-
   private static void requireFiniteBoundedError(double value, String label) {
     if (!Double.isFinite(value) || value < 0.0 || value > BALANCE_TOLERANCE) {
       throw new IllegalStateException(label + " exceeds the qualified tolerance");
@@ -213,16 +192,18 @@ public final class SarirAtmosphericFractionationResult {
     private final double calculatedMassFlowKgPerHour;
     private final double calculatedMassFractionOfFeed;
     private final double meanNormalBoilingPointKelvin;
+    private final ProductBoilingPointDistribution boilingPointDistribution;
     private final double plantMassFlowKgPerHour;
     private final double absoluteRelativeErrorPercentAgainstPlant;
 
     private ProductResult(String productLabel, double calculatedMassFlowKgPerHour, double calculatedMassFractionOfFeed,
-        double meanNormalBoilingPointKelvin, double plantMassFlowKgPerHour,
-        double absoluteRelativeErrorPercentAgainstPlant) {
+        double meanNormalBoilingPointKelvin, ProductBoilingPointDistribution boilingPointDistribution,
+        double plantMassFlowKgPerHour, double absoluteRelativeErrorPercentAgainstPlant) {
       this.productLabel = productLabel;
       this.calculatedMassFlowKgPerHour = calculatedMassFlowKgPerHour;
       this.calculatedMassFractionOfFeed = calculatedMassFractionOfFeed;
       this.meanNormalBoilingPointKelvin = meanNormalBoilingPointKelvin;
+      this.boilingPointDistribution = boilingPointDistribution;
       this.plantMassFlowKgPerHour = plantMassFlowKgPerHour;
       this.absoluteRelativeErrorPercentAgainstPlant = absoluteRelativeErrorPercentAgainstPlant;
     }
@@ -258,6 +239,69 @@ public final class SarirAtmosphericFractionationResult {
      */
     public double getMeanNormalBoilingPointCelsius() {
       return Double.isFinite(meanNormalBoilingPointKelvin) ? meanNormalBoilingPointKelvin - 273.15 : Double.NaN;
+    }
+
+    /**
+     * Report whether this material product has a discrete boiling-point distribution.
+     *
+     * @return true for a material product; false for a non-material candidate row
+     */
+    public boolean hasBoilingPointDistribution() {
+      return boilingPointDistribution != null;
+    }
+
+    /**
+     * Return the ascending positive-component normal-boiling-point support.
+     *
+     * @return defensive copy of temperatures in kelvin
+     * @throws IllegalStateException if this is a non-material product
+     */
+    public double[] getBoilingPointTemperaturesKelvin() {
+      return requireBoilingPointDistribution().getBoilingPointTemperaturesKelvin();
+    }
+
+    /**
+     * Return the normalized cumulative product mole fractions.
+     *
+     * @return defensive copy of cumulative mole fractions
+     * @throws IllegalStateException if this is a non-material product
+     */
+    public double[] getCumulativeMoleFractions() {
+      return requireBoilingPointDistribution().getCumulativeMoleFractions();
+    }
+
+    /**
+     * Return a discrete pseudo-component quantile on cumulative product mole basis.
+     *
+     * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
+     * @return normal boiling point in kelvin
+     * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
+     * @throws IllegalStateException if this is a non-material product
+     */
+    public double getNormalBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      return requireBoilingPointDistribution()
+          .getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+
+    /**
+     * Return a discrete pseudo-component quantile on cumulative product mole basis.
+     *
+     * @param cumulativeMoleFraction requested cumulative product mole fraction in (0, 1]
+     * @return normal boiling point in degrees Celsius
+     * @throws IllegalArgumentException if the request is non-finite or outside (0, 1]
+     * @throws IllegalStateException if this is a non-material product
+     */
+    public double getNormalBoilingPointQuantileCelsius(double cumulativeMoleFraction) {
+      return requireBoilingPointDistribution()
+          .getNormalBoilingPointQuantileCelsius(cumulativeMoleFraction);
+    }
+
+    private ProductBoilingPointDistribution requireBoilingPointDistribution() {
+      if (boilingPointDistribution == null) {
+        throw new IllegalStateException(
+            "Boiling-point distribution is unavailable for a non-material product");
+      }
+      return boilingPointDistribution;
     }
 
     /** @return measured plant product rate in kg/h */

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
@@ -134,8 +134,7 @@ public class SarirAtmosphericFractionationCaseTest {
         inconsistentSpecificGravity, MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
   }
 
-  private static void assertBoilingRange(
-      SarirAtmosphericFractionationResult.ProductResult product) {
+  private static void assertBoilingRange(SarirAtmosphericFractionationResult.ProductResult product) {
     double[] temperatures = product.getBoilingPointTemperaturesKelvin();
     double[] cumulativeFractions = product.getCumulativeMoleFractions();
     assertEquals(temperatures.length, cumulativeFractions.length);
@@ -158,14 +157,10 @@ public class SarirAtmosphericFractionationCaseTest {
     double t90 = product.getNormalBoilingPointQuantileKelvin(0.90);
     assertTrue(t10 <= t50);
     assertTrue(t50 <= t90);
-    assertEquals(t50 - 273.15, product.getNormalBoilingPointQuantileCelsius(0.50),
-        1.0e-12);
-    assertThrows(IllegalArgumentException.class,
-        () -> product.getNormalBoilingPointQuantileKelvin(0.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> product.getNormalBoilingPointQuantileKelvin(1.0001));
-    assertThrows(IllegalArgumentException.class,
-        () -> product.getNormalBoilingPointQuantileKelvin(Double.NaN));
+    assertEquals(t50 - 273.15, product.getNormalBoilingPointQuantileCelsius(0.50), 1.0e-12);
+    assertThrows(IllegalArgumentException.class, () -> product.getNormalBoilingPointQuantileKelvin(0.0));
+    assertThrows(IllegalArgumentException.class, () -> product.getNormalBoilingPointQuantileKelvin(1.0001));
+    assertThrows(IllegalArgumentException.class, () -> product.getNormalBoilingPointQuantileKelvin(Double.NaN));
 
     double originalTemperature = product.getBoilingPointTemperaturesKelvin()[0];
     temperatures[0] = -1.0;

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationCaseTest.java
@@ -2,6 +2,7 @@ package neqsim.process.equipment.distillation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,7 +96,11 @@ public class SarirAtmosphericFractionationCaseTest {
         assertTrue(rows[i].getMeanNormalBoilingPointKelvin() > previousBoilingPoint);
         assertEquals(rows[i].getMeanNormalBoilingPointKelvin() - 273.15, rows[i].getMeanNormalBoilingPointCelsius(),
             1.0e-12);
+        assertTrue(rows[i].hasBoilingPointDistribution());
+        assertBoilingRange(rows[i]);
         previousBoilingPoint = rows[i].getMeanNormalBoilingPointKelvin();
+      } else {
+        assertTrue(!rows[i].hasBoilingPointDistribution());
       }
     }
     assertEquals(result.getProductMassFlowKgPerHour(), calculatedMassFlow, 1.0e-8);
@@ -127,6 +132,46 @@ public class SarirAtmosphericFractionationCaseTest {
     inconsistentSpecificGravity[0] += 0.5;
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericFractionationCase.create("Sarir",
         inconsistentSpecificGravity, MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+  }
+
+  private static void assertBoilingRange(
+      SarirAtmosphericFractionationResult.ProductResult product) {
+    double[] temperatures = product.getBoilingPointTemperaturesKelvin();
+    double[] cumulativeFractions = product.getCumulativeMoleFractions();
+    assertEquals(temperatures.length, cumulativeFractions.length);
+    assertTrue(temperatures.length > 0);
+    assertNotSame(temperatures, product.getBoilingPointTemperaturesKelvin());
+    assertNotSame(cumulativeFractions, product.getCumulativeMoleFractions());
+
+    for (int i = 0; i < temperatures.length; i++) {
+      assertTrue(Double.isFinite(temperatures[i]) && temperatures[i] > 0.0);
+      assertTrue(Double.isFinite(cumulativeFractions[i]) && cumulativeFractions[i] > 0.0);
+      if (i > 0) {
+        assertTrue(temperatures[i] >= temperatures[i - 1]);
+        assertTrue(cumulativeFractions[i] > cumulativeFractions[i - 1]);
+      }
+    }
+    assertEquals(1.0, cumulativeFractions[cumulativeFractions.length - 1], 1.0e-12);
+
+    double t10 = product.getNormalBoilingPointQuantileKelvin(0.10);
+    double t50 = product.getNormalBoilingPointQuantileKelvin(0.50);
+    double t90 = product.getNormalBoilingPointQuantileKelvin(0.90);
+    assertTrue(t10 <= t50);
+    assertTrue(t50 <= t90);
+    assertEquals(t50 - 273.15, product.getNormalBoilingPointQuantileCelsius(0.50),
+        1.0e-12);
+    assertThrows(IllegalArgumentException.class,
+        () -> product.getNormalBoilingPointQuantileKelvin(0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> product.getNormalBoilingPointQuantileKelvin(1.0001));
+    assertThrows(IllegalArgumentException.class,
+        () -> product.getNormalBoilingPointQuantileKelvin(Double.NaN));
+
+    double originalTemperature = product.getBoilingPointTemperaturesKelvin()[0];
+    temperatures[0] = -1.0;
+    cumulativeFractions[0] = -1.0;
+    assertEquals(originalTemperature, product.getBoilingPointTemperaturesKelvin()[0], 0.0);
+    assertTrue(product.getCumulativeMoleFractions()[0] > 0.0);
   }
 
   private static OperatingInputs qualifiedInputs() {


### PR DESCRIPTION
## Summary

Advances #3305 with the next Phase 3 reuse and product-characterization gap after merged PR #3613.

This increment adds one immutable `ProductBoilingPointDistribution` for material process products, refactors the qualified Big Hill vacuum result to reuse it without changing its public API, and extends solved Sarir atmospheric product rows with the same Java/JPype-accessible discrete boiling-range diagnostics.

## Exact-head contract

- Frozen base: `b703de2fdce2bda4b4b212bb0b293984a552b092`
- Exact publication head: `c39a474681dd2fa1a52afcf76badd6c10f8c6741`
- Branch: `codex/refinery-shared-boiling-range`
- Ten ordered commits and exactly five intended files
- Sole active #3305 implementation PR
- Positively identified autonomous implementation occupancy after publication: **5/10**
- No active-PR ownership overlap

## Engineering acceptance

- One shared implementation derives ascending normal-boiling-point support from positive-composition pseudo-components.
- Composition must be finite and non-negative; support temperatures must be finite and positive.
- Composition sum and mole-weighted mean normal boiling point must be finite and positive.
- Every positive component must increase the normalized cumulative product mole fraction.
- Cumulative support closes exactly to one.
- Support and cumulative arrays are defensive copies.
- Quantile requests fail closed unless finite and in `(0, 1]`.
- Material Sarir rows expose T10/T50/T90 with T10 <= T50 <= T90 and exact kelvin/Celsius conversion.
- Non-material Sarir rows explicitly report distribution absence and fail closed on distribution access.
- Existing Big Hill API behavior, Sarir plant-rate evidence, MESH convergence, conservation, ordering, and integration gates remain in force.

## Provenance and scientific boundary

The existing public DOE Big Hill and Sarir assay/literature evidence remains authoritative. No empirical parameter, source value, proprietary dataset, or plant-yield target is introduced.

These values are discrete pseudo-component diagnostics on cumulative product mole basis. They are not continuous simulated-distillation curves, TBP temperatures, ASTM D86 or ASTM D1160 results, pressure-corrected laboratory measurements, product-specification compliance, validated refinery yields, or plant agreement.

## Documentation impact

The Sarir guide now documents the shared API, Java/JPype access, material-row semantics, numerical gates, interpretation, and limitations.

## Validation status

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Connector-side prepublication audit passed:

- exact five-file scope and ten-commit fast-forward history;
- zero commits behind the frozen base at publication;
- balanced Java braces;
- no tabs, trailing whitespace, literal escaped-newline defects, or Java lines over 120 characters;
- no open-PR path overlap.

No local Maven, Java, Spotless, pre-commit, Python, or documentation execution is claimed. The initial hosted run produced only Spotless line wrapping in four Java files. The exact hosted formatter artifact from run `34470462978` (artifact `10149311800`, archive SHA-256 `15846b9f80d06f199e847c6e3c9b886d0ac374cf14abfca75d2a8f66692399f7`) was audited and applied as four sequential formatting-only commits. No behavior, APIs, tests, provenance, assumptions, or acceptance criteria changed. The single formatting-only repair allowance is consumed. Fresh hosted GitHub Actions on exact head `c39a474681dd2fa1a52afcf76badd6c10f8c6741` are authoritative.

No merge, auto-merge, rebase, synchronization, force-push, close, replacement, or ready-for-review transition is authorized.