### PR TITLE
fix(diagrams): correct BFD topology, ports and sheet order (#3619)

### DIFF
--- a/docs/integration/comparesimulations-pfd-pid-acceptance.md
+++ b/docs/integration/comparesimulations-pfd-pid-acceptance.md
@@ -12,6 +12,12 @@ This reference tracks the coordinated visual-acceptance milestone in
 
 ## Source fidelity
 
+Issue [#3619](https://github.com/equinor/neqsim/issues/3619) corrects the earlier acceptance interpretation:
+deterministic output and zero findings from the old route-only diagnostics did not establish visual
+acceptance. The original outputs contained duplicate continuations, endpoint-envelope traversal,
+misordered pages and collisions in the P&ID proposal layer. The core correction below is the first
+dependency in the issue's delivery sequence; the issue remains open for the later qualification gates.
+
 The inspected notebook is blob `68f13ad17dce03ee343e2f711437d57cdcb58f19`.
 Cell `b46addc3` defines reusable `getprocess()`; cell `63e9cf5b` contains a
 detailed reference illustration. Cell `78f9c5ff` is a retained historical
@@ -29,6 +35,20 @@ illustration.
 `EngineeringDiagramDualProfileDelivery` publishes `pfd/` and `pid/`
 sub-deliveries from the same `ProcessSystem`. It fails when either delivery is
 incomplete or the canonical source-graph fingerprints differ.
+
+The full-model reference now also opts into `Request.Builder.blockFlowOverview(sections, layout)`.
+This creates a separate A3 `bfd/overview.svg` and `bfd/overview.pdf`, plus `bfd/document-set.json` and
+`bfd/material-block-graph.json`. The bundle manifest includes their paths, visual evidence and SVG/PDF
+hashes. `Report.getBlockFlowProjection()` and `getBlockFlowRendering()` expose the mapping and rendering.
+The ordinary dual-profile API remains opt-in and returns null for those getters when no BFD is requested.
+
+The seven explicitly declared blocks are feed, separation, recompression, cold process, oil export,
+fuel gas and gas export. Their directed connections come only from the canonical material graph.
+The three product paths remain separate; no gas-export-to-oil-export connection is synthesized.
+Inter-section connections, including condensate returns, retain their complete `sourceConnectionIds`.
+Internal connections remain in each block's `internalConnectionIds`. A full-model test verifies that
+these lists form an exact partition of the canonical material connections. Numerical recycle utilities
+are aggregated with their sections and are not promoted to physical equipment.
 
 Each sub-delivery contains controlled document JSON, native SVG sheet(s), a
 native PDF drawing set, native DEXPI 2.0 Process XML, and a delivery manifest.
@@ -106,7 +126,7 @@ the completeness report retains engineering errors and review gaps.
 | P&ID exchange identity | Companion-only child label plus separate native DEXPI 2.0 Plant and Proteus 4.1 proposal artifacts | Plant assessment, profile labels, artifact and deterministic-regeneration assertions | Qualify the full-model proposal and external interoperability |
 | Stream and H&MB companions | Opt-in governed stream/balance artifacts with exact boundary resolution | Valid, missing-case, unknown-boundary, and repeated-delivery tests | Publish and qualify full-model operating values and boundary assignments |
 | Piping and instrumentation content | Opt-in source-linked proposal registers, sidecars, and per-element P&ID-only SVG/PDF callouts with distributed equipment-boundary attachment points | Register fidelity, immutability, signal classification, full-tag/semantic-ID and distinct attachment-point coverage, unique signal-path, profile-difference, and regeneration tests | Supply governed inputs and materialize reviewed per-element exchange content |
-| Manual layout and routing | Three persistent proposed A1 sheets, serpentine process-order pins, fixed ports, protected-route precedence, deterministic obstacle-aware orthogonal routes, and reciprocal continuations | Layout, obstacle-bypass renderer regression, full-model topology, and repeated-delivery tests | Accountable route refinement and reviewed visual baselines |
+| Manual layout and routing | Three persistent proposed A1 sheets, left-to-right rows, explicit stream-terminal assignments, nozzle-exit constraints, protected-route precedence, shared-track penalties, and unique reciprocal continuations | Reverse/vertical port, endpoint-interior, border, duplicate-emission, page-order and full-model regressions | Accountable route refinement, crossing/junction conventions and reviewed visual baselines |
 | Standards alignment | Explicit scope and no-conformance boundary | Manifest flags and documentation checks | Licensed clause mapping and accountable review |
 
 ## Engineering and qualification boundary
@@ -146,11 +166,15 @@ The retained layout register proposes three A1 landscape detail sheets: three-st
 separation/oil export, flash-gas recompression/dew point, and fuel split/gas
 export compression. Major model objects have persistent proposed sheet
 assignments and paper-millimetre pins. Sheet 1 indexes those three regions with
-their canonical equipment membership while leaving process connectivity to the
-semantic routes and reciprocal continuations above the index. Fixed-port
+their canonical equipment membership; feed, products and numerical-recycle stream terminals are
+assigned to the appropriate detail sheets. The separate A3 BFD provides plant-wide material connectivity.
+The SVG map, PDF pages and each child manifest's `renderedSheetOrder` use actual controlled sheet numbers.
+Consumers must use that list's number/title/path for captions instead of sorted filenames. Fixed-port
 orthogonal routing remains active for unprotected connections and chooses
-deterministic bypass channels before accepting a route through an unrelated
-symbol. Protected manual routes remain authoritative. Full line identities are
+deterministic bypass channels while assessing all symbol envelopes, including endpoint interiors.
+It penalizes shared route tracks and border excursions. Explicit `diagramPortSide` declarations support
+north/east/south/west attachments; ordinary undeclared process ports retain east outlets and west inlets.
+Protected manual routes remain authoritative and any endpoint traversal is reported. Full line identities are
 retained in fixed terminal symbols, with adaptive text no smaller than 2.2 mm.
 These records are reproducible teaching layout evidence, not checked project
 layout or engineering approval.
@@ -165,3 +189,21 @@ labels, markers, and signals. Project metadata, completed and reviewed
 line/nozzle/valve/reducer/instrument/control registers, reviewed exchange
 projection, and accountable discipline review remain
 mandatory before visual acceptance.
+
+## Remaining #3619 qualification work
+
+The completed-scene diagnostics now include estimated text bounds, proposal-marker and signal
+intersections, connectors, borders and repeated routes. They expose previously unreported defects in
+the existing P&ID callout layer. `isComplete()` still means delivery completeness; it does not accept
+those drawings. The manifest separately records `visualAcceptanceStatus: REVIEW_REQUIRED` and the
+checks actually performed. Font widths are estimated and are not measured glyph bounds.
+
+The next gated work is the reviewed family/subtype/orientation symbol catalogue and proportional
+equipment envelopes; declared physical line/nozzle/control attachments and a separate unbound-proposal
+register; printed stream IDs with readable operating tables; comprehensive crossing/junction and
+text-layout qualification; per-element exchange coverage/projection and independent DEXPI/Proteus
+round-trip evidence; and clean execution and visual inspection of the coordinated Colab draft. The
+native Plant and Proteus writers still do not receive the synthesized overlay registers or native scene.
+No displayed-overlay exchange-fidelity claim is made. `DexpiShapeCatalog` already contains family and
+instrument-location geometry and should be reconciled with the native scene before adding another
+symbol catalogue; this correction does not copy or certify its standard references.

--- a/docs/integration/engineering-diagram-delivery.md
+++ b/docs/integration/engineering-diagram-delivery.md
@@ -61,6 +61,13 @@ unit-explicit operating-case snapshot in the controlled document and assessed DE
 designation, layout, and symbol-convention registers can be supplied through the request builder;
 their existing evidence and review rules remain authoritative.
 
+The manifest's `renderedSheetOrder` contains each actual sheet number, title, identity and `svgFile`
+path in PDF page order. Use this list for preview captions and navigation instead of alphabetically
+sorting filenames or inventing sheet numbers by enumeration. Numeric controlled numbers sort
+numerically (2 precedes 10); numeric sheets precede alphanumeric numbers, which sort lexically.
+`visualAcceptanceStatus` remains `REVIEW_REQUIRED`, independently of delivery completeness.
+`rendererCheckScope` identifies the implemented geometric checks and their estimated-text basis.
+
 The destination directory must not exist. The facade writes to a sibling staging directory, runs
 the controlled-document, native-rendering, and bounded DEXPI gates, and publishes the complete
 directory only when every gate passes. It never replaces an existing delivery. Artifact paths in

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -61,10 +61,25 @@ records `DIAGRAM_CONTENT_PROFILE_OBJECT_OMITTED`. These are loss/projection diag
 the omitted objects remain available in the canonical semantic snapshot and to other drawing or
 exchange projections.
 
-The BFD policy treats current unit operations as conservative functional blocks; it does not infer
+The default BFD policy treats current unit operations as conservative functional blocks; it does not infer
 or aggregate licensed-standard process blocks. The PFD and P&ID policies likewise do not qualify
 symbols, content, layout, measurement/control conventions, or drawing practice. None of the three
 profiles claims ISO 10628, ISO 14617, ISA, or project-standard conformance or engineering approval.
+
+## Declared BFD aggregation
+
+For explicitly declared process sections, use `EngineeringBlockFlowProjection.fromGraph(graph,
+sectionByOwnerId)` before creating the BFD document. Assignments use exact canonical equipment or
+boundary-stream owner IDs. Unassigned owners stay visible. The projection retains separate material
+directions, product branches and inter-section returns. Each displayed aggregate connection contains
+`sourceConnectionIds`; each block contains `sourceOwnerIds` and `internalConnectionIds`. Together these
+lists account for every original material connection exactly once. Unknown assignments and unresolved
+material endpoints fail instead of losing a flow. `toGraph()` returns an independent graph snapshot,
+and `toJson()` retains the complete mapping. Section membership never creates a connection.
+
+Material-block rectangles use 4.2 mm label fonts and connection-facing ports, with separate return
+routes below the main flow. These dimensions are schematic, not vessel dimensions or flow-dependent
+equipment sizing. Symbol conventions below continue to apply to the ordinary equipment views.
 
 ## Project symbol conventions
 
@@ -99,8 +114,9 @@ register and remain unchanged.
 
 ## Fixed-port orthogonal routing
 
-Native rendering retains `RoutingMode.LEGACY_CENTER` by default, so every existing constructor keeps
-the previous center-to-center SVG/PDF bytes and visual fingerprints. Select
+Native rendering retains `RoutingMode.LEGACY_CENTER` by default. Its center-to-center geometry and
+font scale are unchanged; both modes now remove duplicate continuation views and order pages by
+controlled sheet number. Select
 `RoutingMode.FIXED_PORT_ORTHOGONAL` through the additive renderer constructors when a controlled
 drawing view needs explicit canonical port geometry:
 
@@ -112,7 +128,7 @@ NativeEngineeringDiagramRenderer.Result result = renderer.render();
 ```
 
 The opt-in mode resolves each connection's stable `sourceEndpointId` and `targetEndpointId`, anchors
-the corresponding port/nozzle at the left or right bound of its owner symbol, and exposes the endpoint
+the corresponding port/nozzle at its owner-symbol bound, and exposes the endpoint
 identity on the SVG port marker. Port slots are sorted by stable identity. Branches therefore retain
 distinct anchors, connections between the same owner pair receive deterministic parallel lanes, and
 declared recycle or backward connections receive a deterministic orthogonal return path. Reciprocal
@@ -121,8 +137,10 @@ where space permits and retain deterministic minimum separation when several con
 sheet edge. Connection labels are selected from horizontal route segments using deterministic
 object- and label-collision scoring instead of being placed on a shared vertical trunk. For an
 unprotected connection, automatic routing evaluates the direct orthogonal path and deterministic
-page channels, then selects by fewest non-endpoint object intersections, best achievable label
-collision score, and shortest route, in that order. A reviewed protected route remains authoritative
+page channels. Routes first leave/approach the actual nozzle side, including on reverse-flow rows.
+Selection penalizes border violations and all object-envelope intersections (including endpoint
+interiors), then shared track length, label collisions and route length. Endpoint boundary contact is
+allowed; traversing the endpoint interior is diagnosed. A reviewed protected route remains authoritative
 and is never replaced by automatic routing. Each fixed-port
 route also carries a deterministic vector arrowhead in SVG and PDF. When the opt-in `LINE_TERMINAL` convention is present,
 each visible off-page label combines the canonical connection designation, directional `TO` or
@@ -130,7 +148,15 @@ each visible off-page label combines the canonical connection designation, direc
 the document model and SVG semantic attributes without being exposed as reader-facing drawing text.
 Long line-terminal identities remain complete and are reduced only as far as 2.2 mm text to fit
 inside the fixed vector symbol; the renderer never truncates or substitutes a machine identifier.
-Legacy convention/routing profiles retain their previous labels and bytes.
+Fixed-port PDF fonts now retain the declared SVG font size in paper units (`mm * 72 / 25.4` points),
+without the previous implicit 22 percent reduction. Legacy-center PDF font scaling is unchanged.
+
+An endpoint may explicitly set `diagramPortSide` to `NORTH`, `EAST`, `SOUTH` or `WEST` before document
+projection. `NativeEngineeringDiagramRenderer.PortSide` enumerates these exact values. North is
+upwards in paper coordinates. Undeclared ordinary process endpoints keep east-facing outlets and
+west-facing inlets. Invalid declarations produce `DIAGRAM_RENDER_INVALID_PORT_SIDE` and fail the
+render-completeness gate. This constraint controls attachment geometry; it does not rotate the
+equipment symbol or establish a reviewed nozzle location.
 
 `DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED` reports a malformed endpoint that cannot resolve to an owner.
 A valid peer owner absent from an off-page connection's current sheet is expected and does not create a
@@ -602,7 +628,15 @@ The rendering result also carries deterministic drawing-quality diagnostics. It 
 object symbols, symbols clipped by the border/header/title-block boundary, primary labels estimated
 to exceed their available symbol width, connection routes crossing non-endpoint objects, connection
 labels overlapping objects or other connection labels, missing connection labels, and missing
-semantic-object references. Existing controlled-document diagnostics are retained in the same report,
+semantic-object references. Validation now also runs on the completed scene after connectors,
+symbols, port markers, P&ID markers/signals and title blocks have been added. The
+`DIAGRAM_RENDER_SCENE_*` diagnostics cover border clipping, estimated text/text and text/route or
+marker collisions, marker/process-route and marker/object intersections, and signal/object
+intersections. `DIAGRAM_RENDER_DUPLICATE_ROUTE` detects identical repeated physical-route emission;
+`DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION` includes protected endpoint traversal without rewriting
+the protected geometry. These checks use conservative rectangles and estimated text widths, not
+measured glyph outlines. Crossing-versus-junction interpretation and reviewed symbol semantics still
+require additional qualification. Existing controlled-document diagnostics are retained in the same report,
 including broken reciprocal off-page pairs and stale manual layout references. Errors make
 `Result.isComplete()` false; warnings retain the proposed geometry unchanged for review. These
 geometric and text-width checks are conservative proposal gates, not proof of standards compliance or

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
@@ -1022,7 +1022,11 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
             "Manual sheet assignment targets an object omitted by the selected content profile", node.getId()));
         continue;
       }
-      if (isConnection(node.getKind())) {
+      // A source Stream is represented by a LINE owner with its own ports, not by connection geometry.
+      boolean streamOwner = node.getKind() == EngineeringNode.Kind.LINE
+          && !node.getProperties().containsKey("sourceEndpointId")
+          && !node.getProperties().containsKey("targetEndpointId");
+      if (isConnection(node.getKind()) && !streamOwner) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_LAYOUT_CONNECTION_ASSIGNMENT_DERIVED",
             "Connection sheet projection is derived from its endpoint assignments; use protected routes for each view",
             node.getId()));
@@ -1090,8 +1094,6 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       String pairId = "offpage-pair:" + key;
       String sourceId = "offpage:" + key + ":source";
       String targetId = "offpage:" + key + ":target";
-      sourceSheet.objectNodeIds.add(node.getId());
-      targetSheet.objectNodeIds.add(node.getId());
       sourceSheet.connectors.add(new OffPageConnector(sourceId, pairId, node.getId(), ConnectorRole.SOURCE,
           sourceSheet.id, targetSheet.id, targetId, "AUTO"));
       targetSheet.connectors.add(new OffPageConnector(targetId, pairId, node.getId(), ConnectorRole.TARGET,

--- a/src/main/java/neqsim/process/examples/Comparesimulations2EngineeringDiagramReference.java
+++ b/src/main/java/neqsim/process/examples/Comparesimulations2EngineeringDiagramReference.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
@@ -22,6 +24,7 @@ import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.SheetDe
 import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.SheetOverviewRegion;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.processmodel.diagram.EngineeringDiagramDualProfileDelivery;
+import neqsim.process.processmodel.diagram.EngineeringBlockFlowProjection;
 import neqsim.process.processmodel.diagram.NativeEngineeringDiagramRenderer;
 import neqsim.process.processmodel.diagram.ProcessDiagramGraphAdapter;
 
@@ -36,6 +39,7 @@ import neqsim.process.processmodel.diagram.ProcessDiagramGraphAdapter;
  * </p>
  */
 public final class Comparesimulations2EngineeringDiagramReference {
+  private static final Logger logger = LogManager.getLogger(Comparesimulations2EngineeringDiagramReference.class);
   private static final String REVISION = "A";
   private static final String OPERATING_CASE = "NORMAL-DEFAULT-2026-09-07";
   private static final String SOURCE = "EvenSol/NeqSim-Colab:notebooks/process/comparesimulations2.ipynb"
@@ -90,6 +94,10 @@ public final class Comparesimulations2EngineeringDiagramReference {
     boundaries.add(boundary("fuel gas", Direction.OUTLET));
     boundaries.add(boundary("export gas", Direction.OUTLET));
     boundaries.add(boundary("export oil", Direction.OUTLET));
+    EngineeringGraph graph = ProcessDiagramGraphAdapter
+        .fromProcessSystem(process, "ANDREASEN-SEPARATION-COMPRESSION", REVISION).getGraph();
+    Map<String, String> sections = blockSections(graph);
+    EngineeringBlockFlowProjection overview = EngineeringBlockFlowProjection.fromGraph(graph, sections);
 
     return EngineeringDiagramDualProfileDelivery.Request
         .builder("ANDREASEN-SEPARATION-COMPRESSION", REVISION, "PFD-ANDREASEN-001", "PID-ANDREASEN-001",
@@ -97,7 +105,56 @@ public final class Comparesimulations2EngineeringDiagramReference {
         .operatingCaseId(OPERATING_CASE).balanceBoundaries(boundaries).includePidEngineeringRegisters(true)
         .sheetFormat(NativeEngineeringDiagramRenderer.SheetFormat.A1_LANDSCAPE)
         .routingMode(NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL)
-        .conventionRegister(proposedSymbolConventions()).layoutRegister(layoutRegister(process)).build();
+        .conventionRegister(proposedSymbolConventions()).layoutRegister(layoutRegister(process))
+        .blockFlowOverview(sections, blockLayout(overview)).build();
+  }
+
+  private static Map<String, String> blockSections(EngineeringGraph graph) {
+    Map<String, String> sectionByName = new LinkedHashMap<String, String>();
+    String[][] sections = { { "Feed", "well stream" }, { "Separation", "20-HA-01", "20-VA-01", "VLV-100", "MIX-101",
+        "20-HA-02", "20-VA-02", "VLV-102", "MIX-102", "20-HA-03", "20-VA-03" },
+        { "Oil export", "21-HA-01", "21-PA-01", "export oil" },
+        { "Recompression", "23-HA-03", "23-VG-03", "23-PA-01", "LP oil recycle", "23-KA-03", "MIX-103", "23-HA-02",
+            "23-VG-02", "23-KA-02", "MIX-100", "23-HA-01", "23-VG-01", "dew point recycle 1",
+            "dew point liquid reflux 1", "third stage reflux" },
+        { "Cold process", "23-KA-01", "24-HA-01", "24-VG-01", "dew point recycle 2", "splitter", "25-HA-01", "25-HA-02",
+            "25-VG-01", "dew point liquid reflux 2" },
+        { "Fuel gas", "fuel gas" }, { "Gas export", "27-KA-01", "27-HA-01", "export gas" } };
+    for (String[] section : sections) {
+      for (int index = 1; index < section.length; index++) {
+        sectionByName.put(section[index], section[0]);
+      }
+    }
+    Map<String, String> result = new LinkedHashMap<String, String>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() == EngineeringNode.Kind.EQUIPMENT || node.getKind() == EngineeringNode.Kind.LINE) {
+        String section = sectionByName.get(node.getLabel());
+        if (section == null) {
+          throw new IllegalStateException("Canonical object needs an explicit BFD section: " + node.getLabel());
+        }
+        result.put(node.getId(), section);
+      }
+    }
+    return result;
+  }
+
+  private static EngineeringDiagramLayoutRegister blockLayout(EngineeringBlockFlowProjection overview) {
+    Map<String, double[]> points = new LinkedHashMap<String, double[]>();
+    points.put("Feed", new double[] { 48.0, 125.0 });
+    points.put("Separation", new double[] { 126.0, 125.0 });
+    points.put("Recompression", new double[] { 214.0, 125.0 });
+    points.put("Cold process", new double[] { 298.0, 125.0 });
+    points.put("Gas export", new double[] { 380.0, 125.0 });
+    points.put("Oil export", new double[] { 126.0, 205.0 });
+    points.put("Fuel gas", new double[] { 298.0, 55.0 });
+    EngineeringDiagramLayoutRegister result = new EngineeringDiagramLayoutRegister();
+    for (Map.Entry<String, String> block : overview.getBlockLabels().entrySet()) {
+      double[] point = points.get(block.getValue());
+      result = result.withPinnedPosition(new PinnedPosition(block.getKey(), "plant", point[0], point[1],
+          CoordinateUnit.MILLIMETRE, SOURCE + ":proposed-bfd-layout",
+          EngineeringDiagramLayoutRegister.EvidenceState.PROPOSED, RECORDED_BY, RECORDED_AT, REVISION));
+    }
+    return result;
   }
 
   private static EngineeringDiagramConventionRegister proposedSymbolConventions() {
@@ -122,7 +179,7 @@ public final class Comparesimulations2EngineeringDiagramReference {
     Map<String, String> equipmentIds = new LinkedHashMap<String, String>();
     String overviewSheetKey = null;
     for (EngineeringNode node : graph.getNodes().values()) {
-      if (node.getKind() == EngineeringNode.Kind.EQUIPMENT) {
+      if (node.getKind() == EngineeringNode.Kind.EQUIPMENT || node.getKind() == EngineeringNode.Kind.LINE) {
         equipmentIds.put(node.getLabel(), node.getId());
       } else if (node.getKind() == EngineeringNode.Kind.AREA) {
         if (overviewSheetKey != null) {
@@ -148,9 +205,30 @@ public final class Comparesimulations2EngineeringDiagramReference {
     register = place(register, "separation", separation, equipmentIds);
     register = place(register, "recompression", recompression, equipmentIds);
     register = place(register, "export", export, equipmentIds);
+    register = placeStream(register, equipmentIds, "well stream", "separation", 35.0, 100.0);
+    register = placeStream(register, equipmentIds, "export oil", "separation", 750.0, 520.0);
+    register = placeStream(register, equipmentIds, "third stage reflux", "separation", 750.0, 210.0);
+    register = placeStream(register, equipmentIds, "dew point liquid reflux 1", "separation", 600.0, 45.0);
+    register = placeStream(register, equipmentIds, "dew point liquid reflux 2", "separation", 750.0, 45.0);
+    register = placeStream(register, equipmentIds, "export gas", "export", 400.0, 460.0);
+    register = placeStream(register, equipmentIds, "fuel gas", "export", 90.0, 205.0);
     return register.withOverviewRegion(overviewRegion(overviewSheetKey, "separation", 36.0))
         .withOverviewRegion(overviewRegion(overviewSheetKey, "recompression", 305.0))
         .withOverviewRegion(overviewRegion(overviewSheetKey, "export", 574.0));
+  }
+
+  private static EngineeringDiagramLayoutRegister placeStream(EngineeringDiagramLayoutRegister register,
+      Map<String, String> ids, String name, String sheet, double x, double y) {
+    String id = ids.get(name);
+    if (id == null) {
+      throw new IllegalStateException("Reference layout requires canonical stream: " + name);
+    }
+    return register
+        .withAssignment(new SheetAssignment(id, sheet, SOURCE + ":proposed-stream-layout",
+            EngineeringDiagramLayoutRegister.EvidenceState.PROPOSED, RECORDED_BY, RECORDED_AT, REVISION))
+        .withPinnedPosition(
+            new PinnedPosition(id, sheet, x, y, CoordinateUnit.MILLIMETRE, SOURCE + ":proposed-stream-layout",
+                EngineeringDiagramLayoutRegister.EvidenceState.PROPOSED, RECORDED_BY, RECORDED_AT, REVISION));
   }
 
   private static SheetOverviewRegion overviewRegion(String overviewSheetKey, String targetSheetKey, double x) {
@@ -176,7 +254,7 @@ public final class Comparesimulations2EngineeringDiagramReference {
       }
       int row = index / columns;
       int positionInRow = index % columns;
-      int column = row % 2 == 0 ? positionInRow : columns - 1 - positionInRow;
+      int column = positionInRow;
       double x = 90.0 + column * (660.0 / (columns - 1));
       double y = rows == 1 ? 280.0 : 100.0 + row * (360.0 / (rows - 1));
       result = result
@@ -199,6 +277,6 @@ public final class Comparesimulations2EngineeringDiagramReference {
     Path destination = args.length == 0 ? Paths.get("build", "comparesimulations2-engineering-diagrams")
         : Paths.get(args[0]);
     EngineeringDiagramDualProfileDelivery.Report report = deliver(createExecutedProcess(), destination);
-    System.out.println(report.toJson());
+    logger.info("{}", report.toJson());
   }
 }

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringBlockFlowProjection.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringBlockFlowProjection.java
@@ -1,0 +1,172 @@
+package neqsim.process.processmodel.diagram;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import neqsim.process.engineering.model.EngineeringEdge;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+
+/**
+ * Material-flow aggregation of a canonical engineering graph into declared process sections.
+ *
+ * <p>
+ * Every material connection belongs to exactly one aggregate connection or to the internal-connection list of a block.
+ * Unassigned equipment and boundary streams remain separate blocks; ordering the declarations never creates
+ * connectivity. Opposite directions and recycle paths remain distinct. This is a schematic projection, not a new
+ * simulation or a declaration of physical equipment sizes.
+ * </p>
+ */
+public final class EngineeringBlockFlowProjection {
+  private final String graphJson;
+
+  private EngineeringBlockFlowProjection(EngineeringGraph graph) {
+    graphJson = graph.toJson();
+  }
+
+  /**
+   * Aggregates material connections using exact canonical owner identities.
+   *
+   * @param source canonical material graph, retained unchanged
+   * @param sectionByOwnerId owner-node identity to human-readable section name; unassigned owners remain visible
+   * @return immutable projection retaining the source connection identities
+   * @throws IllegalArgumentException for unknown assignments or unresolved material endpoints
+   */
+  public static EngineeringBlockFlowProjection fromGraph(EngineeringGraph source,
+      Map<String, String> sectionByOwnerId) {
+    if (source == null || sectionByOwnerId == null) {
+      throw new IllegalArgumentException("source and section assignments are required");
+    }
+    Map<String, String> assignments = new TreeMap<String, String>(sectionByOwnerId);
+    for (Map.Entry<String, String> entry : assignments.entrySet()) {
+      EngineeringNode owner = source.getNode(entry.getKey());
+      if (owner == null || !isOwner(owner) || entry.getValue() == null || entry.getValue().trim().isEmpty()) {
+        throw new IllegalArgumentException("Invalid block section assignment: " + entry.getKey());
+      }
+    }
+    EngineeringGraph result = new EngineeringGraph(source.getProjectId() + ":BFD", source.getRevision());
+    Map<String, EngineeringNode> blocks = new TreeMap<String, EngineeringNode>();
+    Map<String, List<String>> members = new TreeMap<String, List<String>>();
+    Map<String, List<String>> internal = new TreeMap<String, List<String>>();
+    Map<String, String> blockByOwner = new TreeMap<String, String>();
+    Map<String, EngineeringNode> ordered = new TreeMap<String, EngineeringNode>(source.getNodes());
+    Object sourceFingerprint = source.toMap().get("fingerprint");
+    for (EngineeringNode owner : ordered.values()) {
+      if (!isOwner(owner)) {
+        continue;
+      }
+      String section = assignments.get(owner.getId());
+      String id = section == null ? "block:object:" + encode(owner.getId()) : "block:section:" + encode(section);
+      blockByOwner.put(owner.getId(), id);
+      if (!blocks.containsKey(id)) {
+        EngineeringNode block = new EngineeringNode(id, EngineeringNode.Kind.EQUIPMENT, id,
+            section == null ? owner.getLabel() : section).putProperty("projectionKind", "MATERIAL_BLOCK")
+            .putProperty("sourceGraphFingerprint", sourceFingerprint);
+        blocks.put(id, block);
+        members.put(id, new ArrayList<String>());
+        internal.put(id, new ArrayList<String>());
+      }
+      members.get(id).add(owner.getId());
+    }
+    Map<String, List<String>> connections = new TreeMap<String, List<String>>();
+    Map<String, String[]> endpoints = new TreeMap<String, String[]>();
+    Map<String, Boolean> recycles = new TreeMap<String, Boolean>();
+    for (EngineeringNode connection : ordered.values()) {
+      if (connection.getKind() != EngineeringNode.Kind.PIPE_SEGMENT) {
+        continue;
+      }
+      String from = blockByOwner.get(ownerId(source, connection, "sourceEndpointId"));
+      String to = blockByOwner.get(ownerId(source, connection, "targetEndpointId"));
+      if (from == null || to == null) {
+        throw new IllegalArgumentException("Unresolved material connection: " + connection.getId());
+      }
+      if (from.equals(to)) {
+        internal.get(from).add(connection.getId());
+        continue;
+      }
+      String id = "block-flow:" + encode(from) + ":" + encode(to);
+      if (!connections.containsKey(id)) {
+        connections.put(id, new ArrayList<String>());
+        endpoints.put(id, new String[] { from, to });
+      }
+      connections.get(id).add(connection.getId());
+      recycles.put(id, Boolean.valueOf(
+          Boolean.TRUE.equals(recycles.get(id)) || Boolean.TRUE.equals(connection.getProperties().get("recycle"))));
+    }
+    for (EngineeringNode block : blocks.values()) {
+      block.putProperty("sourceOwnerIds", members.get(block.getId())).putProperty("internalConnectionIds",
+          internal.get(block.getId()));
+      result.addNode(block);
+    }
+    int number = 1;
+    for (Map.Entry<String, List<String>> entry : connections.entrySet()) {
+      String id = entry.getKey();
+      String from = endpoints.get(id)[0];
+      String to = endpoints.get(id)[1];
+      String fromPort = id + ":out";
+      String toPort = id + ":in";
+      result.addNode(port(fromPort, from, "OUTLET"));
+      result.addNode(port(toPort, to, "INLET"));
+      result.addNode(new EngineeringNode(id, EngineeringNode.Kind.PIPE_SEGMENT, id, "BF-" + number++)
+          .putProperty("sourceEndpointId", fromPort).putProperty("targetEndpointId", toPort)
+          .putProperty("sourceEquipment", blocks.get(from).getLabel())
+          .putProperty("targetEquipment", blocks.get(to).getLabel()).putProperty("connectionType", "MATERIAL")
+          .putProperty("sourceConnectionIds", entry.getValue()).putProperty("recycle", recycles.get(id)));
+      result.addEdge(new EngineeringEdge(id + ":source-port", from, fromPort, EngineeringEdge.Kind.HAS_PORT, "outlet"));
+      result.addEdge(new EngineeringEdge(id + ":target-port", to, toPort, EngineeringEdge.Kind.HAS_PORT, "inlet"));
+      result
+          .addEdge(new EngineeringEdge(id + ":source-flow", fromPort, id, EngineeringEdge.Kind.PROCESS_FLOW, "source"));
+      result.addEdge(new EngineeringEdge(id + ":target-flow", id, toPort, EngineeringEdge.Kind.PROCESS_FLOW, "target"));
+    }
+    return new EngineeringBlockFlowProjection(result);
+  }
+
+  /** @return a fresh, independently editable graph for the existing BFD document and rendering APIs */
+  public EngineeringGraph toGraph() {
+    return EngineeringGraph.fromJson(graphJson);
+  }
+
+  /** @return deterministic graph JSON including every aggregate-to-canonical connection mapping */
+  public String toJson() {
+    return graphJson;
+  }
+
+  /** @return independent block identity to human-readable label map for layout declarations */
+  public Map<String, String> getBlockLabels() {
+    Map<String, String> result = new LinkedHashMap<String, String>();
+    for (EngineeringNode node : toGraph().getNodes().values()) {
+      if (node.getKind() == EngineeringNode.Kind.EQUIPMENT) {
+        result.put(node.getId(), node.getLabel());
+      }
+    }
+    return result;
+  }
+
+  private static boolean isOwner(EngineeringNode node) {
+    return node.getKind() == EngineeringNode.Kind.EQUIPMENT || node.getKind() == EngineeringNode.Kind.LINE
+        || node.getKind() == EngineeringNode.Kind.BOUNDARY || node.getKind() == EngineeringNode.Kind.PROCESS_TAP;
+  }
+
+  private static String ownerId(EngineeringGraph source, EngineeringNode connection, String property) {
+    Object reference = connection.getProperties().get(property);
+    EngineeringNode endpoint = reference == null ? null : source.getNode(reference.toString());
+    if (endpoint == null) {
+      return "";
+    }
+    Object owner = endpoint.getProperties().get("ownerNodeId");
+    return owner == null && isOwner(endpoint) ? endpoint.getId() : owner == null ? "" : owner.toString();
+  }
+
+  private static EngineeringNode port(String id, String owner, String direction) {
+    return new EngineeringNode(id, EngineeringNode.Kind.PORT, id, direction).putProperty("ownerNodeId", owner)
+        .putProperty("direction", direction).putProperty("connectionType", "MATERIAL");
+  }
+
+  private static String encode(String value) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDelivery.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDelivery.java
@@ -315,6 +315,24 @@ public final class EngineeringDiagramDelivery {
       result.put("deliveryDiagnostics", deliveryDiagnostics);
       result.put("visualFingerprintsBySheetId",
           new LinkedHashMap<String, String>(rendering.getVisualFingerprintsBySheetId()));
+      List<Map<String, Object>> sheetOrder = new ArrayList<Map<String, Object>>();
+      for (String sheetId : rendering.getSvgBySheetId().keySet()) {
+        for (EngineeringDiagramDocumentSet.Drawing drawing : documentSet.getDrawings()) {
+          for (EngineeringDiagramDocumentSet.Sheet sheet : drawing.getSheets()) {
+            if (sheetId.equals(sheet.getId())) {
+              Map<String, Object> entry = new LinkedHashMap<String, Object>();
+              entry.put("sheetId", sheetId);
+              entry.put("number", sheet.getNumber());
+              entry.put("title", sheet.getTitle());
+              entry.put("svgFile", svgRelativePath(sheetId));
+              sheetOrder.add(entry);
+            }
+          }
+        }
+      }
+      result.put("renderedSheetOrder", sheetOrder);
+      result.put("visualAcceptanceStatus", "REVIEW_REQUIRED");
+      result.put("rendererCheckScope", rendering.getPerformedChecks());
       List<Map<String, Object>> rendererDiagnostics = new ArrayList<Map<String, Object>>();
       for (NativeEngineeringDiagramRenderer.Diagnostic diagnostic : rendering.getDiagnostics()) {
         Map<String, Object> item = new LinkedHashMap<String, Object>();
@@ -472,8 +490,7 @@ public final class EngineeringDiagramDelivery {
           artifacts);
       writeArtifact(staging, PDF_FILE, "application/pdf", rendering.getPdf(), artifacts);
       for (Map.Entry<String, String> svg : rendering.getSvgBySheetId().entrySet()) {
-        String relativePath = "svg/" + safeFileName(svg.getKey()) + "-" + sha256(svg.getKey()).substring(0, 12)
-            + ".svg";
+        String relativePath = svgRelativePath(svg.getKey());
         writeArtifact(staging, relativePath, "image/svg+xml", svg.getValue().getBytes(StandardCharsets.UTF_8),
             artifacts);
       }
@@ -574,6 +591,10 @@ public final class EngineeringDiagramDelivery {
     String normalized = requireText(value, "sheetId").replaceAll("[^A-Za-z0-9._-]+", "-");
     normalized = normalized.replaceAll("^-+|-+$", "");
     return normalized.isEmpty() ? "sheet" : normalized;
+  }
+
+  private static String svgRelativePath(String sheetId) {
+    return "svg/" + safeFileName(sheetId) + "-" + sha256(sheetId).substring(0, 12) + ".svg";
   }
 
   private static String requireText(String value, String name) {

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDualProfileDelivery.java
@@ -22,6 +22,8 @@ import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceS
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister;
 import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister;
 import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
 import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
@@ -132,6 +134,8 @@ public final class EngineeringDiagramDualProfileDelivery {
     private final EngineeringDiagramLayoutRegister layoutRegister;
     private final EngineeringDiagramConventionRegister conventionRegister;
     private final boolean includePidEngineeringRegisters;
+    private final Map<String, String> blockFlowSections;
+    private final EngineeringDiagramLayoutRegister blockFlowLayout;
 
     private Request(Builder builder) {
       plantId = requireText(builder.plantId, "plantId");
@@ -147,6 +151,9 @@ public final class EngineeringDiagramDualProfileDelivery {
       layoutRegister = requireNonNull(builder.layoutRegister, "layoutRegister");
       conventionRegister = requireNonNull(builder.conventionRegister, "conventionRegister");
       includePidEngineeringRegisters = builder.includePidEngineeringRegisters;
+      blockFlowSections = builder.blockFlowSections == null ? null
+          : Collections.unmodifiableMap(new LinkedHashMap<String, String>(builder.blockFlowSections));
+      blockFlowLayout = builder.blockFlowLayout;
       if (pfdDrawingNumber.equals(pidDrawingNumber)) {
         throw new IllegalArgumentException("PFD and P&ID drawing numbers must be distinct");
       }
@@ -180,6 +187,8 @@ public final class EngineeringDiagramDualProfileDelivery {
       private final String pfdDrawingNumber;
       private final String pidDrawingNumber;
       private final String title;
+      private Map<String, String> blockFlowSections;
+      private EngineeringDiagramLayoutRegister blockFlowLayout;
       private String operatingCaseId;
       private List<BalanceBoundary> balanceBoundaries = Collections.emptyList();
       private NativeEngineeringDiagramRenderer.SheetFormat sheetFormat = NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE;
@@ -253,6 +262,19 @@ public final class EngineeringDiagramDualProfileDelivery {
         return this;
       }
 
+      /**
+       * Adds a separate material-connected BFD overview with a canonical-connection mapping.
+       *
+       * @param sections canonical owner identity to declared section name
+       * @param layout proposed or reviewed layout for the aggregate graph (sheet key {@code plant})
+       * @return this builder
+       */
+      public Builder blockFlowOverview(Map<String, String> sections, EngineeringDiagramLayoutRegister layout) {
+        blockFlowSections = new LinkedHashMap<String, String>(requireNonNull(sections, "sections"));
+        blockFlowLayout = requireNonNull(layout, "layout");
+        return this;
+      }
+
       /** @return validated immutable request */
       public Request build() {
         return new Request(this);
@@ -274,11 +296,12 @@ public final class EngineeringDiagramDualProfileDelivery {
     private final String pidDesignModelFingerprint;
     private final String pidCompletenessFingerprint;
     private final String fingerprint;
+    private final BlockOverview blockOverview;
 
     private Report(Path directory, EngineeringDiagramDelivery.Report pfd, EngineeringDiagramDelivery.Report pid,
         Request request, EngineeringDiagramStreamTable streamTable, EngineeringDiagramBalanceTable balanceTable,
         Dexpi20ConformanceAssessment.Report pidPlantAssessment, EngineeringDiagramPidRegisters pidEngineeringRegisters,
-        String pidDesignModelJson, String pidCompletenessJson) {
+        String pidDesignModelJson, String pidCompletenessJson, BlockOverview blockOverview) {
       this.directory = directory;
       this.pfd = pfd;
       this.pid = pid;
@@ -288,6 +311,7 @@ public final class EngineeringDiagramDualProfileDelivery {
       this.balanceTable = balanceTable;
       this.pidPlantAssessment = pidPlantAssessment;
       this.pidEngineeringRegisters = pidEngineeringRegisters;
+      this.blockOverview = blockOverview;
       pidDesignModelFingerprint = sha256(pidDesignModelJson);
       pidCompletenessFingerprint = sha256(pidCompletenessJson);
       fingerprint = sha256(new GsonBuilder().create().toJson(toMapWithoutFingerprint()));
@@ -313,6 +337,16 @@ public final class EngineeringDiagramDualProfileDelivery {
       return pidEngineeringRegisters;
     }
 
+    /** @return optional material-block projection with full canonical connection provenance */
+    public EngineeringBlockFlowProjection getBlockFlowProjection() {
+      return blockOverview == null ? null : blockOverview.projection;
+    }
+
+    /** @return optional BFD SVG/PDF rendering and diagnostics */
+    public NativeEngineeringDiagramRenderer.Result getBlockFlowRendering() {
+      return blockOverview == null ? null : blockOverview.rendering;
+    }
+
     /** @return deterministic manifest fingerprint */
     public String getFingerprint() {
       return fingerprint;
@@ -324,6 +358,7 @@ public final class EngineeringDiagramDualProfileDelivery {
           : streamTable != null && streamTable.isValid() && balanceTable != null && balanceTable.isValid()
               && streamTable.getSourceGraphFingerprint().equals(pfd.getDocumentSet().getSourceGraphFingerprint());
       return pfd.isComplete() && pid.isComplete() && pidPlantAssessment != null
+          && (blockOverview == null || blockOverview.rendering.isComplete())
           && pidPlantAssessment.isSchemaAndProfileConformant() && companionEvidenceComplete
           && (pidEngineeringRegisters == null || pidEngineeringRegisters.getSourceGraphFingerprint()
               .equals(pid.getDocumentSet().getSourceGraphFingerprint()))
@@ -362,6 +397,31 @@ public final class EngineeringDiagramDualProfileDelivery {
       result.put("pidNativeDexpiAssessmentFile", PID_DEXPI_PLANT_ASSESSMENT_FILE);
       result.put("pidProteusFile", PID_PROTEUS_FILE);
       result.put("pidNativeDexpiAssessment", pidPlantAssessment.toMap());
+      if (blockOverview != null) {
+        Map<String, Object> overview = new LinkedHashMap<String, Object>();
+        overview.put("projectionFile", "bfd/material-block-graph.json");
+        overview.put("projectionFingerprint", sha256(blockOverview.projection.toJson()));
+        overview.put("documentFile", "bfd/document-set.json");
+        overview.put("svgFile", "bfd/overview.svg");
+        overview.put("pdfFile", "bfd/overview.pdf");
+        overview.put("svgSha256", sha256(blockOverview.rendering.getSvgBySheetId().values().iterator().next()));
+        overview.put("pdfSha256", sha256(blockOverview.rendering.getPdf()));
+        overview.put("visualFingerprints", blockOverview.rendering.getVisualFingerprintsBySheetId());
+        List<Map<String, Object>> checks = new ArrayList<Map<String, Object>>();
+        for (NativeEngineeringDiagramRenderer.Diagnostic diagnostic : blockOverview.rendering.getDiagnostics()) {
+          Map<String, Object> check = new LinkedHashMap<String, Object>();
+          check.put("code", diagnostic.getCode());
+          check.put("severity", diagnostic.getSeverity().name());
+          check.put("subjectId", diagnostic.getSubjectId());
+          check.put("message", diagnostic.getMessage());
+          checks.add(check);
+        }
+        overview.put("rendererDiagnostics", checks);
+        overview.put("rendererCheckScope", blockOverview.rendering.getPerformedChecks());
+        overview.put("sourceGraphFingerprint", pfd.getDocumentSet().getSourceGraphFingerprint());
+        overview.put("qualificationStatus", "REVIEW_REQUIRED");
+        result.put("blockFlowOverview", overview);
+      }
       if (pidEngineeringRegisters != null) {
         result.put("pidDesignModelFile", PID_DESIGN_MODEL_FILE);
         result.put("pidDesignModelFingerprint", pidDesignModelFingerprint);
@@ -409,6 +469,8 @@ public final class EngineeringDiagramDualProfileDelivery {
     try {
       EngineeringDiagramDelivery.Report pfd = EngineeringDiagramDelivery.deliver(processSystem, target.resolve("pfd"),
           deliveryRequest(request, ContentProfile.PFD, request.pfdDrawingNumber, null));
+      BlockOverview blockOverview = request.blockFlowSections == null ? null
+          : deliverBlockOverview(processSystem, request, pfd, target.resolve("bfd"));
       EngineeringDiagramPidRegisters pidRegisters = null;
       String pidModelJson = "";
       String pidCompletenessJson = "";
@@ -461,7 +523,7 @@ public final class EngineeringDiagramDualProfileDelivery {
         Files.write(target.resolve(PID_REGISTERS_FILE), pidRegisters.toJson().getBytes(StandardCharsets.UTF_8));
       }
       Report report = new Report(target, pfd, pid, request, streamTable, balanceTable, pidPlantAssessment, pidRegisters,
-          pidModelJson, pidCompletenessJson);
+          pidModelJson, pidCompletenessJson, blockOverview);
       if (!report.isComplete()) {
         throw new IOException("PFD and P&ID deliveries do not retain one complete canonical plant");
       }
@@ -473,6 +535,47 @@ public final class EngineeringDiagramDualProfileDelivery {
     } catch (RuntimeException ex) {
       deleteRecursively(target);
       throw ex;
+    }
+  }
+
+  private static BlockOverview deliverBlockOverview(ProcessSystem process, Request request,
+      EngineeringDiagramDelivery.Report pfd, Path directory) throws IOException {
+    EngineeringGraph graph = (request.operatingCaseId.isEmpty()
+        ? ProcessDiagramGraphAdapter.fromProcessSystem(process, request.plantId, request.revision)
+        : ProcessDiagramGraphAdapter.fromProcessSystem(process, request.plantId, request.revision,
+            request.operatingCaseId))
+        .getGraph();
+    if (!pfd.getDocumentSet().getSourceGraphFingerprint().equals(graph.toMap().get("fingerprint"))) {
+      throw new IOException("Block overview source graph differs from the PFD canonical plant");
+    }
+    EngineeringBlockFlowProjection projection = EngineeringBlockFlowProjection.fromGraph(graph,
+        request.blockFlowSections);
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(projection.toGraph(),
+        request.pfdDrawingNumber + "-BFD", "Connected material-block overview", ContentProfile.BFD,
+        new EngineeringDiagramDesignationRegister(), request.blockFlowLayout);
+    NativeEngineeringDiagramRenderer.Result rendering = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    if (!rendering.isComplete() || rendering.getSvgBySheetId().size() != 1) {
+      throw new IOException("Block overview must contain one complete controlled sheet");
+    }
+    Files.createDirectories(directory);
+    Files.write(directory.resolve("material-block-graph.json"), projection.toJson().getBytes(StandardCharsets.UTF_8));
+    Files.write(directory.resolve("document-set.json"), documents.toJson().getBytes(StandardCharsets.UTF_8));
+    Files.write(directory.resolve("overview.svg"),
+        rendering.getSvgBySheetId().values().iterator().next().getBytes(StandardCharsets.UTF_8));
+    Files.write(directory.resolve("overview.pdf"), rendering.getPdf());
+    return new BlockOverview(projection, rendering);
+  }
+
+  private static final class BlockOverview {
+    private final EngineeringBlockFlowProjection projection;
+    private final NativeEngineeringDiagramRenderer.Result rendering;
+
+    private BlockOverview(EngineeringBlockFlowProjection projection,
+        NativeEngineeringDiagramRenderer.Result rendering) {
+      this.projection = projection;
+      this.rendering = rendering;
     }
   }
 
@@ -576,8 +679,12 @@ public final class EngineeringDiagramDualProfileDelivery {
   }
 
   private static String sha256(String value) {
+    return sha256(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String sha256(byte[] value) {
     try {
-      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value);
       StringBuilder result = new StringBuilder();
       for (byte item : digest) {
         result.append(String.format("%02x", item & 0xff));

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -102,6 +102,11 @@ public final class NativeEngineeringDiagramRenderer {
     FIXED_PORT_ORTHOGONAL
   }
 
+  /** Explicit endpoint {@code diagramPortSide} values in paper coordinates; north is upwards. */
+  public enum PortSide {
+    NORTH, EAST, SOUTH, WEST
+  }
+
   /** Renderer diagnostic severity. */
   public enum Severity {
     /** Informational source-document evidence retained in the rendering report. */
@@ -153,17 +158,19 @@ public final class NativeEngineeringDiagramRenderer {
     private final byte[] pdf;
     private final Map<String, String> visualFingerprintsBySheetId;
     private final List<Diagnostic> diagnostics;
+    private final boolean checksEndpointInteriors;
 
     private Result(Map<String, String> svgBySheetId, byte[] pdf, Map<String, String> visualFingerprintsBySheetId,
-        List<Diagnostic> diagnostics) {
+        List<Diagnostic> diagnostics, boolean checksEndpointInteriors) {
       this.svgBySheetId = Collections.unmodifiableMap(new LinkedHashMap<String, String>(svgBySheetId));
       this.pdf = Arrays.copyOf(pdf, pdf.length);
       this.visualFingerprintsBySheetId = Collections
           .unmodifiableMap(new LinkedHashMap<String, String>(visualFingerprintsBySheetId));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+      this.checksEndpointInteriors = checksEndpointInteriors;
     }
 
-    /** @return deterministic sheet-ID-ordered native SVG documents */
+    /** @return native SVG documents in controlled drawing and sheet-number order */
     public Map<String, String> getSvgBySheetId() {
       return svgBySheetId;
     }
@@ -190,6 +197,17 @@ public final class NativeEngineeringDiagramRenderer {
     /** @return immutable structured rendering diagnostics */
     public List<Diagnostic> getDiagnostics() {
       return diagnostics;
+    }
+
+    /** @return actual geometric check scope; zero findings are not drawing or standards approval */
+    public List<String> getPerformedChecks() {
+      List<String> checks = new ArrayList<String>(Arrays.asList("OBJECT_AND_ROUTE_ENVELOPES", "SCENE_BORDER_BOUNDS",
+          "ESTIMATED_TEXT_BOUNDS", "TEXT_TEXT_AND_TEXT_ROUTE_INTERSECTIONS", "PID_MARKER_AND_SIGNAL_INTERSECTIONS",
+          "DUPLICATE_SEMANTIC_ROUTES"));
+      if (checksEndpointInteriors) {
+        checks.add("ENDPOINT_INTERIORS");
+      }
+      return Collections.unmodifiableList(checks);
     }
 
     /** @return {@code true} when no renderer error was recorded */
@@ -357,23 +375,32 @@ public final class NativeEngineeringDiagramRenderer {
     addConventionDiagnostics(objects, diagnostics);
     List<Page> pages = new ArrayList<Page>();
     for (Drawing drawing : documentSet.getDrawings()) {
-      for (Sheet sheet : drawing.getSheets()) {
+      List<Sheet> sheets = new ArrayList<Sheet>(drawing.getSheets());
+      Collections.sort(sheets, new Comparator<Sheet>() {
+        @Override
+        public int compare(Sheet left, Sheet right) {
+          String first = left.getNumber();
+          String second = right.getNumber();
+          boolean firstNumeric = first.matches("[0-9]+");
+          boolean secondNumeric = second.matches("[0-9]+");
+          int order = firstNumeric && secondNumeric
+              ? new java.math.BigInteger(first).compareTo(new java.math.BigInteger(second))
+              : firstNumeric != secondNumeric ? (firstNumeric ? -1 : 1) : first.compareTo(second);
+          return order == 0 ? left.getId().compareTo(right.getId()) : order;
+        }
+      });
+      for (Sheet sheet : sheets) {
         pages.add(buildPage(drawing, sheet, objects, diagnostics));
       }
     }
-    Collections.sort(pages, new Comparator<Page>() {
-      @Override
-      public int compare(Page left, Page right) {
-        return left.sheetId.compareTo(right.sheetId);
-      }
-    });
     Map<String, String> svg = new LinkedHashMap<String, String>();
     Map<String, String> visualFingerprints = new LinkedHashMap<String, String>();
     for (Page page : pages) {
       svg.put(page.sheetId, toSvg(page));
       visualFingerprints.put(page.sheetId, visualFingerprint(page));
     }
-    return new Result(svg, toPdf(pages), visualFingerprints, diagnostics);
+    return new Result(svg, toPdf(pages), visualFingerprints, diagnostics,
+        routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL);
   }
 
   /**
@@ -465,7 +492,6 @@ public final class NativeEngineeringDiagramRenderer {
             diagnostics);
       }
     }
-    addRouteQualityDiagnostics(page, positions, diagnostics);
     Map<String, String> sheetNumberById = new TreeMap<String, String>();
     for (Sheet controlledSheet : drawing.getSheets()) {
       sheetNumberById.put(controlledSheet.getId(), controlledSheet.getNumber());
@@ -483,7 +509,116 @@ public final class NativeEngineeringDiagramRenderer {
     addPortMarkers(page, endpointAnchors);
     addPidProposalOverlay(page, objects, positions);
     addTitleBlock(page, drawing, sheet);
+    addRouteQualityDiagnostics(page, positions, diagnostics);
+    addCompletedSceneDiagnostics(page, positions, diagnostics);
     return page;
+  }
+
+  private static void addCompletedSceneDiagnostics(Page page, Map<String, Point> positions,
+      List<Diagnostic> diagnostics) {
+    List<Command> text = new ArrayList<Command>();
+    List<Command> shapes = new ArrayList<Command>();
+    Map<String, String> emittedRoutes = new TreeMap<String, String>();
+    for (Command command : page.commands) {
+      if (command.id.isEmpty() || "sheet-border".equals(command.id)) {
+        continue;
+      }
+      double[] bounds = commandBounds(command);
+      if (bounds[0] < 8.0 || bounds[1] < 8.0 || bounds[2] > page.width - 8.0 || bounds[3] > page.height - 8.0) {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_CLIPPED",
+            "Completed scene element crosses the sheet border (text bounds are estimated)", command.id));
+      }
+      if ("text".equals(command.type)) {
+        text.add(command);
+      } else if ("polyline".equals(command.type)) {
+        String signature = command.toSvg();
+        if (emittedRoutes.put(signature, command.id) != null) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_DUPLICATE_ROUTE",
+              "Completed scene repeats the same route geometry and semantic identity", command.id));
+        }
+        if (command.id.startsWith("pid-signal:")) {
+          for (Map.Entry<String, Point> object : positions.entrySet()) {
+            if (polylineIntersectsObject(command.points, object.getValue(), 0.0001)) {
+              diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_SIGNAL_OBJECT_COLLISION",
+                  "P&ID signal traverses object envelope " + object.getKey(), command.id));
+            }
+          }
+        }
+      } else if (command.id.startsWith("pid-proposal:")) {
+        shapes.add(command);
+      }
+    }
+    for (int index = 0; index < text.size(); index++) {
+      Command label = text.get(index);
+      double[] bounds = commandBounds(label);
+      for (int otherIndex = index + 1; otherIndex < text.size(); otherIndex++) {
+        Command other = text.get(otherIndex);
+        if (boundsOverlap(bounds, commandBounds(other))) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_TEXT_COLLISION",
+              "Estimated text bounds overlap " + other.id, label.id));
+        }
+      }
+      for (Command command : page.commands) {
+        if (!"polyline".equals(command.type) || command.id.equals(label.id) || command.id.isEmpty()) {
+          continue;
+        }
+        if (polylineIntersectsRectangle(command.points, bounds[0], bounds[2], bounds[1], bounds[3])) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_TEXT_ROUTE_COLLISION",
+              "Estimated text bounds intersect route, signal or attachment " + command.id, label.id));
+        }
+      }
+      for (Command shape : shapes) {
+        if (boundsOverlap(bounds, commandBounds(shape))) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_TEXT_SYMBOL_COLLISION",
+              "Estimated text bounds overlap P&ID proposal marker " + shape.id, label.id));
+        }
+      }
+    }
+    for (Command shape : shapes) {
+      double[] bounds = commandBounds(shape);
+      for (Map.Entry<String, Point> object : positions.entrySet()) {
+        Point center = object.getValue();
+        if (boundsOverlap(bounds, new double[] { center.x - OBJECT_WIDTH / 2.0, center.y - OBJECT_HEIGHT / 2.0,
+            center.x + OBJECT_WIDTH / 2.0, center.y + OBJECT_HEIGHT / 2.0 })) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_PROPOSAL_OBJECT_COLLISION",
+              "P&ID proposal marker overlaps object envelope " + object.getKey(), shape.id));
+        }
+      }
+      for (RouteView route : page.routes) {
+        if (polylineIntersectsRectangle(route.points, bounds[0] + 0.0001, bounds[2] - 0.0001, bounds[1] + 0.0001,
+            bounds[3] - 0.0001)) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_SCENE_PROPOSAL_ROUTE_COLLISION",
+              "Unbound P&ID proposal marker overlaps process route " + route.connectionId, shape.id));
+        }
+      }
+    }
+  }
+
+  private static double[] commandBounds(Command command) {
+    if ("text".equals(command.type)) {
+      double width = estimatedTextWidth(command.text, command.size);
+      double left = "middle".equals(command.anchor) ? command.x - width / 2.0
+          : "end".equals(command.anchor) ? command.x - width : command.x;
+      return new double[] { left, command.y - command.size / 2.0, left + width, command.y + command.size / 2.0 };
+    }
+    if ("rect".equals(command.type)) {
+      return new double[] { command.x, command.y, command.x + command.width, command.y + command.height };
+    }
+    double left = Double.POSITIVE_INFINITY;
+    double top = Double.POSITIVE_INFINITY;
+    double right = Double.NEGATIVE_INFINITY;
+    double bottom = Double.NEGATIVE_INFINITY;
+    for (Point point : command.points) {
+      left = Math.min(left, point.x);
+      top = Math.min(top, point.y);
+      right = Math.max(right, point.x);
+      bottom = Math.max(bottom, point.y);
+    }
+    return new double[] { left, top, right, bottom };
+  }
+
+  private static boolean boundsOverlap(double[] first, double[] second) {
+    return first[0] < second[2] && second[0] < first[2] && first[1] < second[3] && second[1] < first[3];
   }
 
   private void addOverviewRegions(Page page, Drawing drawing, Sheet overview, Map<String, SemanticObject> objects,
@@ -673,13 +808,18 @@ public final class NativeEngineeringDiagramRenderer {
       Collections.sort(keys);
       String[] ownerAndSide = entry.getKey().split("\\|", 2);
       Point owner = positions.get(ownerAndSide[0]);
-      boolean outlet = "OUTLET".equals(ownerAndSide[1]);
-      double spacing = keys.size() <= 1 ? 0.0
-          : Math.min(3.0, (OBJECT_HEIGHT - 2.0 * PORT_SLOT_MARGIN) / (keys.size() - 1));
+      PortSide side = PortSide.valueOf(ownerAndSide[1]);
+      boolean horizontal = side == PortSide.EAST || side == PortSide.WEST;
+      double span = horizontal ? OBJECT_HEIGHT : OBJECT_WIDTH;
+      double spacing = keys.size() <= 1 ? 0.0 : Math.min(3.0, (span - 2.0 * PORT_SLOT_MARGIN) / (keys.size() - 1));
       for (int index = 0; index < keys.size(); index++) {
         double offset = (index - (keys.size() - 1) / 2.0) * spacing;
         result.put(keys.get(index),
-            new Point(owner.x + (outlet ? OBJECT_WIDTH / 2.0 : -OBJECT_WIDTH / 2.0), owner.y + offset));
+            horizontal
+                ? new Point(owner.x + (side == PortSide.EAST ? OBJECT_WIDTH / 2.0 : -OBJECT_WIDTH / 2.0),
+                    owner.y + offset)
+                : new Point(owner.x + offset,
+                    owner.y + (side == PortSide.SOUTH ? OBJECT_HEIGHT / 2.0 : -OBJECT_HEIGHT / 2.0)));
       }
     }
     return result;
@@ -703,7 +843,27 @@ public final class NativeEngineeringDiagramRenderer {
     }
     String role = source ? "source" : "target";
     String anchorKey = endpointId + "|" + role;
-    String side = source ? "OUTLET" : "INLET";
+    String defaultSide = source ? "EAST" : "WEST";
+    SemanticObject ownerObject = objects.get(ownerId);
+    if (ownerObject != null && "MATERIAL_BLOCK".equals(ownerObject.getProperties().get("projectionKind"))) {
+      Point from = positions.get(endpointOwnerId(connection, "sourceEndpointId", objects));
+      Point to = positions.get(endpointOwnerId(connection, "targetEndpointId", objects));
+      if (from != null && to != null) {
+        if (Math.abs(to.y - from.y) > Math.abs(to.x - from.x)) {
+          defaultSide = (to.y > from.y) == source ? "SOUTH" : "NORTH";
+        } else if (to.x < from.x) {
+          defaultSide = "SOUTH";
+        }
+      }
+    }
+    String side = stringProperty(endpoint, "diagramPortSide", defaultSide);
+    try {
+      PortSide.valueOf(side);
+    } catch (IllegalArgumentException ex) {
+      diagnostics.add(diagnostic(Severity.ERROR, "DIAGRAM_RENDER_INVALID_PORT_SIDE",
+          "diagramPortSide must be NORTH, EAST, SOUTH or WEST", endpointId));
+      side = source ? "EAST" : "WEST";
+    }
     String groupKey = ownerId + "|" + side;
     List<String> keys = anchorKeysByOwnerSide.get(groupKey);
     if (keys == null) {
@@ -771,48 +931,99 @@ public final class NativeEngineeringDiagramRenderer {
       double laneOffset, Map<String, Point> positions, String sourceOwnerId, String targetOwnerId, double contentBottom,
       String label, List<RouteView> routes, double pageWidth) {
     List<List<Point>> candidates = new ArrayList<List<Point>>();
+    // Exit each actual nozzle before turning. Geometric target direction is not nozzle direction:
+    // a right-to-left return still leaves an east-facing outlet towards the east.
+    double clearance = 10.0 + Math.abs(laneOffset) + laneOffset;
+    Point sourceExit = portExit(source, positions.get(sourceOwnerId), true, clearance);
+    Point targetExit = portExit(target, positions.get(targetOwnerId), false, clearance);
     if (recycle) {
       double returnY = recycleReturnY(source, target, contentBottom, laneOffset);
-      double sourceTurnX = source.x + 10.0 + Math.abs(laneOffset);
-      double targetTurnX = target.x - 10.0 - Math.abs(laneOffset);
-      candidates.add(Arrays.asList(source, new Point(sourceTurnX, source.y), new Point(sourceTurnX, returnY),
-          new Point(targetTurnX, returnY), new Point(targetTurnX, target.y), target));
+      candidates.add(Arrays.asList(source, sourceExit, new Point(sourceExit.x, returnY),
+          new Point(targetExit.x, returnY), targetExit, target));
     } else {
-      double middleX = (source.x + target.x) / 2.0 + laneOffset;
-      candidates.add(Arrays.asList(source, new Point(middleX, source.y), new Point(middleX, target.y), target));
+      double middleX = (sourceExit.x + targetExit.x) / 2.0 + laneOffset;
+      candidates.add(Arrays.asList(source, sourceExit, new Point(middleX, sourceExit.y),
+          new Point(middleX, targetExit.y), targetExit, target));
     }
 
-    double direction = target.x >= source.x ? 1.0 : -1.0;
     double lower = CONTENT_TOP + OBJECT_HEIGHT;
     double upper = contentBottom - OBJECT_HEIGHT;
     for (int offsetIndex = 0; offsetIndex <= 5; offsetIndex++) {
-      double turnOffset = offsetIndex == 0 ? 0.0 : 10.0 + Math.abs(laneOffset) + (offsetIndex - 1) * 12.0;
-      double sourceTurnX = source.x + direction * turnOffset + laneOffset;
-      double targetTurnX = target.x - direction * turnOffset + laneOffset;
+      Point sourceTurn = portExit(source, positions.get(sourceOwnerId), true, clearance + offsetIndex * 12.0);
+      Point targetTurn = portExit(target, positions.get(targetOwnerId), false, clearance + offsetIndex * 12.0);
       for (double channelY = lower; channelY <= upper + 0.0000001; channelY += 12.0) {
-        candidates.add(Arrays.asList(source, new Point(sourceTurnX, source.y), new Point(sourceTurnX, channelY),
-            new Point(targetTurnX, channelY), new Point(targetTurnX, target.y), target));
+        candidates.add(Arrays.asList(source, sourceTurn, new Point(sourceTurn.x, channelY),
+            new Point(targetTurn.x, channelY), targetTurn, target));
       }
     }
 
     List<Point> best = candidates.get(0);
-    int bestScore = routeObjectIntersectionCount(best, positions, sourceOwnerId, targetOwnerId);
+    int bestScore = routeGeometryScore(best, positions, sourceOwnerId, targetOwnerId, pageWidth, contentBottom);
+    double bestOverlap = sharedRouteLength(best, routes);
     int bestLabelScore = bestRouteLabelCollisionScore(best, label, positions, routes, pageWidth, contentBottom);
     double bestLength = routeLength(best);
     for (int index = 1; index < candidates.size(); index++) {
       List<Point> candidate = candidates.get(index);
-      int score = routeObjectIntersectionCount(candidate, positions, sourceOwnerId, targetOwnerId);
+      int score = routeGeometryScore(candidate, positions, sourceOwnerId, targetOwnerId, pageWidth, contentBottom);
+      double overlap = sharedRouteLength(candidate, routes);
       int labelScore = bestRouteLabelCollisionScore(candidate, label, positions, routes, pageWidth, contentBottom);
       double length = routeLength(candidate);
-      if (score < bestScore || score == bestScore && labelScore < bestLabelScore
-          || score == bestScore && labelScore == bestLabelScore && length < bestLength) {
+      if (score < bestScore || score == bestScore && overlap < bestOverlap
+          || score == bestScore && overlap == bestOverlap && labelScore < bestLabelScore
+          || score == bestScore && overlap == bestOverlap && labelScore == bestLabelScore && length < bestLength) {
         best = candidate;
         bestScore = score;
+        bestOverlap = overlap;
         bestLabelScore = labelScore;
         bestLength = length;
       }
     }
     return best;
+  }
+
+  private static double sharedRouteLength(List<Point> points, List<RouteView> routes) {
+    double result = 0.0;
+    for (RouteView route : routes) {
+      for (int i = 1; i < points.size(); i++) {
+        Point a = points.get(i - 1);
+        Point b = points.get(i);
+        for (int j = 1; j < route.points.size(); j++) {
+          Point c = route.points.get(j - 1);
+          Point d = route.points.get(j);
+          if (Math.abs(a.y - b.y) < 0.0001 && Math.abs(c.y - d.y) < 0.0001 && Math.abs(a.y - c.y) < 0.0001) {
+            result += Math.max(0.0,
+                Math.min(Math.max(a.x, b.x), Math.max(c.x, d.x)) - Math.max(Math.min(a.x, b.x), Math.min(c.x, d.x)));
+          } else if (Math.abs(a.x - b.x) < 0.0001 && Math.abs(c.x - d.x) < 0.0001 && Math.abs(a.x - c.x) < 0.0001) {
+            result += Math.max(0.0,
+                Math.min(Math.max(a.y, b.y), Math.max(c.y, d.y)) - Math.max(Math.min(a.y, b.y), Math.min(c.y, d.y)));
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private static Point portExit(Point anchor, Point owner, boolean source, double clearance) {
+    if (owner == null) {
+      return new Point(anchor.x + (source ? clearance : -clearance), anchor.y);
+    }
+    double dx = anchor.x - owner.x;
+    double dy = anchor.y - owner.y;
+    if (Math.abs(dx) / OBJECT_WIDTH >= Math.abs(dy) / OBJECT_HEIGHT) {
+      return new Point(anchor.x + (dx >= 0.0 ? clearance : -clearance), anchor.y);
+    }
+    return new Point(anchor.x, anchor.y + (dy >= 0.0 ? clearance : -clearance));
+  }
+
+  private static int routeGeometryScore(List<Point> points, Map<String, Point> positions, String sourceOwnerId,
+      String targetOwnerId, double width, double contentBottom) {
+    int score = routeObjectIntersectionCount(points, positions, sourceOwnerId, targetOwnerId);
+    for (Point point : points) {
+      if (!inside(point.x, point.y, width, contentBottom)) {
+        score += 10000;
+      }
+    }
+    return score;
   }
 
   private static int bestRouteLabelCollisionScore(List<Point> points, String label, Map<String, Point> positions,
@@ -828,8 +1039,8 @@ public final class NativeEngineeringDiagramRenderer {
       String sourceOwnerId, String targetOwnerId) {
     int count = 0;
     for (Map.Entry<String, Point> entry : positions.entrySet()) {
-      if (!entry.getKey().equals(sourceOwnerId) && !entry.getKey().equals(targetOwnerId)
-          && polylineIntersectsObject(points, entry.getValue())) {
+      boolean endpoint = entry.getKey().equals(sourceOwnerId) || entry.getKey().equals(targetOwnerId);
+      if (polylineIntersectsObject(points, entry.getValue(), endpoint ? 0.0001 : 0.0)) {
         count++;
       }
     }
@@ -917,9 +1128,21 @@ public final class NativeEngineeringDiagramRenderer {
     Collections.sort(objectIds);
     for (int routeIndex = 0; routeIndex < page.routes.size(); routeIndex++) {
       RouteView route = page.routes.get(routeIndex);
+      for (Point point : route.points) {
+        if (!inside(point.x, point.y, page.width, page.height - TITLE_BLOCK_HEIGHT - 7.0)) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_ROUTE_OUTSIDE_SHEET",
+              "Rendered route leaves the drawable sheet area", route.connectionId));
+          break;
+        }
+      }
       for (String objectId : objectIds) {
         Point objectPosition = positions.get(objectId);
         boolean endpointOwner = objectId.equals(route.sourceOwnerId) || objectId.equals(route.targetOwnerId);
+        if (endpointOwner && routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
+            && polylineIntersectsObject(route.points, objectPosition, 0.0001)) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION",
+              "Rendered route traverses its endpoint symbol envelope " + objectId, route.connectionId));
+        }
         if (!endpointOwner && polylineIntersectsObject(route.points, objectPosition)) {
           diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_ROUTE_OBJECT_INTERSECTION",
               "Rendered connection route intersects non-endpoint semantic object " + objectId, route.connectionId));
@@ -983,6 +1206,11 @@ public final class NativeEngineeringDiagramRenderer {
       page.commands.add(symbolCommand(shape, position, stroke, fill, object.getId()));
     }
     String primary = displayLabel(object);
+    if ("MATERIAL_BLOCK".equals(object.getProperties().get("projectionKind"))) {
+      page.commands.add(
+          Command.text(position.x, position.y, primaryTextSize(object), primary, "#111827", object.getId(), "middle"));
+      return;
+    }
     page.commands.add(Command.text(position.x, position.y - 0.8, primaryTextSize(object), primary, "#111827",
         object.getId(), "middle"));
     String secondary = shape == SymbolShape.PROCESS_EQUIPMENT ? equipmentFamily(object) : object.getKind().name();
@@ -1474,7 +1702,7 @@ public final class NativeEngineeringDiagramRenderer {
           + "] /Resources << /Font << /F1 3 0 R >> >> /Contents " + contentObject + " 0 R >>"));
       StringBuilder stream = new StringBuilder("q\n");
       for (Command command : page.commands) {
-        stream.append(command.toPdf(page.height));
+        stream.append(command.toPdf(page.height, routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL));
       }
       stream.append("Q\n");
       byte[] streamBytes = bytes(stream.toString());
@@ -1701,10 +1929,19 @@ public final class NativeEngineeringDiagramRenderer {
   }
 
   private static boolean polylineIntersectsObject(List<Point> points, Point objectPosition) {
-    double left = objectPosition.x - OBJECT_WIDTH / 2.0;
-    double right = objectPosition.x + OBJECT_WIDTH / 2.0;
-    double top = objectPosition.y - OBJECT_HEIGHT / 2.0;
-    double bottom = objectPosition.y + OBJECT_HEIGHT / 2.0;
+    return polylineIntersectsObject(points, objectPosition, 0.0);
+  }
+
+  private static boolean polylineIntersectsObject(List<Point> points, Point objectPosition, double inset) {
+    double left = objectPosition.x - OBJECT_WIDTH / 2.0 + inset;
+    double right = objectPosition.x + OBJECT_WIDTH / 2.0 - inset;
+    double top = objectPosition.y - OBJECT_HEIGHT / 2.0 + inset;
+    double bottom = objectPosition.y + OBJECT_HEIGHT / 2.0 - inset;
+    return polylineIntersectsRectangle(points, left, right, top, bottom);
+  }
+
+  private static boolean polylineIntersectsRectangle(List<Point> points, double left, double right, double top,
+      double bottom) {
     for (int index = 1; index < points.size(); index++) {
       Point start = points.get(index - 1);
       Point end = points.get(index);
@@ -1760,6 +1997,9 @@ public final class NativeEngineeringDiagramRenderer {
   }
 
   private static double primaryTextSize(SemanticObject object) {
+    if ("MATERIAL_BLOCK".equals(object.getProperties().get("projectionKind"))) {
+      return 4.2;
+    }
     double standardSize = 2.8;
     if (object.getKind() != EngineeringNode.Kind.LINE) {
       return standardSize;
@@ -1989,16 +2229,17 @@ public final class NativeEngineeringDiagramRenderer {
       result.append('\n');
     }
 
-    private String toPdf(double pageHeight) {
+    private String toPdf(double pageHeight, boolean paperTextSize) {
       StringBuilder result = new StringBuilder();
       if ("text".equals(type)) {
         double adjustedX = x;
         if ("middle".equals(anchor)) {
-          adjustedX -= text.length() * size * 0.24;
+          adjustedX -= text.length() * size * (paperTextSize ? 0.26 : 0.24);
         } else if ("end".equals(anchor)) {
-          adjustedX -= text.length() * size * 0.48;
+          adjustedX -= text.length() * size * (paperTextSize ? 0.52 : 0.48);
         }
-        result.append(rgb(fill, false)).append(" BT /F1 ").append(number(size * MM_TO_POINT * 0.78)).append(" Tf ")
+        result.append(rgb(fill, false)).append(" BT /F1 ")
+            .append(number(size * MM_TO_POINT * (paperTextSize ? 1.0 : 0.78))).append(" Tf ")
             .append(number(adjustedX * MM_TO_POINT)).append(' ').append(number((pageHeight - y) * MM_TO_POINT))
             .append(" Td (").append(pdf(text)).append(") Tj ET\n");
         return result.toString();

--- a/src/test/java/neqsim/process/examples/Comparesimulations2EngineeringDiagramReferenceTest.java
+++ b/src/test/java/neqsim/process/examples/Comparesimulations2EngineeringDiagramReferenceTest.java
@@ -9,6 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.processmodel.diagram.NativeEngineeringDiagramRenderer;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Sheet;
 import neqsim.process.processmodel.diagram.EngineeringDiagramDualProfileDelivery;
@@ -32,6 +40,43 @@ class Comparesimulations2EngineeringDiagramReferenceTest {
         .deliver(firstProcess, temporaryDirectory.resolve("first"));
 
     assertTrue(first.isComplete(), first.toJson());
+    assertEquals(7, first.getBlockFlowProjection().getBlockLabels().size());
+    assertTrue(Files.isRegularFile(first.getDirectory().resolve("bfd/overview.svg")));
+    assertTrue(Files.isRegularFile(first.getDirectory().resolve("bfd/overview.pdf")));
+    assertTrue(Files.isRegularFile(first.getDirectory().resolve("bfd/material-block-graph.json")));
+    assertTrue(first.getBlockFlowRendering().getDiagnostics().stream()
+        .noneMatch(d -> d.getSeverity() != NativeEngineeringDiagramRenderer.Severity.INFO));
+    Map<String, Integer> connectionCoverage = new TreeMap<String, Integer>();
+    Set<String> blockFlows = new TreeSet<String>();
+    for (EngineeringNode node : first.getBlockFlowProjection().toGraph().getNodes().values()) {
+      Object ids = node.getProperties()
+          .get(node.getKind() == EngineeringNode.Kind.EQUIPMENT ? "internalConnectionIds" : "sourceConnectionIds");
+      if (ids instanceof List<?>) {
+        for (Object id : (List<?>) ids) {
+          String key = id.toString();
+          connectionCoverage.put(key, connectionCoverage.containsKey(key) ? connectionCoverage.get(key) + 1 : 1);
+        }
+      }
+      if (node.getKind() == EngineeringNode.Kind.PIPE_SEGMENT) {
+        blockFlows
+            .add(node.getProperties().get("sourceEquipment") + " -> " + node.getProperties().get("targetEquipment"));
+      }
+    }
+    Set<String> canonicalConnections = new TreeSet<String>();
+    first.getPfd().getDocumentSet().getSemanticObjects().stream()
+        .filter(n -> n.getKind() == EngineeringNode.Kind.PIPE_SEGMENT)
+        .forEach(n -> canonicalConnections.add(n.getId()));
+    assertEquals(canonicalConnections, connectionCoverage.keySet());
+    assertTrue(connectionCoverage.values().stream().allMatch(n -> n == 1));
+    assertTrue(
+        blockFlows.containsAll(Arrays.asList("Separation -> Oil export", "Cold process -> Fuel gas",
+            "Cold process -> Gas export", "Recompression -> Separation", "Cold process -> Separation")),
+        blockFlows.toString());
+    assertFalse(blockFlows.contains("Gas export -> Oil export"));
+    assertTrue(first.getPfd().getRendering().getDiagnostics().stream()
+        .noneMatch(d -> d.getCode().equals("DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION")
+            || d.getCode().equals("DIAGRAM_RENDER_ROUTE_OUTSIDE_SHEET")
+            || d.getCode().equals("DIAGRAM_RENDER_DUPLICATE_ROUTE")));
     assertEquals(first.getPfd().getDocumentSet().getSourceGraphFingerprint(),
         first.getPid().getDocumentSet().getSourceGraphFingerprint());
     assertTrue(first.getPfd().getRendering().getSvgBySheetId().size() >= 3);
@@ -88,6 +133,9 @@ class Comparesimulations2EngineeringDiagramReferenceTest {
         .deliver(secondProcess, temporaryDirectory.resolve("second"));
 
     assertEquals(first.getFingerprint(), second.getFingerprint());
+    assertEquals(first.getBlockFlowProjection().toJson(), second.getBlockFlowProjection().toJson());
+    assertEquals(first.getBlockFlowRendering().getSvgBySheetId(), second.getBlockFlowRendering().getSvgBySheetId());
+    assertArrayEquals(first.getBlockFlowRendering().getPdf(), second.getBlockFlowRendering().getPdf());
     assertEquals(first.getPfd().getRendering().getSvgBySheetId(), second.getPfd().getRendering().getSvgBySheetId());
     assertEquals(first.getPid().getRendering().getSvgBySheetId(), second.getPid().getRendering().getSvgBySheetId());
     assertArrayEquals(Files.readAllBytes(first.getDirectory().resolve("pfd/drawing-set.pdf")),

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringBlockFlowProjectionTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringBlockFlowProjectionTest.java
@@ -1,0 +1,80 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+import org.junit.jupiter.api.Test;
+
+class EngineeringBlockFlowProjectionTest {
+  @Test
+  void preservesBranchesProductsRecyclesAndCompleteConnectionProvenance() {
+    EngineeringGraph graph = graph();
+    String original = graph.toJson();
+    Map<String, String> groups = new LinkedHashMap<String, String>();
+    groups.put("separator", "Separation");
+    groups.put("heater", "Separation");
+    groups.put("compressor", "Gas export");
+    EngineeringBlockFlowProjection projection = EngineeringBlockFlowProjection.fromGraph(graph, groups);
+    List<String> edges = new ArrayList<String>();
+    List<String> evidence = new ArrayList<String>();
+    for (EngineeringNode node : projection.toGraph().getNodes().values()) {
+      if (node.getKind() == EngineeringNode.Kind.PIPE_SEGMENT) {
+        edges.add(node.getProperties().get("sourceEquipment") + " -> " + node.getProperties().get("targetEquipment"));
+        for (Object id : (List<?>) node.getProperties().get("sourceConnectionIds")) {
+          evidence.add(id.toString());
+        }
+      } else if (node.getKind() == EngineeringNode.Kind.EQUIPMENT) {
+        for (Object id : (List<?>) node.getProperties().get("internalConnectionIds")) {
+          evidence.add(id.toString());
+        }
+      }
+    }
+    assertTrue(edges.containsAll(Arrays.asList("Separation -> Gas export", "Separation -> oil", "Gas export -> fuel",
+        "Gas export -> gas", "Gas export -> Separation")), edges.toString());
+    assertFalse(edges.contains("gas -> oil"));
+    Collections.sort(evidence);
+    assertEquals(Arrays.asList("c1", "c2", "c3", "c4", "c5", "c6", "c7"), evidence);
+    assertEquals(original, graph.toJson());
+    assertEquals(projection.toJson(),
+        EngineeringBlockFlowProjection.fromGraph(graph, new TreeMap<String, String>(groups)).toJson());
+    projection.toGraph().getNodes().values().iterator().next().setLabel("mutated copy");
+    assertFalse(projection.toJson().contains("mutated copy"));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringBlockFlowProjection.fromGraph(graph, Collections.singletonMap("missing", "Section")));
+  }
+
+  @Test
+  void rejectsBrokenMaterialEndpointsInsteadOfSilentlyDroppingAFlow() {
+    EngineeringGraph graph = graph();
+    graph.getNode("c1").putProperty("sourceEndpointId", "missing");
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringBlockFlowProjection.fromGraph(graph, Collections.<String, String>emptyMap()));
+  }
+
+  private static EngineeringGraph graph() {
+    EngineeringGraph graph = new EngineeringGraph("BFD-REGRESSION", "A");
+    for (String name : Arrays.asList("separator", "heater", "compressor", "oil", "gas", "fuel")) {
+      graph.addNode(new EngineeringNode(name, EngineeringNode.Kind.EQUIPMENT, name, name));
+    }
+    String[][] links = { { "separator", "heater" }, { "heater", "oil" }, { "separator", "compressor" },
+        { "compressor", "gas" }, { "compressor", "fuel" }, { "compressor", "separator" }, { "heater", "compressor" } };
+    for (int index = 0; index < links.length; index++) {
+      String id = "c" + (index + 1);
+      graph.addNode(new EngineeringNode(id, EngineeringNode.Kind.PIPE_SEGMENT, id, id)
+          .putProperty("sourceEndpointId", links[index][0]).putProperty("targetEndpointId", links[index][1])
+          .putProperty("connectionType", "MATERIAL").putProperty("recycle", Boolean.valueOf(index == 5)));
+    }
+    return graph;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -39,6 +39,146 @@ import org.junit.jupiter.api.Test;
 
 class NativeEngineeringDiagramRendererTest {
   @Test
+  void fixedPortPdfKeepsTheDeclaredPaperFontSize() {
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(fixedPortRoutingGraph(),
+        "PFD-FONT-SCALE", "Paper font size", ContentProfile.PFD);
+    NativeEngineeringDiagramRenderer.Result fixed = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String pdf = new String(fixed.getPdf(), StandardCharsets.ISO_8859_1);
+    // 4.2 mm title font converted to PDF points, without the old implicit 22% reduction.
+    assertTrue(pdf.contains("/F1 11.9055 Tf"));
+    assertFalse(pdf.contains("/F1 9.2863 Tf"));
+  }
+
+  @Test
+  void honorsDeclaredVerticalAndReversePortSidesAndRejectsInvalidValues() {
+    EngineeringGraph graph = fixedPortRoutingGraph();
+    graph.getNode("nozzle:a-out-1").putProperty("diagramPortSide", "NORTH");
+    graph.getNode("nozzle:b-in-1").putProperty("diagramPortSide", "SOUTH");
+    graph.getNode("nozzle:a-out-2").putProperty("diagramPortSide", "WEST");
+    graph.getNode("nozzle:b-in-2").putProperty("diagramPortSide", "EAST");
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition("equipment:a", "plant", 300.0, 180.0))
+        .withPinnedPosition(reviewedPosition("equipment:b", "plant", 100.0, 80.0));
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-PORT-SIDES",
+        "Declared nozzle sides", ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String svg = result.getSvgBySheetId().values().iterator().next();
+    String[] vertical = pointsForSemanticId(svg, "connection:parallel-1").split(" ");
+    assertEquals("300,172", vertical[0]);
+    assertTrue(pointY(vertical[1]) < pointY(vertical[0]));
+    assertEquals("100,88", vertical[vertical.length - 1]);
+    assertTrue(pointY(vertical[vertical.length - 2]) > pointY(vertical[vertical.length - 1]));
+    assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION"));
+    String[] reverse = pointsForSemanticId(svg, "connection:parallel-2").split(" ");
+    assertEquals(283.0, Double.parseDouble(reverse[0].split(",")[0]), 0.0001);
+    assertTrue(Math.abs(pointY(reverse[0]) - 180.0) < 8.0, "nozzle must remain on the west envelope");
+    assertTrue(Double.parseDouble(reverse[1].split(",")[0]) < 283.0);
+    graph.getNode("nozzle:a-out-1").putProperty("diagramPortSide", "UNKNOWN");
+    EngineeringDiagramDocumentSet invalid = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-PORT-SIDES",
+        "Declared nozzle sides", ContentProfile.PFD);
+    NativeEngineeringDiagramRenderer.Result rejected = new NativeEngineeringDiagramRenderer(invalid,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    assertFalse(rejected.isComplete());
+    assertTrue(hasDiagnostic(rejected, "DIAGRAM_RENDER_INVALID_PORT_SIDE"));
+  }
+
+  @Test
+  void ordersSvgAndPdfByControlledSheetNumberIncludingMultiDigitNumbers() {
+    EngineeringGraph graph = fixedPortRoutingGraph();
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withSheet(new SheetDefinition("z-detail", "2", "Second controlled sheet", "fixture", EvidenceState.REVIEWED,
+            "reviewer", "2026-09-10T00:00:00Z", "A"))
+        .withSheet(new SheetDefinition("a-detail", "10", "Tenth controlled sheet", "fixture", EvidenceState.REVIEWED,
+            "reviewer", "2026-09-10T00:00:00Z", "A"))
+        .withAssignment(new SheetAssignment("equipment:a", "z-detail", "fixture", EvidenceState.REVIEWED, "reviewer",
+            "2026-09-10T00:00:00Z", "A"))
+        .withAssignment(new SheetAssignment("equipment:b", "a-detail", "fixture", EvidenceState.REVIEWED, "reviewer",
+            "2026-09-10T00:00:00Z", "A"));
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-ORDER",
+        "Controlled order", ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents).render();
+    Map<String, String> numberById = new TreeMap<String, String>();
+    for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
+      numberById.put(sheet.getId(), sheet.getNumber());
+    }
+    List<String> numbers = new ArrayList<String>();
+    for (String id : result.getSvgBySheetId().keySet()) {
+      numbers.add(numberById.get(id));
+    }
+    assertEquals(Arrays.asList("1", "2", "10"), numbers);
+    String pdf = new String(result.getPdf(), StandardCharsets.ISO_8859_1);
+    assertTrue(pdf.indexOf("Second controlled sheet") < pdf.indexOf("Tenth controlled sheet"));
+  }
+
+  @Test
+  void emitsEachCrossSheetConnectionExactlyOncePerSheet() {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessModel(
+        EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(), "DEXPI-REF-MULTI-AREA", "A",
+        "PFD-UNIQUE", "Unique continuation routes", ContentProfile.PFD);
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
+      assertEquals(new java.util.HashSet<String>(sheet.getObjectNodeIds()).size(), sheet.getObjectNodeIds().size());
+      for (EngineeringDiagramDocumentSet.OffPageConnector connector : sheet.getOffPageConnectors()) {
+        String svg = result.getSvgBySheetId().get(sheet.getId());
+        long count = Arrays.stream(svg.split("\n")).filter(line -> line.contains("<polyline")
+            && line.contains("data-semantic-id=\"" + connector.getSemanticConnectionId() + "\"")).count();
+        assertEquals(1L, count, connector.getSemanticConnectionId());
+      }
+    }
+  }
+
+  @Test
+  void reverseRoutesLeaveAndApproachFixedNozzlesOutsideBothEndpointEnvelopes() {
+    EngineeringGraph graph = fixedPortRoutingGraph();
+    EngineeringDiagramDocumentSet baseline = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-REVERSE",
+        "Reverse nozzle attachments", ContentProfile.PFD);
+    String key = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition("equipment:a", key, 300.0, 100.0))
+        .withPinnedPosition(reviewedPosition("equipment:b", key, 100.0, 100.0));
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-REVERSE",
+        "Reverse nozzle attachments", ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String svg = result.getSvgBySheetId().values().iterator().next();
+    for (String id : Arrays.asList("connection:parallel-1", "connection:parallel-2", "connection:recycle")) {
+      String[] points = pointsForSemanticId(svg, id).split(" ");
+      double firstX = Double.parseDouble(points[0].split(",")[0]);
+      double secondX = Double.parseDouble(points[1].split(",")[0]);
+      double lastX = Double.parseDouble(points[points.length - 1].split(",")[0]);
+      double previousX = Double.parseDouble(points[points.length - 2].split(",")[0]);
+      assertTrue(secondX > firstX, "outlet must first exit east: " + id);
+      assertTrue(previousX < lastX, "inlet must be approached from west: " + id);
+    }
+    assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION"));
+    assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_OUTSIDE_SHEET"));
+  }
+
+  @Test
+  void retainsAndDiagnosesProtectedEndpointTraversal() {
+    EngineeringGraph graph = fixedPortRoutingGraph();
+    EngineeringDiagramDocumentSet baseline = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-PROTECTED-ENDPOINT",
+        "Protected endpoint traversal", ContentProfile.PFD);
+    String key = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition("equipment:a", key, 300.0, 100.0))
+        .withPinnedPosition(reviewedPosition("equipment:b", key, 100.0, 100.0))
+        .withProtectedRoute(new ProtectedRoute("connection:parallel-1", key,
+            Arrays.asList(new Waypoint(317.0, 100.0), new Waypoint(83.0, 100.0)), CoordinateUnit.MILLIMETRE,
+            "reviewed-route-fixture", EvidenceState.REVIEWED, "reviewer", "2026-09-10T00:00:00Z", "A"));
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-PROTECTED-ENDPOINT",
+        "Protected endpoint traversal", ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    assertEquals("317,100 83,100",
+        pointsForSemanticId(result.getSvgBySheetId().values().iterator().next(), "connection:parallel-1"));
+    assertTrue(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION"));
+  }
+
+  @Test
   void rendersDeterministicNativeSvgAndPdfWithoutChangingClassicOutputs() {
     EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
     ProcessSystem process = reference.getProcessSystem();

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -72,8 +72,7 @@ class NativeEngineeringDiagramRendererTest {
     assertTrue(pointY(vertical[vertical.length - 2]) > pointY(vertical[vertical.length - 1]));
     assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION"));
     String[] reverse = pointsForSemanticId(svg, "connection:parallel-2").split(" ");
-    assertEquals(283.0, parseCoordinate(reverse[0].split(",")[0], "west-envelope x for connection:parallel-2"),
-        0.0001);
+    assertEquals(283.0, parseCoordinate(reverse[0].split(",")[0], "west-envelope x for connection:parallel-2"), 0.0001);
     assertTrue(Math.abs(pointY(reverse[0]) - 180.0) < 8.0, "nozzle must remain on the west envelope");
     assertTrue(parseCoordinate(reverse[1].split(",")[0], "first routed x for connection:parallel-2") < 283.0);
     graph.getNode("nozzle:a-out-1").putProperty("diagramPortSide", "UNKNOWN");

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -72,9 +72,10 @@ class NativeEngineeringDiagramRendererTest {
     assertTrue(pointY(vertical[vertical.length - 2]) > pointY(vertical[vertical.length - 1]));
     assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_ROUTE_ENDPOINT_INTERSECTION"));
     String[] reverse = pointsForSemanticId(svg, "connection:parallel-2").split(" ");
-    assertEquals(283.0, Double.parseDouble(reverse[0].split(",")[0]), 0.0001);
+    assertEquals(283.0, parseCoordinate(reverse[0].split(",")[0], "west-envelope x for connection:parallel-2"),
+        0.0001);
     assertTrue(Math.abs(pointY(reverse[0]) - 180.0) < 8.0, "nozzle must remain on the west envelope");
-    assertTrue(Double.parseDouble(reverse[1].split(",")[0]) < 283.0);
+    assertTrue(parseCoordinate(reverse[1].split(",")[0], "first routed x for connection:parallel-2") < 283.0);
     graph.getNode("nozzle:a-out-1").putProperty("diagramPortSide", "UNKNOWN");
     EngineeringDiagramDocumentSet invalid = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-PORT-SIDES",
         "Declared nozzle sides", ContentProfile.PFD);
@@ -146,10 +147,12 @@ class NativeEngineeringDiagramRendererTest {
     String svg = result.getSvgBySheetId().values().iterator().next();
     for (String id : Arrays.asList("connection:parallel-1", "connection:parallel-2", "connection:recycle")) {
       String[] points = pointsForSemanticId(svg, id).split(" ");
-      double firstX = Double.parseDouble(points[0].split(",")[0]);
-      double secondX = Double.parseDouble(points[1].split(",")[0]);
-      double lastX = Double.parseDouble(points[points.length - 1].split(",")[0]);
-      double previousX = Double.parseDouble(points[points.length - 2].split(",")[0]);
+      double firstX = parseCoordinate(points[0].split(",")[0], "first x for " + id + " in '" + points[0] + "'");
+      double secondX = parseCoordinate(points[1].split(",")[0], "second x for " + id + " in '" + points[1] + "'");
+      double lastX = parseCoordinate(points[points.length - 1].split(",")[0],
+          "last x for " + id + " in '" + points[points.length - 1] + "'");
+      double previousX = parseCoordinate(points[points.length - 2].split(",")[0],
+          "previous x for " + id + " in '" + points[points.length - 2] + "'");
       assertTrue(secondX > firstX, "outlet must first exit east: " + id);
       assertTrue(previousX < lastX, "inlet must be approached from west: " + id);
     }


### PR DESCRIPTION
The reviewed comparesimulations2 drawings contain false overview connectivity, duplicate cross-sheet routes, routes through their endpoint symbols, and incorrectly ordered pages. The old diagnostics also miss conflicts added by the P&ID overlay.

This implements the first topology/routing/diagnostics batch requested in #3619 for the shared #1332/#2899 work. It is a core prerequisite, **not completion of #3619**.

Changes:
- Add reusable `EngineeringBlockFlowProjection` and an opt-in A3 BFD bundle. Every canonical material connection belongs to exactly one displayed aggregate or an internal-block mapping. The full reference has seven declared sections, separate oil/fuel/gas products, and traceable return paths.
- Remove duplicate continuation projection and permit explicit placement of source-stream LINE owners. Keep the navigation index on sheet 1 and move the reference's stream terminals to their actual detail sheets.
- Render sheets in controlled numeric order and publish `renderedSheetOrder` with actual numbers, titles and SVG paths.
- Use left-to-right reference rows, declared north/east/south/west port sides, outward nozzle stubs and shared-track penalties. Include endpoint interiors and borders in route scoring; retain protected routes and diagnose invalid geometry.
- Inspect the completed scene, including estimated text bounds, proposal markers, signals, leaders and duplicate routes. Publish the checks actually performed and `visualAcceptanceStatus: REVIEW_REQUIRED`.
- Correct the fixed-port PDF font-size conversion to use the specified paper size. Preserve the legacy-center text scale.

Validation on Java 17.0.20:
- Four added regressions fail on the original baseline and pass with the correction: duplicate cross-sheet emission, numeric sheet order, reverse endpoint traversal and protected-route endpoint diagnostics.
- **47 targeted tests passed, 0 failed, 0 skipped**, including two fresh full-plant runs and byte-for-byte BFD/PFD/P&ID regeneration.
- The full-model test checks the exact partition of canonical material connections, separate product/return topology, and absence of endpoint-interior, out-of-sheet and duplicate-route findings.
- Changed production classes and selected tests compile with `javac --release 8`. Full main-source Maven compilation passed. The full repository test-compilation attempt did not complete in the container; no full-suite pass is claimed.
- Direct Spotless apply/check, documentation-search audit (696 Markdown pages and one standalone HTML file), pre-commit and pre-push hooks all passed. Targeted Javadocs passed.
- Executed the reference separately and inspected all nine generated PDF sheets and enlarged separation details using system Poppler; independently checked the BFD with MuPDF.

Targeted test invocation (after compilation):
```sh
./mvnw -B -ntp -Dtest=NativeEngineeringDiagramRendererTest,EngineeringBlockFlowProjectionTest,EngineeringDiagramDualProfileDeliveryTest,EngineeringDiagramDualProfileCompanionDeliveryTest,EngineeringDiagramDeliveryTest,EngineeringDiagramDeliveryAssessmentTest,EngineeringDiagramSymbolConventionTest,Comparesimulations2EngineeringDiagramReferenceTest -DexcludedTestGroups= surefire:test
```

Remaining qualification:
The fresh BFD has zero renderer warnings/errors. The completed-scene checks report **14 PFD and 413 P&ID warnings**; these drawings are not visually accepted. Reviewed family/orientation symbols and proportions, measured text bounds, crossing/junction conventions, physical P&ID attachments, readable printed stream IDs/tables, per-element exchange coverage/projection and independent DEXPI/Proteus round trips remain subsequent gates. The exchange writers still do not consume the synthesized overlay/native scene.

Documentation impact: updated the diagram document-model guide, delivery guide and comparesimulations acceptance matrix with the APIs, actual checks and remaining gaps.

Validated base: `1a9dcb7b05c6157c58e7f8f7b0239be433fbd99f`. Current master `c8d6e51b7595aaca8b66f94fa04c7ceba2854170` adds an unrelated sulfur change without file overlap.

Prepared for the direct issue-fix request. [NeqSim-Colab draft #156](https://github.com/EvenSol/NeqSim-Colab/pull/156) remains open and unchanged at `308fd1e690eac4d188275c2e862b9d3d6ee6f1fd`; its CO2 CI dependency and coordinated notebook refresh remain in the existing shared lane. This draft does not replace that work or claim a newly published notebook.

---

## Hosted review follow-up — 2026-09-10

Exact head `ace1693445597db57667b6cf4c5526bacee3728a` replaces six direct SVG coordinate parses in tests with the existing guarded helper. All six duplicated review threads are answered and resolved. The hosted Spotless check required one formatter-prescribed line join, applied without semantic change. Production rendering and the previously inspected drawings are unchanged. Nine of ten exact-head workflows pass. Java 21 Ubuntu/Windows, all four slow shards, Javadocs, Java 8 Ubuntu, CodeQL, both notebook workflows, documentation, formatting, pre-commit, performance and PaperLab are green. Only Java 8 Windows remains active, with no failure.

Campaign checkpoint: [ledger](https://github.com/equinor/neqsim/pull/3642#issuecomment-5623194536). Portfolio occupancy is 9/10. This remains an open draft with whole-sheet visual acceptance blocked.

---

## Merged #3619 core prerequisite — 2026-09-10

- Core [PR #3642](https://github.com/equinor/neqsim/pull/3642) merged externally on September 10, 2026 as [`653db71353dc3a5a0fad92b945978fd0bd94e74a`](https://github.com/equinor/neqsim/commit/653db71353dc3a5a0fad92b945978fd0bd94e74a), preserving source head `ace1693445597db57667b6cf4c5526bacee3728a`.
- All ten exact-head workflows passed, including Java 8/21 on Ubuntu and Windows, all four slow shards, Javadocs, both notebook workflows, CodeQL, documentation, formatting, pre-commit, performance and PaperLab. All six review threads remain resolved.
- Delivered core prerequisite: canonical BFD partition/topology, controlled sheet order, duplicate-continuation suppression, flow-aware port routing and completed-scene diagnostics.
- This is not whole-sheet acceptance: the merged reference still records 14 PFD and 413 P&ID completed-scene warnings. Reviewed symbols/typography, physical P&ID attachments, printed stream identities/tables, exchange projection/coverage and independent DEXPI/Proteus round trips remain open.
- Downstream [NeqSim-Colab draft #156](https://github.com/EvenSol/NeqSim-Colab/pull/156) remains exact-head at `308fd1e690eac4d188275c2e862b9d3d6ee6f1fd`, open, draft, unrebased and unmodified. GitHub reports it non-mergeable; no branch disturbance occurred. Its next permitted action is same-branch clean regeneration and whole-sheet reinspection against the merged core prerequisite.
- `24-VB-01` remains absent. No conformance, certification, safety, construction or engineering-approval claim is made.
- Portfolio occupancy is **8/10**.

Status: **CORE PREREQUISITE MERGED AND EXACT-HEAD CI COMPLETE — DOWNSTREAM NOTEBOOK REGENERATION AND WHOLE-SHEET ACCEPTANCE BLOCKED.**