### PR TITLE
feat(refinery): qualify Big Hill vacuum reflux sensitivity

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -249,3 +249,45 @@ validate product quality, or demonstrate equipment turndown.
 All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
 does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
 calibrated VGO/residue yields, equipment design, or plant-agreement evidence.
+
+## Condenser-reflux sensitivity screening
+
+`DoeBigHillVacuumRefluxSensitivity.run(...)` independently rebuilds, solves, and evaluates
+multiple Big Hill vacuum cases while varying only the condenser reflux ratio. Tray count, feed tray,
+feed and reboiler temperatures, all three absolute pressures, feed composition, and feed mass flow
+remain fixed. Reflux ratios must be finite, non-negative, unique, and strictly increasing.
+
+The documented three-point screen stays close to the qualified base point:
+
+```java
+OperatingInputs baseline =
+    new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+double[] refluxRatios = {0.49, 0.50, 0.51};
+
+DoeBigHillVacuumRefluxSensitivity sensitivity =
+    DoeBigHillVacuumRefluxSensitivity.run(
+        "Big Hill vacuum reflux screen", 1000.0, baseline, refluxRatios);
+
+for (DoeBigHillVacuumRefluxSensitivity.PointResult point : sensitivity.getPoints()) {
+  double refluxRatio = point.getCondenserRefluxRatio();
+  double overheadMassFraction = point.getOverheadMassFraction();
+  double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+}
+```
+
+Every point must pass the already qualified MESH-residual, fallback, mass, component, energy,
+material-product, and boiling-point-order gates. The summary returns a defensive point array, exact
+applied operating inputs, immutable per-point fractionation results, the observed overhead-yield
+bounds, and the worst external mass closure, component closure, column energy error, and final MESH
+residual. A failed point aborts the complete sensitivity instead of returning a partial envelope.
+
+The condenser reflux ratio is a dimensionless `DistillationColumn` input. This screen isolates that
+single numerical operating variable; it does not represent a measured, optimized, or
+vendor-recommended reflux policy. The narrow 0.49/0.50/0.51 regression is a convergence and
+conservation test around the documented screening point. It does not establish a measured reflux
+response, require a monotonic yield trend, quantify condenser or reboiler duty, define utilities,
+size equipment, validate product quality, or demonstrate turndown.
+
+All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
+does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
+calibrated VGO/residue yields, optimization, product specifications, or plant-agreement evidence.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivity.java
@@ -9,10 +9,9 @@ import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult
  * Immutable condenser-reflux sensitivity summary for the DOE Big Hill vacuum screening case.
  *
  * <p>
