### PR TITLE
[AI-Assisted] feat(kinetics): invert dimensional H2S reaction targets

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -315,6 +315,40 @@ This diagnostic identifies a crossing within caller-defined aqueous screening se
 not locate a position in a pipeline, calculate flow residence time, size equipment, or couple the
 reaction to phase behavior, mass transfer, oxygen depletion, or a transient solver.
 
+
+## Absolute reacted-moles target crossing
+
+`AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(...)`
+converts a requested reacted total-sulfide amount to the remaining fraction required by the
+existing piecewise target-crossing calculation. With initial molality `c_0`, constant water
+inventory `m_w`, and requested reacted amount `n_target`,
+
+$
+n_0=c_0m_w, \qquad
+f_{\mathrm{target}}=\frac{n_0-n_{\mathrm{target}}}{n_0}.
+$
+
+The immutable result records the input molality and water inventory, initial and target amounts,
+the corresponding remaining amount and fraction, and the existing shortest, nominal, and longest
+crossing times and segment indices. Reacting half of the initial dimensional inventory therefore
+maps exactly to a remaining fraction of `0.5`; at the illustrative reference state the nominal
+time is `22.4288 h`.
+
+Forward evaluation at each reported fit-scatter crossing recovers the requested reacted amount.
+Larger targets require longer times. Scaling both the constant water inventory and reacted-moles
+target by the same factor leaves the target fraction and crossing times unchanged. Unchanged-state
+segment subdivision preserves elapsed times while the reported source-order crossing index follows
+the supplied segmentation. A target of exactly zero crosses at time zero.
+
+The target must be finite, non-negative, and strictly less than the initial dimensional
+total-sulfide inventory; equality would require infinite time in this first-order model. Inputs
+that cannot represent a positive target change at the current floating-point scale fail closed.
+Every fit-scatter path must reach the target within the supplied finite trajectory.
+
+This method dimensionalizes an analytical screening target only. The constant water inventory
+remains caller-supplied and is not a calculated holdup. The output is not a residence-time design,
+pipeline position, signed H2S source, oxygen demand, product yield, or deposition prediction.
+
 ## Scientific stop boundary
 
 This capability does not:
@@ -331,3 +365,4 @@ Electrolyte pH/speciation remains owned by issue #3144. TP flash, dynamics, pipe
 MCP publication remain coordinated with #2937, #2911, the pipeline roadmap, and #3153. Applying
 this atmospheric aqueous correlation to a Northern-Lights-type high-pressure CO2 pipeline requires
 separate phase, pressure, mass-transfer, and composition evidence.
+

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -373,6 +373,45 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.water_inventory_projection_test)
 
+
+    def test_absolute_reacted_moles_target_is_documented_and_executable(self):
+        for token in (
+            "Absolute reacted-moles target crossing",
+            "`AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(...)`",
+            r"n_0=c_0m_w",
+            r"f_{\mathrm{target}}=\frac{n_0-n_{\mathrm{target}}}{n_0}",
+            "shortest, nominal, and longest crossing times and segment indices",
+            "remaining fraction of `0.5`",
+            "nominal time is `22.4288 h`",
+            "Scaling both the constant water inventory and reacted-moles target",
+            "target of exactly zero crosses at time zero",
+            "strictly less than the initial dimensional total-sulfide inventory",
+            "not a calculated holdup",
+            "not a residence-time design",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static ReactedMolesTargetResult timeToReactedMolesRange(",
+            "public static final class ReactedMolesTargetResult",
+            "getInitialTotalSulfideMoles()",
+            "getTargetReactedMoles()",
+            "getTargetRemainingMoles()",
+            "getTargetRemainingFraction()",
+            "getCrossingRange()",
+            "cannot be represented at this inventory scale",
+        ):
+            self.assertIn(token, self.water_inventory_projection)
+
+        for token in (
+            "testReactedMolesTargetReproducesHalfInventoryAndForwardExposure",
+            "testReactedMolesTargetIsMonotonicAndPreservesLinearWaterScaling",
+            "testReactedMolesTargetIsSplitInvariantAndPreservesCrossingSegment",
+            "testReactedMolesTargetIdentityAndInvalidInputsFailClosed",
+            "assertTargetReaction(",
+        ):
+            self.assertIn(token, self.water_inventory_projection_test)
+
     def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
         for token in (
             "Piecewise target crossing",
@@ -434,3 +473,4 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -108,6 +108,56 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
             "Upper-rate trajectory closure residual"));
   }
 
