### PR TITLE
feat(refinery): qualify Big Hill vacuum pressure sensitivity

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -205,3 +205,47 @@ The curve is deliberately discrete and molar-basis. It is not a continuous simul
 curve, a TBP curve, an ASTM D86 or ASTM D1160 result, or a pressure-corrected laboratory
 measurement. With only three heavy pseudo-components it must not be used to infer unreported cut
 tails, detailed product quality, or validated VGO/residue yields.
+
+## Absolute-pressure sensitivity screening
+
+`DoeBigHillVacuumPressureSensitivity.run(...)` independently rebuilds, solves, and evaluates
+multiple Big Hill vacuum cases while scaling the feed, top, and bottom absolute pressures together.
+Tray count, feed tray, feed and reboiler temperatures, reflux ratio, feed composition, and feed mass
+flow remain fixed. Pressure factors must be finite, positive, unique, strictly increasing, and retain
+the qualified sub-atmospheric pressure topology.
+
+The documented three-point screen uses factors close to the qualified base point:
+
+```java
+OperatingInputs baseline =
+    new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+double[] pressureFactors = {0.98, 1.00, 1.02};
+
+DoeBigHillVacuumPressureSensitivity sensitivity =
+    DoeBigHillVacuumPressureSensitivity.run(
+        "Big Hill vacuum pressure screen", 1000.0, baseline, pressureFactors);
+
+for (DoeBigHillVacuumPressureSensitivity.PointResult point : sensitivity.getPoints()) {
+  double factor = point.getPressureScaleFactor();
+  double topPressureBara = point.getOperatingInputs().getTopPressureBara();
+  double overheadMassFraction = point.getOverheadMassFraction();
+  double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+}
+```
+
+Every point must pass the already qualified MESH-residual, fallback, mass, component, energy,
+material-product, and boiling-point-order gates. The summary returns a defensive point array, exact
+applied operating inputs, immutable per-point fractionation results, the observed overhead-yield
+bounds, and the worst external mass closure, component closure, column energy error, and final MESH
+residual. A failed point aborts the complete sensitivity instead of returning a partial envelope.
+
+The factors scale **absolute pressure**, not vacuum gauge or pressure drop. This keeps the relative
+pressure profile fixed and isolates one numerical operating variable; it does not represent an
+optimized or vendor-recommended pressure profile. The narrow 0.98/1.00/1.02 regression is a
+convergence and conservation test around the documented screening point. It does not establish a
+measured pressure response, require a monotonic yield trend, define an uncertainty distribution,
+validate product quality, or demonstrate equipment turndown.
+
+All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
+does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
+calibrated VGO/residue yields, equipment design, or plant-agreement evidence.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivity.java
@@ -1,0 +1,221 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/**
+ * Immutable pressure-sensitivity summary for the DOE Big Hill vacuum screening case.
+ *
+ * <p>
+ * Feed, top, and bottom absolute pressures are scaled together while all other explicit engineering
+ * inputs remain fixed. Each point is independently constructed, solved, and evaluated through the
+ * qualified Big Hill case and result contracts. The sensitivity is numerical screening evidence,
+ * not a measured or calibrated vacuum-column operating envelope.
+ * </p>
+ */
+public final class DoeBigHillVacuumPressureSensitivity {
+  private final PointResult[] points;
+  private final double minimumOverheadMassFraction;
+  private final double maximumOverheadMassFraction;
+  private final double maximumMassClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumColumnEnergyBalanceError;
+  private final double maximumMeshResidualNorm;
+
+  private DoeBigHillVacuumPressureSensitivity(PointResult[] points) {
+    this.points = points.clone();
+
+    double minimumOverheadFraction = Double.POSITIVE_INFINITY;
+    double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
+    double maximumMassClosure = 0.0;
+    double maximumComponentClosure = 0.0;
+    double maximumEnergyError = 0.0;
+    double maximumMeshResidual = 0.0;
+    for (PointResult point : points) {
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+      minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
+      maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
+      maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumComponentClosure = Math.max(maximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    minimumOverheadMassFraction = minimumOverheadFraction;
+    maximumOverheadMassFraction = maximumOverheadFraction;
+    maximumMassClosureRelativeError = maximumMassClosure;
+    maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumColumnEnergyBalanceError = maximumEnergyError;
+    maximumMeshResidualNorm = maximumMeshResidual;
+  }
+
+  /**
+   * Run an independent pressure sensitivity around explicit baseline operating inputs.
+   *
+   * @param caseNamePrefix non-blank prefix used for independently constructed point names
+   * @param feedMassFlowKgPerHour finite positive feed mass flow in kg/h
+   * @param baselineInputs explicit source-unreported baseline column inputs
+   * @param pressureScaleFactors finite positive strictly increasing pressure scale factors
+   * @return immutable sensitivity summary
+   * @throws NullPointerException if {@code baselineInputs} or {@code pressureScaleFactors} is null
+   * @throws IllegalArgumentException if the name, feed flow, factors, or a scaled pressure envelope
+   *         is invalid
+   * @throws IllegalStateException if a point does not solve or pass the qualified result gates
+   */
+  public static DoeBigHillVacuumPressureSensitivity run(String caseNamePrefix,
+      double feedMassFlowKgPerHour, OperatingInputs baselineInputs,
+      double[] pressureScaleFactors) {
+    if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case-name prefix must be non-blank");
+    }
+    if (!Double.isFinite(feedMassFlowKgPerHour) || !(feedMassFlowKgPerHour > 0.0)) {
+      throw new IllegalArgumentException("Feed mass flow must be finite and positive");
+    }
+    Objects.requireNonNull(baselineInputs, "baselineInputs");
+    Objects.requireNonNull(pressureScaleFactors, "pressureScaleFactors");
+    if (pressureScaleFactors.length < 2) {
+      throw new IllegalArgumentException("Pressure sensitivity requires at least two points");
+    }
+
+    double[] factors = pressureScaleFactors.clone();
+    validateFactors(factors);
+    PointResult[] evaluatedPoints = new PointResult[factors.length];
+    for (int i = 0; i < factors.length; i++) {
+      OperatingInputs pointInputs = scaledInputs(baselineInputs, factors[i]);
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase.create(
+          caseNamePrefix + " pressure point " + (i + 1), feedMassFlowKgPerHour, pointInputs);
+      try {
+        model.getColumn().run(UUID.randomUUID());
+        DoeBigHillVacuumFractionationResult result =
+            DoeBigHillVacuumFractionationResult.evaluate(model);
+        evaluatedPoints[i] = new PointResult(factors[i], pointInputs, result);
+      } catch (RuntimeException exception) {
+        throw new IllegalStateException(
+            "Vacuum pressure sensitivity failed at point " + i + " with scale factor "
+                + factors[i],
+            exception);
+      }
+    }
+    return new DoeBigHillVacuumPressureSensitivity(evaluatedPoints);
+  }
+
+  /** @return defensive copy of sensitivity points in increasing scale-factor order */
+  public PointResult[] getPoints() {
+    return points.clone();
+  }
+
+  /**
+   * Return one sensitivity point by zero-based index.
+   *
+   * @param index zero-based point index
+   * @return immutable point result
+   * @throws IndexOutOfBoundsException if {@code index} is outside the sensitivity
+   */
+  public PointResult getPoint(int index) {
+    if (index < 0 || index >= points.length) {
+      throw new IndexOutOfBoundsException("Pressure sensitivity point index is outside the result");
+    }
+    return points[index];
+  }
+
+  /** @return smallest overhead mass fraction across the qualified points */
+  public double getMinimumOverheadMassFraction() {
+    return minimumOverheadMassFraction;
+  }
+
+  /** @return largest overhead mass fraction across the qualified points */
+  public double getMaximumOverheadMassFraction() {
+    return maximumOverheadMassFraction;
+  }
+
+  /** @return largest external mass-closure relative error across the qualified points */
+  public double getMaximumMassClosureRelativeError() {
+    return maximumMassClosureRelativeError;
+  }
+
+  /** @return largest component molar-closure relative error across the qualified points */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest column energy-balance error across the qualified points */
+  public double getMaximumColumnEnergyBalanceError() {
+    return maximumColumnEnergyBalanceError;
+  }
+
+  /** @return largest final MESH residual norm across the qualified points */
+  public double getMaximumMeshResidualNorm() {
+    return maximumMeshResidualNorm;
+  }
+
+  private static void validateFactors(double[] factors) {
+    double previous = Double.NEGATIVE_INFINITY;
+    for (double factor : factors) {
+      if (!Double.isFinite(factor) || !(factor > 0.0)) {
+        throw new IllegalArgumentException("Pressure scale factors must be finite and positive");
+      }
+      if (!(factor > previous)) {
+        throw new IllegalArgumentException(
+            "Pressure scale factors must be strictly increasing and unique");
+      }
+      previous = factor;
+    }
+  }
+
+  private static OperatingInputs scaledInputs(OperatingInputs baseline, double factor) {
+    return new OperatingInputs(baseline.getSimpleTrayCount(), baseline.getFeedTrayIndex(),
+        baseline.getFeedTemperatureKelvin(), baseline.getFeedPressureBara() * factor,
+        baseline.getTopPressureBara() * factor, baseline.getBottomPressureBara() * factor,
+        baseline.getReboilerTemperatureKelvin(), baseline.getCondenserRefluxRatio());
+  }
+
+  /** Immutable result for one scaled absolute-pressure point. */
+  public static final class PointResult {
+    private final double pressureScaleFactor;
+    private final OperatingInputs operatingInputs;
+    private final DoeBigHillVacuumFractionationResult fractionationResult;
+
+    private PointResult(double pressureScaleFactor, OperatingInputs operatingInputs,
+        DoeBigHillVacuumFractionationResult fractionationResult) {
+      this.pressureScaleFactor = pressureScaleFactor;
+      this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
+      this.fractionationResult =
+          Objects.requireNonNull(fractionationResult, "fractionationResult");
+    }
+
+    /** @return dimensionless factor applied to all three baseline absolute pressures */
+    public double getPressureScaleFactor() {
+      return pressureScaleFactor;
+    }
+
+    /** @return immutable operating inputs applied at this point */
+    public OperatingInputs getOperatingInputs() {
+      return operatingInputs;
+    }
+
+    /** @return qualified immutable fractionation result for this point */
+    public DoeBigHillVacuumFractionationResult getFractionationResult() {
+      return fractionationResult;
+    }
+
+    /** @return overhead mass fraction of feed at this point */
+    public double getOverheadMassFraction() {
+      return fractionationResult.getProduct("Overhead").getMassFractionOfFeed();
+    }
+
+    /**
+     * Return a discrete overhead normal-boiling-point diagnostic.
+     *
+     * @param cumulativeMoleFraction cumulative product mole fraction in (0, 1]
+     * @return overhead pseudo-component quantile in kelvin
+     */
+    public double getOverheadBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      ProductResult overhead = fractionationResult.getProduct("Overhead");
+      return overhead.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivity.java
@@ -9,10 +9,10 @@ import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult
  * Immutable pressure-sensitivity summary for the DOE Big Hill vacuum screening case.
  *
  * <p>
- * Feed, top, and bottom absolute pressures are scaled together while all other explicit engineering
- * inputs remain fixed. Each point is independently constructed, solved, and evaluated through the
- * qualified Big Hill case and result contracts. The sensitivity is numerical screening evidence,
- * not a measured or calibrated vacuum-column operating envelope.
+ * Feed, top, and bottom absolute pressures are scaled together while all other explicit engineering inputs remain
+ * fixed. Each point is independently constructed, solved, and evaluated through the qualified Big Hill case and result
+ * contracts. The sensitivity is numerical screening evidence, not a measured or calibrated vacuum-column operating
+ * envelope.
  * </p>
  */
 public final class DoeBigHillVacuumPressureSensitivity {
@@ -62,13 +62,11 @@ public final class DoeBigHillVacuumPressureSensitivity {
    * @param pressureScaleFactors finite positive strictly increasing pressure scale factors
    * @return immutable sensitivity summary
    * @throws NullPointerException if {@code baselineInputs} or {@code pressureScaleFactors} is null
-   * @throws IllegalArgumentException if the name, feed flow, factors, or a scaled pressure envelope
-   *         is invalid
+   * @throws IllegalArgumentException if the name, feed flow, factors, or a scaled pressure envelope is invalid
    * @throws IllegalStateException if a point does not solve or pass the qualified result gates
    */
-  public static DoeBigHillVacuumPressureSensitivity run(String caseNamePrefix,
-      double feedMassFlowKgPerHour, OperatingInputs baselineInputs,
-      double[] pressureScaleFactors) {
+  public static DoeBigHillVacuumPressureSensitivity run(String caseNamePrefix, double feedMassFlowKgPerHour,
+      OperatingInputs baselineInputs, double[] pressureScaleFactors) {
     if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
       throw new IllegalArgumentException("Case-name prefix must be non-blank");
     }
@@ -86,18 +84,15 @@ public final class DoeBigHillVacuumPressureSensitivity {
     PointResult[] evaluatedPoints = new PointResult[factors.length];
     for (int i = 0; i < factors.length; i++) {
       OperatingInputs pointInputs = scaledInputs(baselineInputs, factors[i]);
-      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase.create(
-          caseNamePrefix + " pressure point " + (i + 1), feedMassFlowKgPerHour, pointInputs);
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
+          .create(caseNamePrefix + " pressure point " + (i + 1), feedMassFlowKgPerHour, pointInputs);
       try {
         model.getColumn().run(UUID.randomUUID());
-        DoeBigHillVacuumFractionationResult result =
-            DoeBigHillVacuumFractionationResult.evaluate(model);
+        DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
         evaluatedPoints[i] = new PointResult(factors[i], pointInputs, result);
       } catch (RuntimeException exception) {
         throw new IllegalStateException(
-            "Vacuum pressure sensitivity failed at point " + i + " with scale factor "
-                + factors[i],
-            exception);
+            "Vacuum pressure sensitivity failed at point " + i + " with scale factor " + factors[i], exception);
       }
     }
     return new DoeBigHillVacuumPressureSensitivity(evaluatedPoints);
@@ -159,8 +154,7 @@ public final class DoeBigHillVacuumPressureSensitivity {
         throw new IllegalArgumentException("Pressure scale factors must be finite and positive");
       }
       if (!(factor > previous)) {
-        throw new IllegalArgumentException(
-            "Pressure scale factors must be strictly increasing and unique");
+        throw new IllegalArgumentException("Pressure scale factors must be strictly increasing and unique");
       }
       previous = factor;
     }
@@ -183,8 +177,7 @@ public final class DoeBigHillVacuumPressureSensitivity {
         DoeBigHillVacuumFractionationResult fractionationResult) {
       this.pressureScaleFactor = pressureScaleFactor;
       this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
-      this.fractionationResult =
-          Objects.requireNonNull(fractionationResult, "fractionationResult");
+      this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
     }
 
     /** @return dimensionless factor applied to all three baseline absolute pressures */
@@ -219,3 +212,4 @@ public final class DoeBigHillVacuumPressureSensitivity {
     }
   }
 }
+

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivity.java
@@ -212,4 +212,3 @@ public final class DoeBigHillVacuumPressureSensitivity {
     }
   }
 }
-

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivityTest.java
@@ -1,0 +1,150 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumPressureSensitivity.PointResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/** Qualification tests for {@link DoeBigHillVacuumPressureSensitivity}. */
+public class DoeBigHillVacuumPressureSensitivityTest {
+  private static final double FEED_MASS_FLOW_KG_PER_HOUR = 1000.0;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /**
+   * Execute the documented three-point pressure screen with every other input held fixed.
+   */
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void pressureScreenReturnsQualifiedImmutablePoints() {
+    OperatingInputs baseline = baselineInputs();
+    double[] factors = {0.98, 1.00, 1.02};
+
+    DoeBigHillVacuumPressureSensitivity sensitivity =
+        DoeBigHillVacuumPressureSensitivity.run("Big Hill vacuum pressure screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, factors);
+
+    factors[0] = 99.0;
+    PointResult[] points = sensitivity.getPoints();
+    assertEquals(3, points.length);
+    assertNotSame(points, sensitivity.getPoints());
+    assertEquals(0.98, points[0].getPressureScaleFactor(), 0.0);
+    assertEquals(1.00, points[1].getPressureScaleFactor(), 0.0);
+    assertEquals(1.02, points[2].getPressureScaleFactor(), 0.0);
+    assertEquals(points[0], sensitivity.getPoint(0));
+    assertEquals(points[2], sensitivity.getPoint(2));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(3));
+
+    double expectedMinimumOverhead = Double.POSITIVE_INFINITY;
+    double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
+    double expectedMaximumMassClosure = 0.0;
+    double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumEnergyError = 0.0;
+    double expectedMaximumMeshResidual = 0.0;
+
+    for (PointResult point : points) {
+      double factor = point.getPressureScaleFactor();
+      OperatingInputs applied = point.getOperatingInputs();
+      assertEquals(baseline.getTopPressureBara() * factor, applied.getTopPressureBara(),
+          1.0e-12);
+      assertEquals(baseline.getFeedPressureBara() * factor, applied.getFeedPressureBara(),
+          1.0e-12);
+      assertEquals(baseline.getBottomPressureBara() * factor,
+          applied.getBottomPressureBara(), 1.0e-12);
+      assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
+      assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
+      assertEquals(baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(),
+          0.0);
+      assertEquals(baseline.getReboilerTemperatureKelvin(),
+          applied.getReboilerTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getCondenserRefluxRatio(),
+          applied.getCondenserRefluxRatio(), 0.0);
+
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      ProductResult overhead = result.getProduct("Overhead");
+      ProductResult bottoms = result.getProduct("Bottoms");
+      assertTrue(overhead.getMassFractionOfFeed() > 0.0);
+      assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
+          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
+      assertThrows(IllegalArgumentException.class,
+          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError()
+          <= BALANCE_TOLERANCE);
+      assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
+
+      expectedMinimumOverhead =
+          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead =
+          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure =
+          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumEnergyError =
+          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual =
+          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumMassClosure,
+        sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure,
+        sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError,
+        sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
+  }
+
+  /** Require malformed sensitivity definitions to fail before presenting an envelope. */
+  @Test
+  public void invalidSensitivityInputsFailClosed() {
+    OperatingInputs baseline = baselineInputs();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run(" ", FEED_MASS_FLOW_KG_PER_HOUR,
+            baseline, new double[] {0.98, 1.02}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen", 0.0, baseline,
+            new double[] {0.98, 1.02}));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] {0.98, 1.02}));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {1.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {1.0, 1.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {1.02, 0.98}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline,
+            new double[] {Double.NaN, 1.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {10.0, 11.0}));
+  }
+
+  private static OperatingInputs baselineInputs() {
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivityTest.java
@@ -120,4 +120,3 @@ public class DoeBigHillVacuumPressureSensitivityTest {
     return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
   }
 }
