### PR TITLE
[AI-Assisted] feat(kinetics): project constant-water H2S trajectories

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -254,6 +254,36 @@ reaction heat, pressure or phase transfer, mutate pipeline/transient state, or u
 deposition and wall inventories. Those steps require separately qualified inputs and must compose
 with the existing pipeline and sulfur-deposition implementations.
 
+
+## Constant-water trajectory projection
+
+The overloaded
+`AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(...)` applies one
+caller-supplied constant liquid-water inventory to a complete immutable trajectory. It preserves
+the source order and returns every existing per-segment dimensional projection together with
+cumulative lower-rate, nominal, and upper-rate reacted total-sulfide amounts.
+
+For each fit-scatter path `r`, the segment increments telescope at constant water inventory:
+
+$
+n_{r,\mathrm{reacted}}
+= \sum_i n_{r,i,\mathrm{reacted}}
+= m_w(c_0-c_{r,n,\mathrm{out}}).
+$
+
+The result exposes the difference between the summed increments and this endpoint identity as a
+closure residual in mol. A one-segment trajectory exactly reuses the existing segment projection,
+an unchanged-state subdivision preserves cumulative reacted moles, and a trajectory containing
+only a zero-duration segment reports exactly zero reaction. The segment list is defensively
+immutable. A null trajectory, non-finite or non-positive inventory, numerical underflow, or
+non-finite accumulation fails closed.
+
+The constant inventory is an explicit caller assumption; it is not a calculated pipeline holdup,
+water-dropout history, or moving material-parcel model. The cumulative amounts remain unsigned
+total-sulfide-loss evidence. They do not consume O2, assign sulfur products, calculate heat or
+phase transfer, create signed component sources, mutate pipeline/transient state, or update S8,
+FeS, wall, or sulfur-deposition inventories.
+
 ## Piecewise target crossing
 
 `AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -358,7 +358,7 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "Collections.unmodifiableList",
             "getSegmentProjections()",
             "getLowerRateReactedMoles()",
-            "getNominalRateClosureResidualMoles()",
+            "getNominalClosureResidualMoles()",
             "getUpperRateClosureResidualMoles()",
             "finiteSum(",
             "finiteDifference(",

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -336,6 +336,43 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.water_inventory_projection_test)
 
+
+    def test_constant_water_trajectory_projection_is_documented_and_executable(self):
+        for token in (
+            "Constant-water trajectory projection",
+            "one caller-supplied constant liquid-water inventory",
+            r"n_{r,\mathrm{reacted}}",
+            r"\sum_i n_{r,i,\mathrm{reacted}}",
+            r"m_w(c_0-c_{r,n,\mathrm{out}})",
+            "closure residual in mol",
+            "one-segment trajectory",
+            "unchanged-state subdivision",
+            "defensively immutable",
+            "not a calculated pipeline holdup",
+            "unsigned total-sulfide-loss evidence",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static TrajectoryResult project(",
+            "Collections.unmodifiableList",
+            "getSegmentProjections()",
+            "getLowerRateReactedMoles()",
+            "getNominalRateClosureResidualMoles()",
+            "getUpperRateClosureResidualMoles()",
+            "finiteSum(",
+            "finiteDifference(",
+        ):
+            self.assertIn(token, self.water_inventory_projection)
+
+        for token in (
+            "testTrajectoryProjectionClosesAllPathsAndPreservesSourceOrder",
+            "testTrajectoryProjectionMatchesSingleSegmentAndIsSplitInvariant",
+            "testTrajectoryProjectionZeroDurationIsExactAndResultIsDefensive",
+            "testTrajectoryProjectionFailsClosedForMissingOrInvalidWaterInventory",
+        ):
+            self.assertIn(token, self.water_inventory_projection_test)
+
     def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
         for token in (
             "Piecewise target crossing",

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -1,6 +1,9 @@
 package neqsim.process.equipment.reactor;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Projects qualified aqueous H2S/O2 segment evidence onto an explicit water inventory.
@@ -53,6 +56,64 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
         lowerRateReactedMoles, nominalReactedMoles, upperRateReactedMoles);
   }
 
+
+  /**
+   * Project a complete immutable trajectory onto one constant liquid-water inventory.
+   *
+   * <p>
+   * The same inventory is applied to every source-ordered segment. This preserves the
+   * trajectory's telescoping inventory balance without implying that water holdup has been
+   * calculated.
+   * </p>
+   *
+   * @param trajectoryResult qualified trajectory result
+   * @param waterInventoryKg constant liquid-water inventory [kg]
+   * @return immutable dimensional trajectory evidence
+   */
+  public static TrajectoryResult project(AqueousHydrogenSulfideOxidationTrajectory.Result trajectoryResult,
+      double waterInventoryKg) {
+    if (trajectoryResult == null) {
+      throw new IllegalArgumentException("Trajectory result cannot be null");
+    }
+    requirePositiveFinite(waterInventoryKg, "Water inventory");
+
+    List<Result> segmentProjections = new ArrayList<Result>();
+    double lowerRateReactedMoles = 0.0;
+    double nominalReactedMoles = 0.0;
+    double upperRateReactedMoles = 0.0;
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult : trajectoryResult
+        .getSegmentResults()) {
+      Result projection = project(segmentResult, waterInventoryKg);
+      segmentProjections.add(projection);
+      lowerRateReactedMoles = finiteSum(lowerRateReactedMoles, projection.getLowerRateReactedMoles(),
+          "Cumulative lower-rate reacted total sulfide");
+      nominalReactedMoles = finiteSum(nominalReactedMoles, projection.getNominalReactedMoles(),
+          "Cumulative nominal reacted total sulfide");
+      upperRateReactedMoles = finiteSum(upperRateReactedMoles, projection.getUpperRateReactedMoles(),
+          "Cumulative upper-rate reacted total sulfide");
+    }
+
+    double expectedLowerRateReactedMoles = finiteProduct(
+        trajectoryResult.getInitialTotalSulfideMolality()
+            - trajectoryResult.getFinalTotalSulfideMolalityAtLowerRate(),
+        waterInventoryKg, "Expected cumulative lower-rate reacted total sulfide");
+    double expectedNominalReactedMoles = finiteProduct(trajectoryResult.getReactedTotalSulfideMolality(),
+        waterInventoryKg, "Expected cumulative nominal reacted total sulfide");
+    double expectedUpperRateReactedMoles = finiteProduct(
+        trajectoryResult.getInitialTotalSulfideMolality()
+            - trajectoryResult.getFinalTotalSulfideMolalityAtUpperRate(),
+        waterInventoryKg, "Expected cumulative upper-rate reacted total sulfide");
+
+    return new TrajectoryResult(waterInventoryKg, trajectoryResult.getTotalTimeHours(), segmentProjections,
+        lowerRateReactedMoles, nominalReactedMoles, upperRateReactedMoles,
+        finiteDifference(expectedLowerRateReactedMoles, lowerRateReactedMoles,
+            "Lower-rate trajectory closure residual"),
+        finiteDifference(expectedNominalReactedMoles, nominalReactedMoles,
+            "Nominal trajectory closure residual"),
+        finiteDifference(expectedUpperRateReactedMoles, upperRateReactedMoles,
+            "Upper-rate trajectory closure residual"));
+  }
+
   private static void requirePositiveFinite(double value, String name) {
     if (!Double.isFinite(value) || value <= 0.0) {
       throw new IllegalArgumentException(name + " must be finite and positive");
@@ -65,6 +126,99 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
       throw new IllegalArgumentException(name + " is not finite and non-negative");
     }
     return product;
+  }
+
+
+  private static double finiteSum(double accumulator, double increment, String name) {
+    double sum = accumulator + increment;
+    if (!Double.isFinite(sum) || sum < 0.0) {
+      throw new IllegalArgumentException(name + " is not finite and non-negative");
+    }
+    return sum;
+  }
+
+  private static double finiteDifference(double minuend, double subtrahend, String name) {
+    double difference = minuend - subtrahend;
+    if (!Double.isFinite(difference)) {
+      throw new IllegalArgumentException(name + " is not finite");
+    }
+    return difference;
+  }
+
+
+  /** Immutable dimensional projection for one constant-water trajectory. */
+  public static final class TrajectoryResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double waterInventoryKg;
+    private final double totalTimeHours;
+    private final List<Result> segmentProjections;
+    private final double lowerRateReactedMoles;
+    private final double nominalReactedMoles;
+    private final double upperRateReactedMoles;
+    private final double lowerRateClosureResidualMoles;
+    private final double nominalClosureResidualMoles;
+    private final double upperRateClosureResidualMoles;
+
+    private TrajectoryResult(double waterInventoryKg, double totalTimeHours, List<Result> segmentProjections,
+        double lowerRateReactedMoles, double nominalReactedMoles, double upperRateReactedMoles,
+        double lowerRateClosureResidualMoles, double nominalClosureResidualMoles,
+        double upperRateClosureResidualMoles) {
+      this.waterInventoryKg = waterInventoryKg;
+      this.totalTimeHours = totalTimeHours;
+      this.segmentProjections = Collections.unmodifiableList(new ArrayList<Result>(segmentProjections));
+      this.lowerRateReactedMoles = lowerRateReactedMoles;
+      this.nominalReactedMoles = nominalReactedMoles;
+      this.upperRateReactedMoles = upperRateReactedMoles;
+      this.lowerRateClosureResidualMoles = lowerRateClosureResidualMoles;
+      this.nominalClosureResidualMoles = nominalClosureResidualMoles;
+      this.upperRateClosureResidualMoles = upperRateClosureResidualMoles;
+    }
+
+    /** @return caller-supplied constant liquid-water inventory [kg]. */
+    public double getWaterInventoryKg() {
+      return waterInventoryKg;
+    }
+
+    /** @return total trajectory duration [h]. */
+    public double getTotalTimeHours() {
+      return totalTimeHours;
+    }
+
+    /** @return immutable source-ordered dimensional segment projections. */
+    public List<Result> getSegmentProjections() {
+      return segmentProjections;
+    }
+
+    /** @return cumulative reacted total sulfide for the lower-rate path [mol]. */
+    public double getLowerRateReactedMoles() {
+      return lowerRateReactedMoles;
+    }
+
+    /** @return cumulative reacted total sulfide for the nominal path [mol]. */
+    public double getNominalReactedMoles() {
+      return nominalReactedMoles;
+    }
+
+    /** @return cumulative reacted total sulfide for the upper-rate path [mol]. */
+    public double getUpperRateReactedMoles() {
+      return upperRateReactedMoles;
+    }
+
+    /** @return lower-rate constant-water inventory closure residual [mol]. */
+    public double getLowerRateClosureResidualMoles() {
+      return lowerRateClosureResidualMoles;
+    }
+
+    /** @return nominal constant-water inventory closure residual [mol]. */
+    public double getNominalClosureResidualMoles() {
+      return nominalClosureResidualMoles;
+    }
+
+    /** @return upper-rate constant-water inventory closure residual [mol]. */
+    public double getUpperRateClosureResidualMoles() {
+      return upperRateClosureResidualMoles;
+    }
   }
 
   /** Immutable dimensional projection for one trajectory segment. */

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -179,7 +179,7 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
 
     /** @return immutable source-ordered dimensional segment projections. */
     public List<Result> getSegmentProjections() {
-      return segmentProjections;
+      return Collections.unmodifiableList(new ArrayList<Result>(segmentProjections));
     }
 
     /** @return cumulative reacted total sulfide for the lower-rate path [mol]. */

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -56,14 +56,12 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
         lowerRateReactedMoles, nominalReactedMoles, upperRateReactedMoles);
   }
 
-
   /**
    * Project a complete immutable trajectory onto one constant liquid-water inventory.
    *
    * <p>
-   * The same inventory is applied to every source-ordered segment. This preserves the
-   * trajectory's telescoping inventory balance without implying that water holdup has been
-   * calculated.
+   * The same inventory is applied to every source-ordered segment. This preserves the trajectory's telescoping
+   * inventory balance without implying that water holdup has been calculated.
    * </p>
    *
    * @param trajectoryResult qualified trajectory result
@@ -81,8 +79,7 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     double lowerRateReactedMoles = 0.0;
     double nominalReactedMoles = 0.0;
     double upperRateReactedMoles = 0.0;
-    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult : trajectoryResult
-        .getSegmentResults()) {
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult : trajectoryResult.getSegmentResults()) {
       Result projection = project(segmentResult, waterInventoryKg);
       segmentProjections.add(projection);
       lowerRateReactedMoles = finiteSum(lowerRateReactedMoles, projection.getLowerRateReactedMoles(),
@@ -94,22 +91,19 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     }
 
     double expectedLowerRateReactedMoles = finiteProduct(
-        trajectoryResult.getInitialTotalSulfideMolality()
-            - trajectoryResult.getFinalTotalSulfideMolalityAtLowerRate(),
+        trajectoryResult.getInitialTotalSulfideMolality() - trajectoryResult.getFinalTotalSulfideMolalityAtLowerRate(),
         waterInventoryKg, "Expected cumulative lower-rate reacted total sulfide");
     double expectedNominalReactedMoles = finiteProduct(trajectoryResult.getReactedTotalSulfideMolality(),
         waterInventoryKg, "Expected cumulative nominal reacted total sulfide");
     double expectedUpperRateReactedMoles = finiteProduct(
-        trajectoryResult.getInitialTotalSulfideMolality()
-            - trajectoryResult.getFinalTotalSulfideMolalityAtUpperRate(),
+        trajectoryResult.getInitialTotalSulfideMolality() - trajectoryResult.getFinalTotalSulfideMolalityAtUpperRate(),
         waterInventoryKg, "Expected cumulative upper-rate reacted total sulfide");
 
     return new TrajectoryResult(waterInventoryKg, trajectoryResult.getTotalTimeHours(), segmentProjections,
         lowerRateReactedMoles, nominalReactedMoles, upperRateReactedMoles,
         finiteDifference(expectedLowerRateReactedMoles, lowerRateReactedMoles,
             "Lower-rate trajectory closure residual"),
-        finiteDifference(expectedNominalReactedMoles, nominalReactedMoles,
-            "Nominal trajectory closure residual"),
+        finiteDifference(expectedNominalReactedMoles, nominalReactedMoles, "Nominal trajectory closure residual"),
         finiteDifference(expectedUpperRateReactedMoles, upperRateReactedMoles,
             "Upper-rate trajectory closure residual"));
   }
@@ -128,7 +122,6 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     return product;
   }
 
-
   private static double finiteSum(double accumulator, double increment, String name) {
     double sum = accumulator + increment;
     if (!Double.isFinite(sum) || sum < 0.0) {
@@ -144,7 +137,6 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     }
     return difference;
   }
-
 
   /** Immutable dimensional projection for one constant-water trajectory. */
   public static final class TrajectoryResult implements Serializable {

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -96,8 +96,8 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
   void testProjectionFailsClosedForMissingOrInvalidWaterInventory() {
     AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment = segmentResult(referenceSegment(1.0));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(null, 1.0));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project((AqueousHydrogenSulfideOxidationTrajectory.SegmentResult) null, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, 0.0));
     assertThrows(IllegalArgumentException.class,

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -110,7 +110,6 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, Double.POSITIVE_INFINITY));
   }
 
-
   @Test
   void testTrajectoryProjectionClosesAllPathsAndPreservesSourceOrder() {
     AqueousHydrogenSulfideOxidationTrajectory.Result trajectory = AqueousHydrogenSulfideOxidationTrajectory
@@ -124,14 +123,12 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     assertEquals(0, projection.getSegmentProjections().get(0).getSegmentIndex());
     assertEquals(1, projection.getSegmentProjections().get(1).getSegmentIndex());
 
-    assertEquals((trajectory.getInitialTotalSulfideMolality()
-        - trajectory.getFinalTotalSulfideMolalityAtLowerRate()) * WATER_INVENTORY_KG,
-        projection.getLowerRateReactedMoles(), NUMERICAL_TOLERANCE);
-    assertEquals(trajectory.getReactedTotalSulfideMolality() * WATER_INVENTORY_KG,
-        projection.getNominalReactedMoles(), NUMERICAL_TOLERANCE);
-    assertEquals((trajectory.getInitialTotalSulfideMolality()
-        - trajectory.getFinalTotalSulfideMolalityAtUpperRate()) * WATER_INVENTORY_KG,
-        projection.getUpperRateReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals((trajectory.getInitialTotalSulfideMolality() - trajectory.getFinalTotalSulfideMolalityAtLowerRate())
+        * WATER_INVENTORY_KG, projection.getLowerRateReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(trajectory.getReactedTotalSulfideMolality() * WATER_INVENTORY_KG, projection.getNominalReactedMoles(),
+        NUMERICAL_TOLERANCE);
+    assertEquals((trajectory.getInitialTotalSulfideMolality() - trajectory.getFinalTotalSulfideMolalityAtUpperRate())
+        * WATER_INVENTORY_KG, projection.getUpperRateReactedMoles(), NUMERICAL_TOLERANCE);
     assertEquals(0.0, projection.getLowerRateClosureResidualMoles(), NUMERICAL_TOLERANCE);
     assertEquals(0.0, projection.getNominalClosureResidualMoles(), NUMERICAL_TOLERANCE);
     assertEquals(0.0, projection.getUpperRateClosureResidualMoles(), NUMERICAL_TOLERANCE);
@@ -179,9 +176,8 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     AqueousHydrogenSulfideOxidationTrajectory.Result trajectory = AqueousHydrogenSulfideOxidationTrajectory
         .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(1.0)));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(
-            (AqueousHydrogenSulfideOxidationTrajectory.Result) null, 1.0));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project((AqueousHydrogenSulfideOxidationTrajectory.Result) null, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, 0.0));
     assertThrows(IllegalArgumentException.class,
@@ -190,8 +186,8 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, Double.MIN_VALUE));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, Double.NaN));
-    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection
-        .project(trajectory, Double.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, Double.POSITIVE_INFINITY));
   }
 
   private static void assertProjectionPath(double meanLossMolalityPerHour, double reactedMolality,

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -110,6 +110,90 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, Double.POSITIVE_INFINITY));
   }
 
+
+  @Test
+  void testTrajectoryProjectionClosesAllPathsAndPreservesSourceOrder() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result trajectory = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.TrajectoryResult projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(trajectory, WATER_INVENTORY_KG);
+
+    assertEquals(WATER_INVENTORY_KG, projection.getWaterInventoryKg(), 0.0);
+    assertEquals(trajectory.getTotalTimeHours(), projection.getTotalTimeHours(), 0.0);
+    assertEquals(2, projection.getSegmentProjections().size());
+    assertEquals(0, projection.getSegmentProjections().get(0).getSegmentIndex());
+    assertEquals(1, projection.getSegmentProjections().get(1).getSegmentIndex());
+
+    assertEquals((trajectory.getInitialTotalSulfideMolality()
+        - trajectory.getFinalTotalSulfideMolalityAtLowerRate()) * WATER_INVENTORY_KG,
+        projection.getLowerRateReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(trajectory.getReactedTotalSulfideMolality() * WATER_INVENTORY_KG,
+        projection.getNominalReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals((trajectory.getInitialTotalSulfideMolality()
+        - trajectory.getFinalTotalSulfideMolalityAtUpperRate()) * WATER_INVENTORY_KG,
+        projection.getUpperRateReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(0.0, projection.getLowerRateClosureResidualMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(0.0, projection.getNominalClosureResidualMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(0.0, projection.getUpperRateClosureResidualMoles(), NUMERICAL_TOLERANCE);
+    assertTrue(projection.getLowerRateReactedMoles() < projection.getNominalReactedMoles());
+    assertTrue(projection.getNominalReactedMoles() < projection.getUpperRateReactedMoles());
+  }
+
+  @Test
+  void testTrajectoryProjectionMatchesSingleSegmentAndIsSplitInvariant() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(10.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result segmentProjection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(unsplit.getSegmentResults().get(0), WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.TrajectoryResult whole = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(unsplit, WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.TrajectoryResult parts = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(split, WATER_INVENTORY_KG);
+
+    assertEquals(segmentProjection.getLowerRateReactedMoles(), whole.getLowerRateReactedMoles(), 0.0);
+    assertEquals(segmentProjection.getNominalReactedMoles(), whole.getNominalReactedMoles(), 0.0);
+    assertEquals(segmentProjection.getUpperRateReactedMoles(), whole.getUpperRateReactedMoles(), 0.0);
+    assertEquals(whole.getLowerRateReactedMoles(), parts.getLowerRateReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(whole.getNominalReactedMoles(), parts.getNominalReactedMoles(), NUMERICAL_TOLERANCE);
+    assertEquals(whole.getUpperRateReactedMoles(), parts.getUpperRateReactedMoles(), NUMERICAL_TOLERANCE);
+  }
+
+  @Test
+  void testTrajectoryProjectionZeroDurationIsExactAndResultIsDefensive() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result trajectory = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(0.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.TrajectoryResult projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(trajectory, WATER_INVENTORY_KG);
+
+    assertEquals(0.0, projection.getLowerRateReactedMoles(), 0.0);
+    assertEquals(0.0, projection.getNominalReactedMoles(), 0.0);
+    assertEquals(0.0, projection.getUpperRateReactedMoles(), 0.0);
+    assertThrows(UnsupportedOperationException.class,
+        () -> projection.getSegmentProjections().add(projection.getSegmentProjections().get(0)));
+  }
+
+  @Test
+  void testTrajectoryProjectionFailsClosedForMissingOrInvalidWaterInventory() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result trajectory = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(1.0)));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(
+            (AqueousHydrogenSulfideOxidationTrajectory.Result) null, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, 0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, -1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, Double.MIN_VALUE));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(trajectory, Double.POSITIVE_INFINITY));
+  }
+
   private static void assertProjectionPath(double meanLossMolalityPerHour, double reactedMolality,
       double meanLossMolesPerHour, double meanLossMolesPerSecond, double reactedMoles, double durationHours) {
     assertEquals(meanLossMolalityPerHour * WATER_INVENTORY_KG, meanLossMolesPerHour, 0.0);


### PR DESCRIPTION
Refs #3318.

Adds a constant-water trajectory projection for the already qualified aqueous H2S/O2 Millero screening path.

## Capability

- Overloads `AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(...)` for a complete immutable trajectory.
- Applies one explicit, finite, positive liquid-water inventory to every source-ordered segment.
- Returns the existing per-segment dimensional projections plus cumulative lower/nominal/upper reacted total-sulfide amounts and endpoint closure residuals.
- Preserves defensive immutability and fails closed on missing, invalid, underflowing, or non-finite inputs/accumulations.

## Numerical gates

- one-segment identity with the existing segment projection;
- source-order preservation and immutable result list;
- all three fit paths close against `(initial molality - final molality) * water inventory`;
- unchanged-state segment subdivision invariance;
- exact zero reacted amount for zero-duration trajectories;
- explicit invalid-input and underflow rejection.

## Scientific basis and boundary

The reaction-rate basis remains Millero et al. (1987), [doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003). No new kinetic coefficient, product yield, selectivity, or extrapolation is introduced.

The water inventory is a caller-supplied constant, not a prediction of holdup, free-water appearance, dropout, or a moving material parcel. Outputs remain unsigned total-sulfide-loss evidence. This PR does not consume O2, assign products, calculate reaction heat, pressure or phase transfer, create signed component sources, mutate a pipeline/transient state, or update S8, FeS, wall, or sulfur-deposition inventories.

Coordination remains with #3144, #2937, #2911, the pipeline roadmap, #3153, and the existing sulfur/solid-flash implementations. The changed paths do not overlap active #3640.

## Documentation impact

Updates the primary H2S/O2 guide and its executable documentation contract with the constant-water assumption, equations, numerical gates, and stop boundary.

## Publication and validation

- Exact base: `653db71353dc3a5a0fad92b945978fd0bd94e74a`
- Exact current head: `9cf2e56dd4d17ac932a068951942f5a9ebd12acf`
- Changed files: exactly the four production/test/documentation paths listed above.
- Draft-only publication.
- The exact-head Spotless artifact was applied unchanged to both modified Java files after the initial pre-commit format failure.
- A subsequent compiler ambiguity in the pre-existing null-input test was repaired with an explicit `SegmentResult` cast; production behavior is unchanged.
- The code-quality review request was applied with a fresh defensive copy from `getSegmentProjections()` and its thread is resolved.
- Local build/test/documentation checks were not run in this connector-only execution.
- **VALIDATION REPAIR PENDING EXACT-HEAD CI.**

AI-assisted implementation. Subject to CI and the domain/maintainer review required by repository governance.