### PR TITLE
[AI-Assisted] fix(torg): convert ambient Celsius to Kelvin

### DIFF
--- a/docs/process/torg_integration.md
+++ b/docs/process/torg_integration.md
@@ -74,6 +74,17 @@ String seismicZone = env.getSeismicZone();
 String location = env.getLocation();
 ```
 
+TORG environmental temperatures are in degrees Celsius. For equipment with an applicable
+design standard, `TorgManager` applies the minimum ambient temperature through
+`MechanicalDesign.setMinOperationTemperature(value, "C")`. Mechanical design stores the value
+in Kelvin: a TORG minimum of -30 °C gives 243.15 K from `getMinOperationTemperature()` or
+`getMinOperationTemperature("K")`, and -30 °C from `getMinOperationTemperature("C")`.
+
+The conversion also applies to `apply(...)`, `loadAndApply(...)`, and the active TORG reapplied
+internally by `FieldDevelopmentDesignOrchestrator.runCompleteDesignWorkflow()`. Repeated
+application preserves the temperature. No manual temperature correction is required after
+application; remove any earlier workaround that repeated the unit-aware setter call.
+
 #### SafetyFactors
 
 ```java
@@ -336,6 +347,7 @@ When a TORG is applied to equipment, the following are configured:
 | Setting | Source | Applied To |
 |---------|--------|------------|
 | Design standards | `torg.getStandard(category)` | `mechDesign.setDesignStandard()` |
+| Minimum ambient temperature (°C) | `environmentalConditions.getMinAmbientTemperature()` | `mechDesign.setMinOperationTemperature(value, "C")`, stored in Kelvin |
 | Pressure safety factor | `safetyFactors.getPressureSafetyFactor()` | `mechDesign.setPressureMarginFactor()` |
 | Temperature margin | `safetyFactors.getTemperatureSafetyMargin()` | Design temperature calculation |
 | Corrosion allowance | `safetyFactors.getCorrosionAllowance()` | `mechDesign.setCorrosionAllowance()` |

