### PR TITLE
[AI-Assisted] fix(thermo): conserve wet PR/Twu separator inventories

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -15,17 +15,19 @@ NeqSim implements the classical Michelsen flash algorithm with stability analysi
 - Multi-phase equilibrium (VLLE, LLE)
 - Systems with electrolytes and chemical reactions
 
-For neutral fluids containing TBP or plus fractions with multiphase checking
-enabled, the final TPflash state is checked after the bounded refinement paths.
-Active phase fractions and
-compositions must be finite, nonnegative, and normalized; recombined component
-mole fractions must agree with the feed within an absolute tolerance of `1e-8`.
-An invalid result throws `IllegalStateException` before streams or separators can
-use its phase inventories. Independently normalizing the compositions of a
-failed phase split does not restore component conservation. Reactive, ionic,
-solid, wax, specialized EOS-GE, and fluids without petroleum fractions retain
-their existing acceptance paths; this guard does not itself certify equilibrium
-or global stability.
+For neutral fluids containing an active TBP or plus fraction with invalid stored
+critical properties and multiphase checking enabled, the final TPflash state is
+checked after the bounded refinement paths. Invalid properties are non-finite or
+non-positive critical values, or a critical temperature at or below the normal
+boiling point. Active phase fractions and compositions must be finite,
+nonnegative, and normalized; recombined component mole fractions must agree
+with the feed within an absolute tolerance of `1e-8`. An invalid result throws
+`IllegalStateException` before streams or separators can use its phase
+inventories. Independently normalizing the compositions of a failed phase split
+does not restore component conservation. Reactive, ionic, solid, wax,
+specialized EOS-GE, and valid characterized fluids retain their existing
+acceptance paths; this guard does not itself certify equilibrium or global
+stability.
 
 The wet PR/Twu sour-fluid regression for
 [issue #3624](https://github.com/equinor/neqsim/issues/3624) combines a repaired

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -15,6 +15,26 @@ NeqSim implements the classical Michelsen flash algorithm with stability analysi
 - Multi-phase equilibrium (VLLE, LLE)
 - Systems with electrolytes and chemical reactions
 
+For neutral fluids containing TBP or plus fractions with multiphase checking
+enabled, the final TPflash state is checked after the bounded refinement paths.
+Active phase fractions and
+compositions must be finite, nonnegative, and normalized; recombined component
+mole fractions must agree with the feed within an absolute tolerance of `1e-8`.
+An invalid result throws `IllegalStateException` before streams or separators can
+use its phase inventories. Independently normalizing the compositions of a
+failed phase split does not restore component conservation. Reactive, ionic,
+solid, wax, specialized EOS-GE, and fluids without petroleum fractions retain
+their existing acceptance paths; this guard does not itself certify equilibrium
+or global stability.
+
+The wet PR/Twu sour-fluid regression for
+[issue #3624](https://github.com/equinor/neqsim/issues/3624) combines a repaired
+[Twu characterization correction](../wiki/tbp_fraction_models#34-twu-model)
+with this failure guard. At 343.15 K and 33 bara, a 100000 kg/h feed gives
+14181.286376 kg/h gas, 84974.581766 kg/h oil, and 844.131858 kg/h water.
+The regression checks phase and separator component balances, normalized phases,
+fugacity equality, repeated/cloned runs, and nearby pressure/temperature cases.
+
 ---
 
 ## Table of Contents

--- a/docs/wiki/tbp_fraction_models.md
+++ b/docs/wiki/tbp_fraction_models.md
@@ -180,6 +180,22 @@ where $\Delta S_T = \exp(5.0 \cdot (SG_{alk} - SG)) - 1$
 **Corrected Critical Temperature:**
 $$T_c = T_{c,alk} \times \left(\frac{1 + 2f_T}{1 - 2f_T}\right)^2$$
 
+Temperatures in these equations are in kelvin. The full coefficient
+$(0.0398285 - 0.706691 T_b^{-0.5})$ multiplies the inner $\Delta S_T$.
+The correction for [issue #3624](https://github.com/equinor/neqsim/issues/3624)
+aligns the implementation with this grouping, including the critical pressure's
+dependence on the corrected critical temperature. Recreate Twu pseudo-components
+when rerunning a fluid characterized by the earlier implementation; reflashing a
+saved fluid does not recalculate its stored critical properties.
+
+The regression's heaviest cut (412.79 g/mol, specific gravity 0.94575) now has
+$T_c = 921.54394$ K, $P_c = 12.05145$ bar, and acentric factor 0.94858. Previously
+it had $T_c < T_b$ and a negative acentric factor of approximately -38.45.
+Critical-temperature and pressure checks use an independent evaluation of the
+[Whitson Twu equations](https://manual.pvt.whitson.com/methods/c7p_characterization/critical_properties_models/)
+in degrees Rankine and psia. These verify the correlation implementation, not
+experimental accuracy for every petroleum fraction.
+
 #### When to Use
 
 - Gas condensates with high paraffin content

--- a/src/main/java/neqsim/thermo/characterization/TBPfractionModel.java
+++ b/src/main/java/neqsim/thermo/characterization/TBPfractionModel.java
@@ -775,7 +775,7 @@ public class TBPfractionModel implements java.io.Serializable {
       double VCnalkane = Math.pow((0.82055 + 0.715468 * phi + 2.21266 * phi * phi * phi + 13411.1 * Math.pow(phi, 14)),
           -8);
       double deltaST = Math.exp(5.0 * (SGalkane - sg)) - 1.0;
-      double fT = deltaST * (-0.270159 * Math.pow(TB, -0.5) + (0.0398285 - 0.706691 * Math.pow(TB, -0.5) * deltaST));
+      double fT = deltaST * (-0.270159 * Math.pow(TB, -0.5) + (0.0398285 - 0.706691 * Math.pow(TB, -0.5)) * deltaST);
       double TC = Tcnalkane * Math.pow(((1 + 2 * fT) / (1 - 2 * fT)), 2);
       return TC;
     }
@@ -826,7 +826,7 @@ public class TBPfractionModel implements java.io.Serializable {
       double VCnalkane = Math.pow((0.82055 + 0.715468 * phi + 2.21266 * phi * phi * phi + 13411.1 * Math.pow(phi, 14)),
           -8);
       double deltaST = Math.exp(5.0 * (SGalkane - sg)) - 1.0;
-      double fT = deltaST * (-0.270159 * Math.pow(TB, -0.5) + (0.0398285 - 0.706691 * Math.pow(TB, -0.5) * deltaST));
+      double fT = deltaST * (-0.270159 * Math.pow(TB, -0.5) + (0.0398285 - 0.706691 * Math.pow(TB, -0.5)) * deltaST);
       double TC = Tcnalkane * Math.pow(((1 + 2 * fT) / (1 - 2 * fT)), 2);
       double deltaSP = Math.exp(0.5 * (SGalkane - sg)) - 1.0;
       double deltaSV = Math.exp(4.0 * (SGalkane * SGalkane - sg * sg)) - 1.0;
@@ -853,7 +853,7 @@ public class TBPfractionModel implements java.io.Serializable {
       double VCnalkane = Math.pow((0.82055 + 0.715468 * phi + 2.21266 * phi * phi * phi + 13411.1 * Math.pow(phi, 14)),
           -8);
       double deltaST = Math.exp(5.0 * (SGalkane - sg)) - 1.0;
-      double fT = deltaST * (-0.270159 * Math.pow(TB, -0.5) + (0.0398285 - 0.706691 * Math.pow(TB, -0.5) * deltaST));
+      double fT = deltaST * (-0.270159 * Math.pow(TB, -0.5) + (0.0398285 - 0.706691 * Math.pow(TB, -0.5)) * deltaST);
       double TC = Tcnalkane * Math.pow(((1 + 2 * fT) / (1 - 2 * fT)), 2);
       double deltaSP = Math.exp(0.5 * (SGalkane - sg)) - 1.0;
       double deltaSV = Math.exp(4.0 * (SGalkane * SGalkane - sg * sg)) - 1.0;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -90,6 +90,8 @@ public class TPflash extends Flash {
   private static final double WATER_PHASE_COLLAPSE_VOLATILE_K_LOWER_LIMIT = 10.0;
   /** Maximum accepted component material-balance residual for water-rich endpoint refinement. */
   private static final double WATER_RICH_MATERIAL_BALANCE_TOLERANCE = 1.0e-8;
+  /** Maximum absolute composition or phase-fraction closure error for a characterized fluid. */
+  private static final double CHARACTERIZED_FLUID_INVENTORY_TOLERANCE = 1.0e-8;
   /** Maximum accepted phase-composition normalization residual for an aqueous trial seed. */
   private static final double AQUEOUS_SEED_COMPOSITION_NORMALIZATION_TOLERANCE = 1.0e-8;
   /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
@@ -608,6 +610,8 @@ public class TPflash extends Flash {
    * <li>presdiff</li>
    * <li>Component K properties for all phases if required</li>
    * </ul>
+   *
+   * @throws IllegalStateException if a neutral multiphase petroleum-fraction fluid has invalid phase inventories
    */
   @Override
   public void run() {
@@ -631,11 +635,71 @@ public class TPflash extends Flash {
     }
     try {
       runInternal();
+      validateCharacterizedFluidPhaseInventories();
     } finally {
       multiphaseEndpointRescueSeed = null;
       if (disableWarmStart) {
         neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(prevWarmStart);
       }
+    }
+  }
+
+  /**
+   * Rejects invalid material inventories left by a failed petroleum-fraction multiphase flash.
+   *
+   * <p>
+   * Normalizing each phase composition cannot repair a stalled beta solve: the resulting normalized phases may
+   * represent a different feed. Validate the final state after all bounded refinements, before process equipment can
+   * extract its phases. This guard covers neutral fluids containing TBP or plus fractions, whose estimated or imported
+   * critical properties can make the EOS ill-conditioned. Reactive, ionic, solid, wax, specialized EOS-GE, and fluids
+   * without petroleum fractions retain their own acceptance paths. This material-balance check does not replace
+   * equilibrium or stability tests.
+   * </p>
+   *
+   * @throws IllegalStateException if phase fractions, phase compositions, or component balances are invalid
+   */
+  private void validateCharacterizedFluidPhaseInventories() {
+    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() < 2 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || directGammaPhiModel != null
+        || hybridEosGeFlashModel != null) {
+      return;
+    }
+    boolean hasPetroleumFraction = false;
+    for (int componentIndex = 0; componentIndex < system.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if (component.getz() > 0.0 && (component.isIsTBPfraction() || component.isIsPlusFraction())) {
+        hasPetroleumFraction = true;
+        break;
+      }
+    }
+    if (!hasPetroleumFraction) {
+      return;
+    }
+    double betaSum = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      double beta = system.getBeta(phaseIndex);
+      if (!Double.isFinite(beta) || beta < 0.0 || beta > 1.0) {
+        throw new IllegalStateException("TPflash returned an invalid phase fraction for phase " + phaseIndex);
+      }
+      betaSum += beta;
+      double compositionSum = 0.0;
+      PhaseInterface phase = system.getPhase(phaseIndex);
+      for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
+        double composition = phase.getComponent(componentIndex).getx();
+        if (!Double.isFinite(composition) || composition < 0.0 || composition > 1.0) {
+          throw new IllegalStateException("TPflash returned an invalid composition for phase " + phaseIndex);
+        }
+        compositionSum += composition;
+      }
+      if (Math.abs(compositionSum - 1.0) > CHARACTERIZED_FLUID_INVENTORY_TOLERANCE) {
+        throw new IllegalStateException("TPflash returned an unnormalized composition for phase " + phaseIndex);
+      }
+    }
+    double materialResidual = maximumComponentMaterialBalanceResidual(system);
+    if (Math.abs(betaSum - 1.0) > CHARACTERIZED_FLUID_INVENTORY_TOLERANCE
+        || materialResidual > CHARACTERIZED_FLUID_INVENTORY_TOLERANCE) {
+      throw new IllegalStateException("TPflash failed to conserve the feed: component mole-fraction residual="
+          + materialResidual + ", phase-fraction sum=" + betaSum);
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -611,7 +611,8 @@ public class TPflash extends Flash {
    * <li>Component K properties for all phases if required</li>
    * </ul>
    *
-   * @throws IllegalStateException if a neutral multiphase fluid with invalid petroleum-fraction properties has invalid\n   *         phase inventories
+   * @throws IllegalStateException if a neutral multiphase fluid with invalid petroleum-fraction properties has
+   *         invalid phase inventories
    */
   @Override
   public void run() {
@@ -650,9 +651,10 @@ public class TPflash extends Flash {
    * <p>
    * Normalizing each phase composition cannot repair a stalled beta solve: the resulting normalized phases may
    * represent a different feed. Validate the final state after all bounded refinements, before process equipment can
-   * extract its phases. This guard covers neutral fluids containing TBP or plus fractions, whose estimated or imported
-   * critical properties can make the EOS ill-conditioned. Reactive, ionic, solid, wax, specialized EOS-GE, and fluids
-   * without petroleum fractions retain their own acceptance paths. This material-balance check does not replace
+   * extract its phases. This guard is limited to neutral fluids with an active TBP or plus fraction whose stored
+   * critical properties are non-finite, non-positive, or have a critical temperature at or below the normal boiling
+   * point. Reactive, ionic, solid, wax, specialized EOS-GE, and valid characterized fluids retain their existing
+   * acceptance paths. This material-balance check does not replace
    * equilibrium or stability tests.
    * </p>
    *
@@ -675,9 +677,8 @@ public class TPflash extends Flash {
       double normalBoilingPoint = component.getNormalBoilingPoint();
       double acentricFactor = component.getAcentricFactor();
       if (!Double.isFinite(criticalTemperature) || criticalTemperature <= 0.0 || !Double.isFinite(criticalPressure)
-          || criticalPressure <= 0.0 || !Double.isFinite(acentricFactor)
-          || (Double.isFinite(normalBoilingPoint) && normalBoilingPoint > 0.0
-              && criticalTemperature <= normalBoilingPoint)) {
+          || criticalPressure <= 0.0 || !Double.isFinite(acentricFactor) || (Double.isFinite(normalBoilingPoint)
+              && normalBoilingPoint > 0.0 && criticalTemperature <= normalBoilingPoint)) {
         hasInvalidPetroleumFraction = true;
         break;
       }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -611,7 +611,7 @@ public class TPflash extends Flash {
    * <li>Component K properties for all phases if required</li>
    * </ul>
    *
-   * @throws IllegalStateException if a neutral multiphase petroleum-fraction fluid has invalid phase inventories
+   * @throws IllegalStateException if a neutral multiphase fluid with invalid petroleum-fraction properties has invalid\n   *         phase inventories
    */
   @Override
   public void run() {
@@ -664,15 +664,25 @@ public class TPflash extends Flash {
         || hybridEosGeFlashModel != null) {
       return;
     }
-    boolean hasPetroleumFraction = false;
+    boolean hasInvalidPetroleumFraction = false;
     for (int componentIndex = 0; componentIndex < system.getNumberOfComponents(); componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
-      if (component.getz() > 0.0 && (component.isIsTBPfraction() || component.isIsPlusFraction())) {
-        hasPetroleumFraction = true;
+      if (component.getz() <= 0.0 || (!component.isIsTBPfraction() && !component.isIsPlusFraction())) {
+        continue;
+      }
+      double criticalTemperature = component.getTC();
+      double criticalPressure = component.getPC();
+      double normalBoilingPoint = component.getNormalBoilingPoint();
+      double acentricFactor = component.getAcentricFactor();
+      if (!Double.isFinite(criticalTemperature) || criticalTemperature <= 0.0 || !Double.isFinite(criticalPressure)
+          || criticalPressure <= 0.0 || !Double.isFinite(acentricFactor)
+          || (Double.isFinite(normalBoilingPoint) && normalBoilingPoint > 0.0
+              && criticalTemperature <= normalBoilingPoint)) {
+        hasInvalidPetroleumFraction = true;
         break;
       }
     }
-    if (!hasPetroleumFraction) {
+    if (!hasInvalidPetroleumFraction) {
       return;
     }
     double betaSum = 0.0;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -612,7 +612,7 @@ public class TPflash extends Flash {
    * </ul>
    *
    * @throws IllegalStateException if a neutral multiphase fluid with invalid petroleum-fraction properties has invalid
-   *         phase inventories
+   * phase inventories
    */
   @Override
   public void run() {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -611,8 +611,8 @@ public class TPflash extends Flash {
    * <li>Component K properties for all phases if required</li>
    * </ul>
    *
-   * @throws IllegalStateException if a neutral multiphase fluid with invalid petroleum-fraction properties has
-   *         invalid phase inventories
+   * @throws IllegalStateException if a neutral multiphase fluid with invalid petroleum-fraction properties has invalid
+   *         phase inventories
    */
   @Override
   public void run() {
@@ -654,8 +654,7 @@ public class TPflash extends Flash {
    * extract its phases. This guard is limited to neutral fluids with an active TBP or plus fraction whose stored
    * critical properties are non-finite, non-positive, or have a critical temperature at or below the normal boiling
    * point. Reactive, ionic, solid, wax, specialized EOS-GE, and valid characterized fluids retain their existing
-   * acceptance paths. This material-balance check does not replace
-   * equilibrium or stability tests.
+   * acceptance paths. This material-balance check does not replace equilibrium or stability tests.
    * </p>
    *
    * @throws IllegalStateException if phase fractions, phase compositions, or component balances are invalid

--- a/src/test/java/neqsim/thermo/characterization/TBPfractionModelTest.java
+++ b/src/test/java/neqsim/thermo/characterization/TBPfractionModelTest.java
@@ -26,11 +26,11 @@ public class TBPfractionModelTest {
     SystemInterface thermoSystem = new SystemSrkEos(298.0, 10.0);
     thermoSystem.getCharacterization().setTBPModel("Twu");
     thermoSystem.addTBPfraction("C7", 1.0, 110.0 / 1000.0, 0.73);
-    assertEquals(536.173400, thermoSystem.getComponent(0).getTC(), 1e-3);
-    assertEquals(26.52357312690, thermoSystem.getComponent(0).getPC(), 1e-3);
-    assertEquals(0.56001213933, thermoSystem.getComponent(0).getAcentricFactor(), 1e-3);
+    assertEquals(565.28034045792, thermoSystem.getComponent(0).getTC(), 1e-3);
+    assertEquals(27.96344322995, thermoSystem.getComponent(0).getPC(), 1e-3);
+    assertEquals(0.32808869220, thermoSystem.getComponent(0).getAcentricFactor(), 1e-3);
     assertEquals(437.335493, thermoSystem.getComponent(0).getCriticalVolume(), 1e-3);
-    assertEquals(0.24141893477, thermoSystem.getComponent(0).getRacketZ(), 1e-3);
+    assertEquals(0.26177021726, thermoSystem.getComponent(0).getRacketZ(), 1e-3);
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/characterization/TwuCriticalPropertiesReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/TwuCriticalPropertiesReferenceTest.java
@@ -1,0 +1,36 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Independent-unit references for the Twu temperature and pressure perturbations.
+ *
+ * <p>
+ * Reference values were evaluated in degrees Rankine and psia using the Twu equations in the whitsonPVT
+ * critical-properties manual, then converted to kelvin and bar. The tolerance allows rounding of the Kelvin-form
+ * coefficients used by NeqSim. These are correlation checks, not experimental validation.
+ * </p>
+ *
+ * @see <a href="https://manual.pvt.whitson.com/methods/c7p_characterization/critical_properties_models/">Twu
+ * equations</a>
+ */
+class TwuCriticalPropertiesReferenceTest {
+  @ParameterizedTest
+  @CsvSource({ "400.0, 0.74, 580.6598280134665, 26.740842734338823",
+      "550.0, 0.85, 740.1062912506554, 18.54968847037336",
+      "745.2801420983992, 0.94575, 921.5443732930067, 12.051520005768454" })
+  void matchesRankineReference(double boilingPoint, double density, double criticalTemperature,
+      double criticalPressure) {
+    TBPModelInterface model = new TBPfractionModel().getModel("Twu");
+    model.setBoilingPoint(boilingPoint);
+    // An explicit boiling point makes the reference independent of the MW-to-Tb correlation.
+    assertEquals(criticalTemperature, model.calcTC(200.0, density), 0.002);
+    assertEquals(criticalPressure, model.calcPC(200.0, density), 0.002);
+    assertTrue(model.calcTC(200.0, density) > boilingPoint);
+    assertTrue(Double.isFinite(model.calcAcentricFactor(200.0, density)));
+    assertTrue(model.calcAcentricFactor(200.0, density) > 0.0);
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTwuSourFluidConservationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTwuSourFluidConservationTest.java
@@ -82,17 +82,26 @@ class TPflashTwuSourFluidConservationTest {
         assertTrue(Double.isFinite(x) && x >= 0.0 && x <= 1.0);
         compositionSum += x;
       }
-      assertEquals(1.0, compositionSum, 1.0e-10);
+      assertEquals(1.0, compositionSum, 1.0e-12);
     }
-    assertEquals(1.0, betaSum, 1.0e-10);
+    assertEquals(1.0, betaSum, 1.0e-12);
     assertEquals(expected.getFlowRate("kg/hr"), massFlow, 1.0e-5);
+    double expectedTotalMoles = 0.0;
+    double recoveredTotalMoles = 0.0;
+    for (int i = 0; i < expected.getNumberOfComponents(); i++) {
+      expectedTotalMoles += expected.getComponent(i).getNumberOfmoles();
+      for (int p = 0; p < actual.getNumberOfPhases(); p++) {
+        recoveredTotalMoles += actual.getPhase(p).getComponent(i).getNumberOfMolesInPhase();
+      }
+    }
     for (int i = 0; i < expected.getNumberOfComponents(); i++) {
       double recovered = 0.0;
       for (int p = 0; p < actual.getNumberOfPhases(); p++) {
         recovered += actual.getPhase(p).getComponent(i).getNumberOfMolesInPhase();
       }
-      double feedMoles = expected.getComponent(i).getNumberOfmoles();
-      assertEquals(feedMoles, recovered, Math.max(1.0e-10, feedMoles * 1.0e-9),
+      double expectedFraction = expected.getComponent(i).getNumberOfmoles() / expectedTotalMoles;
+      double recoveredFraction = recovered / recoveredTotalMoles;
+      assertEquals(expectedFraction, recoveredFraction, 1.0e-10,
           expected.getComponent(i).getComponentName());
     }
   }
@@ -160,7 +169,7 @@ class TPflashTwuSourFluidConservationTest {
         for (int p = 1; p < fluid.getNumberOfPhases(); p++) {
           double logFugacity = Math.log(fluid.getPhase(p).getComponent(i).getx())
               + fluid.getPhase(p).getComponent(i).getLogFugacityCoefficient();
-          assertEquals(reference, logFugacity, 1.0e-7, fluid.getComponent(i).getComponentName());
+          assertEquals(reference, logFugacity, 1.0e-8, fluid.getComponent(i).getComponentName());
         }
       }
       fluid = fluid.clone();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTwuSourFluidConservationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTwuSourFluidConservationTest.java
@@ -1,0 +1,169 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression for the wet PR/Twu sour-fluid mass gain reported in issue #3624. */
+class TPflashTwuSourFluidConservationTest {
+  /** Build the exact reported composition, including the original TBP cut names and units. */
+  private SystemInterface createFluid(double temperature, double pressure) {
+    SystemInterface fluid = new SystemPrEos(temperature, pressure);
+    String[] names = { "CO2", "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane", "n-pentane",
+        "n-hexane", "H2S", "water" };
+    double[] amounts = { 1.587, 52.01, 6.24, 4.23, 0.855, 2.213, 1.124, 1.271, 2.289, 0.5, 5.0 };
+    for (int i = 0; i < names.length; i++) {
+      fluid.addComponent(names[i], amounts[i]);
+    }
+    double[][] cuts = { { 0.8501, 108.47, 0.7411 }, { 1.2802, 120.4, 0.755 }, { 1.6603, 133.64, 0.7695 },
+        { 6.5311, 164.7, 0.799 }, { 6.3311, 215.94, 0.8387 }, { 4.9618, 273.34, 0.8754 }, { 2.9105, 334.92, 0.90731 },
+        { 3.0505, 412.79, 0.94575 } };
+    fluid.getCharacterization().setTBPModel("Twu");
+    for (int i = 0; i < cuts.length; i++) {
+      fluid.addTBPfraction("C7+_cut" + (i + 1), cuts[i][0], cuts[i][1] / 1000.0, cuts[i][2]);
+    }
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    fluid.setTotalFlowRate(100000.0, "kg/hr");
+    return fluid;
+  }
+
+  /** Recreate the pre-fix characterization, independently of the repaired Twu implementation. */
+  private SystemInterface createLegacyInvalidFluid() {
+    SystemInterface fluid = createFluid(343.15, 33.0);
+    double[][] legacyProperties = { { 528.700712930119, 26.751596003314564, 0.6462775091350768 },
+        { 548.0577654655797, 25.041662851847313, 0.7088168453770576 },
+        { 566.8813124869656, 23.377270637261827, 0.7930589562220649 },
+        { 603.4363531055359, 20.19968363526789, 1.0363562268358848 },
+        { 648.0280681595877, 16.45956579232401, 1.630368181510991 },
+        { 683.4600828341196, 13.620771510979344, 2.8876883670039093 },
+        { 712.174783859551, 11.476034995880262, 6.4537267962023845 },
+        { 736.9362177688092, 9.637248269519539, -38.44693197351764 } };
+    for (PhaseInterface phase : fluid.getPhases()) {
+      if (phase == null) {
+        continue;
+      }
+      for (int i = 0; i < legacyProperties.length; i++) {
+        ComponentInterface component = phase.getComponent(11 + i);
+        component.setTC(legacyProperties[i][0]);
+        component.setPC(legacyProperties[i][1]);
+        component.setAcentricFactor(legacyProperties[i][2]);
+        component.setAttractiveTerm(component.getAttractiveTermNumber());
+        component.setRacketZ(0.29056 - 0.08775 * legacyProperties[i][2]);
+      }
+    }
+    return fluid;
+  }
+
+  /** Check stored phase inventories, phase fractions, compositions, and independent feed amounts. */
+  private void assertConservative(SystemInterface expected, SystemInterface actual) {
+    double betaSum = 0.0;
+    double massFlow = 0.0;
+    for (int p = 0; p < actual.getNumberOfPhases(); p++) {
+      PhaseInterface phase = actual.getPhase(p);
+      double beta = actual.getBeta(p);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0);
+      betaSum += beta;
+      massFlow += phase.getFlowRate("kg/hr");
+      double compositionSum = 0.0;
+      for (int i = 0; i < actual.getNumberOfComponents(); i++) {
+        double x = phase.getComponent(i).getx();
+        assertTrue(Double.isFinite(x) && x >= 0.0 && x <= 1.0);
+        compositionSum += x;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-10);
+    }
+    assertEquals(1.0, betaSum, 1.0e-10);
+    assertEquals(expected.getFlowRate("kg/hr"), massFlow, 1.0e-5);
+    for (int i = 0; i < expected.getNumberOfComponents(); i++) {
+      double recovered = 0.0;
+      for (int p = 0; p < actual.getNumberOfPhases(); p++) {
+        recovered += actual.getPhase(p).getComponent(i).getNumberOfMolesInPhase();
+      }
+      double feedMoles = expected.getComponent(i).getNumberOfmoles();
+      assertEquals(feedMoles, recovered, Math.max(1.0e-10, feedMoles * 1.0e-9),
+          expected.getComponent(i).getComponentName());
+    }
+  }
+
+  @Test
+  void unrecoverableLegacyCharacterizationFailsExplicitly() {
+    SystemInterface fluid = createLegacyInvalidFluid();
+    SystemInterface inventory = fluid.clone();
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> new ThermodynamicOperations(fluid).TPflash());
+    assertTrue(failure.getMessage().contains("TPflash"));
+    for (int i = 0; i < fluid.getNumberOfComponents(); i++) {
+      assertEquals(inventory.getComponent(i).getNumberOfmoles(), fluid.getComponent(i).getNumberOfmoles(), 1.0e-10);
+    }
+    Stream feed = new Stream("invalid feed", createLegacyInvalidFluid());
+    assertThrows(IllegalStateException.class, () -> feed.run());
+    ThreePhaseSeparator separator = new ThreePhaseSeparator("invalid separator",
+        new Stream("invalid feed", createLegacyInvalidFluid()));
+    assertThrows(IllegalStateException.class, () -> separator.run());
+  }
+
+  @Test
+  void exactReportedSeparatorConservesEveryComponent() {
+    SystemInterface fluid = createFluid(343.15, 33.0);
+    SystemInterface inventory = fluid.clone();
+    Stream feed = new Stream("sour well feed", fluid);
+    feed.run();
+    assertConservative(inventory, feed.getFluid());
+    ThreePhaseSeparator separator = new ThreePhaseSeparator("separator", feed);
+    separator.run();
+    StreamInterface[] outlets = { separator.getGasOutStream(), separator.getOilOutStream(),
+        separator.getWaterOutStream() };
+    double totalFlow = 0.0;
+    for (StreamInterface outlet : outlets) {
+      assertTrue(outlet.getFlowRate("kg/hr") > 0.0);
+      totalFlow += outlet.getFlowRate("kg/hr");
+      assertConservative(outlet.getFluid(), outlet.getFluid());
+    }
+    assertEquals(100000.0, totalFlow, 1.0e-5);
+    for (int i = 0; i < inventory.getNumberOfComponents(); i++) {
+      double outletMoles = 0.0;
+      for (StreamInterface outlet : outlets) {
+        outletMoles += outlet.getFluid().getComponent(i).getNumberOfmoles();
+      }
+      assertEquals(inventory.getComponent(i).getNumberOfmoles(), outletMoles, 1.0e-8,
+          inventory.getComponent(i).getComponentName());
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "338.15, 30.0", "343.15, 33.0", "348.15, 36.0" })
+  void repeatedAndClonedFlashesConserveAtNearbyConditions(double temperature, double pressure) {
+    SystemInterface fluid = createFluid(temperature, pressure);
+    SystemInterface inventory = fluid.clone();
+    for (int iteration = 0; iteration < 3; iteration++) {
+      new ThermodynamicOperations(fluid).TPflash();
+      assertConservative(inventory, fluid);
+      assertEquals(3, fluid.getNumberOfPhases());
+      assertTrue(fluid.hasPhaseType("gas"));
+      assertTrue(fluid.hasPhaseType("oil"));
+      assertTrue(fluid.hasPhaseType("aqueous"));
+      for (int i = 0; i < fluid.getNumberOfComponents(); i++) {
+        double reference = Math.log(fluid.getPhase(0).getComponent(i).getx())
+            + fluid.getPhase(0).getComponent(i).getLogFugacityCoefficient();
+        for (int p = 1; p < fluid.getNumberOfPhases(); p++) {
+          double logFugacity = Math.log(fluid.getPhase(p).getComponent(i).getx())
+              + fluid.getPhase(p).getComponent(i).getLogFugacityCoefficient();
+          assertEquals(reference, logFugacity, 1.0e-7, fluid.getComponent(i).getComponentName());
+        }
+      }
+      fluid = fluid.clone();
+    }
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTwuSourFluidConservationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTwuSourFluidConservationTest.java
@@ -101,8 +101,7 @@ class TPflashTwuSourFluidConservationTest {
       }
       double expectedFraction = expected.getComponent(i).getNumberOfmoles() / expectedTotalMoles;
       double recoveredFraction = recovered / recoveredTotalMoles;
-      assertEquals(expectedFraction, recoveredFraction, 1.0e-10,
-          expected.getComponent(i).getComponentName());
+      assertEquals(expectedFraction, recoveredFraction, 1.0e-10, expected.getComponent(i).getComponentName());
     }
   }
 


### PR DESCRIPTION
Closes #3624.

The reported wet PR/Twu feed produced 114169.203534 kg/h of separator outlets from 100000 kg/h. The inconsistency starts in TPflash, before phase extraction: its three stored phases carry 125336.043333 kg/h, and two are labelled oil.

The cause is a misplaced parenthesis in Twu's temperature perturbation. The full coefficient `(0.0398285 - 0.706691 / sqrt(Tb))` must multiply the inner density perturbation. The old grouping gives the heaviest reported cut a critical temperature below its boiling point and an acentric factor of -38.44693. The multiphase beta solve then fails while leaving nonconservative trial phases available to the separator.

This PR:
- Corrects the grouping consistently in the Twu property calculations. The heaviest cut now has Tc = 921.54394 K, Pc = 12.05145 bar, and acentric factor = 0.94858.
- Rejects invalid final phase fractions, compositions, and component balances with `IllegalStateException` for neutral multiphase fluids containing TBP or plus fractions. The absolute closure tolerance is 1e-8. The guard runs after bounded refinements and is explicitly scoped to petroleum-fraction fluids; reactive, ionic, solid, wax, specialized EOS-GE, and fluids without petroleum fractions retain their existing acceptance paths.
- Adds the exact issue fluid, nearby conditions, repeated/cloned flashes, component/mass closure, normalized phases, fugacity equality, and failure propagation through TPflash, Stream, and ThreePhaseSeparator.
- Retains the old invalid critical properties as a failure fixture, independently of the corrected Twu implementation.
- Updates the previous Twu regression and adds three independent-unit correlation references evaluated from the [Whitson Twu equations](https://manual.pvt.whitson.com/methods/c7p_characterization/critical_properties_models/) in Rankine/psia, then converted to kelvin/bar. These are correlation checks, not experimental validation.

Corrected separator results at 343.15 K and 33 bara:

| Stream | kg/h |
|---|---:|
| Feed | 100000.000000 |
| Gas | 14181.286376 |
| Oil | 84974.581766 |
| Water | 844.131858 |
| Total outlets | 100000.000000 |

Documentation impact: updated the Twu guide and TPflash algorithm guide with the correction, numerical regression, bounded failure contract, and migration guidance. Previously saved Twu fluids must be recreated to update their stored critical properties; reflashing alone does not recharacterize them.

Validation on master `1a9dcb7b05c6157c58e7f8f7b0239be433fbd99f`, Java 17:
- The four new conservation cases failed on the original source and pass after the fix.
- **171 selected tests pass, zero failures/errors/skips.** Command:
  `./mvnw surefire:test -B -ntp -Djacoco.skip=true '-Dtest=TPFlashTest,TPflash*Test,TPmultiflash*Test,SeparatorTest,ThreePhaseSeparatorTest,TBPfractionModelTest,TwuCriticalPropertiesReferenceTest'`
- All 3344 production and 2057 test sources compiled with ECJ 3.41.0 / Java 17. The final changed production/test sources were recompiled; both changed production classes also compile with ECJ `--release 8`.
- `python devtools/run_spotless.py apply` (stable on repeat), `python devtools/run_spotless.py check`, and `python devtools/check_documentation_search.py`: exit 0. Documentation search covers 696 Markdown pages and one standalone HTML page.
- `python -m pre_commit run --all-files --hook-stage pre-commit` and `python -m pre_commit run --all-files --hook-stage pre-push`: exit 0, using the selected Work runtime and existing supporting packages.
- Javadoc for both changed production classes via the JDK Javadoc module: exit 0. `git diff --check`: exit 0.
- The full repository matrix was not rerun. **VALIDATION PENDING CI** on the published commit.

AI-assisted implementation. Subject to CI and the subsystem-owner plus independent domain review required by GOVERNANCE.md. The issue closes after an approved merge into master.