### PR TITLE
[AI-Assisted] feat(optimization): compile fail-closed ProcessModel plans

### DIFF
--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -283,7 +283,8 @@ silently promoted to verified optimization constraints.
 
 Use `ProcessModelCompiledEvaluationPlan` around a configured
 `ProcessModelOperatingActionSetEvaluator` before handing repeated candidates to an external solver.
-Compilation evaluates the unchanged action vector and freezes the exact area order and
+Compilation evaluates the unchanged action vector and freezes model and area object identities,
+the exact area order and
 `ProcessSystem` structure versions, action and required-hydraulic definitions, evaluator
 configuration, installed ratings, and expected installed-capacity and process-boundary identities.
 
@@ -336,6 +337,8 @@ A non-finite or incorrectly sized vector is rejected before a process run. A cha
 action, binding, evaluator definition, installed rating, or availability makes the compiled plan
 stale before candidate mutation. A physically violated candidate retains its complete immutable
 evidence but is not accepted. Any incomplete restoration overrides the candidate classification.
+Replacing a model or removing and recreating an area requires recompilation even when names and
+structure counters match, because callbacks and stream connections may still reference the original objects.
 Shared mutable equipment is never evaluated concurrently; compile independent plans on independent
 model instances for parallel candidate work.
 

--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -1121,6 +1121,16 @@ for (ScenarioResult sr : results) {
 
 ### Scenario Comparison
 
+For an operating-condition comparison, keep installed compressor maps, separator ratings, and
+flowsheet topology fixed across cases. Generate synthetic maps once at a declared design point;
+regenerating them from each cooled operating point compares redesigned equipment. Keep the cooler
+and liquid knockout present in the zero-cooling case when they belong to the installed plant, and
+apply the specified temperature difference and pressure loss at every candidate flow. Check
+`OptimizationResult.isFeasible()` before interpreting a reported rate as achievable production.
+Cooling does not guarantee a production gain when another installed constraint remains limiting.
+The fixed-equipment sweep is exercised by
+`CoolingDutyProductionAnalysisTest.test2026ScenarioCoolingAnalysisThreeCompressors`.
+
 ```java
 import java.util.Arrays;
 import java.util.List;

--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -279,6 +279,71 @@ profiles, ratings, convergence, or exact calculation identity fails closed with 
 numbers. API RP 14E, Rhone-Poulenc, FIV/FRMS/AIV, hydrate/wax, slug, and transient results are not
 silently promoted to verified optimization constraints.
 
+### Compile a fail-closed evaluation plan
+
+Use `ProcessModelCompiledEvaluationPlan` around a configured
+`ProcessModelOperatingActionSetEvaluator` before handing repeated candidates to an external solver.
+Compilation evaluates the unchanged action vector and freezes the exact area order and
+`ProcessSystem` structure versions, action and required-hydraulic definitions, evaluator
+configuration, installed ratings, and expected installed-capacity and process-boundary identities.
+
+```java
+ProcessModelCompiledEvaluationPlan plan =
+    ProcessModelCompiledEvaluationPlan.compile(
+        "production-allocation-v1",
+        "Compiled production allocation",
+        "approved operating envelope revision 4",
+        "NeqSim master and plant configuration revision 2026-09-11",
+        transactionalEvaluator);
+
+ProcessModelCompiledEvaluationPlan.EvaluationResult candidate =
+    plan.evaluate(new double[] {11000.0});
+if (!candidate.isAccepted()) {
+  throw new IllegalStateException(candidate.getDiagnostics().toString());
+}
+String authoritativeJson = candidate.toJson();
+```
+
+`transactionalEvaluator` is a fully configured
+`ProcessModelOperatingActionSetEvaluator`: it must contain at least one exact hydraulic binding,
+and its underlying evaluator must already contain objectives and every required process-boundary
+constraint. Do not add objectives, constraints, actions, equipment, or ratings after compilation.
+`plan.isCurrent()` and `getStalenessDiagnostics()` are preflight views only; `evaluate(...)` repeats
+the same check immediately before model mutation.
+
+JPype uses the same Java authority and returns the same strict JSON. `plan.toJson()` includes the
+qualified no-change compilation evidence; each evaluation result includes its complete delegated
+candidate evidence. Java non-finite values are represented as JSON `null`, not invalid `NaN` or
+`Infinity` tokens.
+
+```python
+CompiledPlan = jneqsim.process.util.optimizer.ProcessModelCompiledEvaluationPlan
+candidate_values = jpype.JArray(jpype.JDouble)([11000.0])
+plan = CompiledPlan.compile(
+    "production-allocation-v1",
+    "Compiled production allocation",
+    "approved operating envelope revision 4",
+    "NeqSim master and plant configuration revision 2026-09-11",
+    transactional_evaluator,
+)
+candidate = plan.evaluate(candidate_values)
+if not candidate.isAccepted():
+    raise RuntimeError(str(candidate.getDiagnostics()))
+authoritative_json = str(candidate.toJson())
+```
+
+A non-finite or incorrectly sized vector is rejected before a process run. A changed topology,
+action, binding, evaluator definition, installed rating, or availability makes the compiled plan
+stale before candidate mutation. A physically violated candidate retains its complete immutable
+evidence but is not accepted. Any incomplete restoration overrides the candidate classification.
+Shared mutable equipment is never evaluated concurrently; compile independent plans on independent
+model instances for parallel candidate work.
+
+The executable Java scale harness is
+`CompiledProcessModelEvaluationPlanBenchmark`. Its default fixture contains 162 units across 20
+areas and writes compilation/evaluation time, main-thread allocation, strict result size, exact
+coverage, convergence, restoration, and mass closure without a CI wall-time assertion.
+
 ---
 
 ## Overview
@@ -1837,4 +1902,3 @@ try {
 | `getMaxUtilization()` | Get maximum utilization across constraints |
 | `isOverloaded()` | Any constraint > 100% |
 | `isHardLimitExceeded()` | Any HARD constraint violated |
-

--- a/docs/process/optimization/benchmarks/compiled-plan-large-71835e21.json
+++ b/docs/process/optimization/benchmarks/compiled-plan-large-71835e21.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "1.0",
+  "campaign": 3154,
+  "sourceBase": "71835e21ef7e9c7b5a0ba809126c17b99aa864d8",
+  "fixture": "compiled-process-model-evaluation-plan",
+  "fixtureProvenance": "#3154 maintained multi-area compiled-plan fixture",
+  "command": "./mvnw -B -ntp -DskipTests -Dexec.classpathScope=test -Dexec.mainClass=neqsim.process.util.optimizer.CompiledProcessModelEvaluationPlanBenchmark -Dexec.args='target/benchmarks/compiled-process-model-evaluation-plan.json 20 2' exec:java",
+  "environment": {
+    "javaVersion": "17.0.20",
+    "osName": "Linux",
+    "availableProcessors": 8,
+    "maxHeapBytes": 5368709120,
+    "mainThreadAllocationOnly": true
+  },
+  "model": {
+    "areas": 20,
+    "units": 162,
+    "eos": "SRK",
+    "mixingRule": 2,
+    "components": 12,
+    "feedMassFlowKgHr": 12000.0,
+    "candidateMassFlowKgHr": 12120.0,
+    "installedExportLimitKgHr": 14000.0,
+    "massClosureToleranceKgHr": 0.05
+  },
+  "result": {
+    "compileElapsedNs": 2689549205,
+    "compileMainThreadAllocatedBytes": 1154759416,
+    "evaluationElapsedNs": 1159243826,
+    "evaluationMainThreadAllocatedBytes": 694325784,
+    "resultJsonBytes": 79243,
+    "expectedInstalledCapacityRows": 41,
+    "expectedBoundaryRows": 1,
+    "candidateAccepted": true,
+    "candidateConverged": true,
+    "baselineRestored": true,
+    "baselineReconverged": true,
+    "restoredFeedKgHr": 11999.999999999996,
+    "restoredProductsKgHr": 11999.999999999996,
+    "restoredMassResidualKgHr": 0.0
+  },
+  "acceptance": {
+    "minimumAreas": 6,
+    "minimumUnits": 150,
+    "exactCoverageRequired": true,
+    "finiteEvidenceRequired": true,
+    "completeRestorationRequired": true,
+    "wallTimeAssertion": false,
+    "speedupClaim": false
+  },
+  "limitations": [
+    "Allocation covers the main thread only.",
+    "Maximum heap is a JVM bound, not measured peak resident memory.",
+    "The fixture advances compiled evaluator scale qualification but does not complete recycle, water-handling, shared-resource transition, or discrete-lineup acceptance."
+  ]
+}

--- a/docs/process/optimization/industrial-sm-benchmark.md
+++ b/docs/process/optimization/industrial-sm-benchmark.md
@@ -240,3 +240,26 @@ threads and the 512 MB maximum heap is a JVM bound, not measured peak usage. The
 piping, compressor, separator and export-quality sequence, complete L fixture, separator
 carry-over/slug evidence, and qualified piping screening envelopes therefore remain open. No
 missing metric or transition is represented as a passed gate.
+
+## Compiled evaluator L-scale increment
+
+The compiled fail-closed evaluator was exercised on the maintained 162-unit, 20-area serial
+`ProcessModel` shape at source base `71835e21ef7e9c7b5a0ba809126c17b99aa864d8`. The added
+`CompiledProcessModelEvaluationPlanBenchmark` configures one bounded feed action, a 14,000 kg/h
+installed export rating, and a hard whole-plant mass-closure boundary. Compilation freezes 41 exact
+installed-capacity identities and one process-boundary identity before evaluating the changed
+12,120 kg/h candidate.
+
+The recorded run compiled the plan in 2.689549205 s with 1,154,759,416 main-thread allocated bytes
+and evaluated the changed candidate in 1.159243826 s with 694,325,784 main-thread allocated bytes.
+The strict authoritative result was 79,243 bytes. The candidate converged and was accepted; every
+action restored, the 12,000 kg/h baseline reconverged, and restored feed and product mass were both
+11,999.999999999996 kg/h, giving a zero recorded mass residual. Raw environment, model, command,
+budget, and limitation evidence is retained in
+[`benchmarks/compiled-plan-large-71835e21.json`](benchmarks/compiled-plan-large-71835e21.json).
+
+These are single-run acceptance budgets, not CI timing limits or a #2939 speedup claim. Allocation
+is main-thread-only and the 5 GiB maximum heap is not measured peak memory. This increment proves
+compiled-plan scale, exact evidence coverage, strict JSON size, convergence, and restoration. It
+does not yet add the full recycle, water-handling, common-shaft/total-power transition, discrete
+line-up, or bounded mixed continuous/discrete orchestration required by the final L fixture.

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlan.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlan.java
@@ -1,0 +1,673 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProcessModelOperatingAction.ActionState;
+import neqsim.process.util.optimizer.ProcessModelOperatingActionEvaluator.HydraulicConstraintBinding;
+import neqsim.process.util.optimizer.ProcessModelOperatingActionSetEvaluator.CandidateSetEvaluationResult;
+
+/**
+ * Immutable fail-closed plan for repeated transactional {@link ProcessModel} evaluations.
+ *
+ * <p>
+ * Compilation qualifies the current converged baseline through the supplied
+ * {@link ProcessModelOperatingActionSetEvaluator}, then freezes area order and structure versions, action and
+ * hydraulic-binding definitions, evaluator configuration, and exact installed-capacity and process-boundary coverage.
+ * Candidate evaluation is refused before mutation when any frozen definition has changed. A delegated candidate is
+ * accepted only when the full model converged, every action was restored, the restored baseline reconverged, and the
+ * exact expected evidence remains finite and complete.
+ * </p>
+ *
+ * <p>
+ * The plan deliberately does not schedule candidates concurrently because all candidates share mutable equipment. Use
+ * independently cloned models and independently compiled plans for parallel optimization. The class adds no equipment
+ * physics and does not infer missing capacity ratings.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public final class ProcessModelCompiledEvaluationPlan implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1L;
+
+  /** JSON schema version. */
+  private static final String SCHEMA_VERSION = "1.0";
+
+  /** Stable plan identifier. */
+  private final String id;
+
+  /** Human-readable plan name. */
+  private final String name;
+
+  /** Engineering provenance for compilation. */
+  private final String provenance;
+
+  /** Exact source baseline supplied by the caller. */
+  private final String sourceBaseline;
+
+  /** Mutable evaluator authority used only through synchronized evaluation. */
+  private final ProcessModelOperatingActionSetEvaluator evaluator;
+
+  /** Frozen area names in model insertion order. */
+  private final List<String> areaNames;
+
+  /** Frozen ProcessSystem structure versions in area order. */
+  private final List<Long> areaStructureVersions;
+
+  /** Frozen action definitions in declaration order. */
+  private final List<String> actionDefinitions;
+
+  /** Frozen hydraulic-binding definitions in declaration order. */
+  private final List<String> hydraulicBindingDefinitions;
+
+  /** Frozen evaluator definition JSON. */
+  private final String evaluatorDefinitionJson;
+
+  /** Exact expected installed-capacity identities in deterministic order. */
+  private final List<String> expectedInstalledCapacityIdentities;
+
+  /** Frozen installed-capacity definitions in deterministic identity order. */
+  private final List<String> expectedInstalledCapacityDefinitions;
+
+  /** Exact expected process-boundary identities in deterministic order. */
+  private final List<String> expectedBoundaryIdentities;
+
+  /** Baseline qualification evidence retained without mutable callbacks. */
+  private final CandidateSetEvaluationResult compilationEvidence;
+
+  /** Result classification for a compiled candidate. */
+  public enum Outcome {
+    /** Candidate passed every frozen-plan and delegated evaluation gate. */
+    ACCEPTED,
+    /** Candidate vector was null, incorrectly sized, or non-finite. */
+    CANDIDATE_VECTOR_INVALID,
+    /** Topology, actions, bindings, evaluator configuration, or installed ratings changed. */
+    PLAN_STALE,
+    /** The transactional evaluator rejected the candidate. */
+    CANDIDATE_REJECTED,
+    /** Candidate evidence did not contain the exact finite compiled coverage. */
+    EVIDENCE_INCOMPLETE,
+    /** Candidate actions or the converged baseline were not completely restored. */
+    RESTORATION_FAILED
+  }
+
+  /** Creates a compiled plan from already qualified immutable evidence. */
+  private ProcessModelCompiledEvaluationPlan(String id, String name, String provenance, String sourceBaseline,
+      ProcessModelOperatingActionSetEvaluator evaluator, CandidateSetEvaluationResult compilationEvidence) {
+    this.id = id;
+    this.name = name;
+    this.provenance = provenance;
+    this.sourceBaseline = sourceBaseline;
+    this.evaluator = evaluator;
+    ProcessModel model = evaluator.getSimulationEvaluator().getProcessModel();
+    this.areaNames = immutableStrings(model.getProcessSystemNames());
+    this.areaStructureVersions = captureAreaStructureVersions(model, areaNames);
+    this.actionDefinitions = actionDefinitions(evaluator.getActions());
+    this.hydraulicBindingDefinitions = bindingDefinitions(evaluator.getRequiredHydraulicConstraints());
+    this.evaluatorDefinitionJson = evaluator.getSimulationEvaluator().toJson();
+    this.expectedInstalledCapacityIdentities = installedIdentities(
+        compilationEvidence.getInstalledEquipmentCapacityEvidence());
+    this.expectedInstalledCapacityDefinitions = installedDefinitions(
+        compilationEvidence.getInstalledEquipmentCapacityEvidence());
+    this.expectedBoundaryIdentities = boundaryIdentities(compilationEvidence.getProcessBoundaryConstraintEvidence());
+    this.compilationEvidence = compilationEvidence;
+  }
+
+  /**
+   * Compiles and qualifies a transactional evaluation plan at the current baseline.
+   *
+   * <p>
+   * The current action values are evaluated as a no-change candidate. Compilation fails unless that candidate is fully
+   * feasible, all actions restore, the baseline reconverges, and at least one installed-capacity constraint is present.
+   * </p>
+   *
+   * @param id stable plan identifier
+   * @param name human-readable plan name
+   * @param provenance engineering source for the selected actions and required evidence
+   * @param sourceBaseline exact source or configuration baseline identifier
+   * @param evaluator configured transactional evaluator
+   * @return immutable compiled plan
+   */
+  public static ProcessModelCompiledEvaluationPlan compile(String id, String name, String provenance,
+      String sourceBaseline, ProcessModelOperatingActionSetEvaluator evaluator) {
+    String safeId = requireText(id, "Compiled-plan identifier");
+    String safeName = requireText(name, "Compiled-plan name");
+    String safeProvenance = requireText(provenance, "Compiled-plan provenance");
+    String safeBaseline = requireText(sourceBaseline, "Compiled-plan source baseline");
+    if (evaluator == null) {
+      throw new IllegalArgumentException("Transactional evaluator is required");
+    }
+    if (evaluator.getRequiredHydraulicConstraints().isEmpty()) {
+      throw new IllegalStateException("At least one exact hydraulic constraint is required before compilation");
+    }
+    ProcessModel model = evaluator.getSimulationEvaluator().getProcessModel();
+    if (model == null) {
+      throw new IllegalStateException("Transactional evaluator must contain a process model");
+    }
+    try {
+      model.run();
+    } catch (RuntimeException exception) {
+      throw new IllegalStateException("Compiled-plan baseline run failed: " + safeMessage(exception), exception);
+    }
+    if (!model.isModelConverged()) {
+      throw new IllegalStateException("Compiled-plan baseline did not converge");
+    }
+    List<ProcessModelOperatingAction> actions = evaluator.getActions();
+    double[] baselineValues = new double[actions.size()];
+    for (int index = 0; index < actions.size(); index++) {
+      ActionState state = actions.get(index).capture(model);
+      baselineValues[index] = state.getValue();
+      if (!Double.isFinite(baselineValues[index])) {
+        throw new IllegalStateException("Compiled-plan baseline action is non-finite: " + actions.get(index).getId());
+      }
+    }
+    CandidateSetEvaluationResult qualification = evaluator.evaluate(baselineValues);
+    if (!qualification.isFeasible() || !qualification.isCandidateSimulationConverged()
+        || !qualification.isBaselineRestored() || !qualification.isBaselineSimulationConverged()) {
+      throw new IllegalStateException("Compiled-plan baseline qualification failed: " + qualification.getOutcome() + " "
+          + qualification.getDiagnostics());
+    }
+    if (qualification.getInstalledEquipmentCapacityEvidence().isEmpty()) {
+      throw new IllegalStateException("Compiled plan requires at least one installed-capacity evidence row");
+    }
+    List<String> diagnostics = validateEvidence(qualification,
+        installedIdentities(qualification.getInstalledEquipmentCapacityEvidence()),
+        boundaryIdentities(qualification.getProcessBoundaryConstraintEvidence()));
+    if (!diagnostics.isEmpty()) {
+      throw new IllegalStateException("Compiled-plan baseline evidence is incomplete: " + diagnostics);
+    }
+    return new ProcessModelCompiledEvaluationPlan(safeId, safeName, safeProvenance, safeBaseline, evaluator,
+        qualification);
+  }
+
+  /**
+   * Evaluates one candidate against the frozen plan and complete transactional replay.
+   *
+   * @param candidateValues values in action declaration order and declared units
+   * @return immutable fail-closed result
+   */
+  public synchronized EvaluationResult evaluate(double[] candidateValues) {
+    double[] candidates = candidateValues == null ? new double[0]
+        : Arrays.copyOf(candidateValues, candidateValues.length);
+    List<String> diagnostics = new ArrayList<String>();
+    if (candidateValues == null || candidates.length != actionDefinitions.size()) {
+      diagnostics.add("Candidate vector length must equal the compiled action count " + actionDefinitions.size());
+      return EvaluationResult.rejected(this, candidates, Outcome.CANDIDATE_VECTOR_INVALID, null, diagnostics);
+    }
+    for (int index = 0; index < candidates.length; index++) {
+      if (!Double.isFinite(candidates[index])) {
+        diagnostics.add("Candidate value is non-finite at action index " + index);
+        return EvaluationResult.rejected(this, candidates, Outcome.CANDIDATE_VECTOR_INVALID, null, diagnostics);
+      }
+    }
+    diagnostics.addAll(inspectStaleness());
+    if (!diagnostics.isEmpty()) {
+      return EvaluationResult.rejected(this, candidates, Outcome.PLAN_STALE, null, diagnostics);
+    }
+
+    CandidateSetEvaluationResult candidate = evaluator.evaluate(candidates);
+    if (!candidate.isBaselineRestored() || !candidate.isBaselineSimulationConverged()) {
+      diagnostics.add("Transactional evaluator did not completely restore a converged baseline");
+      diagnostics.addAll(candidate.getDiagnostics());
+      return EvaluationResult.rejected(this, candidates, Outcome.RESTORATION_FAILED, candidate, diagnostics);
+    }
+    if (!candidate.isFeasible()) {
+      diagnostics.add("Transactional evaluator rejected the candidate: " + candidate.getOutcome());
+      diagnostics.addAll(candidate.getDiagnostics());
+      return EvaluationResult.rejected(this, candidates, Outcome.CANDIDATE_REJECTED, candidate, diagnostics);
+    }
+
+    diagnostics.addAll(validateEvidence(candidate, expectedInstalledCapacityIdentities, expectedBoundaryIdentities));
+    if (!expectedInstalledCapacityDefinitions
+        .equals(installedDefinitions(candidate.getInstalledEquipmentCapacityEvidence()))) {
+      diagnostics.add("Installed-capacity definitions differ from the compiled rating snapshot");
+    }
+    if (!diagnostics.isEmpty()) {
+      return EvaluationResult.rejected(this, candidates, Outcome.EVIDENCE_INCOMPLETE, candidate, diagnostics);
+    }
+    return EvaluationResult.accepted(this, candidates, candidate);
+  }
+
+  /** Returns diagnostics when any frozen plan definition has changed. */
+  private List<String> inspectStaleness() {
+    List<String> diagnostics = new ArrayList<String>();
+    ProcessModel model = evaluator.getSimulationEvaluator().getProcessModel();
+    if (model == null) {
+      diagnostics.add("Compiled process model is no longer available");
+      return diagnostics;
+    }
+    List<String> currentAreas = model.getProcessSystemNames();
+    if (!areaNames.equals(currentAreas)) {
+      diagnostics.add("ProcessModel area order or identity changed after compilation");
+      return diagnostics;
+    }
+    List<Long> currentVersions = captureAreaStructureVersions(model, currentAreas);
+    if (!areaStructureVersions.equals(currentVersions)) {
+      diagnostics.add("At least one ProcessSystem structure version changed after compilation");
+    }
+    if (!actionDefinitions.equals(actionDefinitions(evaluator.getActions()))) {
+      diagnostics.add("Operating-action definitions changed after compilation");
+    }
+    if (!hydraulicBindingDefinitions.equals(bindingDefinitions(evaluator.getRequiredHydraulicConstraints()))) {
+      diagnostics.add("Required hydraulic bindings changed after compilation");
+    }
+    if (!evaluatorDefinitionJson.equals(evaluator.getSimulationEvaluator().toJson())) {
+      diagnostics.add("Simulation evaluator definition changed after compilation");
+    }
+    List<InstalledEquipmentCapacityEvidence> currentCapacity = evaluator.getSimulationEvaluator()
+        .snapshotInstalledEquipmentCapacityEvidence(model);
+    if (!expectedInstalledCapacityDefinitions.equals(installedDefinitions(currentCapacity))) {
+      diagnostics.add("Installed-capacity availability or rating changed after compilation");
+    }
+    return diagnostics;
+  }
+
+  /** Verifies exact identities and finite evidence for a completed feasible candidate. */
+  private static List<String> validateEvidence(CandidateSetEvaluationResult result,
+      List<String> expectedInstalledIdentities, List<String> expectedBoundaryIdentities) {
+    List<String> diagnostics = new ArrayList<String>();
+    List<InstalledEquipmentCapacityEvidence> installed = result.getInstalledEquipmentCapacityEvidence();
+    List<String> installedIds = installedIdentities(installed);
+    if (!expectedInstalledIdentities.equals(installedIds)) {
+      diagnostics.add("Installed-capacity coverage differs from the compiled exact identity set");
+    }
+    for (InstalledEquipmentCapacityEvidence evidence : installed) {
+      if (!evidence.hasFiniteEvidence() || !Double.isFinite(evidence.getPhysicalMargin())
+          || !Double.isFinite(evidence.getRequiredRelief())) {
+        diagnostics.add("Installed-capacity evidence is unavailable: " + evidence.getQualifiedConstraintName());
+      }
+    }
+    List<ProcessBoundaryConstraintEvidence> boundaries = result.getProcessBoundaryConstraintEvidence();
+    List<String> boundaryIds = boundaryIdentities(boundaries);
+    if (!expectedBoundaryIdentities.equals(boundaryIds)) {
+      diagnostics.add("Process-boundary coverage differs from the compiled exact identity set");
+    }
+    for (ProcessBoundaryConstraintEvidence evidence : boundaries) {
+      if (!evidence.isCalculable() || !Double.isFinite(evidence.getSampledValue())
+          || !Double.isFinite(evidence.getSignedMargin())) {
+        diagnostics.add("Process-boundary evidence is unavailable: " + evidence.getQualifiedConstraintName());
+      }
+    }
+    return diagnostics;
+  }
+
+  /** Captures ProcessSystem structure versions in exact area order. */
+  private static List<Long> captureAreaStructureVersions(ProcessModel model, List<String> names) {
+    List<Long> versions = new ArrayList<Long>();
+    for (String areaName : names) {
+      ProcessSystem area = model.get(areaName);
+      versions.add(Long.valueOf(area == null ? Long.MIN_VALUE : area.getStructureVersion()));
+    }
+    return Collections.unmodifiableList(versions);
+  }
+
+  /** Creates deterministic action definition strings. */
+  private static List<String> actionDefinitions(List<ProcessModelOperatingAction> actions) {
+    List<String> definitions = new ArrayList<String>();
+    for (ProcessModelOperatingAction action : actions) {
+      definitions.add(
+          action.getId() + "|" + action.getName() + "|" + action.getAddress() + "|" + action.getValueSemantics().name()
+              + "|" + Double.toString(action.getLowerBound()) + "|" + Double.toString(action.getUpperBound()) + "|"
+              + Arrays.toString(action.getAllowedValues()) + "|" + action.getUnit() + "|" + action.getProvenance() + "|"
+              + Double.toString(action.getReadBackAbsoluteTolerance()) + "|"
+              + Double.toString(action.getReadBackRelativeTolerance()) + "|" + action.getReadBackToleranceProvenance());
+    }
+    return immutableStrings(definitions);
+  }
+
+  /** Creates deterministic hydraulic-binding definition strings. */
+  private static List<String> bindingDefinitions(List<HydraulicConstraintBinding> bindings) {
+    List<String> definitions = new ArrayList<String>();
+    for (HydraulicConstraintBinding binding : bindings) {
+      definitions
+          .add(binding.getRole().name() + "|" + binding.getQualifiedConstraintName() + "|" + binding.getProvenance());
+    }
+    return immutableStrings(definitions);
+  }
+
+  /** Returns deterministic installed-capacity identities. */
+  private static List<String> installedIdentities(List<InstalledEquipmentCapacityEvidence> evidence) {
+    List<String> identities = new ArrayList<String>();
+    for (InstalledEquipmentCapacityEvidence row : evidence) {
+      identities.add(row.getQualifiedConstraintName());
+    }
+    Collections.sort(identities);
+    return immutableStrings(identities);
+  }
+
+  /** Returns deterministic installed-capacity definition signatures without sampled load. */
+  private static List<String> installedDefinitions(List<InstalledEquipmentCapacityEvidence> evidence) {
+    List<String> definitions = new ArrayList<String>();
+    for (InstalledEquipmentCapacityEvidence row : evidence) {
+      definitions.add(
+          row.getQualifiedConstraintName() + "|" + row.getEquipmentClassName() + "|" + row.getReferenceDesignation()
+              + "|" + row.getConstraintOrigin().name() + "|" + row.getConstraintType().name() + "|"
+              + row.getSeverity().name() + "|" + row.isEnabled() + "|" + row.getLimitDirection().name() + "|"
+              + Double.toString(row.getDesignValue()) + "|" + Double.toString(row.getMinimumValue()) + "|"
+              + Double.toString(row.getMaximumValue()) + "|" + Double.toString(row.getApplicableLimit()) + "|"
+              + Double.toString(row.getWarningThreshold()) + "|" + row.getPhysicalUnit() + "|" + row.getDataSource()
+              + "|" + row.hasConfidence() + "|" + Double.toString(row.getConfidence()) + "|" + row.hasValidityRange()
+              + "|" + Double.toString(row.getValidityMinimum()) + "|" + Double.toString(row.getValidityMaximum()));
+    }
+    Collections.sort(definitions);
+    return immutableStrings(definitions);
+  }
+
+  /** Returns deterministic process-boundary identities. */
+  private static List<String> boundaryIdentities(List<ProcessBoundaryConstraintEvidence> evidence) {
+    List<String> identities = new ArrayList<String>();
+    for (ProcessBoundaryConstraintEvidence row : evidence) {
+      identities.add(row.getQualifiedConstraintName());
+    }
+    Collections.sort(identities);
+    return immutableStrings(identities);
+  }
+
+  /** Returns an immutable defensive string list. */
+  private static List<String> immutableStrings(List<String> values) {
+    return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+
+  /** Requires non-empty trimmed text. */
+  private static String requireText(String value, String label) {
+    if (value == null || value.trim().length() == 0) {
+      throw new IllegalArgumentException(label + " is required");
+    }
+    return value;
+  }
+
+  /** Returns a safe exception message. */
+  private static String safeMessage(RuntimeException exception) {
+    return exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage();
+  }
+
+  /** @return stable compiled-plan identifier */
+  public String getId() {
+    return id;
+  }
+
+  /** @return human-readable compiled-plan name */
+  public String getName() {
+    return name;
+  }
+
+  /** @return engineering provenance for compilation */
+  public String getProvenance() {
+    return provenance;
+  }
+
+  /** @return exact source baseline supplied by the caller */
+  public String getSourceBaseline() {
+    return sourceBaseline;
+  }
+
+  /** @return fresh immutable area names in compiled order */
+  public List<String> getAreaNames() {
+    return immutableStrings(areaNames);
+  }
+
+  /** @return fresh immutable ProcessSystem structure versions in area order */
+  public List<Long> getAreaStructureVersions() {
+    return Collections.unmodifiableList(new ArrayList<Long>(areaStructureVersions));
+  }
+
+  /** @return fresh immutable operating-action definitions in declaration order */
+  public List<String> getActionDefinitions() {
+    return immutableStrings(actionDefinitions);
+  }
+
+  /** @return fresh immutable required hydraulic-binding definitions in declaration order */
+  public List<String> getHydraulicBindingDefinitions() {
+    return immutableStrings(hydraulicBindingDefinitions);
+  }
+
+  /** @return fresh immutable exact installed-capacity identities */
+  public List<String> getExpectedInstalledCapacityIdentities() {
+    return immutableStrings(expectedInstalledCapacityIdentities);
+  }
+
+  /** @return fresh immutable exact process-boundary identities */
+  public List<String> getExpectedBoundaryIdentities() {
+    return immutableStrings(expectedBoundaryIdentities);
+  }
+
+  /** @return immutable no-change baseline qualification evidence */
+  public CandidateSetEvaluationResult getCompilationEvidence() {
+    return compilationEvidence;
+  }
+
+  /** @return true when every frozen definition still matches the attached model and evaluator */
+  public boolean isCurrent() {
+    return inspectStaleness().isEmpty();
+  }
+
+  /** @return fresh immutable staleness diagnostics */
+  public List<String> getStalenessDiagnostics() {
+    return immutableStrings(inspectStaleness());
+  }
+
+  /**
+   * Returns a deterministic JSON-friendly compiled-plan definition.
+   *
+   * @return fresh ordered definition map
+   */
+  public Map<String, Object> getDefinition() {
+    Map<String, Object> definition = new LinkedHashMap<String, Object>();
+    definition.put("schemaVersion", SCHEMA_VERSION);
+    definition.put("type", "ProcessModelCompiledEvaluationPlan");
+    definition.put("id", id);
+    definition.put("name", name);
+    definition.put("provenance", provenance);
+    definition.put("sourceBaseline", sourceBaseline);
+    definition.put("areaNames", getAreaNames());
+    definition.put("areaStructureVersions", getAreaStructureVersions());
+    definition.put("actions", getActionDefinitions());
+    definition.put("hydraulicBindings", getHydraulicBindingDefinitions());
+    definition.put("evaluator", sanitize(JsonParser.parseString(evaluatorDefinitionJson)));
+    definition.put("expectedInstalledCapacityIdentities", getExpectedInstalledCapacityIdentities());
+    definition.put("expectedBoundaryIdentities", getExpectedBoundaryIdentities());
+    Gson evidenceGson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+    definition.put("compilationEvidence", sanitize(evidenceGson.toJsonTree(compilationEvidence)));
+    definition.put("current", Boolean.valueOf(isCurrent()));
+    definition.put("stalenessDiagnostics", getStalenessDiagnostics());
+    return definition;
+  }
+
+  /** @return strict JSON plan definition with no non-finite numeric tokens */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(getDefinition());
+  }
+
+  /** Immutable result from one compiled-plan evaluation. */
+  public static final class EvaluationResult implements Serializable {
+    /** Serialization version UID. */
+    private static final long serialVersionUID = 1L;
+
+    /** Stable compiled-plan identifier. */
+    private final String planId;
+
+    /** Human-readable compiled-plan name. */
+    private final String planName;
+
+    /** Engineering provenance retained from compilation. */
+    private final String planProvenance;
+
+    /** Exact source baseline retained from compilation. */
+    private final String sourceBaseline;
+
+    /** Requested candidate values. */
+    private final double[] candidateValues;
+
+    /** Fail-closed outcome. */
+    private final Outcome outcome;
+
+    /** Complete delegated evidence, or null when rejected before model mutation. */
+    private final CandidateSetEvaluationResult candidateEvidence;
+
+    /** Exact expected installed-capacity coverage retained for external audit. */
+    private final List<String> expectedInstalledCapacityIdentities;
+
+    /** Exact expected process-boundary coverage retained for external audit. */
+    private final List<String> expectedBoundaryIdentities;
+
+    /** Immutable diagnostics. */
+    private final List<String> diagnostics;
+
+    /** Creates an immutable result. */
+    private EvaluationResult(ProcessModelCompiledEvaluationPlan plan, double[] candidateValues, Outcome outcome,
+        CandidateSetEvaluationResult candidateEvidence, List<String> diagnostics) {
+      this.planId = plan.id;
+      this.planName = plan.name;
+      this.planProvenance = plan.provenance;
+      this.sourceBaseline = plan.sourceBaseline;
+      this.candidateValues = Arrays.copyOf(candidateValues, candidateValues.length);
+      this.outcome = outcome;
+      this.candidateEvidence = candidateEvidence;
+      this.expectedInstalledCapacityIdentities = immutableStrings(plan.expectedInstalledCapacityIdentities);
+      this.expectedBoundaryIdentities = immutableStrings(plan.expectedBoundaryIdentities);
+      this.diagnostics = immutableStrings(diagnostics);
+    }
+
+    /** Creates an accepted result. */
+    private static EvaluationResult accepted(ProcessModelCompiledEvaluationPlan plan, double[] candidateValues,
+        CandidateSetEvaluationResult evidence) {
+      List<String> diagnostics = new ArrayList<String>();
+      diagnostics.add("Candidate passed the compiled plan and complete transactional replay");
+      return new EvaluationResult(plan, candidateValues, Outcome.ACCEPTED, evidence, diagnostics);
+    }
+
+    /** Creates a rejected result. */
+    private static EvaluationResult rejected(ProcessModelCompiledEvaluationPlan plan, double[] candidateValues,
+        Outcome outcome, CandidateSetEvaluationResult evidence, List<String> diagnostics) {
+      return new EvaluationResult(plan, candidateValues, outcome, evidence, diagnostics);
+    }
+
+    /** @return stable compiled-plan identifier */
+    public String getPlanId() {
+      return planId;
+    }
+
+    /** @return human-readable compiled-plan name */
+    public String getPlanName() {
+      return planName;
+    }
+
+    /** @return compiled-plan provenance */
+    public String getPlanProvenance() {
+      return planProvenance;
+    }
+
+    /** @return exact source baseline supplied at compilation */
+    public String getSourceBaseline() {
+      return sourceBaseline;
+    }
+
+    /** @return defensive candidate array */
+    public double[] getCandidateValues() {
+      return Arrays.copyOf(candidateValues, candidateValues.length);
+    }
+
+    /** @return fail-closed outcome */
+    public Outcome getOutcome() {
+      return outcome;
+    }
+
+    /** @return true only when every compiled and delegated acceptance gate passed */
+    public boolean isAccepted() {
+      return outcome == Outcome.ACCEPTED;
+    }
+
+    /** @return complete delegated immutable evidence, or null for a preflight rejection */
+    public CandidateSetEvaluationResult getCandidateEvidence() {
+      return candidateEvidence;
+    }
+
+    /** @return fresh immutable expected installed-capacity identities */
+    public List<String> getExpectedInstalledCapacityIdentities() {
+      return immutableStrings(expectedInstalledCapacityIdentities);
+    }
+
+    /** @return fresh immutable expected process-boundary identities */
+    public List<String> getExpectedBoundaryIdentities() {
+      return immutableStrings(expectedBoundaryIdentities);
+    }
+
+    /** @return fresh immutable diagnostics */
+    public List<String> getDiagnostics() {
+      return immutableStrings(diagnostics);
+    }
+
+    /** @return strict JSON with complete delegated evidence and non-finite values represented as null */
+    public String toJson() {
+      Gson evidenceGson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", SCHEMA_VERSION);
+      result.put("type", "ProcessModelCompiledEvaluationResult");
+      result.put("planId", planId);
+      result.put("planName", planName);
+      result.put("planProvenance", planProvenance);
+      result.put("sourceBaseline", sourceBaseline);
+      result.put("candidateValues", candidateValues);
+      result.put("outcome", outcome.name());
+      result.put("accepted", Boolean.valueOf(isAccepted()));
+      result.put("expectedInstalledCapacityIdentities", expectedInstalledCapacityIdentities);
+      result.put("expectedBoundaryIdentities", expectedBoundaryIdentities);
+      result.put("diagnostics", diagnostics);
+      JsonElement resultTree = evidenceGson.toJsonTree(result);
+      JsonObject root = sanitize(resultTree).getAsJsonObject();
+      root.add("candidateEvidence", sanitize(evidenceGson.toJsonTree(candidateEvidence)));
+      return new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(root);
+    }
+  }
+
+  /** Rebuilds a JSON tree with non-finite numeric primitives represented as JSON null. */
+  private static JsonElement sanitize(JsonElement element) {
+    if (element == null || element.isJsonNull()) {
+      return JsonNull.INSTANCE;
+    }
+    if (element.isJsonPrimitive()) {
+      JsonPrimitive primitive = element.getAsJsonPrimitive();
+      if (primitive.isNumber() && !Double.isFinite(primitive.getAsDouble())) {
+        return JsonNull.INSTANCE;
+      }
+      if (primitive.isString() && isNonFiniteToken(primitive.getAsString())) {
+        return JsonNull.INSTANCE;
+      }
+      return primitive;
+    }
+    if (element.isJsonArray()) {
+      JsonArray clean = new JsonArray();
+      for (JsonElement value : element.getAsJsonArray()) {
+        clean.add(sanitize(value));
+      }
+      return clean;
+    }
+    JsonObject clean = new JsonObject();
+    for (Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+      clean.add(entry.getKey(), sanitize(entry.getValue()));
+    }
+    return clean;
+  }
+
+  /** Returns true for exact non-finite tokens emitted by existing evaluator JSON views. */
+  private static boolean isNonFiniteToken(String value) {
+    return "NaN".equals(value) || "Infinity".equals(value) || "-Infinity".equals(value);
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlan.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlan.java
@@ -29,9 +29,10 @@ import neqsim.process.util.optimizer.ProcessModelOperatingActionSetEvaluator.Can
  * Compilation qualifies the current converged baseline through the supplied
  * {@link ProcessModelOperatingActionSetEvaluator}, then freezes area order and structure versions, action and
  * hydraulic-binding definitions, evaluator configuration, and exact installed-capacity and process-boundary coverage.
- * Candidate evaluation is refused before mutation when any frozen definition has changed. A delegated candidate is
- * accepted only when the full model converged, every action was restored, the restored baseline reconverged, and the
- * exact expected evidence remains finite and complete.
+ * The qualified model and area object identities are also frozen: equal names and structure counters do not authorize
+ * replacement instances. Candidate evaluation is refused before mutation when any frozen definition has changed. A
+ * delegated candidate is accepted only when the full model converged, every action was restored, the restored baseline
+ * reconverged, and the exact expected evidence remains finite and complete.
  * </p>
  *
  * <p>
@@ -64,6 +65,12 @@ public final class ProcessModelCompiledEvaluationPlan implements Serializable {
 
   /** Mutable evaluator authority used only through synchronized evaluation. */
   private final ProcessModelOperatingActionSetEvaluator evaluator;
+
+  /** Exact mutable model instance qualified at compilation. */
+  private final ProcessModel compiledModel;
+
+  /** Exact mutable area instances qualified at compilation, in area order. */
+  private final List<ProcessSystem> compiledAreas;
 
   /** Frozen area names in model insertion order. */
   private final List<String> areaNames;
@@ -117,7 +124,13 @@ public final class ProcessModelCompiledEvaluationPlan implements Serializable {
     this.sourceBaseline = sourceBaseline;
     this.evaluator = evaluator;
     ProcessModel model = evaluator.getSimulationEvaluator().getProcessModel();
+    this.compiledModel = model;
     this.areaNames = immutableStrings(model.getProcessSystemNames());
+    List<ProcessSystem> areas = new ArrayList<ProcessSystem>();
+    for (String areaName : areaNames) {
+      areas.add(model.get(areaName));
+    }
+    this.compiledAreas = Collections.unmodifiableList(areas);
     this.areaStructureVersions = captureAreaStructureVersions(model, areaNames);
     this.actionDefinitions = actionDefinitions(evaluator.getActions());
     this.hydraulicBindingDefinitions = bindingDefinitions(evaluator.getRequiredHydraulicConstraints());
@@ -253,10 +266,20 @@ public final class ProcessModelCompiledEvaluationPlan implements Serializable {
       diagnostics.add("Compiled process model is no longer available");
       return diagnostics;
     }
+    if (model != compiledModel) {
+      diagnostics.add("ProcessModel instance changed after compilation");
+      return diagnostics;
+    }
     List<String> currentAreas = model.getProcessSystemNames();
     if (!areaNames.equals(currentAreas)) {
       diagnostics.add("ProcessModel area order or identity changed after compilation");
       return diagnostics;
+    }
+    for (int index = 0; index < areaNames.size(); index++) {
+      if (model.get(areaNames.get(index)) != compiledAreas.get(index)) {
+        diagnostics.add("ProcessSystem instance changed after compilation: " + areaNames.get(index));
+        return diagnostics;
+      }
     }
     List<Long> currentVersions = captureAreaStructureVersions(model, currentAreas);
     if (!areaStructureVersions.equals(currentVersions)) {

--- a/src/test/java/neqsim/process/util/optimizer/CompiledProcessModelEvaluationPlanBenchmark.java
+++ b/src/test/java/neqsim/process/util/optimizer/CompiledProcessModelEvaluationPlanBenchmark.java
@@ -1,0 +1,268 @@
+package neqsim.process.util.optimizer;
+
+import java.io.BufferedWriter;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.network.NetworkDecisionVariable;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProcessModelCompiledEvaluationPlan.EvaluationResult;
+import neqsim.process.util.optimizer.ProcessModelOperatingActionEvaluator.HydraulicLimitRole;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Standalone raw-budget qualification for a compiled 162-unit, 20-area evaluation plan.
+ *
+ * <p>
+ * The fixture extends the maintained large multi-area steady-state shape with an explicit feed-rate action, exact
+ * installed export capacity, and a hard mass-closure boundary. It reports construction-independent compilation and
+ * candidate wall time, main-thread allocation, strict JSON size, coverage, convergence, restoration, and mass closure.
+ * No CI wall-time assertion or speedup claim is made.
+ * </p>
+ *
+ * <p>
+ * Arguments: output JSON path, area count, thermal stages per area. Defaults produce 162 units in 20 areas:
+ * {@code compiled-process-model-evaluation-plan.json 20 2}.
+ * </p>
+ */
+public final class CompiledProcessModelEvaluationPlanBenchmark {
+  /** Exact source label for the maintained fixture. */
+  private static final String FIXTURE_PROVENANCE = "#3154 maintained multi-area compiled-plan fixture";
+
+  /** Mutable fixture used only by one serialized benchmark path. */
+  private static final class Fixture {
+    private final ProcessModel model = new ProcessModel();
+    private final List<ProcessSystem> areas = new ArrayList<ProcessSystem>();
+    private final List<StreamInterface> products = new ArrayList<StreamInterface>();
+    private Stream feed;
+    private Separator exportSeparator;
+
+    /** Returns total terminal and removed-liquid product mass flow. */
+    private double productMassFlow() {
+      double total = 0.0;
+      for (StreamInterface product : products) {
+        total += product.getFlowRate("kg/hr");
+      }
+      return total;
+    }
+
+    /** Returns total ProcessSystem unit count. */
+    private int unitCount() {
+      int total = 0;
+      for (ProcessSystem area : areas) {
+        total += area.getUnitOperations().size();
+      }
+      return total;
+    }
+  }
+
+  /** Builds the maintained multi-area serial process. */
+  private static Fixture createFixture(int areaCount, int stagesPerArea) {
+    if (areaCount < 6 || stagesPerArea < 1) {
+      throw new IllegalArgumentException("Compiled-plan fixture requires at least six areas and one thermal stage");
+    }
+    Fixture fixture = new Fixture();
+    fixture.model.setMaxIterations(8);
+    StreamInterface current = null;
+    for (int areaIndex = 0; areaIndex < areaCount; areaIndex++) {
+      ProcessSystem area = new ProcessSystem("area " + areaIndex);
+      fixture.areas.add(area);
+      if (current == null) {
+        fixture.feed = new Stream("feed", fluid());
+        fixture.feed.setFlowRate(12000.0, "kg/hr");
+        area.add(fixture.feed);
+        current = fixture.feed;
+      }
+      Separator inletSeparator = new Separator("area " + areaIndex + " inlet separator", current);
+      area.add(inletSeparator);
+      fixture.products.add(inletSeparator.getLiquidOutStream());
+      Compressor compressor = new Compressor("area " + areaIndex + " compressor", inletSeparator.getGasOutStream());
+      compressor.setOutletPressure(90.0, "bara");
+      compressor.setIsentropicEfficiency(0.75);
+      area.add(compressor);
+      current = compressor.getOutletStream();
+      for (int stage = 0; stage < stagesPerArea; stage++) {
+        Heater heater = new Heater("area " + areaIndex + " heater " + stage, current);
+        heater.setOutTemperature(328.15 + stage);
+        area.add(heater);
+        Cooler cooler = new Cooler("area " + areaIndex + " cooler " + stage, heater.getOutletStream());
+        cooler.setOutTemperature(298.15 + stage);
+        area.add(cooler);
+        ThrottlingValve valve = new ThrottlingValve("area " + areaIndex + " valve " + stage, cooler.getOutletStream());
+        valve.setOutletPressure(90.0 - 10.0 * (stage + 1.0) / stagesPerArea, "bara");
+        area.add(valve);
+        current = valve.getOutletStream();
+      }
+      if (areaIndex == areaCount - 1) {
+        fixture.exportSeparator = new Separator("export separator", current);
+        area.add(fixture.exportSeparator);
+        fixture.products.add(fixture.exportSeparator.getGasOutStream());
+        fixture.products.add(fixture.exportSeparator.getLiquidOutStream());
+      }
+      fixture.model.add(area.getName(), area);
+    }
+    fixture.model.setUseOptimizedExecution(true);
+    return fixture;
+  }
+
+  /** Creates the normalized 12-component rich-gas feed. */
+  private static SystemInterface fluid() {
+    SystemInterface fluid = new SystemSrkEos(313.15, 80.0);
+    String[] names = { "nitrogen", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane",
+        "n-pentane", "n-hexane", "n-heptane", "n-octane" };
+    double[] fractions = { 0.01, 0.02, 0.65, 0.10, 0.06, 0.02, 0.03, 0.015, 0.015, 0.03, 0.03, 0.02 };
+    for (int index = 0; index < names.length; index++) {
+      fluid.addComponent(names[index], fractions[index]);
+    }
+    fluid.setMixingRule(2);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  /** Creates the compiled plan authority and exact expected coverage. */
+  private static ProcessModelOperatingActionSetEvaluator createEvaluator(final Fixture fixture) {
+    String exportArea = "area " + (fixture.areas.size() - 1);
+    CapacityConstraint exportCapacity = new CapacityConstraint("installed export mass rate", "kg/hr",
+        ConstraintType.HARD).setDesignValue(14000.0).setSeverity(ConstraintSeverity.HARD)
+        .setDataSource("maintained #3154 export rating").setConfidence(0.95).setValidityRange(10000.0, 14000.0)
+        .setValueSupplier(() -> fixture.productMassFlow());
+    fixture.exportSeparator.clearCapacityConstraints();
+    fixture.exportSeparator.addCapacityConstraint(exportCapacity);
+
+    ProcessModelSimulationEvaluator simulation = new ProcessModelSimulationEvaluator(fixture.model);
+    simulation.setIncludeStrategyCapacityConstraints(false);
+    simulation.addObjective("terminal production", model -> fixture.productMassFlow(),
+        ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE);
+    ProcessBoundaryConstraintEvidence.Metadata massClosure = new ProcessBoundaryConstraintEvidence.Metadata(
+        "whole-plant-mass-closure", exportArea, "whole plant", ProcessBoundaryConstraintEvidence.Kind.EXPORT_CAPACITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.NOT_APPLICABLE, NetworkDecisionVariable.RateBasis.MASS,
+        FIXTURE_PROVENANCE, 1.0, null, null, ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE,
+        "feed minus products", "steady-state component and total material balance", null, -1);
+    simulation.addBoundaryConstraint("whole plant mass residual", massClosure,
+        model -> ProcessBoundaryConstraintEvidence.Sample
+            .available(fixture.feed.getFlowRate("kg/hr") - fixture.productMassFlow()),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.EQUALITY, 0.0, Double.POSITIVE_INFINITY, 0.05,
+        "kg/hr", true, 10.0, 12000.0);
+    ProcessModelOperatingAction feedAction = ProcessModelOperatingAction.continuous("feed-mass-rate",
+        "Plant feed mass rate", "area 0::feed.flowRate", 10000.0, 13000.0, "kg/hr",
+        "maintained #3154 large-case feed envelope");
+    return new ProcessModelOperatingActionSetEvaluator("large-case-action-set", "Large-case feed action",
+        FIXTURE_PROVENANCE, simulation, Arrays.asList(feedAction))
+        .requireHydraulicConstraint(HydraulicLimitRole.PIPELINE_HYDRAULICS, exportArea, "export separator",
+            "installed export mass rate", "maintained #3154 export capacity");
+  }
+
+  /** Returns main-thread allocated bytes when the JVM exposes them. */
+  private static long allocatedBytes() {
+    java.lang.management.ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+    if (bean instanceof com.sun.management.ThreadMXBean) {
+      com.sun.management.ThreadMXBean allocationBean = (com.sun.management.ThreadMXBean) bean;
+      if (allocationBean.isThreadAllocatedMemorySupported() && allocationBean.isThreadAllocatedMemoryEnabled()) {
+        return allocationBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+      }
+    }
+    return -1L;
+  }
+
+  /** Returns a non-negative allocation delta or -1 when unavailable. */
+  private static long allocationDelta(long before, long after) {
+    return before < 0L || after < 0L ? -1L : after - before;
+  }
+
+  /**
+   * Runs one compilation and one changed candidate, then writes raw acceptance evidence.
+   *
+   * @param args output path, area count, and thermal stages per area
+   * @throws Exception if construction, simulation, acceptance, restoration, or output fails
+   */
+  public static void main(String[] args) throws Exception {
+    Path output = Paths.get(args.length > 0 ? args[0] : "compiled-process-model-evaluation-plan.json");
+    int areaCount = args.length > 1 ? Integer.parseInt(args[1]) : 20;
+    int stagesPerArea = args.length > 2 ? Integer.parseInt(args[2]) : 2;
+    Fixture fixture = createFixture(areaCount, stagesPerArea);
+    ProcessModelOperatingActionSetEvaluator evaluator = createEvaluator(fixture);
+
+    long compileAllocatedBefore = allocatedBytes();
+    long compileStart = System.nanoTime();
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("large-case-plan",
+        "Compiled large ProcessModel evaluation", FIXTURE_PROVENANCE, "runtime current-master source", evaluator);
+    long compileElapsed = System.nanoTime() - compileStart;
+    long compileAllocatedAfter = allocatedBytes();
+
+    long evaluationAllocatedBefore = allocatedBytes();
+    long evaluationStart = System.nanoTime();
+    EvaluationResult result = plan.evaluate(new double[] { 12120.0 });
+    long evaluationElapsed = System.nanoTime() - evaluationStart;
+    long evaluationAllocatedAfter = allocatedBytes();
+    String resultJson = result.toJson();
+
+    double restoredFeed = fixture.feed.getFlowRate("kg/hr");
+    double restoredProducts = fixture.productMassFlow();
+    double restoredMassResidual = restoredFeed - restoredProducts;
+    JsonObject report = new JsonObject();
+    report.addProperty("fixture", "compiled-process-model-evaluation-plan");
+    report.addProperty("provenance", FIXTURE_PROVENANCE);
+    report.addProperty("areas", fixture.areas.size());
+    report.addProperty("units", fixture.unitCount());
+    report.addProperty("compileElapsedNs", compileElapsed);
+    report.addProperty("compileMainThreadAllocatedBytes",
+        allocationDelta(compileAllocatedBefore, compileAllocatedAfter));
+    report.addProperty("evaluationElapsedNs", evaluationElapsed);
+    report.addProperty("evaluationMainThreadAllocatedBytes",
+        allocationDelta(evaluationAllocatedBefore, evaluationAllocatedAfter));
+    report.addProperty("resultJsonBytes", resultJson.getBytes(StandardCharsets.UTF_8).length);
+    report.addProperty("expectedInstalledCapacityRows", plan.getExpectedInstalledCapacityIdentities().size());
+    report.addProperty("expectedBoundaryRows", plan.getExpectedBoundaryIdentities().size());
+    report.addProperty("candidateAccepted", result.isAccepted());
+    report.addProperty("candidateConverged",
+        result.getCandidateEvidence() != null && result.getCandidateEvidence().isCandidateSimulationConverged());
+    report.addProperty("baselineRestored",
+        result.getCandidateEvidence() != null && result.getCandidateEvidence().isBaselineRestored());
+    report.addProperty("baselineReconverged",
+        result.getCandidateEvidence() != null && result.getCandidateEvidence().isBaselineSimulationConverged());
+    report.addProperty("restoredFeedKgHr", restoredFeed);
+    report.addProperty("restoredProductsKgHr", restoredProducts);
+    report.addProperty("restoredMassResidualKgHr", restoredMassResidual);
+    report.addProperty("javaVersion", System.getProperty("java.version"));
+    report.addProperty("osName", System.getProperty("os.name"));
+    report.addProperty("availableProcessors", Runtime.getRuntime().availableProcessors());
+    report.addProperty("maxHeapBytes", Runtime.getRuntime().maxMemory());
+    report.addProperty("mainThreadAllocationOnly", true);
+    report.addProperty("wallTimeAcceptanceAssertion", false);
+
+    Path parent = output.toAbsolutePath().getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    try (BufferedWriter writer = Files.newBufferedWriter(output, StandardCharsets.UTF_8)) {
+      new GsonBuilder().setPrettyPrinting().create().toJson(report, writer);
+    }
+    if (fixture.areas.size() < 6 || fixture.unitCount() < 150 || !result.isAccepted()
+        || Math.abs(restoredMassResidual) > 0.05) {
+      throw new IllegalStateException("Compiled large-case acceptance failed: " + report);
+    }
+  }
+
+  /** Prevents instantiation. */
+  private CompiledProcessModelEvaluationPlanBenchmark() {
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/CoolingDutyProductionAnalysisTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/CoolingDutyProductionAnalysisTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.util.optimizer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -928,6 +929,14 @@ public class CoolingDutyProductionAnalysisTest {
    * Builds process with compressor 2 using the SAME curve as compressor 1.
    */
   private ProcessSystem buildProcessWithIdenticalCompressors(double coolingDeltaT) {
+    return buildProcessWithIdenticalCompressors(coolingDeltaT, false);
+  }
+
+  /**
+   * Builds the synthetic design once; fixed hardware keeps the cooler separator at zero cooling and uses a constant
+   * pressure loss and temperature difference instead of outlet values frozen at the construction flow.
+   */
+  private ProcessSystem buildProcessWithIdenticalCompressors(double coolingDeltaT, boolean fixedHardware) {
     SystemInterface testSystem = createTestFluid();
     ProcessSystem processSystem = new ProcessSystem();
 
@@ -967,12 +976,19 @@ public class CoolingDutyProductionAnalysisTest {
 
     StreamInterface feedToSplitter2;
 
-    if (coolingDeltaT > 0) {
+    if (coolingDeltaT > 0 || fixedHardware) {
       Heater gasCooler = new Heater("Gas Cooler", finalSeparator.getGasOutStream());
       double inletTemp = finalSeparator.getGasOutStream().getTemperature("C");
       gasCooler.setOutTemperature(inletTemp - coolingDeltaT, "C");
       double inletPressure = finalSeparator.getGasOutStream().getPressure("bara");
-      gasCooler.setOutPressure(inletPressure - 0.5, "bara");
+      if (fixedHardware) {
+        // Select Kelvin before the relative-temperature specification, which uses the configured temperature unit.
+        gasCooler.setOutletTemperature(finalSeparator.getGasOutStream().getTemperature());
+        gasCooler.setdT(-coolingDeltaT);
+        gasCooler.setPressureDrop(0.5);
+      } else {
+        gasCooler.setOutPressure(inletPressure - 0.5, "bara");
+      }
       gasCooler.run();
       processSystem.add(gasCooler);
 
@@ -2589,22 +2605,21 @@ public class CoolingDutyProductionAnalysisTest {
   }
 
   /**
-   * 2026 Scenario: Cooling Effect Analysis with 3 Compressors. Compressors 1 and 2 have identical bundles (same
-   * compressor curve), and compressor 3 is in operation with its own curve. All compressors use smooth VFD motor power
-   * curves to avoid oscillation.
-   *
-   * Configuration: - ups1 and ups2: example_compressor_curve.json, 44.4 MW max at 7383 RPM - ups3:
-   * compressor_curve_ups3.json, 50 MW max at 6726 RPM - Cooler pressure drop: 0.5 bar
+   * 2026 synthetic cooling-effect regression with three compressors and smooth VFD driver curves. Compressor maps and
+   * separator ratings are generated once at the uncooled design point, then held fixed for the complete sweep. These
+   * generated maps are not vendor JSON curves or identical bundles: each uses its own design flow. The installed cooler
+   * and knockout remain present at zero cooling, with a constant 0.5 bar pressure loss. Production comparisons use only
+   * feasible, replayed optima on this unchanged hardware.
    */
   @Test
   public void test2026ScenarioCoolingAnalysisThreeCompressors() {
     logger.info("\n" + StringUtils.repeat("=", 110));
-    logger.info("2026 SCENARIO: COOLING EFFECT ANALYSIS - 3 COMPRESSORS (UPS1=UPS2 BUNDLE, UPS3 IN OPERATION)");
+    logger.info("2026 SCENARIO: COOLING EFFECT ANALYSIS - 3 COMPRESSORS WITH FIXED SYNTHETIC MAPS");
     logger.info(StringUtils.repeat("=", 110));
     logger.info("Configuration:");
-    System.out.println("  - Compressor 1 (ups1): example_compressor_curve.json, 44.4 MW max @ 7383 RPM");
-    logger.info("  - Compressor 2 (ups2): SAME curve as ups1 (identical bundle)");
-    logger.info("  - Compressor 3 (ups3): compressor_curve_ups3.json, 50 MW max @ 6726 RPM");
+    logger.info("  - Compressor 1 (ups1): synthetic generated map, 44.4 MW VFD driver");
+    logger.info("  - Compressor 2 (ups2): same map template, scaled to its design flow, 44.4 MW VFD driver");
+    logger.info("  - Compressor 3 (ups3): synthetic generated map, 50 MW VFD driver");
     logger.info("  - All compressors use SMOOTH VFD motor power curves");
     logger.info("  - Cooler pressure drop: 0.5 bar");
     logger.info("  - Cooling water: 10Â°C inlet, 20Â°C outlet (Î”T = 10Â°C)");
@@ -2622,8 +2637,11 @@ public class CoolingDutyProductionAnalysisTest {
     // Store results for table output
     List<double[]> results = new ArrayList<>();
 
-    // Get baseline (no cooling) first
-    ProcessSystem baselineProcess = buildProcessWithIdenticalCompressors(0.0);
+    // Size the liquid knockout and generate maps once at the uncooled design point. Then vary only cooling
+    // and feed rate on that installed plant; rebuilding at each temperature would redesign the compressor maps.
+    ProcessSystem baselineProcess = buildProcessWithIdenticalCompressors(0.0, true);
+    Heater installedCooler = (Heater) baselineProcess.getUnit("Gas Cooler");
+    installedCooler.setdT(0.0);
     Stream baselineInletStream = (Stream) baselineProcess.getUnit("Inlet Stream");
     double originalFlow = baselineInletStream.getFlowRate("kg/hr");
 
@@ -2638,6 +2656,7 @@ public class CoolingDutyProductionAnalysisTest {
     OptimizationResult baselineResult = baselineOptimizer.optimize(baselineProcess, baselineInletStream, baselineConfig,
         Collections.singletonList(baselineThroughputObjective), Collections.emptyList());
 
+    assertTrue(baselineResult.isFeasible(), baselineResult.getInfeasibilityDiagnosis());
     double baselineFlow = baselineResult.getOptimalRate();
     double baselineMSm3Day = baselineFlow / gasStdDensity * 24.0 / 1e6;
     String baselineBottleneck = baselineResult.getBottleneck() != null ? baselineResult.getBottleneck().getName()
@@ -2648,8 +2667,10 @@ public class CoolingDutyProductionAnalysisTest {
 
     // Sweep cooling from 0 to 15Â°C
     for (double coolingDeltaT = 0.0; coolingDeltaT <= 15.5; coolingDeltaT += 1.0) {
-      ProcessSystem process = buildProcessWithIdenticalCompressors(coolingDeltaT);
-      Stream inletStream = (Stream) process.getUnit("Inlet Stream");
+      ProcessSystem process = baselineProcess;
+      Stream inletStream = baselineInletStream;
+      inletStream.setFlowRate(originalFlow, "kg/hr");
+      installedCooler.setdT(-coolingDeltaT);
 
       ProductionOptimizer optimizer = new ProductionOptimizer();
       OptimizationConfig config = new OptimizationConfig(originalFlow * 0.9, originalFlow * 1.15).rateUnit("kg/hr")
@@ -2662,9 +2683,22 @@ public class CoolingDutyProductionAnalysisTest {
       OptimizationResult result = optimizer.optimize(process, inletStream, config,
           Collections.singletonList(throughputObjective), Collections.emptyList());
 
+      assertTrue(result.isFeasible(), "Cooling " + coolingDeltaT + ": " + result.getInfeasibilityDiagnosis());
+
       // Calculate cooling duty from cooler
       Heater cooler = (Heater) process.getUnit("Gas Cooler");
-      double coolingDutyKW = cooler != null ? -cooler.getDuty() / 1000.0 : 0.0;
+      assertEquals(coolingDeltaT, cooler.getInletStream().getTemperature() - cooler.getOutletStream().getTemperature(),
+          1.0e-8, "The requested temperature difference must survive every optimizer replay");
+      assertEquals(0.5, cooler.getInletStream().getPressure() - cooler.getOutletStream().getPressure(), 1.0e-8,
+          "The installed cooler pressure loss must remain constant");
+      assertEquals(result.getOptimalRate(), inletStream.getFlowRate("kg/hr"), originalFlow * 1.0e-8,
+          "The live plant must represent the verified optimum");
+      double coolingDutyKW = -cooler.getDuty() / 1000.0;
+      assertTrue(Double.isFinite(coolingDutyKW), "Duty must be finite");
+      // Holding temperature across a pressure loss can require heat input in the zero-cooling case.
+      if (coolingDeltaT > 0.0) {
+        assertTrue(coolingDutyKW > 0.0, "A cooled case must remove heat");
+      }
       double coolingDutyMW = coolingDutyKW / 1000.0;
 
       // Calculate cooling water requirement
@@ -2694,7 +2728,7 @@ public class CoolingDutyProductionAnalysisTest {
 
     // Print detailed results table
     logger.info("\n" + StringUtils.repeat("=", 140));
-    logger.info("2026 SCENARIO DETAILED RESULTS TABLE - 3 COMPRESSORS (UPS1=UPS2, UPS3 OPERATING)");
+    logger.info("2026 SCENARIO DETAILED RESULTS TABLE - 3 COMPRESSORS WITH FIXED SYNTHETIC MAPS");
     logger.info(StringUtils.repeat("=", 140));
     logger.info(String.format("%-12s %-18s %-18s %-16s %-18s %-14s %-18s", "Cooling(Â°C)", "Production(MSmÂ³/d)",
         "Production(kg/hr)", "Duty(MW)", "CoolingWater(mÂ³/hr)", "Increase(%)", "Increase(MSmÂ³/d)"));
@@ -2714,7 +2748,7 @@ public class CoolingDutyProductionAnalysisTest {
     double maxIncreaseMSm3 = results.get(results.size() - 1)[5];
 
     logger.info(StringUtils.repeat("-", 140));
-    System.out.println("\n2026 SCENARIO SUMMARY (3 Compressors - ups1=ups2 bundle, ups3 operating):");
+    logger.info("\n2026 SCENARIO SUMMARY (3 Compressors with fixed synthetic maps):");
     logger.info(String.format("  Baseline production (no cooling): %.2f MSmÂ³/day", baselineMSm3Day));
     logger.info(String.format("  Maximum production (%.0fÂ°C cooling): %.2f MSmÂ³/day", maxCooling, maxFlow));
     logger.info(String.format("  Total production increase: %.3f MSmÂ³/day (+%.2f%%)", maxIncreaseMSm3, maxIncrease));

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlanTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlanTest.java
@@ -1,0 +1,271 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.network.NetworkDecisionVariable;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProcessModelCompiledEvaluationPlan.EvaluationResult;
+import neqsim.process.util.optimizer.ProcessModelCompiledEvaluationPlan.Outcome;
+import neqsim.process.util.optimizer.ProcessModelOperatingActionEvaluator.HydraulicLimitRole;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests for {@link ProcessModelCompiledEvaluationPlan}. */
+class ProcessModelCompiledEvaluationPlanTest {
+  /** Controlled two-action process fixture. */
+  private static final class Fixture {
+    private final Stream producerA;
+    private final Stream producerB;
+    private final CapacityConstraint sharedCapacity;
+    private final ProcessSystem wells;
+    private final ProcessModel model;
+
+    private Fixture(Stream producerA, Stream producerB, CapacityConstraint sharedCapacity, ProcessSystem wells,
+        ProcessModel model) {
+      this.producerA = producerA;
+      this.producerB = producerB;
+      this.sharedCapacity = sharedCapacity;
+      this.wells = wells;
+      this.model = model;
+    }
+  }
+
+  /** Creates independently addressable producers with one exact installed and boundary capacity. */
+  private Fixture createFixture() {
+    SystemInterface fluidA = new SystemSrkEos(298.15, 50.0);
+    fluidA.addComponent("methane", 0.90);
+    fluidA.addComponent("ethane", 0.10);
+    fluidA.setMixingRule("classic");
+    fluidA.setTotalFlowRate(600.0, "kg/hr");
+    SystemInterface fluidB = fluidA.clone();
+    fluidB.setTotalFlowRate(400.0, "kg/hr");
+
+    Stream producerA = new Stream("producer A", fluidA);
+    Stream producerB = new Stream("producer B", fluidB);
+    ThrottlingValve chokeA = new ThrottlingValve("choke A", producerA);
+    ThrottlingValve chokeB = new ThrottlingValve("choke B", producerB);
+    chokeA.setOutletPressure(30.0, "bara");
+    chokeB.setOutletPressure(30.0, "bara");
+    Separator gatheringSink = new Separator("gathering sink", chokeA.getOutletStream());
+    CapacityConstraint sharedCapacity = new CapacityConstraint("installed gathering rate", "kg/hr", ConstraintType.HARD)
+        .setDesignValue(1200.0).setSeverity(ConstraintSeverity.HARD).setDataSource("synthetic shared manifold basis")
+        .setConfidence(0.95).setValidityRange(500.0, 1400.0)
+        .setValueSupplier(() -> producerA.getFlowRate("kg/hr") + producerB.getFlowRate("kg/hr"));
+    gatheringSink.clearCapacityConstraints();
+    gatheringSink.addCapacityConstraint(sharedCapacity);
+
+    ProcessSystem wells = new ProcessSystem("wells");
+    wells.add(producerA);
+    wells.add(producerB);
+    wells.add(chokeA);
+    wells.add(chokeB);
+    ProcessSystem gathering = new ProcessSystem("gathering");
+    gathering.add(gatheringSink);
+    ProcessModel model = new ProcessModel();
+    model.add("wells", wells);
+    model.add("gathering", gathering);
+    model.run();
+    return new Fixture(producerA, producerB, sharedCapacity, wells, model);
+  }
+
+  /** Creates the transactional authority used by the compiled plan. */
+  private ProcessModelOperatingActionSetEvaluator createEvaluator(Fixture fixture) {
+    ProcessModelSimulationEvaluator simulation = new ProcessModelSimulationEvaluator(fixture.model);
+    simulation.setIncludeStrategyCapacityConstraints(false);
+    simulation.addObjective("total production",
+        model -> fixture.producerA.getFlowRate("kg/hr") + fixture.producerB.getFlowRate("kg/hr"),
+        ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE);
+    ProcessBoundaryConstraintEvidence.Metadata boundary = new ProcessBoundaryConstraintEvidence.Metadata(
+        "host-receiving", "gathering", "host inlet", ProcessBoundaryConstraintEvidence.Kind.RECEIVING_CAPACITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.INTO_PROCESS, NetworkDecisionVariable.RateBasis.MASS,
+        "synthetic host receiving basis", 1.0, null, null,
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED, "total rate", null, null, -1);
+    simulation.addBoundaryConstraint("host receiving rate", boundary,
+        model -> ProcessBoundaryConstraintEvidence.Sample
+            .available(fixture.producerA.getFlowRate("kg/hr") + fixture.producerB.getFlowRate("kg/hr")),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 2000.0, 0.0,
+        "kg/hr", true, 10.0, 1000.0);
+    ProcessModelOperatingAction actionA = ProcessModelOperatingAction.continuous("producer-a-rate", "Producer A rate",
+        "wells::producer A.flowRate", 200.0, 1000.0, "kg/hr", "synthetic producer A envelope");
+    ProcessModelOperatingAction actionB = ProcessModelOperatingAction.continuous("producer-b-rate", "Producer B rate",
+        "wells::producer B.flowRate", 200.0, 1000.0, "kg/hr", "synthetic producer B envelope");
+    return new ProcessModelOperatingActionSetEvaluator("well-allocation", "Coupled well allocation",
+        "synthetic two-well allocation basis", simulation, Arrays.asList(actionA, actionB))
+        .requireHydraulicConstraint(HydraulicLimitRole.GATHERING_HYDRAULICS, "gathering", "gathering sink",
+            "installed gathering rate", "shared installed gathering capacity");
+  }
+
+  /** Compiles at a converged baseline and accepts only complete exact-coverage replay evidence. */
+  @Test
+  void compilesAndAcceptsCompleteCandidateEvidence() {
+    Fixture fixture = createFixture();
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline",
+        createEvaluator(fixture));
+
+    assertTrue(plan.isCurrent(), plan.getStalenessDiagnostics().toString());
+    assertEquals(Arrays.asList("wells", "gathering"), plan.getAreaNames());
+    assertEquals(1, plan.getExpectedInstalledCapacityIdentities().size());
+    assertEquals(1, plan.getExpectedBoundaryIdentities().size());
+    assertTrue(plan.getCompilationEvidence().isFeasible());
+
+    EvaluationResult result = plan.evaluate(new double[] { 700.0, 300.0 });
+    assertEquals(Outcome.ACCEPTED, result.getOutcome(), result.getDiagnostics().toString());
+    assertTrue(result.isAccepted());
+    assertTrue(result.getCandidateEvidence().isFeasible());
+    assertTrue(result.getCandidateEvidence().isBaselineRestored());
+    assertTrue(result.getCandidateEvidence().isBaselineSimulationConverged());
+    assertArrayEquals(new double[] { 600.0, 400.0 }, result.getCandidateEvidence().getBaselineValues(), 1.0e-8);
+    assertEquals(600.0, fixture.producerA.getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(400.0, fixture.producerB.getFlowRate("kg/hr"), 1.0e-8);
+
+    JsonObject planJson = JsonParser.parseString(plan.toJson()).getAsJsonObject();
+    JsonObject resultJson = JsonParser.parseString(result.toJson()).getAsJsonObject();
+    assertEquals("ProcessModelCompiledEvaluationPlan", planJson.get("type").getAsString());
+    assertTrue(planJson.get("current").getAsBoolean());
+    assertEquals("ACCEPTED", resultJson.get("outcome").getAsString());
+    assertEquals(1, resultJson.getAsJsonArray("expectedInstalledCapacityIdentities").size());
+    assertEquals(1, resultJson.getAsJsonArray("expectedBoundaryIdentities").size());
+    assertTrue(resultJson.getAsJsonObject("candidateEvidence").get("candidateSimulationConverged").getAsBoolean());
+  }
+
+  /** Rejects invalid values before any baseline run or candidate mutation. */
+  @Test
+  void rejectsNonFiniteAndWrongLengthCandidatesBeforeDelegation() {
+    Fixture fixture = createFixture();
+    ProcessModelOperatingActionSetEvaluator evaluator = createEvaluator(fixture);
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline", evaluator);
+    int evaluationsBefore = evaluator.getSimulationEvaluator().getEvaluationCount();
+
+    EvaluationResult nonFinite = plan.evaluate(new double[] { Double.NaN, 300.0 });
+    EvaluationResult wrongLength = plan.evaluate(new double[] { 700.0 });
+
+    assertEquals(Outcome.CANDIDATE_VECTOR_INVALID, nonFinite.getOutcome());
+    assertEquals(Outcome.CANDIDATE_VECTOR_INVALID, wrongLength.getOutcome());
+    assertNull(nonFinite.getCandidateEvidence());
+    assertEquals(evaluationsBefore, evaluator.getSimulationEvaluator().getEvaluationCount());
+    assertFalse(nonFinite.toJson().contains("NaN"));
+    assertFalse(nonFinite.toJson().contains("Infinity"));
+    assertEquals(600.0, fixture.producerA.getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(400.0, fixture.producerB.getFlowRate("kg/hr"), 1.0e-8);
+  }
+
+  /** Rejects structural model changes before candidate mutation. */
+  @Test
+  void rejectsStaleProcessSystemStructureBeforeDelegation() {
+    Fixture fixture = createFixture();
+    ProcessModelOperatingActionSetEvaluator evaluator = createEvaluator(fixture);
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline", evaluator);
+    int evaluationsBefore = evaluator.getSimulationEvaluator().getEvaluationCount();
+    Stream addedAfterCompilation = new Stream("late stream", fixture.producerA.getThermoSystem().clone());
+    fixture.wells.add(addedAfterCompilation);
+
+    EvaluationResult result = plan.evaluate(new double[] { 700.0, 300.0 });
+
+    assertEquals(Outcome.PLAN_STALE, result.getOutcome(), result.getDiagnostics().toString());
+    assertFalse(plan.isCurrent());
+    assertTrue(result.getDiagnostics().toString().contains("structure version"));
+    assertEquals(evaluationsBefore, evaluator.getSimulationEvaluator().getEvaluationCount());
+    assertEquals(600.0, fixture.producerA.getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(400.0, fixture.producerB.getFlowRate("kg/hr"), 1.0e-8);
+  }
+
+  /** Rejects changed installed ratings and evaluator definitions as stale compiled authority. */
+  @Test
+  void rejectsChangedRatingAndEvaluatorDefinition() {
+    Fixture ratingFixture = createFixture();
+    ProcessModelOperatingActionSetEvaluator ratingEvaluator = createEvaluator(ratingFixture);
+    ProcessModelCompiledEvaluationPlan ratingPlan = ProcessModelCompiledEvaluationPlan.compile("rating-plan",
+        "Compiled rating", "controlled rating qualification", "master-test-baseline", ratingEvaluator);
+    ratingFixture.sharedCapacity.setDesignValue(1300.0);
+
+    EvaluationResult changedRating = ratingPlan.evaluate(new double[] { 700.0, 300.0 });
+    assertEquals(Outcome.PLAN_STALE, changedRating.getOutcome(), changedRating.getDiagnostics().toString());
+    assertTrue(changedRating.getDiagnostics().toString().contains("rating"));
+
+    Fixture definitionFixture = createFixture();
+    ProcessModelOperatingActionSetEvaluator definitionEvaluator = createEvaluator(definitionFixture);
+    ProcessModelCompiledEvaluationPlan definitionPlan = ProcessModelCompiledEvaluationPlan.compile("definition-plan",
+        "Compiled definition", "controlled evaluator qualification", "master-test-baseline", definitionEvaluator);
+    definitionEvaluator.getSimulationEvaluator().addConstraintUpperBound("late constraint", model -> 0.0, 1.0);
+
+    EvaluationResult changedDefinition = definitionPlan.evaluate(new double[] { 700.0, 300.0 });
+    assertEquals(Outcome.PLAN_STALE, changedDefinition.getOutcome(), changedDefinition.getDiagnostics().toString());
+    assertTrue(changedDefinition.getDiagnostics().toString().contains("evaluator definition"));
+  }
+
+  /** Preserves complete rejected evidence and restores the baseline after a physical overload. */
+  @Test
+  void preservesRejectedEvidenceAndRestoresOverloadedCandidate() {
+    Fixture fixture = createFixture();
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline",
+        createEvaluator(fixture));
+
+    EvaluationResult result = plan.evaluate(new double[] { 800.0, 500.0 });
+
+    assertEquals(Outcome.CANDIDATE_REJECTED, result.getOutcome(), result.getDiagnostics().toString());
+    assertFalse(result.isAccepted());
+    assertNotSame(result.getDiagnostics(), result.getDiagnostics());
+    assertNotSame(result.getExpectedInstalledCapacityIdentities(), result.getExpectedInstalledCapacityIdentities());
+    assertTrue(result.getCandidateEvidence().isBaselineRestored());
+    assertTrue(result.getCandidateEvidence().isBaselineSimulationConverged());
+    assertFalse(result.getCandidateEvidence().isFeasible());
+    assertEquals(600.0, fixture.producerA.getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(400.0, fixture.producerB.getFlowRate("kg/hr"), 1.0e-8);
+    assertThrows(UnsupportedOperationException.class, () -> result.getDiagnostics().clear());
+  }
+
+  /** Keeps the complete accepted result serializable for Java and JPype consumers. */
+  @Test
+  void serializesImmutableAcceptedResult() throws Exception {
+    Fixture fixture = createFixture();
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline",
+        createEvaluator(fixture));
+    EvaluationResult original = plan.evaluate(new double[] { 700.0, 300.0 });
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(original);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    EvaluationResult restored = (EvaluationResult) input.readObject();
+    input.close();
+
+    assertTrue(restored.isAccepted());
+    assertEquals("allocation-plan", restored.getPlanId());
+    assertArrayEquals(new double[] { 700.0, 300.0 }, restored.getCandidateValues(), 0.0);
+    assertTrue(restored.getCandidateEvidence().isFeasible());
+    assertTrue(plan.toJson().contains("compilationEvidence"));
+    assertFalse(plan.toJson().contains("NaN"));
+    assertFalse(plan.toJson().contains("Infinity"), plan.toJson());
+    double[] values = restored.getCandidateValues();
+    values[0] = -1.0;
+    assertArrayEquals(new double[] { 700.0, 300.0 }, restored.getCandidateValues(), 0.0);
+    assertFalse(restored.toJson().contains("NaN"));
+    assertFalse(restored.toJson().contains("Infinity"));
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlanTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelCompiledEvaluationPlanTest.java
@@ -192,6 +192,47 @@ class ProcessModelCompiledEvaluationPlanTest {
     assertEquals(400.0, fixture.producerB.getFlowRate("kg/hr"), 1.0e-8);
   }
 
+  /** Equal area names and structure counters do not authorize a replacement model. */
+  @Test
+  void rejectsReplacementModelBeforeDelegation() {
+    Fixture fixture = createFixture();
+    ProcessModelOperatingActionSetEvaluator evaluator = createEvaluator(fixture);
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline", evaluator);
+    Fixture replacement = createFixture();
+    int evaluationsBefore = evaluator.getSimulationEvaluator().getEvaluationCount();
+    evaluator.getSimulationEvaluator().setProcessModel(replacement.model);
+
+    assertFalse(plan.isCurrent());
+    EvaluationResult result = plan.evaluate(new double[] { 700.0, 300.0 });
+    assertEquals(Outcome.PLAN_STALE, result.getOutcome(), result.getDiagnostics().toString());
+    assertNull(result.getCandidateEvidence());
+    assertEquals(evaluationsBefore, evaluator.getSimulationEvaluator().getEvaluationCount());
+    assertEquals(600.0, replacement.producerA.getFlowRate("kg/hr"), 1.0e-8);
+  }
+
+  /** Replacing an area with equal counters must invalidate its frozen object identity. */
+  @Test
+  void rejectsReplacementAreaBeforeDelegation() {
+    Fixture fixture = createFixture();
+    ProcessModelOperatingActionSetEvaluator evaluator = createEvaluator(fixture);
+    ProcessModelCompiledEvaluationPlan plan = ProcessModelCompiledEvaluationPlan.compile("allocation-plan",
+        "Compiled allocation", "controlled two-producer qualification", "master-test-baseline", evaluator);
+    Fixture replacement = createFixture();
+    assertEquals(fixture.model.get("gathering").getStructureVersion(),
+        replacement.model.get("gathering").getStructureVersion());
+    fixture.model.remove("gathering");
+    fixture.model.add("gathering", replacement.model.get("gathering"));
+    int evaluationsBefore = evaluator.getSimulationEvaluator().getEvaluationCount();
+
+    assertFalse(plan.isCurrent());
+    EvaluationResult result = plan.evaluate(new double[] { 700.0, 300.0 });
+    assertEquals(Outcome.PLAN_STALE, result.getOutcome(), result.getDiagnostics().toString());
+    assertNull(result.getCandidateEvidence());
+    assertEquals(evaluationsBefore, evaluator.getSimulationEvaluator().getEvaluationCount());
+    assertEquals(600.0, replacement.producerA.getFlowRate("kg/hr"), 1.0e-8);
+  }
+
   /** Rejects changed installed ratings and evaluator definitions as stale compiled authority. */
   @Test
   void rejectsChangedRatingAndEvaluatorDefinition() {

--- a/src/test/java/neqsim/process/util/optimizer/ProductionOptimizationGuideExamplesTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProductionOptimizationGuideExamplesTest.java
@@ -79,6 +79,7 @@ class ProductionOptimizationGuideExamplesTest extends NeqSimTest {
       + "static PlantConstraintRegistry registry;\n" + "static String calculationId;\n"
       + "static boolean fullModelConverged;\n" + "static PlantConstraintSample powerSample;\n"
       + "static ProcessModelSimulationEvaluator evaluator;\n"
+      + "static ProcessModelOperatingActionSetEvaluator transactionalEvaluator;\n"
       + "static ProcessModelDebottleneckStudy.StudyResult study1100, study1150, study1200;\n"
       + "static neqsim.process.equipment.stream.MechanicalShaft shaft;\n"
       + "static neqsim.process.equipment.stream.EnergyPort casingAPort, casingBPort, driverPort;\n"

--- a/src/test/python/test_production_optimization_guides.py
+++ b/src/test/python/test_production_optimization_guides.py
@@ -55,12 +55,63 @@ def production_context():
     process, feed, comp = create_process()
     optimizer_class = jneqsim.process.util.optimizer.ProductionOptimizer
     config_class = optimizer_class.OptimizationConfig
+    separator = process.getUnit("HP Separator")
+    capacity_class = jneqsim.process.equipment.capacity.CapacityConstraint
+    installed_capacity = capacity_class(
+        "installed gas rate",
+        "kg/hr",
+        capacity_class.ConstraintType.HARD,
+    ).setDesignValue(20000.0).setMaxValue(22000.0).setDataSource(
+        "executable documentation fixture",
+    ).setConfidence(0.95).setValidityRange(
+        5000.0,
+        20000.0,
+    ).setValueSupplier(lambda: feed.getFlowRate("kg/hr"))
+    separator.clearCapacityConstraints()
+    separator.addCapacityConstraint(installed_capacity)
+    process_model = jneqsim.process.processmodel.ProcessModel()
+    process_model.add("Production", process)
+    simulation_evaluator = (
+        jneqsim.process.util.optimizer.ProcessModelSimulationEvaluator(process_model)
+    )
+    simulation_evaluator.setIncludeStrategyCapacityConstraints(False)
+    simulation_evaluator.addObjective(
+        "feed production",
+        lambda model: feed.getFlowRate("kg/hr"),
+        simulation_evaluator.ObjectiveDefinition.Direction.MAXIMIZE,
+    )
+    action = jneqsim.process.util.optimizer.ProcessModelOperatingAction.continuous(
+        "feed-rate",
+        "Feed rate",
+        "Production::Well Feed.flowRate",
+        5000.0,
+        15000.0,
+        "kg/hr",
+        "executable documentation fixture",
+    )
+    action_list = jpype.JClass("java.util.ArrayList")()
+    action_list.add(action)
+    transactional_evaluator = (
+        jneqsim.process.util.optimizer.ProcessModelOperatingActionSetEvaluator(
+            "feed-action-set",
+            "Feed action set",
+            "executable documentation fixture",
+            simulation_evaluator,
+            action_list,
+        ).requireHydraulicConstraint(
+            jneqsim.process.util.optimizer.ProcessModelOperatingActionEvaluator.HydraulicLimitRole.GATHERING_HYDRAULICS,
+            "Production",
+            "HP Separator",
+            "installed gas rate",
+            "executable documentation fixture",
+        )
+    )
     return dict(
         jneqsim=jneqsim, jpype=jpype, process=process, feed=feed, comp=comp,
         OptConfig=config_class, ProductionOptimizer=optimizer_class,
         SearchMode=optimizer_class.SearchMode,
         config=config_class(1000.0, 20000.0).tolerance(10.0),
-        optimizer=optimizer_class(),
+        optimizer=optimizer_class(), transactional_evaluator=transactional_evaluator,
     )
 
 


### PR DESCRIPTION
Advances #3154.

## Summary

Adds one immutable, compiled, fail-closed authority for repeated `ProcessModel` candidate replay on top of the merged operating-action evaluator.

- qualifies the unchanged converged baseline before compilation;
- freezes exact area order, `ProcessSystem` structure versions, action/binding/evaluator definitions, installed ratings/availability, and exact installed-capacity plus process-boundary identities;
- rejects null, incorrectly sized, or non-finite vectors before model mutation;
- rejects stale topology/configuration/rating state before candidate mutation;
- accepts only converged, feasible candidates with exact finite evidence and complete, reconverged baseline restoration;
- exposes the same qualified compilation and candidate evidence through Java getters, JPype-compatible arrays/collections, and strict JSON where non-finite numeric tokens become `null`;
- deliberately serializes candidate access on shared mutable equipment and requires independent model instances for parallel work.

No new equipment physics, scheduling, caching, allocation, MCP surface, pipeline transient, flash, or column internals are introduced.

## Capability contract

**Engineering question.** Can an external bounded optimizer repeatedly evaluate a configured multi-area NeqSim plant without accepting stale, non-finite, unconverged, incompletely covered, or partially restored candidates?

**Maturity.** Current: transactional replay and immutable equipment/boundary evidence existed after #3597 and the earlier #3154 foundations. Target in this batch: contract-tested compiled replay authority with measured L-scale acceptance. This does not claim final campaign closure or industrial physics validation.

**Exact baseline.** `71835e21ef7e9c7b5a0ba809126c17b99aa864d8` (`docs: restore foundational package navigation (#3647)`). Exact publication head: `ad96bad818df51f42deada352cd90a3ae1fa554a`.

**Java authority and views.** `ProcessModelCompiledEvaluationPlan` wraps `ProcessModelOperatingActionSetEvaluator`. Java getters are authoritative; `toJson()` supplies strict JSON for Java/JPype consumers. The executable guide uses the same class and evaluator.

**Inputs.** Ordered action values in each action's declared unit; explicit plan ID/name/provenance/source baseline; a fully configured evaluator with objectives, required boundary constraints, and at least one exact hydraulic binding. Installed ratings and observations remain the existing NeqSim capacity evidence—missing evidence is never zero utilization.

**Outputs.** Stable outcome enum, immutable diagnostics, expected identity coverage, full delegated candidate evidence, baseline qualification evidence, strict JSON, convergence/restoration flags, physical margins and units from the existing evidence model.

**Basis, provenance, validity.** The plan freezes caller provenance, source baseline, area/structure identity, action and binding definitions, evaluator JSON, and installed rating/availability definitions. It does not infer design data or extend validity ranges.

**Acceptance.** Exact installed/boundary identity coverage; finite/calculable evidence; converged feasible candidate; complete reverse-order restoration and reconverged baseline. Physical violations retain complete evidence but are rejected. Restoration failure overrides all other classifications.

**Benchmark plan.** The added standalone harness executes 162 units across 20 areas, one bounded feed action, an explicit 14,000 kg/h installed export rating, and a hard 0.05 kg/h whole-plant mass-closure boundary. It records compile/evaluation wall time, main-thread allocation, JSON size, exact coverage, convergence and restoration. No CI wall-time assertion or #2939 speedup claim is made.

**Compatibility and documentation.** Additive Java 8-compatible API; no existing defaults changed. Javadocs, Java/JPype guide snippets, executable fence context, L-scale guide evidence, and raw JSON are included.

**Stop boundary.** This batch stops at compiled continuous-candidate replay and the measured serial L-scale increment. Bounded mixed continuous/discrete orchestration, the complete recycle/water-handling/shared-resource L fixture, and independent current-master closure audit remain for later #3154 batches. Generic scheduling/caching/allocation/performance remains #2939-owned; MCP remains #3153-owned.

## Validation

Passing locally on the exact tree:

- Maven compile plus 46 focused/adjacent tests: `ProcessModelCompiledEvaluationPlanTest`, `ProcessModelOperatingActionSetEvaluatorTest`, `ProcessModelOperatingActionEvaluatorTest`, and `ProcessModelSimulationEvaluatorTest`;
- direct `javac --release 8` compilation of the new public API;
- direct Java 8 Javadoc doclint of the new public API with zero warnings;
- Spotless apply/check;
- documentation search audit: 696 Markdown pages and 1 standalone HTML page;
- optimizer documentation unit tests: 3 passed;
- Python guide-runner syntax compilation and raw JSON parsing;
- clean `git diff --check`;
- L fixture: 162 units / 20 areas, 41 installed-capacity rows, 1 boundary row, accepted and converged candidate, complete reconverged restoration, zero recorded mass residual;
- measured run: compile 2.689549205 s and 1,154,759,416 main-thread allocated bytes; evaluation 1.159243826 s and 694,325,784 bytes; result JSON 79,243 bytes.

Local JPype execution was unavailable because `JPype1` is not installed. Full Maven Javadoc was blocked by unavailable uncached plugin dependencies; the direct source Javadoc gate passed. `pre-commit`/`pre-push` were unavailable because the command is not installed. Hosted exact-head CI must verify those missing gates.

## Portfolio and review

Before publication, four EvenSol implementation PRs were open; this becomes 5/10. No other open #3154 PR or path overlap was found. This must remain draft. Owner/domain and independent maintainer review are required before readiness.

**VALIDATION PENDING CI.** Do not merge, enable auto-merge, mark ready, rebase, force-push, replace, or close this branch.

## PR repair — 2026-09-12

Commit: `bd0c57614d348b7d2ea5047a772949801ce46ec1`, directly on the existing `67a3740ddc7876bc3ac3043d0f9d353c9878396d` head.

The failed Java 21 slow shard reported `CoolingDutyProductionAnalysisTest.test2026ScenarioCoolingAnalysisThreeCompressors`: “Production should increase with cooling.” The original test and its full class passed locally on Java 17, so the exact hosted failure was not reproduced locally. Inspection identified a defective comparison: each temperature rebuilt and auto-sized the plant and regenerated compressor maps from that temperature's operating point; the zero-cooling case also omitted the knockout and pressure loss. These were different equipment designs, not an operating-condition sweep.

The repaired fixture generates maps and ratings once at the uncooled design point, keeps the installed cooler and knockout, and varies only the cooling specification and candidate flow. Every optimizer result must be feasible; assertions verify actual temperature reduction, constant 0.5 bar pressure loss, finite duty, heat removal for cooled cases, and agreement between the live feed and selected rate. Both positive-production-gain assertions remain. The synthetic fixture now gives 69.08 → 74.91 MSm3/day (+8.43%) at 15 K cooling. This is a regression fixture, not plant or vendor qualification.

Documentation impact: updated the scenario-comparison guidance and test Javadocs/labels to explain fixed installed equipment and synthetic-map provenance. No production implementation, optimizer acceptance threshold, or compiled-plan API changed.

Final local validation on Java 17.0.20 (Maven bootstrapped with the work-with-neqsim helper):

- `./mvnw -B -ntp -Djacoco.skip=true -DexcludedTestGroups= -Dtest=CoolingDutyProductionAnalysisTest,ProcessModelCompiledEvaluationPlanTest,ProcessModelOperatingActionSetEvaluatorTest,ProcessModelOperatingActionEvaluatorTest,ProcessModelSimulationEvaluatorTest,ProductionOptimizerSelectedPointTest,ProductionOptimizationGuideExamplesTest test`: exit 0; **66 tests, 0 failures, 0 errors, 0 skipped**.
- `$CODEX_PRIMARY_RUNTIME_PYTHON devtools/run_spotless.py apply`: exit 0; final repeat made no changes.
- `$CODEX_PRIMARY_RUNTIME_PYTHON devtools/run_spotless.py check`: exit 0.
- `$CODEX_PRIMARY_RUNTIME_PYTHON devtools/check_documentation_search.py`: exit 0; 696 Markdown pages and one standalone HTML page.
- `git diff --check`: exit 0.
- The pre-commit executable/module is unavailable; its configured formatting and documentation gates ran directly.

**VALIDATION PENDING EXACT-HEAD CI.** The existing draft and its ancestry are preserved.


## Compiled-plan repair and requested closure — 2026-09-12

Commit: `17fa694b183b79af1fbf540e820915f56b292974`, directly on `bd0c57614d348b7d2ea5047a772949801ce46ec1`. The concurrent fixed-equipment cooling fixture and its positive-gain assertions are preserved unchanged.

Found and reproduced a fail-closed defect: replacing the evaluator's ProcessModel, or removing and recreating its last area, could retain identical names, structure counters and capacity metadata while callbacks and connections still referenced the original objects. Both new regression tests failed before the fix (`isCurrent()` incorrectly returned true). The plan now freezes exact model and area object identities and rejects replacements before evaluation or candidate mutation.

Documentation impact: updated the compiled-plan guide and class Javadoc to require recompilation after object replacement.

Final combined-tree validation (Java 17):

- `./mvnw -B -ntp -Djacoco.skip=true -DexcludedTestGroups= -Dtest=CoolingDutyProductionAnalysisTest#test2026ScenarioCoolingAnalysisThreeCompressors,ProcessModelCompiledEvaluationPlanTest,ProductionOptimizationGuideExamplesTest test`: exit 0; **11 tests, zero failures/errors/skips**.
- `$CODEX_PRIMARY_RUNTIME_PYTHON devtools/run_spotless.py apply`: exit 0; final repeat made no changes.
- `$CODEX_PRIMARY_RUNTIME_PYTHON devtools/run_spotless.py check`: exit 0.
- `$CODEX_PRIMARY_RUNTIME_PYTHON devtools/check_documentation_search.py`: exit 0; 696 Markdown pages and one standalone HTML page.
- `git diff HEAD --check`: exit 0. Published tree SHA exactly matches the validated local tree.
- Pre-commit executable/module unavailable; configured formatting and documentation gates ran directly.

**Full exact-head CI remains pending; no full-matrix success is claimed.**

The user explicitly requested “fix ... close when fixed.” Close this PR unmerged after the verified repair, preserving the branch and all commits. That newer instruction supersedes the historical no-close text above. No merge, auto-merge, branch deletion, or closure of the broader #3154 roadmap is performed.