-

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumPressureSensitivityTest.java
@@ -24,11 +24,10 @@ public class DoeBigHillVacuumPressureSensitivityTest {
   @Timeout(value = 300, unit = TimeUnit.SECONDS)
   public void pressureScreenReturnsQualifiedImmutablePoints() {
     OperatingInputs baseline = baselineInputs();
-    double[] factors = {0.98, 1.00, 1.02};
+    double[] factors = { 0.98, 1.00, 1.02 };
 
-    DoeBigHillVacuumPressureSensitivity sensitivity =
-        DoeBigHillVacuumPressureSensitivity.run("Big Hill vacuum pressure screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, factors);
+    DoeBigHillVacuumPressureSensitivity sensitivity = DoeBigHillVacuumPressureSensitivity
+        .run("Big Hill vacuum pressure screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, factors);
 
     factors[0] = 99.0;
     PointResult[] points = sensitivity.getPoints();
@@ -52,60 +51,43 @@ public class DoeBigHillVacuumPressureSensitivityTest {
     for (PointResult point : points) {
       double factor = point.getPressureScaleFactor();
       OperatingInputs applied = point.getOperatingInputs();
-      assertEquals(baseline.getTopPressureBara() * factor, applied.getTopPressureBara(),
-          1.0e-12);
-      assertEquals(baseline.getFeedPressureBara() * factor, applied.getFeedPressureBara(),
-          1.0e-12);
-      assertEquals(baseline.getBottomPressureBara() * factor,
-          applied.getBottomPressureBara(), 1.0e-12);
+      assertEquals(baseline.getTopPressureBara() * factor, applied.getTopPressureBara(), 1.0e-12);
+      assertEquals(baseline.getFeedPressureBara() * factor, applied.getFeedPressureBara(), 1.0e-12);
+      assertEquals(baseline.getBottomPressureBara() * factor, applied.getBottomPressureBara(), 1.0e-12);
       assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
       assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
-      assertEquals(baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(),
-          0.0);
-      assertEquals(baseline.getReboilerTemperatureKelvin(),
-          applied.getReboilerTemperatureKelvin(), 0.0);
-      assertEquals(baseline.getCondenserRefluxRatio(),
-          applied.getCondenserRefluxRatio(), 0.0);
+      assertEquals(baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getReboilerTemperatureKelvin(), applied.getReboilerTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getCondenserRefluxRatio(), applied.getCondenserRefluxRatio(), 0.0);
 
       DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
       ProductResult overhead = result.getProduct("Overhead");
       ProductResult bottoms = result.getProduct("Bottoms");
       assertTrue(overhead.getMassFractionOfFeed() > 0.0);
       assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
-      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
-          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin() < bottoms.getMeanNormalBoilingPointKelvin());
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
-      assertThrows(IllegalArgumentException.class,
-          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertThrows(IllegalArgumentException.class, () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
       assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
-      assertTrue(result.getMaximumComponentMolarClosureRelativeError()
-          <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
-      expectedMinimumOverhead =
-          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
-      expectedMaximumOverhead =
-          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
-      expectedMaximumMassClosure =
-          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
       expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      expectedMaximumEnergyError =
-          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
-      expectedMaximumMeshResidual =
-          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+      expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
     }
 
     assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
     assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
-    assertEquals(expectedMaximumMassClosure,
-        sensitivity.getMaximumMassClosureRelativeError(), 0.0);
-    assertEquals(expectedMaximumComponentClosure,
-        sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
-    assertEquals(expectedMaximumEnergyError,
-        sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMassClosure, sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure, sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
     assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
   }
 
@@ -114,37 +96,28 @@ public class DoeBigHillVacuumPressureSensitivityTest {
   public void invalidSensitivityInputsFailClosed() {
     OperatingInputs baseline = baselineInputs();
 
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumPressureSensitivity.run(" ",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 0.98, 1.02 }));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run(" ", FEED_MASS_FLOW_KG_PER_HOUR,
-            baseline, new double[] {0.98, 1.02}));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen", 0.0, baseline,
-            new double[] {0.98, 1.02}));
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen", 0.0, baseline, new double[] { 0.98, 1.02 }));
+    assertThrows(NullPointerException.class, () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 0.98, 1.02 }));
     assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] {0.98, 1.02}));