- * Condenser reflux ratio is varied while all other explicit engineering inputs remain fixed. Each
- * point is independently constructed, solved, and evaluated through the qualified Big Hill case and
- * result contracts. The sensitivity is numerical screening evidence, not a measured or calibrated
- * vacuum-column operating envelope.
+ * Condenser reflux ratio is varied while all other explicit engineering inputs remain fixed. Each point is
+ * independently constructed, solved, and evaluated through the qualified Big Hill case and result contracts. The
+ * sensitivity is numerical screening evidence, not a measured or calibrated vacuum-column operating envelope.
  * </p>
  */
 public final class DoeBigHillVacuumRefluxSensitivity {
@@ -38,12 +37,10 @@ public final class DoeBigHillVacuumRefluxSensitivity {
       double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
       minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
       maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
-      maximumMassClosure =
-          Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
       maximumComponentClosure = Math.max(maximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      maximumEnergyError =
-          Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
       maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
     }
 
@@ -63,14 +60,12 @@ public final class DoeBigHillVacuumRefluxSensitivity {
    * @param baselineInputs explicit source-unreported baseline column inputs
    * @param condenserRefluxRatios finite non-negative strictly increasing reflux ratios
    * @return immutable sensitivity summary
-   * @throws NullPointerException if {@code baselineInputs} or
-   *         {@code condenserRefluxRatios} is null
+   * @throws NullPointerException if {@code baselineInputs} or {@code condenserRefluxRatios} is null
    * @throws IllegalArgumentException if the name, feed flow, or reflux ratios are invalid
    * @throws IllegalStateException if a point does not solve or pass the qualified result gates
    */
-  public static DoeBigHillVacuumRefluxSensitivity run(String caseNamePrefix,
-      double feedMassFlowKgPerHour, OperatingInputs baselineInputs,
-      double[] condenserRefluxRatios) {
+  public static DoeBigHillVacuumRefluxSensitivity run(String caseNamePrefix, double feedMassFlowKgPerHour,
+      OperatingInputs baselineInputs, double[] condenserRefluxRatios) {
     if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
       throw new IllegalArgumentException("Case-name prefix must be non-blank");
     }
@@ -88,21 +83,15 @@ public final class DoeBigHillVacuumRefluxSensitivity {
     PointResult[] evaluatedPoints = new PointResult[ratios.length];
     for (int i = 0; i < ratios.length; i++) {
       OperatingInputs pointInputs = refluxInputs(baselineInputs, ratios[i]);
-      DoeBigHillVacuumFractionationCase model =
-          DoeBigHillVacuumFractionationCase.create(
-              caseNamePrefix + " reflux point " + (i + 1),
-              feedMassFlowKgPerHour,
-              pointInputs);
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
+          .create(caseNamePrefix + " reflux point " + (i + 1), feedMassFlowKgPerHour, pointInputs);
       try {
         model.getColumn().run(UUID.randomUUID());
-        DoeBigHillVacuumFractionationResult result =
-            DoeBigHillVacuumFractionationResult.evaluate(model);
+        DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
         evaluatedPoints[i] = new PointResult(ratios[i], pointInputs, result);
       } catch (RuntimeException exception) {
         throw new IllegalStateException(
-            "Vacuum reflux sensitivity failed at point " + i
-                + " with condenser reflux ratio " + ratios[i],
-            exception);
+            "Vacuum reflux sensitivity failed at point " + i + " with condenser reflux ratio " + ratios[i], exception);
       }
     }
     return new DoeBigHillVacuumRefluxSensitivity(evaluatedPoints);
@@ -122,8 +111,7 @@ public final class DoeBigHillVacuumRefluxSensitivity {
    */
   public PointResult getPoint(int index) {
     if (index < 0 || index >= points.length) {
-      throw new IndexOutOfBoundsException(
-          "Reflux sensitivity point index is outside the result");
+      throw new IndexOutOfBoundsException("Reflux sensitivity point index is outside the result");
     }
     return points[index];
   }
@@ -162,27 +150,19 @@ public final class DoeBigHillVacuumRefluxSensitivity {
     double previous = Double.NEGATIVE_INFINITY;
     for (double ratio : ratios) {
       if (!Double.isFinite(ratio) || ratio < 0.0) {
-        throw new IllegalArgumentException(
-            "Condenser reflux ratios must be finite and non-negative");
+        throw new IllegalArgumentException("Condenser reflux ratios must be finite and non-negative");
       }
       if (!(ratio > previous)) {
-        throw new IllegalArgumentException(
-            "Condenser reflux ratios must be strictly increasing and unique");
+        throw new IllegalArgumentException("Condenser reflux ratios must be strictly increasing and unique");
       }
       previous = ratio;
     }
   }
 
   private static OperatingInputs refluxInputs(OperatingInputs baseline, double ratio) {
-    return new OperatingInputs(
-        baseline.getSimpleTrayCount(),
-        baseline.getFeedTrayIndex(),
-        baseline.getFeedTemperatureKelvin(),
-        baseline.getFeedPressureBara(),
-        baseline.getTopPressureBara(),
-        baseline.getBottomPressureBara(),
-        baseline.getReboilerTemperatureKelvin(),
-        ratio);
+    return new OperatingInputs(baseline.getSimpleTrayCount(), baseline.getFeedTrayIndex(),
+        baseline.getFeedTemperatureKelvin(), baseline.getFeedPressureBara(), baseline.getTopPressureBara(),
+        baseline.getBottomPressureBara(), baseline.getReboilerTemperatureKelvin(), ratio);
   }
 
   /** Immutable result for one condenser-reflux point. */
@@ -195,8 +175,7 @@ public final class DoeBigHillVacuumRefluxSensitivity {
         DoeBigHillVacuumFractionationResult fractionationResult) {
       this.condenserRefluxRatio = condenserRefluxRatio;
       this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
-      this.fractionationResult =
-          Objects.requireNonNull(fractionationResult, "fractionationResult");
+      this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
     }
 
     /** @return dimensionless condenser reflux ratio applied at this point */

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivity.java
@@ -1,0 +1,233 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/**
+ * Immutable condenser-reflux sensitivity summary for the DOE Big Hill vacuum screening case.
+ *
+ * <p>
+ * Condenser reflux ratio is varied while all other explicit engineering inputs remain fixed. Each
+ * point is independently constructed, solved, and evaluated through the qualified Big Hill case and
+ * result contracts. The sensitivity is numerical screening evidence, not a measured or calibrated
+ * vacuum-column operating envelope.
+ * </p>
+ */
+public final class DoeBigHillVacuumRefluxSensitivity {
+  private final PointResult[] points;
+  private final double minimumOverheadMassFraction;
+  private final double maximumOverheadMassFraction;
+  private final double maximumMassClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumColumnEnergyBalanceError;
+  private final double maximumMeshResidualNorm;
+
+  private DoeBigHillVacuumRefluxSensitivity(PointResult[] points) {
+    this.points = points.clone();
+
+    double minimumOverheadFraction = Double.POSITIVE_INFINITY;
+    double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
+    double maximumMassClosure = 0.0;
+    double maximumComponentClosure = 0.0;
+    double maximumEnergyError = 0.0;
+    double maximumMeshResidual = 0.0;
+    for (PointResult point : points) {
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+      minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
+      maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
+      maximumMassClosure =
+          Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumComponentClosure = Math.max(maximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      maximumEnergyError =
+          Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    minimumOverheadMassFraction = minimumOverheadFraction;
+    maximumOverheadMassFraction = maximumOverheadFraction;
+    maximumMassClosureRelativeError = maximumMassClosure;
+    maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumColumnEnergyBalanceError = maximumEnergyError;
+    maximumMeshResidualNorm = maximumMeshResidual;
+  }
+
+  /**
+   * Run an independent condenser-reflux sensitivity around explicit baseline operating inputs.
+   *
+   * @param caseNamePrefix non-blank prefix used for independently constructed point names
+   * @param feedMassFlowKgPerHour finite positive feed mass flow in kg/h
+   * @param baselineInputs explicit source-unreported baseline column inputs
+   * @param condenserRefluxRatios finite non-negative strictly increasing reflux ratios
+   * @return immutable sensitivity summary
+   * @throws NullPointerException if {@code baselineInputs} or
+   *         {@code condenserRefluxRatios} is null
+   * @throws IllegalArgumentException if the name, feed flow, or reflux ratios are invalid
+   * @throws IllegalStateException if a point does not solve or pass the qualified result gates
+   */
+  public static DoeBigHillVacuumRefluxSensitivity run(String caseNamePrefix,
+      double feedMassFlowKgPerHour, OperatingInputs baselineInputs,
+      double[] condenserRefluxRatios) {
+    if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case-name prefix must be non-blank");
+    }
+    if (!Double.isFinite(feedMassFlowKgPerHour) || !(feedMassFlowKgPerHour > 0.0)) {
+      throw new IllegalArgumentException("Feed mass flow must be finite and positive");
+    }
+    Objects.requireNonNull(baselineInputs, "baselineInputs");
+    Objects.requireNonNull(condenserRefluxRatios, "condenserRefluxRatios");
+    if (condenserRefluxRatios.length < 2) {
+      throw new IllegalArgumentException("Reflux sensitivity requires at least two points");
+    }
+
+    double[] ratios = condenserRefluxRatios.clone();
+    validateRatios(ratios);
+    PointResult[] evaluatedPoints = new PointResult[ratios.length];
+    for (int i = 0; i < ratios.length; i++) {
+      OperatingInputs pointInputs = refluxInputs(baselineInputs, ratios[i]);
+      DoeBigHillVacuumFractionationCase model =
+          DoeBigHillVacuumFractionationCase.create(
+              caseNamePrefix + " reflux point " + (i + 1),
+              feedMassFlowKgPerHour,
+              pointInputs);
+      try {
+        model.getColumn().run(UUID.randomUUID());
+        DoeBigHillVacuumFractionationResult result =
+            DoeBigHillVacuumFractionationResult.evaluate(model);
+        evaluatedPoints[i] = new PointResult(ratios[i], pointInputs, result);
+      } catch (RuntimeException exception) {
+        throw new IllegalStateException(
+            "Vacuum reflux sensitivity failed at point " + i
+                + " with condenser reflux ratio " + ratios[i],
+            exception);
+      }
+    }
+    return new DoeBigHillVacuumRefluxSensitivity(evaluatedPoints);
+  }
+
+  /** @return defensive copy of sensitivity points in increasing reflux-ratio order */
+  public PointResult[] getPoints() {
+    return points.clone();
+  }
+
+  /**
+   * Return one sensitivity point by zero-based index.
+   *
+   * @param index zero-based point index
+   * @return immutable point result
+   * @throws IndexOutOfBoundsException if {@code index} is outside the sensitivity
+   */
+  public PointResult getPoint(int index) {
+    if (index < 0 || index >= points.length) {
+      throw new IndexOutOfBoundsException(
+          "Reflux sensitivity point index is outside the result");
+    }
+    return points[index];
+  }
+
+  /** @return smallest overhead mass fraction across the qualified points */
+  public double getMinimumOverheadMassFraction() {
+    return minimumOverheadMassFraction;
+  }
+
+  /** @return largest overhead mass fraction across the qualified points */
+  public double getMaximumOverheadMassFraction() {
+    return maximumOverheadMassFraction;
+  }
+
+  /** @return largest external mass-closure relative error across the qualified points */
+  public double getMaximumMassClosureRelativeError() {
+    return maximumMassClosureRelativeError;
+  }
+
+  /** @return largest component molar-closure relative error across the qualified points */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest column energy-balance error across the qualified points */
+  public double getMaximumColumnEnergyBalanceError() {
+    return maximumColumnEnergyBalanceError;
+  }
+
+  /** @return largest final MESH residual norm across the qualified points */
+  public double getMaximumMeshResidualNorm() {
+    return maximumMeshResidualNorm;
+  }
+
+  private static void validateRatios(double[] ratios) {
+    double previous = Double.NEGATIVE_INFINITY;
+    for (double ratio : ratios) {
+      if (!Double.isFinite(ratio) || ratio < 0.0) {
+        throw new IllegalArgumentException(
+            "Condenser reflux ratios must be finite and non-negative");
+      }
+      if (!(ratio > previous)) {
+        throw new IllegalArgumentException(
+            "Condenser reflux ratios must be strictly increasing and unique");
+      }
+      previous = ratio;
+    }
+  }
+
+  private static OperatingInputs refluxInputs(OperatingInputs baseline, double ratio) {
+    return new OperatingInputs(
+        baseline.getSimpleTrayCount(),
+        baseline.getFeedTrayIndex(),
+        baseline.getFeedTemperatureKelvin(),
+        baseline.getFeedPressureBara(),
+        baseline.getTopPressureBara(),
+        baseline.getBottomPressureBara(),
+        baseline.getReboilerTemperatureKelvin(),
+        ratio);
+  }
+
+  /** Immutable result for one condenser-reflux point. */
+  public static final class PointResult {
+    private final double condenserRefluxRatio;
+    private final OperatingInputs operatingInputs;
+    private final DoeBigHillVacuumFractionationResult fractionationResult;
+
+    private PointResult(double condenserRefluxRatio, OperatingInputs operatingInputs,
+        DoeBigHillVacuumFractionationResult fractionationResult) {
+      this.condenserRefluxRatio = condenserRefluxRatio;
+      this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
+      this.fractionationResult =
+          Objects.requireNonNull(fractionationResult, "fractionationResult");
+    }
+
+    /** @return dimensionless condenser reflux ratio applied at this point */
+    public double getCondenserRefluxRatio() {
+      return condenserRefluxRatio;
+    }
+
+    /** @return immutable operating inputs applied at this point */
+    public OperatingInputs getOperatingInputs() {
+      return operatingInputs;
+    }
+
+    /** @return qualified immutable fractionation result for this point */
+    public DoeBigHillVacuumFractionationResult getFractionationResult() {
+      return fractionationResult;
+    }
+
+    /** @return overhead mass fraction of feed at this point */
+    public double getOverheadMassFraction() {
+      return fractionationResult.getProduct("Overhead").getMassFractionOfFeed();
+    }
+
+    /**
+     * Return a discrete overhead normal-boiling-point diagnostic.
+     *
+     * @param cumulativeMoleFraction cumulative product mole fraction in (0, 1]
+     * @return overhead pseudo-component quantile in kelvin
+     */
+    public double getOverheadBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      ProductResult overhead = fractionationResult.getProduct("Overhead");
+      return overhead.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivityTest.java
@@ -22,14 +22,10 @@ public class DoeBigHillVacuumRefluxSensitivityTest {
   @Timeout(value = 300, unit = TimeUnit.SECONDS)
   public void refluxScreenReturnsQualifiedImmutablePoints() {
     OperatingInputs baseline = baselineInputs();
-    double[] ratios = {0.49, 0.50, 0.51};
+    double[] ratios = { 0.49, 0.50, 0.51 };
 
-    DoeBigHillVacuumRefluxSensitivity sensitivity =
-        DoeBigHillVacuumRefluxSensitivity.run(
-            "Big Hill vacuum reflux screen",
-            FEED_MASS_FLOW_KG_PER_HOUR,
-            baseline,
-            ratios);
+    DoeBigHillVacuumRefluxSensitivity sensitivity = DoeBigHillVacuumRefluxSensitivity
+        .run("Big Hill vacuum reflux screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, ratios);
 
     ratios[0] = 99.0;
     PointResult[] points = sensitivity.getPoints();
@@ -56,68 +52,41 @@ public class DoeBigHillVacuumRefluxSensitivityTest {
       assertEquals(ratio, applied.getCondenserRefluxRatio(), 0.0);
       assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
       assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
-      assertEquals(
-          baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(), 0.0);
       assertEquals(baseline.getFeedPressureBara(), applied.getFeedPressureBara(), 0.0);
       assertEquals(baseline.getTopPressureBara(), applied.getTopPressureBara(), 0.0);
       assertEquals(baseline.getBottomPressureBara(), applied.getBottomPressureBara(), 0.0);
-      assertEquals(
-          baseline.getReboilerTemperatureKelvin(),
-          applied.getReboilerTemperatureKelvin(),
-          0.0);
+      assertEquals(baseline.getReboilerTemperatureKelvin(), applied.getReboilerTemperatureKelvin(), 0.0);
 
       DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
       ProductResult overhead = result.getProduct("Overhead");
       ProductResult bottoms = result.getProduct("Bottoms");
       assertTrue(overhead.getMassFractionOfFeed() > 0.0);
       assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
-      assertTrue(
-          overhead.getMeanNormalBoilingPointKelvin()
-              < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin() < bottoms.getMeanNormalBoilingPointKelvin());
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertThrows(IllegalArgumentException.class, () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
       assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
-      assertTrue(
-          result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
-      expectedMinimumOverhead =
-          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
-      expectedMaximumOverhead =
-          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
-      expectedMaximumMassClosure =
-          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
-      expectedMaximumComponentClosure = Math.max(
-          expectedMaximumComponentClosure,
+      expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      expectedMaximumEnergyError =
-          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
-      expectedMaximumMeshResidual =
-          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+      expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
     }
 
-    assertEquals(
-        expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
-    assertEquals(
-        expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
-    assertEquals(
-        expectedMaximumMassClosure,
-        sensitivity.getMaximumMassClosureRelativeError(),
-        0.0);
-    assertEquals(
-        expectedMaximumComponentClosure,
-        sensitivity.getMaximumComponentMolarClosureRelativeError(),
-        0.0);
-    assertEquals(
-        expectedMaximumEnergyError,
-        sensitivity.getMaximumColumnEnergyBalanceError(),
-        0.0);
-    assertEquals(
-        expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
+    assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumMassClosure, sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure, sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
   }
 
   /** Require malformed sensitivity definitions to fail before presenting an envelope. */
@@ -125,45 +94,24 @@ public class DoeBigHillVacuumRefluxSensitivityTest {
   public void invalidSensitivityInputsFailClosed() {
     OperatingInputs baseline = baselineInputs();
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            " ", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.49, 0.51}));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", 0.0, baseline, new double[] {0.49, 0.51}));
-    assertThrows(
-        NullPointerException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] {0.49, 0.51}));
-    assertThrows(
-        NullPointerException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.5}));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.5, 0.5}));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.51, 0.49}));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen",
-            FEED_MASS_FLOW_KG_PER_HOUR,
-            baseline,
-            new double[] {Double.NaN, 0.5}));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> DoeBigHillVacuumRefluxSensitivity.run(
-            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {-0.1, 0.5}));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumRefluxSensitivity.run(" ",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 0.49, 0.51 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run("screen", 0.0, baseline, new double[] { 0.49, 0.51 }));
+    assertThrows(NullPointerException.class, () -> DoeBigHillVacuumRefluxSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 0.49, 0.51 }));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run("screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumRefluxSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 0.5 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumRefluxSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 0.5, 0.5 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumRefluxSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 0.51, 0.49 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumRefluxSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { Double.NaN, 0.5 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumRefluxSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { -0.1, 0.5 }));
   }
 
   private static OperatingInputs baselineInputs() {

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumRefluxSensitivityTest.java
@@ -1,0 +1,172 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumRefluxSensitivity.PointResult;
+
+/** Qualification tests for {@link DoeBigHillVacuumRefluxSensitivity}. */
+public class DoeBigHillVacuumRefluxSensitivityTest {
+  private static final double FEED_MASS_FLOW_KG_PER_HOUR = 1000.0;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /** Execute the documented three-point reflux screen with every other input held fixed. */
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void refluxScreenReturnsQualifiedImmutablePoints() {
+    OperatingInputs baseline = baselineInputs();
+    double[] ratios = {0.49, 0.50, 0.51};
+
+    DoeBigHillVacuumRefluxSensitivity sensitivity =
+        DoeBigHillVacuumRefluxSensitivity.run(
+            "Big Hill vacuum reflux screen",
+            FEED_MASS_FLOW_KG_PER_HOUR,
+            baseline,
+            ratios);
+
+    ratios[0] = 99.0;
+    PointResult[] points = sensitivity.getPoints();
+    assertEquals(3, points.length);
+    assertNotSame(points, sensitivity.getPoints());
+    assertEquals(0.49, points[0].getCondenserRefluxRatio(), 0.0);
+    assertEquals(0.50, points[1].getCondenserRefluxRatio(), 0.0);
+    assertEquals(0.51, points[2].getCondenserRefluxRatio(), 0.0);
+    assertEquals(points[0], sensitivity.getPoint(0));
+    assertEquals(points[2], sensitivity.getPoint(2));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(3));
+
+    double expectedMinimumOverhead = Double.POSITIVE_INFINITY;
+    double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
+    double expectedMaximumMassClosure = 0.0;
+    double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumEnergyError = 0.0;
+    double expectedMaximumMeshResidual = 0.0;
+
+    for (PointResult point : points) {
+      double ratio = point.getCondenserRefluxRatio();
+      OperatingInputs applied = point.getOperatingInputs();
+      assertEquals(ratio, applied.getCondenserRefluxRatio(), 0.0);
+      assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
+      assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
+      assertEquals(
+          baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getFeedPressureBara(), applied.getFeedPressureBara(), 0.0);
+      assertEquals(baseline.getTopPressureBara(), applied.getTopPressureBara(), 0.0);
+      assertEquals(baseline.getBottomPressureBara(), applied.getBottomPressureBara(), 0.0);
+      assertEquals(
+          baseline.getReboilerTemperatureKelvin(),
+          applied.getReboilerTemperatureKelvin(),
+          0.0);
+
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      ProductResult overhead = result.getProduct("Overhead");
+      ProductResult bottoms = result.getProduct("Bottoms");
+      assertTrue(overhead.getMassFractionOfFeed() > 0.0);
+      assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
+      assertTrue(
+          overhead.getMeanNormalBoilingPointKelvin()
+              < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(
+          result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
+
+      expectedMinimumOverhead =
+          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead =
+          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure =
+          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(
+          expectedMaximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumEnergyError =
+          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual =
+          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    assertEquals(
+        expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(
+        expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(
+        expectedMaximumMassClosure,
+        sensitivity.getMaximumMassClosureRelativeError(),
+        0.0);
+    assertEquals(
+        expectedMaximumComponentClosure,
+        sensitivity.getMaximumComponentMolarClosureRelativeError(),
+        0.0);
+    assertEquals(
+        expectedMaximumEnergyError,
+        sensitivity.getMaximumColumnEnergyBalanceError(),
+        0.0);
+    assertEquals(
+        expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
+  }
+
+  /** Require malformed sensitivity definitions to fail before presenting an envelope. */
+  @Test
+  public void invalidSensitivityInputsFailClosed() {
+    OperatingInputs baseline = baselineInputs();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            " ", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.49, 0.51}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", 0.0, baseline, new double[] {0.49, 0.51}));
+    assertThrows(
+        NullPointerException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] {0.49, 0.51}));
+    assertThrows(
+        NullPointerException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.5}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.5, 0.5}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {0.51, 0.49}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen",
+            FEED_MASS_FLOW_KG_PER_HOUR,
+            baseline,
+            new double[] {Double.NaN, 0.5}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DoeBigHillVacuumRefluxSensitivity.run(
+            "screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {-0.1, 0.5}));
+  }
+
+  private static OperatingInputs baselineInputs() {
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+  }
+}


### PR DESCRIPTION
Advances #3305.

## Capability

Adds a reusable Java/JPype condenser-reflux sensitivity runner for the qualified DOE Big Hill 650 degF+ vacuum-screening case.

- Varies finite, non-negative, strictly increasing condenser reflux ratios.
- Holds tray topology, temperatures, all three absolute pressures, feed composition, and mass flow fixed.
- Independently constructs, solves, and evaluates every point through the existing qualified MESH-residual case/result contracts.
- Fails closed for malformed ratios, non-convergence, fallback, non-conservation, non-finite results, or unordered products.
- Returns defensive immutable points, exact applied inputs, per-point fractionation results, overhead-yield bounds, and worst conservation/energy/MESH diagnostics.
- Qualifies the documented narrow 0.49/0.50/0.51 screen and all Java code shown in the guide.

## Provenance and engineering boundary

The public DOE Big Hill assay and existing three-cut 650 degF+ normalization are unchanged. All operating values remain explicit source-unreported engineering assumptions.

This is numerical sensitivity evidence around one transparent screening point. It is not a measured or calibrated reflux envelope, does not require or claim a monotonic yield trend, and does not add ASTM D1160/TBP correction, duties or utilities, equipment sizing, optimization, product specifications, validated VGO/residue yields, or plant agreement.

## Files and validation

Exactly three files and five ordered commits:

1. new `DoeBigHillVacuumRefluxSensitivity.java`
2. new `DoeBigHillVacuumRefluxSensitivityTest.java`
3. updated Big Hill refinery guide
4. exact hosted Spotless formatting of the production class
5. exact hosted Spotless formatting of the focused test

Connector audit confirms:

- exact base `71835e21ef7e9c7b5a0ba809126c17b99aa864d8`;
- current exact head `6bc117f03a4c9bea3754c64a4b0990fe78604500`;
- five commits, exactly three intended files, and zero commits behind the frozen base;
- no open-PR ownership overlap;
- pre-commit failed solely on Spotless while documentation search passed;
- the single permitted formatter repair was copied exactly from hosted artifact `10185710584` for workflow run `34565054551`, archive digest `sha256:04565b93e578be1237cd74c9c9871ba82859bedc2fa204741fed8cd7f835326f`;
- formatted blob SHAs match the artifact patch targets: `103dab732346d8be80bd245cc10389df0af580ec` and `ea64198c390564067d483db8ea5072e8b1e65942`;
- the repair changed formatting only and preserved one final newline in each Java file.

**VALIDATION COMPLETE — HUMAN REVIEW REQUIRED.**

Exact-head CI passes: Java 8/21 on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, and agent-skill checks.

The current open autonomous PRs have no overlap with the three owned refinery files.

This adds a public engineering API and therefore requires subsystem-owner and independent-maintainer review under `GOVERNANCE.md`.