--- a/src/main/java/neqsim/process/mechanicaldesign/torg/TorgManager.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/torg/TorgManager.java
@@ -174,6 +174,11 @@ public class TorgManager {
   /**
    * Apply a TORG to a single equipment item.
    *
+   * <p>
+   * For equipment with applicable standards, the minimum ambient temperature is converted from the TORG's Celsius value
+   * to the Kelvin minimum operating temperature stored by the mechanical design.
+   * </p>
+   *
    * @param torg the TORG to apply
    * @param equipment the equipment to configure
    */
@@ -211,7 +216,7 @@ public class TorgManager {
     // Apply environmental conditions if available
     TechnicalRequirementsDocument.EnvironmentalConditions env = torg.getEnvironmentalConditions();
     if (env != null) {
-      design.setMinOperationTemperature(env.getMinAmbientTemperature());
+      design.setMinOperationTemperature(env.getMinAmbientTemperature(), "C");
     }
 
     // Apply safety factors if available

--- a/src/test/java/neqsim/process/mechanicaldesign/FieldDevelopmentDesignOrchestratorTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/FieldDevelopmentDesignOrchestratorTest.java
@@ -11,8 +11,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+import neqsim.process.mechanicaldesign.torg.TechnicalRequirementsDocument;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -145,6 +149,30 @@ class FieldDevelopmentDesignOrchestratorTest {
   @Nested
   @DisplayName("TORG Tests")
   class TorgTests {
+    @ParameterizedTest
+    @CsvSource({ "-30.0, 243.15", "15.0, 288.15" })
+    void shouldPreserveAmbientTemperatureDuringTorgReapplication(double minAmbientCelsius, double expectedKelvin) {
+      TechnicalRequirementsDocument torg = TechnicalRequirementsDocument.builder().projectId("TEST-001")
+          .addStandard(StandardType.API_12J.getDesignStandardCategory(), StandardType.API_12J)
+          .environmentalConditions(minAmbientCelsius, 40.0).build();
+      MechanicalDesign design = processSystem.getUnit("Separator").getMechanicalDesign();
+      design.setCompanySpecificDesignStandards("default");
+      orchestrator.getTorgManager().apply(torg, processSystem);
+
+      for (int run = 0; run < 2; run++) {
+        // A different valid value proves that the workflow reapplies the active TORG.
+        design.setMinOperationTemperature(5.0, "C");
+        orchestrator.runCompleteDesignWorkflow();
+
+        assertTrue(orchestrator.getWorkflowHistory().stream()
+            .anyMatch(step -> "Apply TORG Standards".equals(step.getStepName()) && step.isSuccess()));
+        assertTrue(orchestrator.getTorgManager().getAppliedStandards("Separator").contains(StandardType.API_12J));
+        assertEquals(expectedKelvin, design.getMinOperationTemperature(), 1.0e-9);
+        assertEquals(expectedKelvin, design.getMinOperationTemperature("K"), 1.0e-9);
+        assertEquals(minAmbientCelsius, design.getMinOperationTemperature("C"), 1.0e-9);
+      }
+    }
+
     @Test
     @DisplayName("Should have TORG manager")
     void shouldHaveTorgManager() {

--- a/src/test/java/neqsim/process/mechanicaldesign/torg/TorgManagerTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/torg/TorgManagerTest.java
@@ -12,8 +12,11 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.mechanicaldesign.MechanicalDesign;
 import neqsim.process.mechanicaldesign.designstandards.StandardType;
 import neqsim.process.processmodel.ProcessSystem;
 
@@ -90,6 +93,14 @@ class TorgManagerTest {
     List<StandardType> compressorStandards = manager.getAppliedStandards("Test Compressor");
     assertFalse(compressorStandards.isEmpty());
     assertTrue(compressorStandards.contains(StandardType.API_617));
+
+    for (int application = 0; application < 2; application++) {
+      assertTrue(manager.loadAndApply("PROJ-001", process));
+      assertEquals(233.15, separator.getMechanicalDesign().getMinOperationTemperature("K"), 1.0e-9);
+      assertEquals(-40.0, separator.getMechanicalDesign().getMinOperationTemperature("C"), 1.0e-9);
+      assertEquals(233.15, compressor.getMechanicalDesign().getMinOperationTemperature("K"), 1.0e-9);
+      assertEquals(-40.0, compressor.getMechanicalDesign().getMinOperationTemperature("C"), 1.0e-9);
+    }
   }
 
   @Test
@@ -195,15 +206,21 @@ class TorgManagerTest {
     assertFalse(applied);
   }
 
-  @Test
-  void testApplyWithEnvironmentalConditions() {
+  @ParameterizedTest
+  @CsvSource({ "-46.0, 227.15", "-30.0, 243.15", "0.0, 273.15", "15.0, 288.15" })
+  void testApplyWithEnvironmentalConditions(double minAmbientCelsius, double expectedKelvin) {
     TechnicalRequirementsDocument torg = TechnicalRequirementsDocument.builder().projectId("ENV-001")
-        .environmentalConditions(-46.0, 40.0).addStandard("separator process design", StandardType.API_12J).build();
+        .environmentalConditions(minAmbientCelsius, 40.0)
+        .addStandard(StandardType.API_12J.getDesignStandardCategory(), StandardType.API_12J).build();
 
     Separator separator = new Separator("Env Test");
-    manager.applyToEquipment(torg, separator);
-
-    // Environmental conditions should be applied
-    assertEquals(-46.0, separator.getMechanicalDesign().getMinOperationTemperature(), 0.01);
+    MechanicalDesign design = separator.getMechanicalDesign();
+    for (int application = 0; application < 3; application++) {
+      manager.applyToEquipment(torg, separator);
+      assertTrue(manager.getAppliedStandards(separator.getName()).contains(StandardType.API_12J));
+      assertEquals(expectedKelvin, design.getMinOperationTemperature(), 1.0e-9);
+      assertEquals(expectedKelvin, design.getMinOperationTemperature("K"), 1.0e-9);
+      assertEquals(minAmbientCelsius, design.getMinOperationTemperature("C"), 1.0e-9);
+    }
   }
 }


### PR DESCRIPTION
TORG ambient temperatures are Celsius, but `TorgManager.applyToEquipment` passed the minimum to the Kelvin-only overload. A minimum of -30 °C was therefore stored as -30 K instead of 243.15 K, including when the design orchestrator reapplied the active TORG.

This PR uses the existing `setMinOperationTemperature(value, "C")` overload. It corrects the test that asserted the wrong Kelvin value and verifies the raw/Kelvin/Celsius getters for -46, -30, 0, and +15 °C. It also covers repeated single-equipment application, repeated CSV load/application to separators and compressors, and two complete orchestrator runs for both cold and warm ambient conditions.

Closes #3617.

### Documentation impact

Updated the application Javadoc and `docs/process/torg_integration.md` with the Celsius input/Kelvin storage contract, repeated-application behavior, and removal of the need for a manual correction. No public API was added or changed.

The temporary correction mentioned in the issue currently exists in the separate, unmerged documentation repair #3620, not in the current master guide. The unit guidance in this PR supersedes that workaround; retain the corrected guidance when integrating that documentation repair.

### Validation

Validated against master `1a9dcb7b05c6157c58e7f8f7b0239be433fbd99f`, using JDK 17 and NeqSim 3.20.0 source. Maven was prepared with the work-with-neqsim helper; final checks reused cached dependencies offline.

- Before the production fix: **43 tests executed, 7 expected regression failures**, zero errors. Failures included both orchestrator temperature cases.
- After the fix: **77 tests passed**, zero failures/errors/skips across `TorgManagerTest`, `FieldDevelopmentDesignOrchestratorTest`, `TechnicalRequirementsDocumentTest`, `CsvTorgDataSourceTest`, `DesignConditionValueTest`, `MechanicalDesignDataSourceTest`, and `TemperatureUnitTest`.
- Full baseline production compilation: `./mvnw -B -ntp -DskipTests -Djacoco.skip=true -DskipJava8CompatCheck=true compile` — exit 0.
- Changed production class and focused test classes compiled with `java com.sun.tools.javac.Main -source 8 -target 8` against the built classes and dependency classpath — exit 0. This checks Java 8 syntax/target compatibility; it is not a Java 8 runtime test.
- Focused execution: `./mvnw -o -B -ntp surefire:test -Dtest=TorgManagerTest,FieldDevelopmentDesignOrchestratorTest,TechnicalRequirementsDocumentTest,CsvTorgDataSourceTest,DesignConditionValueTest,MechanicalDesignDataSourceTest,TemperatureUnitTest -Djacoco.skip=true` — exit 0.
- `python devtools/run_spotless.py apply` — exit 0; repeated successfully with no additional changes.
- `pre-commit run --all-files --hook-stage pre-commit` — exit 0.
- `python devtools/run_spotless.py check` — exit 0.
- `python devtools/check_documentation_search.py` — exit 0.
- `pre-commit run --all-files --hook-stage pre-push` — exit 0.
- `git diff --check` and comparison of the diff before/after the final gates — exit 0.

Only four files changed. Full repository test matrix and independent maintainer review remain pending CI/review.