### PR TITLE
docs: modernize transient accumulation example logging

### DIFF
--- a/docs/examples/TransientPipelineLiquidAccumulationExample.java
+++ b/docs/examples/TransientPipelineLiquidAccumulationExample.java
@@ -1,6 +1,8 @@
 package examples;
 
 import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
@@ -28,6 +30,9 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
  * @version 1.0
  */
 public class TransientPipelineLiquidAccumulationExample {
+  private static final Logger logger =
+      LogManager.getLogger(TransientPipelineLiquidAccumulationExample.class);
+
 
   /**
    * Main entry point.
@@ -35,11 +40,11 @@ public class TransientPipelineLiquidAccumulationExample {
    * @param args Command line arguments (not used)
    */
   public static void main(String[] args) {
-    System.out.println("=============================================================");
-    System.out.println("  Transient Pipeline Liquid Accumulation Simulation");
-    System.out.println("  80 km, 0.5 m diameter subsea pipeline");
-    System.out.println("  Gas condensate with water");
-    System.out.println("=============================================================\n");
+    logger.info("=============================================================");
+    logger.info("  Transient Pipeline Liquid Accumulation Simulation");
+    logger.info("  80 km, 0.5 m diameter subsea pipeline");
+    logger.info("  Gas condensate with water");
+    logger.info("=============================================================\n");
 
     // Run the simulation for different flow rates
     runFlowRateSensitivityStudy();
@@ -100,28 +105,28 @@ public class TransientPipelineLiquidAccumulationExample {
     // Flow rates to simulate (kg/s) - higher flow rates
     double[] flowRates = {50.0, 100.0, 150.0};
 
-    System.out.println("Pipeline Configuration:");
-    System.out.println("  Length:           " + (pipeLength / 1000) + " km");
-    System.out.println("  Diameter:         " + (pipeDiameter * 1000) + " mm");
-    System.out.println("  Inlet temperature:" + inletTemperature + " °C");
-    System.out.println("  Inlet pressure:   " + inletPressure + " bara");
-    System.out.println("  Outlet pressure:  " + outletPressure + " bara");
-    System.out.println("  Number of sections: " + numberOfSections);
-    System.out.println();
+    logger.info("Pipeline Configuration:");
+    logger.info("  Length:           " + (pipeLength / 1000) + " km");
+    logger.info("  Diameter:         " + (pipeDiameter * 1000) + " mm");
+    logger.info("  Inlet temperature:" + inletTemperature + " °C");
+    logger.info("  Inlet pressure:   " + inletPressure + " bara");
+    logger.info("  Outlet pressure:  " + outletPressure + " bara");
+    logger.info("  Number of sections: " + numberOfSections);
+    logger.info("");
 
     // Create terrain profile with some undulations
     double[] elevationProfile = createSubseaTerrainProfile(numberOfSections, pipeLength);
 
     // Results storage
-    System.out.println("=============================================================");
-    System.out.println("  STEADY-STATE RESULTS AT DIFFERENT FLOW RATES");
-    System.out.println("=============================================================");
-    System.out.println();
-    System.out.printf("%-12s %-15s %-15s %-15s %-15s%n", "Flow Rate", "Liquid Inv.", "Water Holdup",
-        "Oil Holdup", "Pressure Drop");
-    System.out.printf("%-12s %-15s %-15s %-15s %-15s%n", "(kg/s)", "(m³)", "(avg)", "(avg)",
-        "(bar)");
-    System.out.println("-------------------------------------------------------------");
+    logger.info("=============================================================");
+    logger.info("  STEADY-STATE RESULTS AT DIFFERENT FLOW RATES");
+    logger.info("=============================================================");
+    logger.info("");
+    logger.info("{}", String.format("%-12s %-15s %-15s %-15s %-15s%n", "Flow Rate", "Liquid Inv.", "Water Holdup",
+        "Oil Holdup", "Pressure Drop"));
+    logger.info("{}", String.format("%-12s %-15s %-15s %-15s %-15s%n", "(kg/s)", "(m³)", "(avg)", "(avg)",
+        "(bar)"));
+    logger.info("-------------------------------------------------------------");
 
     for (double flowRate : flowRates) {
       // Create fluid
@@ -136,12 +141,11 @@ public class TransientPipelineLiquidAccumulationExample {
 
       // Debug: show phases for first flow rate
       if (flowRate == flowRates[0]) {
-        System.out.println("Inlet fluid phases: " + inlet.getFluid().getNumberOfPhases());
+        logger.info("Inlet fluid phases: " + inlet.getFluid().getNumberOfPhases());
         for (int p = 0; p < inlet.getFluid().getNumberOfPhases(); p++) {
-          System.out
-              .println("  Phase " + p + ": " + inlet.getFluid().getPhase(p).getPhaseTypeName());
+          logger.info("  Phase " + p + ": " + inlet.getFluid().getPhase(p).getPhaseTypeName());
         }
-        System.out.println();
+        logger.info("");
       }
 
       // Create two-fluid pipe
@@ -174,11 +178,11 @@ public class TransientPipelineLiquidAccumulationExample {
       double pressureDrop =
           (pressureProfile[0] - pressureProfile[pressureProfile.length - 1]) / 1e5;
 
-      System.out.printf("%-12.1f %-15.2f %-15.4f %-15.4f %-15.2f%n", flowRate, liquidInventory,
-          avgWaterHoldup, avgOilHoldup, pressureDrop);
+      logger.info("{}", String.format("%-12.1f %-15.2f %-15.4f %-15.4f %-15.2f%n", flowRate, liquidInventory,
+          avgWaterHoldup, avgOilHoldup, pressureDrop));
     }
 
-    System.out.println();
+    logger.info("");
 
     // Now run detailed transient simulation for one flow rate
     runDetailedTransientSimulation(pipeLength, pipeDiameter, numberOfSections, elevationProfile,
@@ -238,12 +242,12 @@ public class TransientPipelineLiquidAccumulationExample {
   private static void runDetailedTransientSimulation(double pipeLength, double pipeDiameter,
       int numberOfSections, double[] elevationProfile, double inletTemperature,
       double inletPressure, double outletPressure) {
-    System.out.println("=============================================================");
-    System.out.println("  TRANSIENT SIMULATION: FLOW RATE RAMP-UP");
-    System.out.println("  Starting from 50 kg/s, ramping to 150 kg/s over 2 hours");
-    System.out.println("  Total simulation time: 4 hours");
-    System.out.println("=============================================================");
-    System.out.println();
+    logger.info("=============================================================");
+    logger.info("  TRANSIENT SIMULATION: FLOW RATE RAMP-UP");
+    logger.info("  Starting from 50 kg/s, ramping to 150 kg/s over 2 hours");
+    logger.info("  Total simulation time: 4 hours");
+    logger.info("=============================================================");
+    logger.info("");
 
     // Create fluid and inlet stream
     SystemInterface fluid = createGasCondensateWithWater(inletTemperature, inletPressure);
@@ -269,9 +273,9 @@ public class TransientPipelineLiquidAccumulationExample {
     pipe.run();
 
     double initialInventory = pipe.getLiquidInventory("m3");
-    System.out.printf("Initial steady-state (50 kg/s):%n");
-    System.out.printf("  Liquid inventory: %.2f m³%n", initialInventory);
-    System.out.println();
+    logger.info("{}", String.format("Initial steady-state (50 kg/s):%n"));
+    logger.info("{}", String.format("  Liquid inventory: %.2f m³%n", initialInventory));
+    logger.info("");
 
     // Transient simulation parameters
     double dt = 120.0; // 120 second time step (larger for faster simulation)
@@ -283,14 +287,14 @@ public class TransientPipelineLiquidAccumulationExample {
 
     UUID runId = UUID.randomUUID();
 
-    System.out.printf("%-12s %-12s %-15s %-15s %-15s%n", "Time (min)", "Flow (kg/s)", "Liquid (m³)",
-        "Avg Water HL", "Avg Oil HL");
-    System.out.println("-------------------------------------------------------------");
+    logger.info("{}", String.format("%-12s %-12s %-15s %-15s %-15s%n", "Time (min)", "Flow (kg/s)", "Liquid (m³)",
+        "Avg Water HL", "Avg Oil HL"));
+    logger.info("-------------------------------------------------------------");
 
     // Print initial state at t=0 (before any transient steps)
-    System.out.printf("%-12.1f %-12.1f %-15.2f %-15.4f %-15.4f%n", 0.0, startFlowRate,
+    logger.info("{}", String.format("%-12.1f %-12.1f %-15.2f %-15.4f %-15.4f%n", 0.0, startFlowRate,
         initialInventory, calculateAverage(pipe.getWaterHoldupProfile()),
-        calculateAverage(pipe.getOilHoldupProfile()));
+        calculateAverage(pipe.getOilHoldupProfile())));
 
     // Run transient simulation (starting from dt, not 0)
     for (double t = dt; t <= totalSimTime; t += dt) {
@@ -315,33 +319,33 @@ public class TransientPipelineLiquidAccumulationExample {
         double avgWaterHoldup = calculateAverage(pipe.getWaterHoldupProfile());
         double avgOilHoldup = calculateAverage(pipe.getOilHoldupProfile());
 
-        System.out.printf("%-12.1f %-12.1f %-15.2f %-15.4f %-15.4f%n", t / 60.0, flowRate,
-            liquidInventory, avgWaterHoldup, avgOilHoldup);
+        logger.info("{}", String.format("%-12.1f %-12.1f %-15.2f %-15.4f %-15.4f%n", t / 60.0, flowRate,
+            liquidInventory, avgWaterHoldup, avgOilHoldup));
       }
     }
 
     double finalInventory = pipe.getLiquidInventory("m3");
-    System.out.println();
-    System.out.printf("Final steady-state (150 kg/s):%n");
-    System.out.printf("  Liquid inventory: %.2f m³%n", finalInventory);
-    System.out.printf("  Inventory change: %.2f m³%n", finalInventory - initialInventory);
-    System.out.println();
+    logger.info("");
+    logger.info("{}", String.format("Final steady-state (150 kg/s):%n"));
+    logger.info("{}", String.format("  Liquid inventory: %.2f m³%n", finalInventory));
+    logger.info("{}", String.format("  Inventory change: %.2f m³%n", finalInventory - initialInventory));
+    logger.info("");
 
     // Debug: Print detailed section info for first few sections
-    System.out.println("DEBUG: Section details (first 5 and last 5):");
+    logger.info("DEBUG: Section details (first 5 and last 5):");
     double[] oilHL = pipe.getOilHoldupProfile();
     double[] waterHL = pipe.getWaterHoldupProfile();
     double[] liqHL = pipe.getLiquidHoldupProfile();
     for (int i = 0; i < Math.min(5, oilHL.length); i++) {
-      System.out.printf("  Section %d: LiqHL=%.4f, OilHL=%.4f, WaterHL=%.4f%n", i, liqHL[i],
-          oilHL[i], waterHL[i]);
+      logger.info("{}", String.format("  Section %d: LiqHL=%.4f, OilHL=%.4f, WaterHL=%.4f%n", i, liqHL[i],
+          oilHL[i], waterHL[i]));
     }
-    System.out.println("  ...");
+    logger.info("  ...");
     for (int i = Math.max(0, oilHL.length - 5); i < oilHL.length; i++) {
-      System.out.printf("  Section %d: LiqHL=%.4f, OilHL=%.4f, WaterHL=%.4f%n", i, liqHL[i],
-          oilHL[i], waterHL[i]);
+      logger.info("{}", String.format("  Section %d: LiqHL=%.4f, OilHL=%.4f, WaterHL=%.4f%n", i, liqHL[i],
+          oilHL[i], waterHL[i]));
     }
-    System.out.println();
+    logger.info("");
 
     // Print holdup profile at key locations
     printHoldupProfileSummary(pipe, elevationProfile);
@@ -351,10 +355,10 @@ public class TransientPipelineLiquidAccumulationExample {
    * Prints a summary of liquid holdup along the pipeline.
    */
   private static void printHoldupProfileSummary(TwoFluidPipe pipe, double[] elevationProfile) {
-    System.out.println("=============================================================");
-    System.out.println("  HOLDUP PROFILE ALONG PIPELINE (FINAL STATE)");
-    System.out.println("=============================================================");
-    System.out.println();
+    logger.info("=============================================================");
+    logger.info("  HOLDUP PROFILE ALONG PIPELINE (FINAL STATE)");
+    logger.info("=============================================================");
+    logger.info("");
 
     double[] positions = pipe.getPositionProfile();
     double[] pressures = pipe.getPressureProfile();
@@ -363,29 +367,29 @@ public class TransientPipelineLiquidAccumulationExample {
     double[] oilHoldups = pipe.getOilHoldupProfile();
     double[] liquidHoldups = pipe.getLiquidHoldupProfile();
 
-    System.out.printf("%-10s %-12s %-12s %-12s %-12s %-12s %-12s%n", "Position", "Elevation",
-        "Pressure", "Temp", "Liq Holdup", "Water HL", "Oil HL");
-    System.out.printf("%-10s %-12s %-12s %-12s %-12s %-12s %-12s%n", "(km)", "(m)", "(bara)",
-        "(°C)", "(-)", "(-)", "(-)");
-    System.out.println("-------------------------------------------------------------------------");
+    logger.info("{}", String.format("%-10s %-12s %-12s %-12s %-12s %-12s %-12s%n", "Position", "Elevation",
+        "Pressure", "Temp", "Liq Holdup", "Water HL", "Oil HL"));
+    logger.info("{}", String.format("%-10s %-12s %-12s %-12s %-12s %-12s %-12s%n", "(km)", "(m)", "(bara)",
+        "(°C)", "(-)", "(-)", "(-)"));
+    logger.info("-------------------------------------------------------------------------");
 
     // Print every 10 km
     int step = positions.length / 8;
     for (int i = 0; i < positions.length; i += step) {
-      System.out.printf("%-10.1f %-12.1f %-12.1f %-12.1f %-12.4f %-12.4f %-12.4f%n",
+      logger.info("{}", String.format("%-10.1f %-12.1f %-12.1f %-12.1f %-12.4f %-12.4f %-12.4f%n",
           positions[i] / 1000.0, elevationProfile[i], pressures[i] / 1e5, temperatures[i] - 273.15,
-          liquidHoldups[i], waterHoldups[i], oilHoldups[i]);
+          liquidHoldups[i], waterHoldups[i], oilHoldups[i]));
     }
     // Print final position
     int last = positions.length - 1;
-    System.out.printf("%-10.1f %-12.1f %-12.1f %-12.1f %-12.4f %-12.4f %-12.4f%n",
+    logger.info("{}", String.format("%-10.1f %-12.1f %-12.1f %-12.1f %-12.4f %-12.4f %-12.4f%n",
         positions[last] / 1000.0, elevationProfile[last], pressures[last] / 1e5,
-        temperatures[last] - 273.15, liquidHoldups[last], waterHoldups[last], oilHoldups[last]);
+        temperatures[last] - 273.15, liquidHoldups[last], waterHoldups[last], oilHoldups[last]));
 
-    System.out.println();
+    logger.info("");
 
     // Identify accumulation zones
-    System.out.println("Liquid Accumulation Zones (valleys):");
+    logger.info("Liquid Accumulation Zones (valleys):");
     double maxHoldup = 0;
     int maxIdx = 0;
     for (int i = 0; i < liquidHoldups.length; i++) {
@@ -394,8 +398,8 @@ public class TransientPipelineLiquidAccumulationExample {
         maxIdx = i;
       }
     }
-    System.out.printf("  Maximum holdup: %.4f at %.1f km (elevation: %.1f m)%n", maxHoldup,
-        positions[maxIdx] / 1000.0, elevationProfile[maxIdx]);
+    logger.info("{}", String.format("  Maximum holdup: %.4f at %.1f km (elevation: %.1f m)%n", maxHoldup,
+        positions[maxIdx] / 1000.0, elevationProfile[maxIdx]));
   }
 
   /**

--- a/docs/examples/TransientPipelineLiquidAccumulationExample.java
+++ b/docs/examples/TransientPipelineLiquidAccumulationExample.java
@@ -1,12 +1,12 @@
 package examples;
 
 import java.util.UUID;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkCPAstatoil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Example demonstrating transient liquid (water and oil) accumulation in a long subsea pipeline
@@ -32,7 +32,6 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
 public class TransientPipelineLiquidAccumulationExample {
   private static final Logger logger =
       LogManager.getLogger(TransientPipelineLiquidAccumulationExample.class);
-
 
   /**
    * Main entry point.
@@ -106,12 +105,12 @@ public class TransientPipelineLiquidAccumulationExample {
     double[] flowRates = {50.0, 100.0, 150.0};
 
     logger.info("Pipeline Configuration:");
-    logger.info("  Length:           " + (pipeLength / 1000) + " km");
-    logger.info("  Diameter:         " + (pipeDiameter * 1000) + " mm");
-    logger.info("  Inlet temperature:" + inletTemperature + " °C");
-    logger.info("  Inlet pressure:   " + inletPressure + " bara");
-    logger.info("  Outlet pressure:  " + outletPressure + " bara");
-    logger.info("  Number of sections: " + numberOfSections);
+    logger.info("  Length:           {} km", pipeLength / 1000);
+    logger.info("  Diameter:         {} mm", pipeDiameter * 1000);
+    logger.info("  Inlet temperature:{} °C", inletTemperature);
+    logger.info("  Inlet pressure:   {} bara", inletPressure);
+    logger.info("  Outlet pressure:  {} bara", outletPressure);
+    logger.info("  Number of sections: {}", numberOfSections);
     logger.info("");
 
     // Create terrain profile with some undulations
@@ -141,9 +140,9 @@ public class TransientPipelineLiquidAccumulationExample {
 
       // Debug: show phases for first flow rate
       if (flowRate == flowRates[0]) {
-        logger.info("Inlet fluid phases: " + inlet.getFluid().getNumberOfPhases());
+        logger.info("Inlet fluid phases: {}", inlet.getFluid().getNumberOfPhases());
         for (int p = 0; p < inlet.getFluid().getNumberOfPhases(); p++) {
-          logger.info("  Phase " + p + ": " + inlet.getFluid().getPhase(p).getPhaseTypeName());
+          logger.info("  Phase {}: {}", p, inlet.getFluid().getPhase(p).getPhaseTypeName());
         }
         logger.info("");
       }

--- a/src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java
+++ b/src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java
@@ -38,7 +38,8 @@ public class StandaloneJavaDocumentationCompilationTest {
       "EclipseE300ExportImportExample.java", "FlowRegimeDebug.java", "FlowRegimeDetectionExample.java",
       "MultiScenarioVFPExample.java", "MultiphaseModelPressureDropComparison.java",
       "OffshoreEmissionReportingExample.java", "RealTimeIntegrationExample.java", "SlugTrackingComparisonExample.java",
-      "TwoFluidPipeExample.java", "WellToOilStabilizationExample.java");
+      "TransientPipelineLiquidAccumulationExample.java", "TwoFluidPipeExample.java",
+      "WellToOilStabilizationExample.java");
 
   @TempDir
   Path compilationOutput;


### PR DESCRIPTION
Advances documentation-quality campaign #2499, D142 (scope 6), with a frozen standalone-example logging-policy batch.

## Frozen contract

- Exact base: `b703de2fdce2bda4b4b212bb0b293984a552b092`
- Exact head: `874dda7b73f5a5f22324c31a8a5bd286253cda27`
- Branch: `docs/d142-transient-accumulation-logging`
- Shape: exactly 2 files, 3 ordered commits, 79 additions, 75 deletions
- Files:
  - `docs/examples/TransientPipelineLiquidAccumulationExample.java`
  - `src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java`

## Repair

- Replace all 60 legacy `System.out` operations in the transient pipeline liquid-accumulation example with a class-scoped Log4j2 logger.
- Preserve table formatting through `String.format` and parameterize all dynamic reporting.
- Preserve fluid composition, pipeline geometry, terrain profile, heat-transfer inputs, flow ramp, calculations, control flow, labels, units, and displayed precision.
- Add the example to the existing standalone Java logging-policy regression; all 15 maintained standalone sources remain compilation-covered and 12 are now protected by the logging policy.

## Prepublication validation

Connector-side gates pass:

- exactly two frozen files and three linear commits
- 60 `logger.info` calls and zero `System.out` / `System.err` operations in the example
- class-scoped `LogManager.getLogger(TransientPipelineLiquidAccumulationExample.class)`
- exactly one new logging-policy entry while retaining the 15-source compilation contract
- balanced braces and parentheses
- no tabs or trailing whitespace
- no overlap with any currently open pull request

Hosted exact-head formatting, pre-commit, Javadocs, agent-skill/reference, examples, and initial CodeQL checks pass. Documentation/search, Java 21 fast/slow suites, notebooks, and remaining CodeQL analysis are still running: **VALIDATION PENDING CI**.

## Evidence boundary

This PR modernizes source reporting and extends compilation/source-policy evidence only. The transient production-system example was not executed or engineering-qualified. No production code, TwoFluidPipe behavior, model assumption, numerical result, notebook, generated output, diagram/DEXPI/P&ID, MCP, refinery, kinetics, reaction data, release, or Huldra scope is changed.

## Workflow guardrails

Draft only. Preserve the exact head. Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon this PR for capacity.