### PR TITLE
[AI-Assisted] fix(thermo): safely disable solid phase checks

### DIFF
--- a/docs/thermo/flash_calculations_guide.md
+++ b/docs/thermo/flash_calculations_guide.md
@@ -132,6 +132,12 @@ fluid.setSolidPhaseCheck(true);
 ops.TPflash(true);  // Includes solid equilibrium
 ```
 
+Call `fluid.setSolidPhaseCheck(false)` to disable solid checking for all components,
+including those in cached phases. This is safe before any solid phase has been
+allocated and can be called repeatedly. Disabling preserves the existing phase
+count, phase fractions and component inventories; it does not run a flash or
+remove an existing solid phase.
+
 ---
 
 ## Phase Equilibrium Modes (VLE, LLE, VLLE)

--- a/docs/thermo/system/README.md
+++ b/docs/thermo/system/README.md
@@ -276,6 +276,11 @@ fluid.setPhaseType(1, "oil");
 fluid.setSolidPhaseCheck(true);
 ```
 
+`setSolidPhaseCheck(false)` safely disables solid checking even on a fresh fluid.
+Repeated calls clear the component flags in every allocated phase while preserving
+the phase count and composition. Existing phases remain allocated; the setter
+does not recalculate equilibrium.
+
 ---
 
 ## System Methods

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -2870,9 +2870,14 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
   public void setPressure(double newPressure, String unit);
 
   /**
-   * Setter for property solidPhaseCheck.
+   * Enable or disable solid checking for all components in every allocated phase, including cached phases.
    *
-   * @param test a boolean
+   * <p>
+   * Disabling is safe and idempotent even when no solid phase has been allocated. It preserves the phase count,
+   * composition and component inventories without reallocating phases or recalculating equilibrium.
+   * </p>
+   *
+   * @param test true to enable solid checking, false to disable it
    */
   public void setSolidPhaseCheck(boolean test);
 

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -5826,12 +5826,14 @@ public abstract class SystemThermo implements SystemInterface {
     if (solidPhaseCheck && !this.hasSolidPhase()) {
       addSolidPhase();
     }
-    // init(0);
 
-    for (int phaseNum = 0; phaseNum < numberOfPhases; phaseNum++) {
-      for (int k = 0; k < getPhases()[0].getNumberOfComponents(); k++) {
-        getPhase(phaseNum).getComponent(k).setSolidCheck(solidPhaseCheck);
-        getPhase(3).getComponent(k).setSolidCheck(solidPhaseCheck);
+    // Include cached phases without requiring a solid phase or a particular phase-index mapping.
+    for (PhaseInterface phase : phaseArray) {
+      if (phase == null) {
+        continue;
+      }
+      for (int k = 0; k < phase.getNumberOfComponents(); k++) {
+        phase.getComponent(k).setSolidCheck(solidPhaseCheck);
       }
     }
     setNumberOfPhases(oldphase);

--- a/src/test/java/neqsim/thermo/system/SystemThermoSolidPhaseCheckTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoSolidPhaseCheckTest.java
@@ -1,0 +1,152 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression coverage for disabling solid checks on fresh and reused fluids (issue #3623). */
+class SystemThermoSolidPhaseCheckTest extends neqsim.NeqSimTest {
+  private static Stream<SystemInterface> fluids() {
+    return Stream.of(new SystemPrEos(308.15, 9.0), new SystemSrkEos(308.15, 9.0), new SystemSrkCPAstatoil(308.15, 9.0));
+  }
+
+  @ParameterizedTest
+  @MethodSource("fluids")
+  void disablingOnFreshFluidIsSafeAndIdempotent(SystemInterface fluid) {
+    fluid.addComponent("methane", 1.0);
+    SystemInterface before = fluid.clone();
+
+    fluid.setSolidPhaseCheck(false);
+    fluid.setSolidPhaseCheck(false);
+
+    assertNull(fluid.getPhases()[3], "Disabling must not allocate a solid phase");
+    assertSolidChecks(fluid, false);
+    assertUnchangedPhaseState(before, fluid);
+  }
+
+  @ParameterizedTest
+  @MethodSource("fluids")
+  void enableDisableDisableSequenceClearsCachedPhases(SystemInterface fluid) {
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("CO2", 0.05);
+    fluid.setSolidPhaseCheck(true);
+    SystemInterface before = fluid.clone();
+
+    fluid.setSolidPhaseCheck(false);
+    fluid.setSolidPhaseCheck(false);
+
+    assertSolidChecks(fluid, false);
+    assertUnchangedPhaseState(before, fluid);
+
+    fluid.setSolidPhaseCheck(true);
+    assertSolidChecks(fluid, true);
+    assertEquals(before.getNumberOfPhases(), fluid.getNumberOfPhases());
+  }
+
+  @Test
+  void disablingPreservesThreePhaseFlashState() {
+    SystemInterface fluid = new SystemPrEos(308.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-decane", 0.1);
+    fluid.addComponent("water", 0.1);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(fluid).TPflash();
+    assertEquals(3, fluid.getNumberOfPhases(), "Fixture must contain gas, oil and aqueous phases");
+    SystemInterface before = fluid.clone();
+
+    fluid.setSolidPhaseCheck(false);
+    fluid.setSolidPhaseCheck(false);
+
+    assertNull(fluid.getPhases()[3]);
+    assertSolidChecks(fluid, false);
+    assertUnchangedPhaseState(before, fluid);
+  }
+
+  @Test
+  void disablingClearsInactiveSolidWithReorderedPhaseIndices() {
+    SystemInterface fluid = new SystemPrEos(308.15, 9.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("CO2", 0.05);
+    fluid.setSolidPhaseCheck(true);
+    assertTrue(fluid.getPhases()[3].getComponent("CO2").doSolidCheck());
+    fluid.setPhaseIndex(0, 1);
+    fluid.setPhaseIndex(1, 0);
+    fluid.setPhaseIndex(2, 3);
+    fluid.setPhaseIndex(3, 2);
+    SystemInterface before = fluid.clone();
+
+    fluid.setSolidPhaseCheck(false);
+    fluid.setSolidPhaseCheck(false);
+
+    assertSolidChecks(fluid, false);
+    assertUnchangedPhaseState(before, fluid);
+  }
+
+  @Test
+  void disablingClearsComponentSelectedChecks() {
+    SystemInterface fluid = new SystemPrEos(308.15, 9.0);
+    fluid.addComponent("methane", 0.999);
+    fluid.addComponent("S8", 0.001);
+    fluid.setSolidPhaseCheck("S8");
+    assertTrue(fluid.getComponent("S8").doSolidCheck());
+    assertFalse(fluid.getComponent("methane").doSolidCheck());
+    SystemInterface before = fluid.clone();
+
+    fluid.setSolidPhaseCheck(false);
+    fluid.setSolidPhaseCheck(false);
+
+    assertSolidChecks(fluid, false);
+    assertUnchangedPhaseState(before, fluid);
+  }
+
+  private static void assertSolidChecks(SystemInterface fluid, boolean expected) {
+    assertEquals(expected, fluid.doSolidPhaseCheck());
+    for (PhaseInterface phase : fluid.getPhases()) {
+      if (phase != null) {
+        for (int component = 0; component < phase.getNumberOfComponents(); component++) {
+          assertEquals(expected, phase.getComponent(component).doSolidCheck());
+        }
+      }
+    }
+  }
+
+  private static void assertUnchangedPhaseState(SystemInterface before, SystemInterface after) {
+    assertEquals(before.getNumberOfPhases(), after.getNumberOfPhases());
+    assertEquals(before.getMaxNumberOfPhases(), after.getMaxNumberOfPhases());
+    assertEquals(before.doMultiPhaseCheck(), after.doMultiPhaseCheck());
+    assertEquals(before.getTotalNumberOfMoles(), after.getTotalNumberOfMoles(), 0.0);
+    for (int index = 0; index < before.getPhases().length; index++) {
+      assertEquals(before.getPhaseIndex(index), after.getPhaseIndex(index));
+      PhaseInterface expected = before.getPhases()[index];
+      PhaseInterface actual = after.getPhases()[index];
+      if (expected == null) {
+        assertNull(actual);
+        continue;
+      }
+      assertEquals(expected.getType(), actual.getType());
+      assertEquals(expected.getTemperature(), actual.getTemperature(), 0.0);
+      assertEquals(expected.getPressure(), actual.getPressure(), 0.0);
+      assertEquals(expected.getBeta(), actual.getBeta(), 0.0);
+      assertEquals(expected.getNumberOfMolesInPhase(), actual.getNumberOfMolesInPhase(), 0.0);
+      assertEquals(expected.getNumberOfComponents(), actual.getNumberOfComponents());
+      for (int component = 0; component < expected.getNumberOfComponents(); component++) {
+        ComponentInterface expectedComponent = expected.getComponent(component);
+        ComponentInterface actualComponent = actual.getComponent(component);
+        assertEquals(expectedComponent.getComponentName(), actualComponent.getComponentName());
+        assertEquals(expectedComponent.getNumberOfmoles(), actualComponent.getNumberOfmoles(), 0.0);
+        assertEquals(expectedComponent.getNumberOfMolesInPhase(), actualComponent.getNumberOfMolesInPhase(), 0.0);
+        assertEquals(expectedComponent.getz(), actualComponent.getz(), 0.0);
+        assertEquals(expectedComponent.getx(), actualComponent.getx(), 0.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Calling `setSolidPhaseCheck(false)` on a fresh fluid dereferences an unallocated phase through `getPhase(3)` and throws before the first flash. The same hard-coded lookup can leave the stored solid's component flags enabled after phase indices are reordered.

This change updates component flags by iterating over allocated phase objects and skipping empty slots. Disabling is safe and idempotent, clears cached phase flags, and preserves phase count, phase ordering, composition and component inventories. Existing allocation behavior when enabling solid checks is retained.

- Add nine regression cases covering fresh PR/SRK/CPA fluids, true/false/false and re-enabling, a gas/oil/aqueous flash, reordered phase indices, and an S8-selected fluid.
- Update `SystemInterface` Javadoc and both existing phase-option guides to document reset behavior and preservation of the current equilibrium state.

Closes #3623.

Validation on NeqSim 3.20.0, OpenJDK 17.0.20, based on master `1a9dcb7b05c6157c58e7f8f7b0239be433fbd99f`:

- Before the fix: the new suite reproduced four phase-lookup errors and four flag assertions (9 cases, 1 passing).
- After the fix: **40 passed, 1 existing disabled test**, including all nine new cases and adjacent system, solid-flash and freezing-point tests.
- `./mvnw -B -ntp validate`: exit 0.
- Baseline `./mvnw -B -ntp test -Dtest=SystemThermoSolidPhaseCheckTest -Djacoco.skip=true`: exit 1, expected regression failures.
- Fixed `./mvnw -B -ntp test -Dtest=SystemThermoSolidPhaseCheckTest,SystemThermoTest,SystemThermoFixesTest,SystemThermoFluidWideSettersTest,SolidFlash1Test,FreezingPointTemperatureFlashTest,SystemSolidHelmholtzEosTest -Djacoco.skip=true -Dmaven.compiler.useIncrementalCompilation=false`: exit 0.
- `python devtools/run_spotless.py apply`: exit 0, repeated with no content changes.
- `pre-commit run --all-files --hook-stage pre-commit`: exit 0.
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0 (696 Markdown pages and 1 standalone HTML page).
- `pre-commit run --all-files --hook-stage pre-push`: exit 0.
- `./mvnw -B -ntp javadoc:javadoc -Dsubpackages=neqsim.thermo.system -Dmaven.compiler.useIncrementalCompilation=false`, with `javadocExecutable` pointing to a task-local launcher for the installed JDK's `jdk.javadoc` module: exit 0. The runtime lacks the native launcher; initial launcher setup attempts returned exit 1. Existing missing-comment warnings remain.
- `git diff --check` and final file checksum verification: exit 0. Published blob hashes match the locally validated files.

Python commands used the runtime's selected interpreter; pre-commit dependencies were isolated outside the repository.

Documentation impact: updated public API Javadoc and the flash/system guides. No public signature or dependency changes.

**VALIDATION PENDING CI** for the full repository matrix, including Java 8 and Windows. No merge performed.