+  /**
+   * Locate when an absolute reacted total-sulfide target is reached at constant water inventory.
+   *
+   * <p>
+   * The dimensional target is converted to a remaining fraction and delegated to the existing piecewise analytical
+   * crossing calculation. No product identity, oxygen demand, or process source term is inferred.
+   * </p>
+   *
+   * @param initialTotalSulfideMolality initial total-sulfide molality [mol/kg water]
+   * @param targetReactedMoles requested reacted total sulfide [mol]
+   * @param waterInventoryKg constant liquid-water inventory [kg]
+   * @param segments non-empty ordered exposure segments
+   * @return immutable dimensional target and piecewise crossing evidence
+   * @throws IllegalArgumentException when inputs are outside the source or numerical domain, the target is not less
+   * than the initial dimensional inventory, or every fit-scatter path cannot reach the target
+   */
+  public static ReactedMolesTargetResult timeToReactedMolesRange(double initialTotalSulfideMolality,
+      double targetReactedMoles, double waterInventoryKg,
+      List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments) {
+    if (!Double.isFinite(initialTotalSulfideMolality)
+        || initialTotalSulfideMolality < AqueousHydrogenSulfideOxidationTrajectory.MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY
+        || initialTotalSulfideMolality > AqueousHydrogenSulfideOxidationTrajectory.MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY) {
+      throw new IllegalArgumentException("Initial total-sulfide molality must be within the source experiment range");
+    }
+    requirePositiveFinite(waterInventoryKg, "Water inventory");
+
+    double initialTotalSulfideMoles = finiteProduct(initialTotalSulfideMolality, waterInventoryKg,
+        "Initial total sulfide");
+    if (!Double.isFinite(targetReactedMoles) || targetReactedMoles < 0.0
+        || targetReactedMoles >= initialTotalSulfideMoles) {
+      throw new IllegalArgumentException(
+          "Target reacted total sulfide must be finite, non-negative, and less than the initial inventory");
+    }
+
+    double targetRemainingMoles = finiteDifference(initialTotalSulfideMoles, targetReactedMoles,
+        "Target remaining total sulfide");
+    if (targetRemainingMoles <= 0.0 || (targetReactedMoles > 0.0 && targetRemainingMoles == initialTotalSulfideMoles)) {
+      throw new IllegalArgumentException("Target reacted total sulfide cannot be represented at this inventory scale");
+    }
+    double targetRemainingFraction = targetRemainingMoles / initialTotalSulfideMoles;
+    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0 || targetRemainingFraction > 1.0) {
+      throw new IllegalArgumentException("Target remaining fraction must be finite and in the interval (0, 1]");
+    }
+
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(targetRemainingFraction, segments);
+    return new ReactedMolesTargetResult(initialTotalSulfideMolality, waterInventoryKg, initialTotalSulfideMoles,
+        targetReactedMoles, targetRemainingMoles, targetRemainingFraction, crossingRange);
+  }
+
   private static void requirePositiveFinite(double value, String name) {
     if (!Double.isFinite(value) || value <= 0.0) {
       throw new IllegalArgumentException(name + " must be finite and positive");
@@ -136,6 +186,67 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
       throw new IllegalArgumentException(name + " is not finite");
     }
     return difference;
+  }
+
+  /** Immutable dimensional reacted-moles target and piecewise crossing evidence. */
+  public static final class ReactedMolesTargetResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double initialTotalSulfideMolality;
+    private final double waterInventoryKg;
+    private final double initialTotalSulfideMoles;
+    private final double targetReactedMoles;
+    private final double targetRemainingMoles;
+    private final double targetRemainingFraction;
+    private final AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange;
+
+    private ReactedMolesTargetResult(double initialTotalSulfideMolality, double waterInventoryKg,
+        double initialTotalSulfideMoles, double targetReactedMoles, double targetRemainingMoles,
+        double targetRemainingFraction,
+        AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange) {
+      this.initialTotalSulfideMolality = initialTotalSulfideMolality;
+      this.waterInventoryKg = waterInventoryKg;
+      this.initialTotalSulfideMoles = initialTotalSulfideMoles;
+      this.targetReactedMoles = targetReactedMoles;
+      this.targetRemainingMoles = targetRemainingMoles;
+      this.targetRemainingFraction = targetRemainingFraction;
+      this.crossingRange = crossingRange;
+    }
+
+    /** @return initial total-sulfide molality [mol/kg water]. */
+    public double getInitialTotalSulfideMolality() {
+      return initialTotalSulfideMolality;
+    }
+
+    /** @return caller-supplied constant liquid-water inventory [kg]. */
+    public double getWaterInventoryKg() {
+      return waterInventoryKg;
+    }
+
+    /** @return initial total-sulfide inventory [mol]. */
+    public double getInitialTotalSulfideMoles() {
+      return initialTotalSulfideMoles;
+    }
+
+    /** @return requested reacted total sulfide [mol]. */
+    public double getTargetReactedMoles() {
+      return targetReactedMoles;
+    }
+
+    /** @return remaining total sulfide at the requested target [mol]. */
+    public double getTargetRemainingMoles() {
+      return targetRemainingMoles;
+    }
+
+    /** @return remaining fraction corresponding to the requested dimensional target. */
+    public double getTargetRemainingFraction() {
+      return targetRemainingFraction;
+    }
+
+    /** @return immutable lower, nominal, and upper piecewise crossing evidence. */
+    public AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult getCrossingRange() {
+      return crossingRange;
+    }
   }
 
   /** Immutable dimensional projection for one constant-water trajectory. */

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -190,6 +190,117 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(trajectory, Double.POSITIVE_INFINITY));
   }
 