-    assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {1.0}));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {1.0, 1.0}));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {1.02, 0.98}));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline,
-            new double[] {Double.NaN, 1.0}));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumPressureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {10.0, 11.0}));
+        () -> DoeBigHillVacuumPressureSensitivity.run("screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 1.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 1.0, 1.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 1.02, 0.98 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { Double.NaN, 1.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumPressureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 10.0, 11.0 }));
   }
 
   private static OperatingInputs baselineInputs() {
     return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
   }
 }
+


### PR DESCRIPTION
Advances #3305.

## Capability

Adds a reusable Java/JPype pressure-sensitivity runner for the qualified DOE Big Hill 650 degF+ vacuum-screening case.

- Scales feed, top, and bottom absolute pressures together across finite, positive, strictly increasing factors.
- Holds tray topology, temperatures, reflux, feed composition, and mass flow fixed.
- Independently constructs, solves, and evaluates every point through the existing qualified MESH-residual case/result contracts.
- Fails closed for malformed factors, invalid sub-atmospheric topology, non-convergence, fallback, non-conservation, non-finite results, or unordered products.
- Returns defensive immutable points, exact applied inputs, per-point fractionation results, overhead-yield bounds, and worst conservation/energy/MESH diagnostics.
- Qualifies the documented 0.98/1.00/1.02 screen and all Java code shown in the guide.

