### PR TITLE
[AI-Assisted] fix(filter): conserve captured sulfur in outlet streams

### DIFF
--- a/docs/process/equipment/filters.md
+++ b/docs/process/equipment/filters.md
@@ -263,6 +263,22 @@ count define the inherited loading capacity. See the
 [reactor guide](reactors.md#sulfur-oxidation-reactor) for a complete
 `SulfurOxidationReactor` to `SulfurFilter` example.
 
+Sulfur capture is evaluated at the inlet temperature and the pressure after the
+filter pressure drop. The effective efficiency includes configured breakthrough
+and bypass. Capture uses only the S8 inventory physically present in solid
+phases, rather than the total S8 inventory or the mass of unrelated solids.
+The outlet is re-equilibrated after subtracting the captured S8; dissolved S8
+and any remaining solids can still leave the filter, including at 100% solid
+capture efficiency.
+
+`getSolidSulfurRemovalRate()` is the captured mass flow in kg/hr. It equals the
+inlet-minus-outlet total mass flow, and inlet S8 equals outlet S8 plus captured
+S8. Every other component flow is conserved. The capture rate is converted to
+accumulated loading only during transient steps; repeated steady-state runs
+leave the inlet and accumulated loading unchanged. These balances are covered
+by `SulfurFilterMassBalanceTest`, including dry gas/solid and wet multiphase
+feeds at 0%, 90%, and 100% efficiency and the sulfur-oxidation reactor feed.
+
 For molecular removal, use the dedicated
 [mercury guard-bed model](../mercury_removal.md),
 [adsorption-bed model](adsorption_bed.md), or

--- a/src/main/java/neqsim/process/equipment/filter/SulfurFilter.java
+++ b/src/main/java/neqsim/process/equipment/filter/SulfurFilter.java
@@ -28,10 +28,16 @@ import neqsim.util.nucleation.ClassicalNucleationTheory;
  * <ul>
  * <li>Performs TP-solid flash on inlet to detect solid S8 phase</li>
  * <li>Removes solid S8 from the outlet stream based on removal efficiency</li>
- * <li>Tracks cumulative S8 mass loading (kg/hr) for filter element sizing</li>
+ * <li>Reports captured S8 mass flow (kg/hr) and accumulates loading (kg) during transient operation</li>
  * <li>Calculates filter change interval based on element capacity</li>
  * <li>Integrates with {@link SulfurFilterMechanicalDesign} for vessel sizing and cost</li>
  * </ul>
+ *
+ * <p>
+ * Capture is based on S8 moles in the solid phase after the pressure drop, at the inlet temperature. The outlet is
+ * re-equilibrated with the captured S8 subtracted from its overall component inventory; all other component flows are
+ * conserved. Removal efficiency applies to solid S8, so dissolved sulfur and uncaptured solids may remain.
+ * </p>
  *
  * <p>
  * Usage example:
@@ -150,53 +156,40 @@ public class SulfurFilter extends Filter {
     solidSulfurRemovalRate = 0.0;
     solidS8MassFractionInlet = 0.0;
 
-    // Check if solid phase exists and contains S8
-    if (system.hasPhaseType(PhaseType.SOLID) && system.hasComponent("S8")) {
-      solidS8Detected = true;
-
-      // Find the solid phase and get S8 mass
+    // Component.getNumberOfmoles() is the system inventory replicated in every phase.
+    // Capture must use the S8 inventory physically present in solid phases.
+    if (system.hasComponent("S8")) {
+      double solidS8Moles = 0.0;
       for (int phaseIdx = 0; phaseIdx < system.getNumberOfPhases(); phaseIdx++) {
         if (system.getPhase(phaseIdx).getType() == PhaseType.SOLID) {
-          double solidPhaseMass = system.getPhase(phaseIdx).getMass();
-          // S8 mass fraction in the total stream that is solid
-          double totalMass = system.getMass("kg");
-          if (totalMass > 0) {
-            solidS8MassFractionInlet = solidPhaseMass / totalMass;
-          }
-          break;
+          solidS8Moles += system.getPhase(phaseIdx).getComponent("S8").getNumberOfMolesInPhase();
         }
       }
-
-      // Calculate removal rate: mass flow * solid fraction * efficiency
-      double effectiveRemovalEfficiency = getCurrentRemovalEfficiency();
-      solidSulfurRemovalRate = gasFlowRate * solidS8MassFractionInlet * effectiveRemovalEfficiency;
-
-      // Remove solid S8 from outlet: reduce S8 component by removal efficiency
-      // Set S8 content in outlet to only the fraction that passes through
-      if (system.hasComponent("S8") && effectiveRemovalEfficiency > 0) {
-        // Get current S8 moles in gas phase and reduce total S8
-        double currentS8Moles = 0.0;
-        double solidS8Moles = 0.0;
-        for (int phaseIdx = 0; phaseIdx < system.getNumberOfPhases(); phaseIdx++) {
-          if (system.getPhase(phaseIdx).getType() == PhaseType.SOLID) {
-            solidS8Moles = system.getPhase(phaseIdx).getComponent("S8").getNumberOfmoles();
-          }
-          currentS8Moles += system.getPhase(phaseIdx).getComponent("S8").getNumberOfmoles();
+      solidS8Detected = solidS8Moles > 0.0;
+      if (solidS8Detected) {
+        int s8Index = system.getComponent("S8").getComponentNumber();
+        double s8MolarMass = system.getComponent("S8").getMolarMass();
+        if (gasFlowRate > 0.0) {
+          solidS8MassFractionInlet = solidS8Moles * s8MolarMass * 3600.0 / gasFlowRate;
         }
 
-        // Remove solid S8 from the system (filter captures it)
-        double molesToRemove = solidS8Moles * effectiveRemovalEfficiency;
-        if (molesToRemove > 0 && currentS8Moles > molesToRemove) {
-          system.addComponent("S8", -molesToRemove);
+        double[] outletMolarFlows = system.getMolarRate();
+        double molesToRemove = Math.min(outletMolarFlows[s8Index], solidS8Moles * getCurrentRemovalEfficiency());
+        if (molesToRemove > 0.0) {
+          outletMolarFlows[s8Index] -= molesToRemove;
+          // Reset all allocated phases from one component ledger. Negative addComponent
+          // updates can otherwise be overwritten when a solid-bearing system is initialized.
+          system.setMolarFlowRates(outletMolarFlows);
+          // Restore the fluid/solid phase mapping before equilibrium is recalculated.
+          system.init(0);
+          ops.TPSolidflash();
+          system.initProperties();
+          solidSulfurRemovalRate = molesToRemove * s8MolarMass * 3600.0;
         }
-
-        // Re-flash without solid check to get clean gas outlet
-        ops.TPflash();
-        system.initProperties();
       }
     }
-
     outStream.setThermoSystem(system);
+    outStream.setCalculationIdentifier(id);
     setCalculationIdentifier(id);
 
     // Run particle size prediction using CNT
@@ -214,6 +207,7 @@ public class SulfurFilter extends Filter {
    * @param system the thermodynamic system after flash calculation
    */
   private void runParticleSizePrediction(SystemInterface system) {
+    supersaturationRatio = 1.0;
     nucleationModel = ClassicalNucleationTheory.sulfurS8();
     nucleationModel.setTemperature(system.getTemperature());
     nucleationModel.setTotalPressure(system.getPressure() * 1e5); // bara to Pa
@@ -226,10 +220,10 @@ public class SulfurFilter extends Filter {
       double solidS8moles = 0;
       for (int i = 0; i < system.getNumberOfPhases(); i++) {
         if (system.getPhase(i).hasComponent("S8")) {
-          double moles = system.getPhase(i).getComponent("S8").getNumberOfmoles();
+          double moles = system.getPhase(i).getComponent("S8").getNumberOfMolesInPhase();
           totalS8moles += moles;
           if (system.getPhase(i).getType() == PhaseType.SOLID) {
-            solidS8moles = moles;
+            solidS8moles += moles;
           }
         }
       }

--- a/src/test/java/neqsim/process/equipment/filter/SulfurFilterMassBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/filter/SulfurFilterMassBalanceTest.java
@@ -1,0 +1,215 @@
+package neqsim.process.equipment.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.reactor.SulfurOxidationReactor;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Material-balance regressions for solid S8 capture, including issue #3621.
+ */
+class SulfurFilterMassBalanceTest extends neqsim.NeqSimTest {
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, 0.9, 1.0 })
+  void gasSolidCaptureConservesMassAndComponents(double efficiency) {
+    checkCapture(createFeed(false), efficiency, false);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, 0.9, 1.0 })
+  void wetMultiphaseCaptureConservesMassAndComponents(double efficiency) {
+    checkCapture(createFeed(true), efficiency, true);
+  }
+
+  @Test
+  void reactorFeedLosesExactlyTheReportedCapturedSulfur() {
+    SystemInterface fluid = new SystemPrEos(308.15, 9.0);
+    fluid.addComponent("methane", 0.979);
+    fluid.addComponent("H2S", 0.02);
+    fluid.addComponent("oxygen", 0.001);
+    fluid.addComponent("water", 0.001);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    fluid.setTotalFlowRate(1000.0, "kg/hr");
+    Stream inlet = new Stream("inlet", fluid);
+    inlet.run();
+
+    SulfurOxidationReactor reactor = new SulfurOxidationReactor("reactor", inlet);
+    reactor.setH2SConversionTarget(0.025);
+    reactor.setSolidFlashEnabled(false);
+    reactor.run();
+
+    checkCapture(reactor.getOutStream(), 0.9, false);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, 1.0e-20 })
+  void feedWithoutSolidSulfurResetsCaptureAndSupersaturation(double s8Moles) {
+    SulfurFilter filter = new SulfurFilter("filter", createFeed(false));
+    filter.setDeltaP(0.0);
+    filter.setRemovalEfficiency(0.9);
+    filter.run();
+    assertTrue(filter.getSolidSulfurRemovalRate() > 0.0);
+
+    SystemInterface fluid = new SystemPrEos(373.15, 9.0);
+    fluid.addComponent("methane", 0.98);
+    fluid.addComponent("H2S", 0.02);
+    if (s8Moles > 0.0) {
+      fluid.addComponent("S8", s8Moles);
+    }
+    fluid.setMixingRule("classic");
+    fluid.setTotalFlowRate(1000.0, "kg/hr");
+    Stream cleanFeed = new Stream("clean feed", fluid);
+    cleanFeed.run();
+    filter.setInletStream(cleanFeed);
+    filter.run();
+
+    assertFalse(filter.isSolidS8Detected());
+    assertEquals(0.0, filter.getSolidSulfurRemovalRate());
+    assertEquals(0.0, filter.getSolidS8MassFractionInlet());
+    assertEquals(1.0, filter.getSupersaturationRatio());
+    assertEquals(cleanFeed.getFlowRate("kg/hr"), filter.getOutStream().getFlowRate("kg/hr"), 1.0e-7);
+    assertInventories(filter.getOutStream().getThermoSystem(), componentMoles(cleanFeed.getThermoSystem()), 0.0);
+  }
+
+  @Test
+  void transientLoadingMatchesCapturedMass() {
+    Stream feed = createFeed(false);
+    SulfurFilter filter = new SulfurFilter("filter", feed);
+    filter.setDeltaP(0.0);
+    filter.setRemovalEfficiency(0.9);
+    filter.setFilterElementCapacity(1000.0);
+    filter.setNumberOfElements(1);
+    filter.setPressureDropIncreaseAtCapacity(0.0);
+    filter.setCalculateSteadyState(false);
+    filter.runTransient(600.0, UUID.randomUUID());
+
+    double massLoss = feed.getFlowRate("kg/hr") - filter.getOutStream().getFlowRate("kg/hr");
+    assertTrue(massLoss > 0.0);
+    assertEquals(massLoss, filter.getSolidSulfurRemovalRate(), 1.0e-7);
+    assertEquals(massLoss * 600.0 / 3600.0, filter.getSolidsLoading(), 1.0e-7);
+  }
+
+  /**
+   * Creates a gas/solid feed with an optional separate aqueous phase.
+   *
+   * @param wet whether water is present
+   * @return initialized feed
+   */
+  private Stream createFeed(boolean wet) {
+    SystemInterface fluid = new SystemPrEos(308.15, 9.0);
+    fluid.addComponent("methane", 0.979);
+    fluid.addComponent("H2S", 0.02);
+    fluid.addComponent("S8", 0.001);
+    if (wet) {
+      fluid.addComponent("water", 0.02);
+    }
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    fluid.setSolidPhaseCheck("S8");
+    fluid.setTotalFlowRate(1000.0, "kg/hr");
+    Stream feed = new Stream("feed", fluid);
+    feed.run();
+    return feed;
+  }
+
+  /**
+   * Checks capture against the independently flashed solid-phase inventory.
+   *
+   * @param feed filter inlet
+   * @param efficiency solid removal fraction
+   * @param requireAqueous whether a separate aqueous phase must be present
+   */
+  private void checkCapture(StreamInterface feed, double efficiency, boolean requireAqueous) {
+    SystemInterface inlet = feed.getThermoSystem();
+    double[] inletMoles = componentMoles(inlet);
+    double inletMass = feed.getFlowRate("kg/hr");
+    SystemInterface equilibrium = inlet.clone();
+    equilibrium.setMultiPhaseCheck(true);
+    equilibrium.setSolidPhaseCheck("S8");
+    new ThermodynamicOperations(equilibrium).TPSolidflash();
+    equilibrium.initProperties();
+    assertTrue(equilibrium.hasPhaseType(PhaseType.GAS));
+    assertTrue(equilibrium.hasPhaseType(PhaseType.SOLID));
+    if (requireAqueous) {
+      assertTrue(equilibrium.hasPhaseType(PhaseType.AQUEOUS));
+    }
+
+    double solidS8Moles = 0.0;
+    for (int phase = 0; phase < equilibrium.getNumberOfPhases(); phase++) {
+      if (equilibrium.getPhase(phase).getType() == PhaseType.SOLID) {
+        solidS8Moles += equilibrium.getPhase(phase).getComponent("S8").getNumberOfMolesInPhase();
+      }
+    }
+    assertTrue(solidS8Moles > 0.0);
+    double capturedMoles = solidS8Moles * efficiency;
+    double molarMass = inlet.getComponent("S8").getMolarMass();
+    double capturedMass = capturedMoles * molarMass * 3600.0;
+
+    SulfurFilter filter = new SulfurFilter("filter", feed);
+    filter.setDeltaP(0.0);
+    filter.setRemovalEfficiency(efficiency);
+    UUID calculationId = UUID.randomUUID();
+    filter.run(calculationId);
+
+    assertEquals(calculationId, filter.getOutStream().getCalculationIdentifier());
+    assertEquals(capturedMass, filter.getSolidSulfurRemovalRate(), 1.0e-7);
+    assertEquals(capturedMass, inletMass - filter.getOutStream().getFlowRate("kg/hr"), 1.0e-7);
+    assertEquals(solidS8Moles * molarMass * 3600.0 / inletMass, filter.getSolidS8MassFractionInlet(), 1.0e-10);
+    assertInventories(inlet, inletMoles, 0.0);
+    assertInventories(filter.getOutStream().getThermoSystem(), inletMoles, capturedMoles);
+
+    filter.run(UUID.randomUUID());
+    assertEquals(capturedMass, filter.getSolidSulfurRemovalRate(), 1.0e-7);
+    assertEquals(capturedMass, inletMass - filter.getOutStream().getFlowRate("kg/hr"), 1.0e-7);
+    assertInventories(inlet, inletMoles, 0.0);
+    assertInventories(filter.getOutStream().getThermoSystem(), inletMoles, capturedMoles);
+    assertEquals(0.0, filter.getSolidsLoading());
+  }
+
+  /**
+   * Reads the system component inventories once, without summing their replicated global counters.
+   *
+   * @param fluid thermodynamic system
+   * @return component molar flows in mol/s
+   */
+  private double[] componentMoles(SystemInterface fluid) {
+    double[] moles = new double[fluid.getNumberOfComponents()];
+    for (int component = 0; component < moles.length; component++) {
+      moles[component] = fluid.getComponent(component).getNumberOfmoles();
+    }
+    return moles;
+  }
+
+  /**
+   * Checks both the overall component ledger and the sum of physical phase inventories.
+   *
+   * @param fluid thermodynamic system to check
+   * @param inletMoles original component molar flows
+   * @param capturedS8 captured S8 molar flow
+   */
+  private void assertInventories(SystemInterface fluid, double[] inletMoles, double capturedS8) {
+    for (int component = 0; component < inletMoles.length; component++) {
+      String name = fluid.getComponent(component).getComponentName();
+      double expected = inletMoles[component] - ("S8".equals(name) ? capturedS8 : 0.0);
+      assertEquals(expected, fluid.getComponent(component).getNumberOfmoles(), 1.0e-9, name);
+      double phaseMoles = 0.0;
+      for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+        double moles = fluid.getPhase(phase).getComponent(component).getNumberOfMolesInPhase();
+        assertTrue(moles >= -1.0e-12, name + " has a negative phase inventory");
+        phaseMoles += moles;
+      }
+      assertEquals(expected, phaseMoles, 1.0e-8, name + " phase balance");
+    }
+  }
+}


### PR DESCRIPTION
SulfurFilter could report captured sulfur while leaving outlet mass and S8 unchanged. The issue reproducer reported 0.8775915954 kg/hr captured but lost 0 kg/hr from the outlet, which would hide sulfur carryover in downstream equipment.

This change calculates capture from the S8 moles physically present in solid phases. It subtracts the captured amount from a single overall component-flow ledger, reinitializes the phase mapping, and re-equilibrates the outlet with a solid flash. The same captured amount determines the reported removal rate and transient loading. It also corrects phase-inventory accounting in the particle-size calculation, clears stale supersaturation on feed changes, and propagates the calculation identifier to the outlet.

Closes #3621.

### Regression and engineering evidence

- The original implementation fails five positive-capture balance cases; both zero-efficiency cases pass.
- Ten new regressions cover dry gas/solid and wet gas/aqueous/solid feeds at 0%, 90%, and 100% efficiency, the exact reactor reproducer, repeat execution and inlet immutability, component totals and physical phase inventories, sulfur-free/soluble-sulfur feed changes, and transient captured-mass accumulation.
- The exact reproducer now loses 0.8775915954 kg/hr from the outlet, matching the reported captured sulfur.
- All 24 affected tests pass with zero failures, errors, or skips: SulfurFilterMassBalanceTest, FilterTest, FilterDocumentationTest, SulfurOxidationReactorTest, and FilterMechanicalDesignTest.
- Mass closure is checked to 1e-7 kg/hr; component totals to 1e-9 mol/s and summed phase inventories to 1e-8 mol/s.

### Validation

Source baseline: master `1a9dcb7b05c6157c58e7f8f7b0239be433fbd99f`; Java 17, NeqSim 3.20.0. The changed implementation and affected tests were compiled directly with `java com.sun.tools.javac.Main --release 8` against source-built current classes and the project dependency classpath.

After bootstrapping Maven with the work-with-neqsim helper, the following gates passed (exit 0). Python commands used the selected Linux Python runtime.

- `./mvnw -o surefire:test -Dtest=SulfurFilterMassBalanceTest,FilterTest,FilterDocumentationTest,SulfurOxidationReactorTest,FilterMechanicalDesignTest -DargLine=` — 24 passed.
- `python devtools/run_spotless.py apply` — passed; repeated without further changes.
- `python devtools/run_spotless.py check` — passed.
- `python devtools/check_documentation_search.py` — passed: 696 Markdown pages and one standalone HTML page.
- `python -m pre_commit run --all-files --hook-stage pre-commit` — passed.
- `python -m pre_commit run --all-files --hook-stage pre-push` — passed.
- Focused Javadoc generation with `-Xdoclint:all` — passed without diagnostics.
- `git diff --check` — passed.

Full repository test matrix: VALIDATION PENDING CI.

### Documentation impact

Updated SulfurFilter Javadoc and the filter equipment guide to explain capture conditions, S8-only removal, component and mass closure, remaining dissolved sulfur/solids, and the distinction between steady-state captured flow and transient accumulated loading.