+  @Test
+  void testReactedMolesTargetReproducesHalfInventoryAndForwardExposure() {
+    AqueousHydrogenSulfideOxidationTrajectory.Segment segment = referenceSegment(100.0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentEvidence = segmentResult(segment);
+    double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
+    double targetReactedMoles = 0.5 * initialMoles;
+
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult target = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, targetReactedMoles, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+
+    assertEquals(initialMoles, target.getInitialTotalSulfideMoles(), 0.0);
+    assertEquals(targetReactedMoles, target.getTargetReactedMoles(), 0.0);
+    assertEquals(0.5 * initialMoles, target.getTargetRemainingMoles(), 0.0);
+    assertEquals(0.5, target.getTargetRemainingFraction(), 0.0);
+    assertEquals(22.4288, target.getCrossingRange().getNominalTimeHours(), 1.0e-4);
+
+    assertTargetReaction(targetReactedMoles, initialMoles, segmentEvidence.getUpperPseudoFirstOrderRate(),
+        target.getCrossingRange().getShortestTimeHours());
+    assertTargetReaction(targetReactedMoles, initialMoles, segmentEvidence.getNominalPseudoFirstOrderRate(),
+        target.getCrossingRange().getNominalTimeHours());
+    assertTargetReaction(targetReactedMoles, initialMoles, segmentEvidence.getLowerPseudoFirstOrderRate(),
+        target.getCrossingRange().getLongestTimeHours());
+  }
+
+  @Test
+  void testReactedMolesTargetIsMonotonicAndPreservesLinearWaterScaling() {
+    AqueousHydrogenSulfideOxidationTrajectory.Segment segment = referenceSegment(100.0);
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult smaller = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.006, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult larger = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult scaled = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.030, 2.0 * WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+
+    assertTrue(smaller.getCrossingRange().getShortestTimeHours() < larger.getCrossingRange().getShortestTimeHours());
+    assertTrue(smaller.getCrossingRange().getNominalTimeHours() < larger.getCrossingRange().getNominalTimeHours());
+    assertTrue(smaller.getCrossingRange().getLongestTimeHours() < larger.getCrossingRange().getLongestTimeHours());
+    assertEquals(larger.getCrossingRange().getShortestTimeHours(), scaled.getCrossingRange().getShortestTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(larger.getCrossingRange().getNominalTimeHours(), scaled.getCrossingRange().getNominalTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(larger.getCrossingRange().getLongestTimeHours(), scaled.getCrossingRange().getLongestTimeHours(),
+        NUMERICAL_TOLERANCE);
+  }
+
+  @Test
+  void testReactedMolesTargetIsSplitInvariantAndPreservesCrossingSegment() {
+    double targetReactedMoles = 0.015;
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult unsplit = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, targetReactedMoles, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult split = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, targetReactedMoles, WATER_INVENTORY_KG,
+            Arrays.asList(referenceSegment(10.0), referenceSegment(90.0)));
+
+    assertEquals(unsplit.getCrossingRange().getShortestTimeHours(), split.getCrossingRange().getShortestTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(unsplit.getCrossingRange().getNominalTimeHours(), split.getCrossingRange().getNominalTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(unsplit.getCrossingRange().getLongestTimeHours(), split.getCrossingRange().getLongestTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(0, unsplit.getCrossingRange().getNominalCrossingSegmentIndex());
+    assertEquals(1, split.getCrossingRange().getNominalCrossingSegmentIndex());
+  }
+
+  @Test
+  void testReactedMolesTargetIdentityAndInvalidInputsFailClosed() {
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult identity = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.0, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(0.0)));
+    assertEquals(0.0, identity.getCrossingRange().getShortestTimeHours(), 0.0);
+    assertEquals(0.0, identity.getCrossingRange().getNominalTimeHours(), 0.0);
+    assertEquals(0.0, identity.getCrossingRange().getLongestTimeHours(), 0.0);
+
+    double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(19.0e-6, 0.001,
+            WATER_INVENTORY_KG, Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, -1.0, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Double.MIN_VALUE, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.001, Double.NaN, Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(1.0))));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.0, WATER_INVENTORY_KG, null));
+  }
+
+  private static void assertTargetReaction(double targetReactedMoles, double initialMoles, double pseudoFirstOrderRate,
+      double crossingTimeHours) {
+    double reactedMoles = initialMoles * -Math.expm1(-pseudoFirstOrderRate * crossingTimeHours);
+    assertEquals(targetReactedMoles, reactedMoles, NUMERICAL_TOLERANCE);
+  }
+
   private static void assertProjectionPath(double meanLossMolalityPerHour, double reactedMolality,
       double meanLossMolesPerHour, double meanLossMolesPerSecond, double reactedMoles, double durationHours) {
     assertEquals(meanLossMolalityPerHour * WATER_INVENTORY_KG, meanLossMolesPerHour, 0.0);


### PR DESCRIPTION
Refs #3318.

Adds a dimensional target-time inversion for the already qualified aqueous H2S/O2 Millero screening path.

## Capability

- Adds `AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(...)`.
- Converts a caller-requested reacted total-sulfide amount, explicit constant liquid-water inventory, and source-range initial molality into the existing piecewise remaining-fraction crossing.
- Returns immutable initial/target dimensional evidence plus the established shortest, nominal, and longest crossing times and source-order segment indices.
- Reuses the existing lower/nominal/upper Millero fit-scatter paths without introducing a new kinetic parameter.

## Numerical gates

- half of the initial dimensional inventory reproduces a remaining fraction of 0.5 and the nominal 22.4288 h reference half-life;
- forward evaluation of every returned crossing recovers the requested reacted amount;
- larger reacted targets require longer times;
- proportional water-inventory and target scaling preserves crossing times;
- unchanged-state segment subdivision preserves elapsed crossing times;
- zero reacted target crosses at exact time zero;
- invalid, unreachable, unrepresentable, underflowing, or non-finite inputs fail closed.

## Scientific basis and boundary

The rate basis remains Millero et al. (1987), [doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003). The implementation remains atmospheric aqueous total-sulfide-loss screening. It does not calculate water holdup/dropout, H2S/HS- speciation, oxygen solubility or consumption, products/selectivity, reaction heat, pressure or phase transfer, signed component sources, pipeline/transient mutation, or S8/FeS/wall/deposition inventories.

Coordination remains with #3144, #2937, #2911, the pipeline roadmap, #3153, and the existing sulfur/solid-flash implementations. The four changed paths do not overlap the other open autonomous PRs identified at publication.

## Documentation impact

Updates the primary H2S/O2 guide and executable documentation contract with the dimensional target equations, validity rules, numerical invariants, and stop boundary.

## Validation

- Repository Spotless 3.10.1/Eclipse 4.35: apply and repeat check passed for both modified Java files.
- Java 8 ECJ 3.41.0 compilation passed for the complete three-class kinetics/projection chain.
- 13 focused JUnit methods passed through a local Java 8 reflection harness.
- Documentation contract: 16/16 tests passed.
- Python byte compilation of the documentation contract passed.
- Full repository Maven matrix, pre-commit/pre-push, documentation search, Javadocs, security, and hosted checks are deferred to exact-head CI.

## Publication

- Exact base: `944e3ce0530b2193ac575cd5d91b1cb2e11f7973`
- Exact head: `6f9e12bb55b36cb0d6b373710bd8cc52d340a125`
- Changed files: exactly four (production, JUnit, guide, documentation contract).
- Draft-only.
- **VALIDATION PENDING EXACT-HEAD CI.**

AI-assisted implementation. Subject to CI and the subsystem-owner plus independent review required by repository governance.