### PR TITLE
docs: restore foundational package navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ description: "Industrial Agentic Engineering with NeqSim — AI Agents for Engin
 <li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="thermo/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Thermo Package</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Equations of state, mixing rules, fluids</span></li>
 <li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="thermodynamicoperations/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Thermodynamic Operations</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Flash calculations, phase envelopes</span></li>
 <li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="physical_properties/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Physical Properties</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Viscosity, conductivity, diffusivity</span></li>
+<li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="chemicalreactions/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Chemical Reactions</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Chemical equilibrium and reaction kinetics</span></li>
 <li style="padding: 0.5rem 0;"><a href="chemicalreactions/co2_impurity_kinetics_guide.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Experimental CO₂ Impurity Kinetic Reactor</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Balanced trace-reaction network, reactor usage, safeguards, and limitations</span></li>
 </ul>
 </div>
@@ -72,6 +73,7 @@ description: "Industrial Agentic Engineering with NeqSim — AI Agents for Engin
 <ul style="list-style: none; padding: 0; margin: 0;">
 <li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="pvtsimulation/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>PVT Simulation</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Reservoir fluid characterization</span></li>
 <li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="blackoil/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Black Oil Models</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Simplified correlations</span></li>
+<li style="padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;"><a href="statistics/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Statistics &amp; Parameter Fitting</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Parameter estimation, Monte Carlo simulation, and data analysis</span></li>
 <li style="padding: 0.5rem 0;"><a href="fielddevelopment/README.html" style="color: #155799; text-decoration: none; font-weight: 500;"><strong>Field Development</strong></a><br><span style="color: #6a737d; font-size: 0.9rem;">Integrated workflows</span></li>
 </ul>
 </div>

--- a/docs/test_top_level_navigation.py
+++ b/docs/test_top_level_navigation.py
@@ -7,6 +7,11 @@ from urllib.parse import unquote, urlsplit
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
 REFERENCE_INDEX = DOCS / "REFERENCE_MANUAL_INDEX.md"
+LANDING_PAGE = DOCS / "index.md"
+FOUNDATIONAL_PACKAGE_TARGETS = {
+    "chemicalreactions/README.html": DOCS / "chemicalreactions" / "README.md",
+    "statistics/README.html": DOCS / "statistics" / "README.md",
+}
 
 FRONT_MATTER = re.compile(r"\A---\n(?P<fields>.*?)\n---\n", re.DOTALL)
 MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
@@ -108,6 +113,14 @@ def test_top_level_landing_relative_targets_resolve() -> None:
             assert any(candidate.exists() for candidate in candidates), (
                 f"{page}: unresolved relative target {target}"
             )
+
+
+def test_main_landing_routes_to_foundational_package_guides() -> None:
+    targets = _link_targets(LANDING_PAGE.read_text(encoding="utf-8"))
+    for destination, package_landing in FOUNDATIONAL_PACKAGE_TARGETS.items():
+        assert destination in targets, f"{LANDING_PAGE}: missing {destination}"
+        assert package_landing in _target_candidates(LANDING_PAGE, destination)
+        assert package_landing.is_file()
 
 
 def test_single_landing_directories_are_discoverable() -> None:


### PR DESCRIPTION
Advances documentation-quality campaign #2499, D144 (scope 1), with a frozen foundational-package navigation batch.

## Frozen contract

- Exact base: `653db71353dc3a5a0fad92b945978fd0bd94e74a`
- Exact head: `8f2cb39c357f484be4587c438ac9e56801053fdb`
- Branch: `docs/d144-foundational-package-navigation`
- Shape: exactly 2 files, 2 ordered commits, 15 additions, no deletions
- Files:
  - `docs/index.md`
  - `docs/test_top_level_navigation.py`

## Defect and repair

The main documentation landing page links the specialized experimental CO₂ impurity reactor guide but not the maintained chemical-reactions package landing, and it omits the maintained statistics/parameter-fitting foundation. Both package landings are already present in the package map and reference manual.

- Add a direct Chemical Reactions route to the thermodynamics navigation card.
- Add a direct Statistics & Parameter Fitting route to the applications card.
- Preserve the specialized experimental guide and all existing routes.
- Extend the top-level navigation contract so both published `.html` routes are required and resolve to their canonical `README.md` sources.

## Prepublication validation

Connector-side gates pass:

- exactly two frozen files and two linear commits
- 2 additions to the landing page and 13 additions to its navigation contract
- each new published target occurs exactly once in the page and once in the contract
- both canonical package landing files exist at the exact head
- no tabs or trailing whitespace
- balanced existing Markdown fences
- zero commits behind the exact base
- no overlap with open autonomous PRs #3646, #3645, #3644, or #3640

Hosted documentation/source-contract, Jekyll/search, pre-commit, formatting, CodeQL, and applicable build checks are starting: **VALIDATION PENDING CI**.

## Evidence boundary

This PR repairs navigation and adds source-contract evidence only. It does not alter or execute chemical-equilibrium, kinetics, parameter-fitting, statistics, thermodynamic, or process behavior. No package-guide content, code example, production code, numerical result, notebook source/output, generated output, diagram/DEXPI/P&ID, MCP, refinery, kinetics implementation, reaction data, release, or Huldra scope is changed.

## Workflow guardrails

Draft only. Preserve the exact head. Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon this PR for capacity.