## Provenance and engineering boundary

The public DOE Big Hill assay and existing three-cut 650 degF+ normalization are unchanged. All operating values remain explicit source-unreported engineering assumptions.

This is numerical sensitivity evidence around one transparent screening point. It is not a measured or calibrated vacuum-column envelope, does not require or claim a monotonic yield trend, and does not add ASTM D1160/TBP correction, uncertainty statistics, product specifications, equipment design, validated VGO/residue yields, or plant agreement.

## Files

Exactly three files and seven ordered commits:

1. new `DoeBigHillVacuumPressureSensitivity.java`
2. new `DoeBigHillVacuumPressureSensitivityTest.java`
3. updated Big Hill refinery guide
4. hosted Spotless formatting of the new production class
5. hosted Spotless formatting of the new test
6. exact hosted EOF normalization of the production class
7. exact hosted EOF normalization of the test

## Validation

Connector-side publication and repair audit confirms:

- exact base `653db71353dc3a5a0fad92b945978fd0bd94e74a`;
- current exact head `b3fe7fb16c89658bb645dead5d5e4bc0871d0818`;
- seven commits, three intended files, and zero commits behind the frozen base;
- no tabs, trailing whitespace, literal `\\n` defects, or Java lines over 120 characters;
- no overlap with active autonomous PR-owned files;
- the single permitted formatter repair was copied exactly from hosted artifact `10177227000` for workflow run `34540911214`, archive digest `sha256:d1e7075902af5fb9740be3cc2d9293cd3b5c780e725275a8b84e9b94e2cd9ef1`;
- that artifact touched only the two new Java files and made formatting-only changes;
- connector transfer added one blank EOF line to each file; hosted follow-up artifact `10177361103` from run `34541275797` (archive digest `sha256:231ac89e776ca77e6441713bfbb3d178d7e3ee9b8cc00e3bfa9033f619102d98`) confirmed the exact two-line normalization now applied.

**VALIDATION COMPLETE — HUMAN REVIEW REQUIRED.**

Exact-head CI passes: Java 8/21 on Ubuntu and Windows, four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, and agent-skill checks.

This adds a public engineering API and therefore still requires subsystem-owner and independent maintainer review under `GOVERNANCE.md`. The PR remains draft-only and is not classified READY TO MERGE until those human gates pass.