### PR TITLE
[AI-Assisted] test(mcp): qualify bounded LOPA screening

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Run focused bounded risk-matrix Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.RiskMatrixRunnerTest test -ntp
 
+      - name: Run focused bounded LOPA Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.LOPARunnerTest test -ntp
+
       - name: Run focused pre-flight validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.ValidatorTest test -ntp
 
@@ -159,6 +162,9 @@ jobs:
 
       - name: Run focused real-MCP bounded risk-matrix qualification
         run: cd neqsim-mcp-server && python test_risk_matrix_protocol.py
+
+      - name: Run focused real-MCP bounded LOPA qualification
+        run: cd neqsim-mcp-server && python test_lopa_protocol.py
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py

--- a/neqsim-mcp-server/MCP_CONTRACT.md
+++ b/neqsim-mcp-server/MCP_CONTRACT.md
@@ -96,7 +96,7 @@ industrial validation.
 | `queryDataCatalog` | ADVISORY | v1.2 | Browse thermodynamic databases (components, standards, materials, EOS models) |
 | `generateVisualization` | CALCULATION | v1.2 | Inline SVG/Mermaid/HTML visualization |
 | `runRelief` | CALCULATION | v1.3 | PSV sizing per API 520 (gas/liquid/two-phase) and API 521 fire heat input |
-| `runLOPA` | CALCULATION | v1.3 | Layer of Protection Analysis per IEC 61511 / CCPS, with required-SIL gap analysis |
+| `runLOPA` | CALCULATION | v1.3 | Bounded caller-supplied LOPA screening with canonical numerical evidence; no IPL, SIL, risk-acceptance, or standards-conformance claim |
 | `runSIL` | CALCULATION | v1.3 | SIL verification per IEC 61508 / 61511 (1oo1, 1oo2, 2oo3 architectures) |
 | `runRiskMatrix` | CALCULATION | v1.3 | Bounded generic 5×5 screening; caller owns project criteria and qualified review |
 | `runFlareNetwork` | CALCULATION | v1.3 | Flare radiation profile and API 521 safe-distance contour |

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -238,7 +238,7 @@ code-level `enforceAccess()` — returns structured error JSON, not a silent ski
 | `saveSimulationState`         | Save process state as a JSON snapshot                                                                                                                |
 | `runOperationalStudy`         | P&ID/tag-driven valve scenarios, field-data binding, controller response metrics, and evidence-package bottleneck reports on a local simulation copy |
 | `runRelief`                   | PSV sizing per API 520/521                                                                                                                           |
-| `runLOPA`                     | Layer of Protection Analysis per IEC 61511 / CCPS                                                                                                    |
+| `runLOPA`                     | Bounded caller-supplied LOPA screening; IEC 61511/CCPS context only, with qualified process-safety review required                                   |
 | `runSIL`                      | SIL verification per IEC 61508 / IEC 61511                                                                                                           |
 | `runRiskMatrix`               | Bounded generic 5x5 screening of caller-supplied probability and consequence inputs; no standards-conformance claim                                  |
 | `runFlareNetwork`             | Flare radiation and safe-distance contours                                                                                                           |

--- a/neqsim-mcp-server/docs/evidence/LOPA_SCREENING_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/LOPA_SCREENING_CONTRACT.md
@@ -1,0 +1,91 @@
+# Bounded LOPA screening contract
+
+## Purpose
+
+`runLOPA` is a deterministic screening calculation for caller-supplied Layer of
+Protection Analysis inputs. It uses NeqSim's canonical `LOPAResult` and
+`SafetyInstrumentedFunction` calculations. This contract qualifies the MCP
+request, response, and failure boundaries; it is not a process-safety study or
+an assertion that the supplied layers are valid independent protection layers.
+
+## Request contract
+
+The request is one UTF-8 JSON object no larger than 16,384 bytes. It contains:
+
+- an optional non-blank `scenario` of at most 256 characters;
+- finite, strictly positive `initiatingEventFrequency_per_year` and
+  `targetFrequency_per_year` values;
+- a non-empty `layers` array with at most 100 entries; and
+- for every layer, a non-blank `name` of at most 256 characters and a finite
+  `pfd` greater than zero and at most one.
+
+Layer order is significant and is preserved. Missing, malformed, non-finite,
+out-of-range, oversized, and numerically unrepresentable inputs fail closed
+with stable error codes. Parser or exception details are not returned.
+
+## Canonical calculation
+
+For initiating frequency \(f_0\) and caller-supplied layer PFDs \(p_i\), the
+ordered frequency trace is
+
+\[
+f_i = f_{i-1} p_i,
+\qquad
+f_{mitigated} = f_0 \prod_i p_i.
+\]
+
+`LOPAResult` remains the authority for the ordered layer trace, mitigated
+frequency, target comparison, gap, total risk-reduction factor, and additional
+risk-reduction factor. `SafetyInstrumentedFunction.calculateRequiredPfd`
+remains the authority for the additional PFD calculation. The returned
+additional SIL band is explicitly labelled indicative; it is not SIL
+verification or design.
+
+The MCP runner adds validation and advisory metadata but does not introduce an
+alternative risk, LOPA, or SIL model.
+
+## Output evidence
+
+A successful response includes:
+
+- `screeningOnly: true` and `standardConformanceClaimed: false`;
+- `inputBasis: CALLER_SUPPLIED_FREQUENCIES_AND_LAYER_PFDS`;
+- the canonical `lopa` evidence, including ordered layers and frequency trace;
+- `gapAnalysis`, including target status and canonical additional-reduction
+  evidence when the target is not met; and
+- explicit caller-assumption and advisory-boundary statements.
+
+IEC 61511 and CCPS LOPA are named only as context. The response does not claim
+compliance with either source.
+
+## Engineering and safety boundary
+
+The caller owns the initiating-event frequency, target frequency, PFD values,
+layer claims, independence claims, common-cause assumptions, human-reliability
+assumptions, proof-test assumptions, consequence basis, and project risk
+criteria.
+
+This capability does not:
+
+- identify hazards or initiating events;
+- validate frequencies, consequences, safeguards, IPL independence, common
+  cause, or human reliability;
+- verify a SIF, SIL, proof-test interval, architecture, or lifecycle;
+- determine tolerable risk or accept a scenario;
+- certify standards or regulatory compliance;
+- authorize plant, operating, maintenance, or design action; or
+- replace a qualified process-safety study and accountable approval.
+
+## Executable evidence
+
+- `src/test/java/neqsim/mcp/runners/LOPARunnerTest.java` exercises canonical
+  calculations, deterministic order, input types and ranges, request/layer/text
+  bounds, non-finite values, underflow, and stable errors.
+- `neqsim-mcp-server/test_lopa_protocol.py` exercises discovery and the same
+  contract through the packaged real-MCP STDIO transport.
+- `neqsim-mcp-server/test_mcp_server.py` protects the public tool inventory and
+  direct discovery boundary within the comprehensive protocol regression.
+
+This qualification does not promote `runLOPA` in the Phase 0 evidence
+inventory. Promotion requires a later, separately accepted increment after this
+contract has merged and remained green on its exact published head.

--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
@@ -2158,20 +2158,21 @@ public class NeqSimTools {
   }
 
   /**
-   * Run a Layer of Protection Analysis (LOPA) per IEC 61511 / CCPS LOPA.
+   * Run a bounded Layer of Protection Analysis (LOPA) screening calculation.
    *
    * @param lopaJson JSON spec with scenario, frequencies, and layers
    * @return JSON string with LOPA result and gap analysis
    */
-  @Tool(description = "Run a Layer of Protection Analysis (LOPA) per IEC 61511 / CCPS LOPA. "
-      + "Computes the mitigated event frequency by stacking PFDs of independent "
-      + "protection layers (BPCS, alarms, relief valves, SIFs), compares against a target, "
-      + "and reports the gap, total RRF, and required additional SIL/PFD if the target "
-      + "is not met.")
+  @Tool(description = "Run bounded caller-supplied LOPA screening (maximum 16384 UTF-8 bytes and 100 layers). "
+      + "Uses NeqSim's canonical LOPA result to multiply ordered layer PFDs and compare the mitigated "
+      + "frequency with a caller-supplied target. IEC 61511 and CCPS are context only: this tool does not "
+      + "identify hazards, establish IPL independence, verify SIL or safeguards, determine risk acceptance, "
+      + "claim standards compliance, authorize plant action, or replace qualified process-safety review.")
   public String runLOPA(
       @ToolArg(description = "JSON with: 'scenario' (name), 'initiatingEventFrequency_per_year', "
-          + "'targetFrequency_per_year', and 'layers' array. Each layer has 'name' and 'pfd' "
-          + "(probability of failure on demand, 0-1). Example: "
+          + "'targetFrequency_per_year', and a non-empty 'layers' array (maximum 100). Frequencies must be "
+          + "finite and greater than zero. Each layer has a non-blank 'name' and finite 'pfd' "
+          + "(probability of failure on demand, greater than 0 and at most 1). Example: "
           + "{\"scenario\":\"HP separator overpressure\",\"initiatingEventFrequency_per_year\":0.1,"
           + "\"targetFrequency_per_year\":1e-5,\"layers\":[{\"name\":\"BPCS\",\"pfd\":0.1},"
           + "{\"name\":\"PSV\",\"pfd\":0.01}]}") String lopaJson) {

--- a/neqsim-mcp-server/test_lopa_protocol.py
+++ b/neqsim-mcp-server/test_lopa_protocol.py
@@ -1,0 +1,361 @@
+"""Packaged-MCP qualification for bounded caller-supplied LOPA screening.
+
+The scenarios exercise the real STDIO transport, canonical NeqSim LOPA
+calculation, deterministic ordering, request/layer/text bounds, stable
+fail-closed errors, and the explicit engineering-review boundary. They do not
+identify hazards, verify IPL independence or SIL, determine risk acceptance,
+establish standards compliance, authorize plant action, or replace qualified
+process-safety review.
+"""
+
+import json
+import subprocess
+import time
+
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+def require(condition, message, detail=None):
+    if condition:
+        return
+    suffix = "" if detail is None else "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "tool",
+        "code",
+        "errors",
+        "message",
+        "validation",
+        "qualityGate",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+class McpClient:
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-lopa-screening-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        require("result" in self.receive(), "MCP initialize did not return a result")
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def request(self, method, params):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": method,
+                "params": params,
+            }
+        )
+        return self.receive()
+
+    def list_tools(self):
+        return self.request("tools/list", {}).get("result", {}).get("tools", [])
+
+    def call_lopa(self, request):
+        response = self.request(
+            "tools/call",
+            {
+                "name": "runLOPA",
+                "arguments": {"lopaJson": json.dumps(request)},
+            },
+        )
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP LOPA call returned no content", response)
+        return json.loads(content[0].get("text", ""))
+
+    def call_raw_lopa(self, request_text):
+        response = self.request(
+            "tools/call",
+            {"name": "runLOPA", "arguments": {"lopaJson": request_text}},
+        )
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP LOPA call returned no content", response)
+        return json.loads(content[0].get("text", ""))
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def assert_success(response):
+    result = payload(response)
+    require(result.get("status") == "success", "LOPA request failed", response)
+    require(result.get("tool") == "runLOPA", "tool identity drifted", response)
+    require(
+        result.get("validation", {}).get("valid") is True,
+        "standard validation evidence drifted",
+        response,
+    )
+    require(
+        result.get("qualityGate", {}).get("verdict") == "passed",
+        "software gate did not pass",
+        response,
+    )
+    require(result.get("screeningOnly") is True, "screening boundary missing", result)
+    require(
+        result.get("standardConformanceClaimed") is False,
+        "standards boundary missing",
+        result,
+    )
+    require(
+        result.get("standard")
+        == "Caller-supplied LOPA screening; project-specific verification required",
+        "standard descriptor drifted",
+        result,
+    )
+    require(
+        result.get("inputBasis") == "CALLER_SUPPLIED_FREQUENCIES_AND_LAYER_PFDS",
+        "input basis drifted",
+        result,
+    )
+    return result
+
+
+def assert_error(response, expected_code):
+    result = payload(response)
+    require(result.get("status") == "error", "request did not fail closed", response)
+    errors = result.get("errors", [])
+    code = result.get("code")
+    if code is None and errors:
+        code = errors[0].get("code")
+    require(code == expected_code, "LOPA error code drifted", result)
+    require(result.get("screeningOnly") is True, "error boundary missing", result)
+    require(
+        result.get("standardConformanceClaimed") is False,
+        "error standards boundary missing",
+        result,
+    )
+    return result
+
+
+def valid_request():
+    return {
+        "scenario": "Synthetic separator overpressure",
+        "initiatingEventFrequency_per_year": 0.1,
+        "targetFrequency_per_year": 1.1e-4,
+        "layers": [
+            {"name": "Caller-supplied BPCS claim", "pfd": 0.1},
+            {"name": "Caller-supplied relief claim", "pfd": 0.01},
+        ],
+    }
+
+
+def test_discovery_boundary(client):
+    tool = next((item for item in client.list_tools() if item.get("name") == "runLOPA"), None)
+    require(tool is not None, "runLOPA is missing from tools/list")
+    description = tool.get("description", "")
+    require(
+        "16384 UTF-8 bytes" in description
+        and "100 layers" in description
+        and "does not identify hazards" in description
+        and "qualified process-safety review" in description,
+        "LOPA discovery boundary drifted",
+        tool,
+    )
+
+
+def test_canonical_target_met_calculation(client):
+    result = assert_success(client.call_lopa(valid_request()))
+    lopa = result.get("lopa", {})
+    gap = result.get("gapAnalysis", {})
+    require(abs(lopa.get("initiatingEventFrequency", 0) - 0.1) < 1e-15, "initiating frequency drifted", lopa)
+    require(abs(lopa.get("mitigatedFrequency", 0) - 0.0001) < 1e-15, "canonical product drifted", lopa)
+    require(abs(lopa.get("totalRRF", 0) - 1000.0) < 1e-12, "canonical RRF drifted", lopa)
+    require(gap.get("targetMet") is True, "target classification drifted", gap)
+    require(
+        [layer.get("name") for layer in lopa.get("protectionLayers", [])]
+        == ["Caller-supplied BPCS claim", "Caller-supplied relief claim"],
+        "caller layer order drifted",
+        lopa,
+    )
+
+
+def test_canonical_gap_and_indicative_sil(client):
+    request = valid_request()
+    request["initiatingEventFrequency_per_year"] = 0.5
+    request["targetFrequency_per_year"] = 1.0e-5
+    request["layers"] = [{"name": "Caller-supplied BPCS claim", "pfd": 0.1}]
+    gap = assert_success(client.call_lopa(request)).get("gapAnalysis", {})
+    require(gap.get("targetMet") is False, "gap classification drifted", gap)
+    require(gap.get("requiredAdditionalRRF") == 5000.0, "required RRF drifted", gap)
+    require(gap.get("requiredAdditionalSIL") == 3, "canonical SIL band drifted", gap)
+    require(gap.get("requiredAdditionalSILIsIndicative") is True, "indicative SIL label missing", gap)
+    require(gap.get("requiredAdditionalPFD") == 0.0002, "required PFD drifted", gap)
+
+
+def test_fail_closed_request_and_frequency_inputs(client):
+    assert_error(client.call_raw_lopa("[]"), "INVALID_INPUT")
+    malformed = assert_error(client.call_raw_lopa("{not-json"), "INVALID_INPUT")
+    require("line" not in malformed.get("message", ""), "parser detail leaked", malformed)
+    request = valid_request()
+    del request["targetFrequency_per_year"]
+    assert_error(client.call_lopa(request), "INVALID_INPUT")
+    for field, value in (
+        ("initiatingEventFrequency_per_year", 0),
+        ("initiatingEventFrequency_per_year", -0.1),
+        ("targetFrequency_per_year", 0),
+        ("targetFrequency_per_year", "rare"),
+    ):
+        request = valid_request()
+        request[field] = value
+        assert_error(client.call_lopa(request), "INVALID_INPUT")
+    assert_error(
+        client.call_raw_lopa(
+            '{"initiatingEventFrequency_per_year":NaN,"targetFrequency_per_year":1e-5,'
+            '"layers":[{"name":"Layer","pfd":0.1}]}'
+        ),
+        "INVALID_INPUT",
+    )
+
+
+def test_fail_closed_layer_contract(client):
+    invalid_layers = (
+        [],
+        ["not-an-object"],
+        [{"pfd": 0.1}],
+        [{"name": " ", "pfd": 0.1}],
+        [{"name": "Layer", "pfd": 0}],
+        [{"name": "Layer", "pfd": 1.01}],
+        [{"name": "Layer", "pfd": "low"}],
+    )
+    for layers in invalid_layers:
+        request = valid_request()
+        request["layers"] = layers
+        expected = "INVALID_INPUT" if layers == [] else "INVALID_LAYER"
+        assert_error(client.call_lopa(request), expected)
+
+
+def test_collection_text_and_request_bounds(client):
+    request = valid_request()
+    request["layers"] = [{"name": "L" + str(i), "pfd": 1.0} for i in range(101)]
+    assert_error(client.call_lopa(request), "TOO_MANY_LAYERS")
+    request = valid_request()
+    request["scenario"] = "s" * 257
+    assert_error(client.call_lopa(request), "INVALID_INPUT")
+    request = valid_request()
+    request["layers"] = [{"name": "n" * 257, "pfd": 0.1}]
+    assert_error(client.call_lopa(request), "INVALID_LAYER")
+    request["layers"] = [{"name": "x" * 16400, "pfd": 0.1}]
+    assert_error(client.call_lopa(request), "REQUEST_TOO_LARGE")
+
+
+def test_deterministic_screening_and_advisory_evidence(client):
+    first = assert_success(client.call_lopa(valid_request()))
+    second = assert_success(client.call_lopa(valid_request()))
+    for result in (first, second):
+        for key in ("validation", "qualityGate", "provenance"):
+            result.pop(key, None)
+    require(first == second, "LOPA response is not deterministic", {"first": first, "second": second})
+    require(len(first.get("assumptions", [])) == 3, "assumption evidence drifted", first)
+    boundary = first.get("advisoryBoundary", "")
+    require(
+        "claimed IPL independence" in boundary
+        and "verify SIL" in boundary
+        and "authorize plant action" in boundary,
+        "advisory boundary drifted",
+        first,
+    )
+
+
+def test_inventory_remains_confirmed_gap(client):
+    response = client.request("tools/call", {"name": "getCapabilities", "arguments": {}})
+    content = response.get("result", {}).get("content", [])
+    require(content, "getCapabilities returned no content", response)
+    result = payload(json.loads(content[0].get("text", "")))
+    inventory = result.get("phase0EvidenceInventory", {})
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get("runLOPA", {})
+    require(
+        inventory.get("inventoryVersion") == "1.36"
+        and limitations.get("contractTestedToolCount") == 36
+        and limitations.get("confirmedGapToolCount") == 15
+        and limitations.get("contractPromotionCandidateCount") == 0,
+        "qualification changed inventory accounting",
+        inventory,
+    )
+    require(record.get("coverageStatus") == "CONFIRMED_GAP", "runLOPA was promoted prematurely", record)
+
+
+def main():
+    client = McpClient()
+    client.start()
+    try:
+        scenarios = [
+            test_discovery_boundary,
+            test_canonical_target_met_calculation,
+            test_canonical_gap_and_indicative_sil,
+            test_fail_closed_request_and_frequency_inputs,
+            test_fail_closed_layer_contract,
+            test_collection_text_and_request_bounds,
+            test_deterministic_screening_and_advisory_evidence,
+            test_inventory_remains_confirmed_gap,
+        ]
+        for scenario in scenarios:
+            scenario(client)
+    finally:
+        client.close()
+    print("PASS: bounded LOPA packaged-MCP contract (8 scenarios)")
+
+
+if __name__ == "__main__":
+    main()

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -322,6 +322,15 @@ def test_protocol():
     for name in tier2:
         check(f"tier2 tool '{name}'", name in tool_names)
 
+    lopa_tool = next((tool for tool in tools if tool.get("name") == "runLOPA"), {})
+    lopa_description = lopa_tool.get("description", "")
+    check("bounded LOPA discovery contract",
+          "16384 UTF-8 bytes" in lopa_description
+          and "100 layers" in lopa_description
+          and "does not identify hazards" in lopa_description
+          and "qualified process-safety review" in lopa_description,
+          lopa_description)
+
     # Tier 3 — Experimental (15 tools)
     tier3 = ["manageSession", "solveTask", "composeWorkflow", "generateReport",
              "runPlugin", "getProgress", "streamSimulation",

--- a/src/main/java/neqsim/mcp/runners/LOPARunner.java
+++ b/src/main/java/neqsim/mcp/runners/LOPARunner.java
@@ -89,7 +89,12 @@ public final class LOPARunner {
           return errorJson("INVALID_LAYER",
               "layers[" + i + "].name must be a non-blank string of at most 256 characters");
         }
-        double pfd = readFiniteNumber(layer, "pfd", "layers[" + i + "].pfd");
+        double pfd;
+        try {
+          pfd = readFiniteNumber(layer, "pfd", "layers[" + i + "].pfd");
+        } catch (IllegalArgumentException invalidPfd) {
+          return errorJson("INVALID_LAYER", invalidPfd.getMessage());
+        }
         if (pfd <= 0.0 || pfd > 1.0) {
           return errorJson("INVALID_LAYER", "layers[" + i + "].pfd must be greater than 0 and at most 1");
         }

--- a/src/main/java/neqsim/mcp/runners/LOPARunner.java
+++ b/src/main/java/neqsim/mcp/runners/LOPARunner.java
@@ -1,73 +1,128 @@
 package neqsim.mcp.runners;
 
+import java.nio.charset.StandardCharsets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import neqsim.process.safety.risk.sis.LOPAResult;
 import neqsim.process.safety.risk.sis.SafetyInstrumentedFunction;
 
 /**
- * MCP runner for Layer of Protection Analysis (LOPA).
+ * MCP runner for bounded Layer of Protection Analysis (LOPA) screening.
  *
  * <p>
- * Computes the mitigated event frequency from an initiating event and a list of independent protection layers (IPLs),
- * checks against a target frequency, and returns the gap and required additional risk reduction (RRF / SIL).
+ * Computes the mitigated event frequency from caller-supplied initiating-event frequency and probability-of-failure-on-
+ * demand values. The calculation uses NeqSim's canonical {@link LOPAResult}; it does not establish that a protection
+ * layer is independent or suitable, verify SIL, determine risk acceptance, or claim standards compliance.
  * </p>
  *
  * @author Even Solbraa
- * @version 1.0
+ * @version 1.1
  */
 public final class LOPARunner {
 
+  /** Maximum accepted serialized request size. */
+  private static final int MAX_REQUEST_BYTES = 16384;
+  /** Maximum number of protection layers in one request. */
+  private static final int MAX_LAYERS = 100;
+  /** Maximum trimmed scenario or layer-name length. */
+  private static final int MAX_NAME_LENGTH = 256;
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create();
 
   private LOPARunner() {
   }
 
   /**
-   * Runs a LOPA calculation from a JSON definition.
+   * Runs a bounded LOPA screening calculation from a JSON definition.
    *
    * @param json JSON with scenario, initiatingEventFrequency, targetFrequency and layers array
-   * @return JSON string with LOPA result
+   * @return JSON string with canonical LOPA result and screening boundary
    */
   public static String run(String json) {
     if (json == null || json.trim().isEmpty()) {
-      return errorJson("JSON input is null or empty");
+      return errorJson("INVALID_INPUT", "JSON input is null or empty");
+    }
+    if (json.getBytes(StandardCharsets.UTF_8).length > MAX_REQUEST_BYTES) {
+      return errorJson("REQUEST_TOO_LARGE", "LOPA input exceeds 16384 UTF-8 bytes");
     }
     try {
-      JsonObject input = JsonParser.parseString(json).getAsJsonObject();
-      String scenarioName = input.has("scenario") ? input.get("scenario").getAsString() : "unnamed scenario";
-      double initiating = req(input, "initiatingEventFrequency_per_year");
-      double target = req(input, "targetFrequency_per_year");
+      JsonElement parsed = JsonParser.parseString(json);
+      if (!parsed.isJsonObject()) {
+        return errorJson("INVALID_INPUT", "LOPA input must be a JSON object");
+      }
+      JsonObject input = parsed.getAsJsonObject();
+      String scenarioName = readBoundedString(input, "scenario", "unnamed scenario");
+      if (scenarioName == null) {
+        return errorJson("INVALID_INPUT", "scenario must be a non-blank string of at most 256 characters");
+      }
+      double initiating = readPositiveFiniteNumber(input, "initiatingEventFrequency_per_year");
+      double target = readPositiveFiniteNumber(input, "targetFrequency_per_year");
+
+      if (!input.has("layers") || !input.get("layers").isJsonArray()) {
+        return errorJson("INVALID_INPUT", "Missing required field: layers (array)");
+      }
+      JsonArray layers = input.getAsJsonArray("layers");
+      if (layers.size() == 0) {
+        return errorJson("INVALID_INPUT", "At least one protection layer is required");
+      }
+      if (layers.size() > MAX_LAYERS) {
+        return errorJson("TOO_MANY_LAYERS", "At most 100 protection layers are allowed");
+      }
 
       LOPAResult lopa = new LOPAResult(scenarioName);
       lopa.setInitiatingEventFrequency(initiating);
       lopa.setTargetFrequency(target);
 
       double current = initiating;
-      if (input.has("layers")) {
-        JsonArray layers = input.getAsJsonArray("layers");
-        for (JsonElement el : layers) {
-          JsonObject layer = el.getAsJsonObject();
-          String name = layer.has("name") ? layer.get("name").getAsString() : "Layer " + (current);
-          double pfd = layer.get("pfd").getAsDouble();
-          double before = current;
-          double after = before * pfd;
-          lopa.addLayer(name, pfd, before, after);
-          current = after;
+      for (int i = 0; i < layers.size(); i++) {
+        JsonElement element = layers.get(i);
+        if (!element.isJsonObject()) {
+          return errorJson("INVALID_LAYER", "layers[" + i + "] must be a JSON object");
         }
+        JsonObject layer = element.getAsJsonObject();
+        String name = readBoundedString(layer, "name", null);
+        if (name == null) {
+          return errorJson("INVALID_LAYER",
+              "layers[" + i + "].name must be a non-blank string of at most 256 characters");
+        }
+        double pfd = readFiniteNumber(layer, "pfd", "layers[" + i + "].pfd");
+        if (pfd <= 0.0 || pfd > 1.0) {
+          return errorJson("INVALID_LAYER", "layers[" + i + "].pfd must be greater than 0 and at most 1");
+        }
+        double before = current;
+        double after = before * pfd;
+        if (!Double.isFinite(after) || after == 0.0) {
+          return errorJson("CALCULATION_OUT_OF_RANGE",
+              "LOPA layer calculation is outside the finite representable range");
+        }
+        lopa.addLayer(name, pfd, before, after);
+        current = after;
       }
       lopa.setMitigatedFrequency(current);
 
       JsonObject out = new JsonObject();
       out.addProperty("status", "success");
-      out.addProperty("standard", "IEC 61511 / CCPS LOPA");
+      out.addProperty("screeningOnly", true);
+      out.addProperty("standardConformanceClaimed", false);
+      out.addProperty("standard", "Caller-supplied LOPA screening; project-specific verification required");
+      out.addProperty("standardContext",
+          "IEC 61511 and CCPS LOPA are context only; this result does not demonstrate conformance");
+      out.addProperty("inputBasis", "CALLER_SUPPLIED_FREQUENCIES_AND_LAYER_PFDS");
+      out.addProperty("advisoryBoundary",
+          "The caller supplies frequencies, layer PFDs, and claimed IPL independence; the result does not identify hazards, validate safeguards or independence, verify SIL, determine risk acceptance, certify compliance, or authorize plant action");
+      JsonArray assumptions = new JsonArray();
+      assumptions.add("Initiating-event frequency and target frequency are caller supplied and unverified");
+      assumptions.add(
+          "Layer PFDs, independence, common-cause assumptions, and human reliability are caller supplied and unverified");
+      assumptions
+          .add("Proof-test intervals, consequences, safeguards, and project risk criteria require qualified review");
+      out.add("assumptions", assumptions);
       out.add("lopa", JsonParser.parseString(lopa.toJson()));
 
-      // Add explicit gap analysis with required SIL
       JsonObject gap = new JsonObject();
       gap.addProperty("targetMet", lopa.isTargetMet());
       gap.addProperty("gapToTarget_per_year", round(lopa.getGapToTarget(), 12));
@@ -75,28 +130,82 @@ public final class LOPARunner {
       if (!lopa.isTargetMet()) {
         gap.addProperty("requiredAdditionalRRF", round(lopa.getRequiredAdditionalRRF(), 2));
         gap.addProperty("requiredAdditionalSIL", lopa.getRequiredAdditionalSIL());
+        gap.addProperty("requiredAdditionalSILIsIndicative", true);
         double requiredPfd = SafetyInstrumentedFunction.calculateRequiredPfd(current, target);
         gap.addProperty("requiredAdditionalPFD", round(requiredPfd, 6));
       }
       out.add("gapAnalysis", gap);
       return GSON.toJson(out);
+    } catch (IllegalArgumentException e) {
+      return errorJson("INVALID_INPUT", e.getMessage());
     } catch (Exception e) {
-      return errorJson("LOPA calculation failed: " + e.getMessage());
+      return errorJson("INVALID_INPUT", "LOPA input could not be processed");
     }
   }
 
   /**
-   * Reads a required double field from JSON.
+   * Reads and trims a bounded string field.
    *
-   * @param input JSON object
+   * @param object source object
    * @param field field name
-   * @return field value
+   * @param defaultValue value when the field is absent
+   * @return bounded string, default value, or {@code null} when invalid
    */
-  private static double req(JsonObject input, String field) {
-    if (!input.has(field)) {
-      throw new IllegalArgumentException("Missing required field: " + field);
+  private static String readBoundedString(JsonObject object, String field, String defaultValue) {
+    if (!object.has(field)) {
+      return defaultValue;
     }
-    return input.get(field).getAsDouble();
+    JsonElement value = object.get(field);
+    if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+      return null;
+    }
+    String text = value.getAsString().trim();
+    if (text.isEmpty() || text.length() > MAX_NAME_LENGTH) {
+      return null;
+    }
+    return text;
+  }
+
+  /**
+   * Reads a required positive finite numeric field.
+   *
+   * @param input source object
+   * @param field field name
+   * @return positive finite value
+   */
+  private static double readPositiveFiniteNumber(JsonObject input, String field) {
+    double value = readFiniteNumber(input, field, field);
+    if (value <= 0.0) {
+      throw new IllegalArgumentException(field + " must be greater than 0");
+    }
+    return value;
+  }
+
+  /**
+   * Reads a required finite numeric field.
+   *
+   * @param input source object
+   * @param field field name
+   * @param displayName stable field path for errors
+   * @return finite value
+   */
+  private static double readFiniteNumber(JsonObject input, String field, String displayName) {
+    if (!input.has(field)) {
+      throw new IllegalArgumentException("Missing required field: " + displayName);
+    }
+    JsonElement element = input.get(field);
+    if (!element.isJsonPrimitive()) {
+      throw new IllegalArgumentException(displayName + " must be a finite number");
+    }
+    JsonPrimitive primitive = element.getAsJsonPrimitive();
+    if (!primitive.isNumber()) {
+      throw new IllegalArgumentException(displayName + " must be a finite number");
+    }
+    double value = primitive.getAsDouble();
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(displayName + " must be a finite number");
+    }
+    return value;
   }
 
   /**
@@ -112,15 +221,19 @@ public final class LOPARunner {
   }
 
   /**
-   * Error JSON.
+   * Returns a stable fail-closed error response.
    *
-   * @param message message
-   * @return JSON string
+   * @param code stable error code
+   * @param message sanitized message
+   * @return JSON error response
    */
-  private static String errorJson(String message) {
+  private static String errorJson(String code, String message) {
     JsonObject err = new JsonObject();
     err.addProperty("status", "error");
+    err.addProperty("code", code);
     err.addProperty("message", message);
+    err.addProperty("screeningOnly", true);
+    err.addProperty("standardConformanceClaimed", false);
     return err.toString();
   }
 }

--- a/src/test/java/neqsim/mcp/runners/LOPARunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/LOPARunnerTest.java
@@ -1,8 +1,10 @@
 package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -12,37 +14,139 @@ import com.google.gson.JsonParser;
 class LOPARunnerTest {
 
   @Test
-  void testTargetMet() {
-    String json = "{" + "\"scenario\":\"Overpressure of HP separator\"," + "\"initiatingEventFrequency_per_year\":0.1,"
-        + "\"targetFrequency_per_year\":1.0e-5," + "\"layers\":[" + "  {\"name\":\"BPCS\",\"pfd\":0.1},"
-        + "  {\"name\":\"Operator response\",\"pfd\":0.1}," + "  {\"name\":\"Relief valve\",\"pfd\":0.01},"
-        + "  {\"name\":\"SIF\",\"pfd\":0.01}" + "]" + "}";
-    String result = LOPARunner.run(json);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("success", obj.get("status").getAsString());
-    assertTrue(obj.has("lopa"));
-    JsonObject gap = obj.getAsJsonObject("gapAnalysis");
-    assertTrue(gap.get("targetMet").getAsBoolean());
-    assertTrue(gap.get("totalRRF").getAsDouble() > 1.0);
+  void calculatesCanonicalTargetMetCaseWithScreeningBoundary() {
+    JsonObject result = run("{" + "\"scenario\":\"Overpressure of HP separator\","
+        + "\"initiatingEventFrequency_per_year\":0.1," + "\"targetFrequency_per_year\":1.1e-4," + "\"layers\":["
+        + "{\"name\":\"BPCS\",\"pfd\":0.1}," + "{\"name\":\"Relief valve\",\"pfd\":0.01}" + "]}");
+
+    assertEquals("success", result.get("status").getAsString());
+    assertTrue(result.get("screeningOnly").getAsBoolean());
+    assertFalse(result.get("standardConformanceClaimed").getAsBoolean());
+    assertEquals("CALLER_SUPPLIED_FREQUENCIES_AND_LAYER_PFDS", result.get("inputBasis").getAsString());
+    assertTrue(result.get("advisoryBoundary").getAsString().contains("does not identify hazards"));
+    assertEquals(3, result.getAsJsonArray("assumptions").size());
+
+    JsonObject lopa = result.getAsJsonObject("lopa");
+    assertEquals(0.1, lopa.get("initiatingEventFrequency").getAsDouble(), 0.0);
+    assertEquals(0.0001, lopa.get("mitigatedFrequency").getAsDouble(), 1.0e-15);
+    assertEquals(1000.0, lopa.get("totalRRF").getAsDouble(), 1.0e-12);
+    assertTrue(result.getAsJsonObject("gapAnalysis").get("targetMet").getAsBoolean());
   }
 
   @Test
-  void testTargetNotMet() {
-    String json = "{" + "\"scenario\":\"Insufficient mitigation\"," + "\"initiatingEventFrequency_per_year\":0.5,"
-        + "\"targetFrequency_per_year\":1.0e-5," + "\"layers\":[" + "  {\"name\":\"BPCS\",\"pfd\":0.1}" + "]" + "}";
-    String result = LOPARunner.run(json);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("success", obj.get("status").getAsString());
-    JsonObject gap = obj.getAsJsonObject("gapAnalysis");
-    assertEquals(false, gap.get("targetMet").getAsBoolean());
-    assertTrue(gap.has("requiredAdditionalSIL"));
-    assertTrue(gap.get("requiredAdditionalRRF").getAsDouble() > 1.0);
+  void calculatesCanonicalGapAndLabelsIndicativeSilBand() {
+    JsonObject result = run(
+        "{" + "\"scenario\":\"Insufficient mitigation\"," + "\"initiatingEventFrequency_per_year\":0.5,"
+            + "\"targetFrequency_per_year\":1.0e-5," + "\"layers\":[{\"name\":\"BPCS\",\"pfd\":0.1}]}");
+    JsonObject gap = result.getAsJsonObject("gapAnalysis");
+
+    assertEquals("success", result.get("status").getAsString());
+    assertFalse(gap.get("targetMet").getAsBoolean());
+    assertEquals(5000.0, gap.get("requiredAdditionalRRF").getAsDouble(), 0.0);
+    assertEquals(3, gap.get("requiredAdditionalSIL").getAsInt());
+    assertTrue(gap.get("requiredAdditionalSILIsIndicative").getAsBoolean());
+    assertEquals(0.0002, gap.get("requiredAdditionalPFD").getAsDouble(), 0.0);
   }
 
   @Test
-  void testMissingFields() {
-    String result = LOPARunner.run("{\"scenario\":\"x\"}");
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("error", obj.get("status").getAsString());
+  void preservesCallerLayerOrderAndDeterministicDefaultScenario() {
+    String input = "{" + "\"initiatingEventFrequency_per_year\":0.1," + "\"targetFrequency_per_year\":1.0e-5,"
+        + "\"layers\":[" + "{\"name\":\"First\",\"pfd\":0.1},{\"name\":\"Second\",\"pfd\":0.2}]}";
+    JsonObject first = run(input);
+    JsonObject second = run(input);
+    JsonArray layers = first.getAsJsonObject("lopa").getAsJsonArray("protectionLayers");
+
+    assertEquals("unnamed scenario", first.getAsJsonObject("lopa").get("scenarioName").getAsString());
+    assertEquals("First", layers.get(0).getAsJsonObject().get("name").getAsString());
+    assertEquals("Second", layers.get(1).getAsJsonObject().get("name").getAsString());
+    assertEquals(first, second);
+  }
+
+  @Test
+  void rejectsMissingWrongShapeAndMalformedRequestsWithoutParserDetails() {
+    assertErrorCode("", "INVALID_INPUT");
+    assertErrorCode("[]", "INVALID_INPUT");
+    assertErrorCode("{not-json", "INVALID_INPUT");
+    assertErrorCode("{\"scenario\":\"x\"}", "INVALID_INPUT");
+    JsonObject malformed = run("{not-json");
+    assertFalse(malformed.get("message").getAsString().contains("line"));
+  }
+
+  @Test
+  void rejectsNonFiniteNonPositiveAndWrongTypeFrequencies() {
+    assertErrorCode(request("0", "1e-5", oneLayer()), "INVALID_INPUT");
+    assertErrorCode(request("-0.1", "1e-5", oneLayer()), "INVALID_INPUT");
+    assertErrorCode(request("NaN", "1e-5", oneLayer()), "INVALID_INPUT");
+    assertErrorCode(request("0.1", "Infinity", oneLayer()), "INVALID_INPUT");
+    assertErrorCode(request("\"often\"", "1e-5", oneLayer()), "INVALID_INPUT");
+  }
+
+  @Test
+  void rejectsInvalidLayerShapesNamesAndPfds() {
+    assertErrorCode(request("0.1", "1e-5", "[]"), "INVALID_INPUT");
+    assertErrorCode(request("0.1", "1e-5", "[\"layer\"]"), "INVALID_LAYER");
+    assertErrorCode(request("0.1", "1e-5", "[{\"pfd\":0.1}]"), "INVALID_LAYER");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\" \" ,\"pfd\":0.1}]"), "INVALID_LAYER");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":0}]"), "INVALID_LAYER");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":1.01}]"), "INVALID_LAYER");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":NaN}]"), "INVALID_INPUT");
+  }
+
+  @Test
+  void boundsRequestLayerCountAndNames() {
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"" + repeat('n', 257) + "\",\"pfd\":0.1}]"), "INVALID_LAYER");
+    StringBuilder layers = new StringBuilder("[");
+    for (int i = 0; i < 101; i++) {
+      if (i > 0) {
+        layers.append(',');
+      }
+      layers.append("{\"name\":\"L").append(i).append("\",\"pfd\":1}");
+    }
+    layers.append(']');
+    assertErrorCode(request("0.1", "1e-5", layers.toString()), "TOO_MANY_LAYERS");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"" + repeat('x', 16400) + "\",\"pfd\":0.1}]"),
+        "REQUEST_TOO_LARGE");
+  }
+
+  @Test
+  void rejectsUnderflowInsteadOfReportingAbsoluteProtection() {
+    StringBuilder layers = new StringBuilder("[");
+    for (int i = 0; i < 100; i++) {
+      if (i > 0) {
+        layers.append(',');
+      }
+      layers.append("{\"name\":\"L").append(i).append("\",\"pfd\":1e-100}");
+    }
+    layers.append(']');
+    assertErrorCode(request("0.1", "1e-5", layers.toString()), "CALCULATION_OUT_OF_RANGE");
+  }
+
+  private static JsonObject run(String input) {
+    return JsonParser.parseString(LOPARunner.run(input)).getAsJsonObject();
+  }
+
+  private static String request(String initiating, String target, String layers) {
+    return "{\"initiatingEventFrequency_per_year\":" + initiating + ",\"targetFrequency_per_year\":" + target
+        + ",\"layers\":" + layers + "}";
+  }
+
+  private static String oneLayer() {
+    return "[{\"name\":\"Layer\",\"pfd\":0.1}]";
+  }
+
+  private static void assertErrorCode(String input, String code) {
+    JsonObject result = run(input);
+    assertEquals("error", result.get("status").getAsString());
+    assertEquals(code, result.get("code").getAsString());
+    assertTrue(result.get("screeningOnly").getAsBoolean());
+    assertFalse(result.get("standardConformanceClaimed").getAsBoolean());
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
   }
 }

--- a/src/test/java/neqsim/mcp/runners/LOPARunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/LOPARunnerTest.java
@@ -89,7 +89,8 @@ class LOPARunnerTest {
     assertErrorCode(request("0.1", "1e-5", "[{\"name\":\" \" ,\"pfd\":0.1}]"), "INVALID_LAYER");
     assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":0}]"), "INVALID_LAYER");
     assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":1.01}]"), "INVALID_LAYER");
-    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":NaN}]"), "INVALID_INPUT");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":NaN}]"), "INVALID_LAYER");
+    assertErrorCode(request("0.1", "1e-5", "[{\"name\":\"x\",\"pfd\":\"low\"}]"), "INVALID_LAYER");
   }
 
   @Test


### PR DESCRIPTION
Advances #3153.

## Summary

Qualifies the existing `runLOPA` surface as a bounded, deterministic screening calculation while retaining NeqSim's canonical LOPA and SIF numerical authorities.

- bounds requests at 16,384 UTF-8 bytes and 100 ordered layers;
- requires finite positive initiating/target frequencies and finite layer PFDs in `(0, 1]`;
- bounds scenario and layer names;
- rejects malformed, non-finite, oversized, and underflowing calculations with stable sanitized error codes;
- preserves caller layer order and canonical `LOPAResult` frequency, RRF, target-gap, and `SafetyInstrumentedFunction` additional-PFD calculations;
- labels any additional SIL band as indicative;
- replaces standards-conformance implications with explicit caller-input and qualified-review boundaries.

This is a qualification increment only. `runLOPA` remains `CONFIRMED_GAP`; Phase 0 inventory remains **1.36 / 20 explicit + 36 contract-tested + 15 confirmed gaps** until a later separately accepted promotion.

## Capability contract

**Engineering question.** Can an MCP client run a deterministic, bounded layer-of-protection screening calculation through NeqSim's canonical LOPA model while preventing malformed, unbounded, or non-finite inputs and clearly separating numerical screening from hazard identification, IPL verification, SIL verification, risk acceptance, standards compliance, and accountable engineering approval?

The frozen contract is recorded in [#3153](https://github.com/equinor/neqsim/issues/3153#issuecomment-5632814960).

## Canonical model and advisory boundary

The calculation continues to use:

- `neqsim.process.safety.risk.sis.LOPAResult`;
- `SafetyInstrumentedFunction.calculateRequiredPfd(...)`; and
- the canonical SIL-band mapping already used by `LOPAResult`.

No MCP-only risk or SIL model is introduced. IEC 61511 and CCPS LOPA are context only, not conformance claims.

The caller owns initiating-event frequency, target frequency, PFDs, layer claims, IPL independence, common cause, human reliability, proof-test assumptions, consequence basis, and project risk criteria. The tool does not identify hazards, validate safeguards or independence, verify SIL, determine risk acceptance, certify compliance, authorize plant action, or replace qualified process-safety review.

## Frozen scope

Exactly nine files:

1. `src/main/java/neqsim/mcp/runners/LOPARunner.java`
2. `src/test/java/neqsim/mcp/runners/LOPARunnerTest.java`
3. `neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java`
4. `neqsim-mcp-server/test_lopa_protocol.py`
5. `neqsim-mcp-server/test_mcp_server.py`
6. `.github/workflows/mcp_protocol_qualification.yml`
7. `neqsim-mcp-server/README.md`
8. `neqsim-mcp-server/MCP_CONTRACT.md`
9. `neqsim-mcp-server/docs/evidence/LOPA_SCREENING_CONTRACT.md`

No schema, inventory, process model, thermodynamic model, numerical method, production policy, or plant-control behavior changes.

## Exact continuity and coordination

- Exact base: `8a16c6c80842f2f9311c508b0fa5c246db14dfd0`
- Exact head: `5edce1e766f80eabe17934de20a7af0d6fc31f39`
- #3651 merged externally from preserved head `c75240226354fb9b2fc5a80ea421f8e836d51667` as `f6e7bad36e90565718a951ff5d7ac1e660849d85`; all exact-head workflow runs succeeded.
- Open autonomous scopes #3656, #3654, #3653, and #3649 have no path overlap.
- Portfolio occupancy is **5/10**.

## Validation

Passing locally on the exact repaired nine-file tree:

- focused `LOPARunnerTest`: **8/8**;
- repository Spotless apply and repeat check;
- documentation search audit: 696 Markdown pages and 1 standalone HTML page;
- documentation checker unit tests: **10/10**;
- Python byte compilation for focused and comprehensive protocol sources;
- clean `git diff --check`.

Hosted exact-head validation now passes:

- focused LOPA Java: **8/8**;
- packaged LOPA MCP: **8 scenarios**;
- comprehensive MCP: **335/335**;
- Java 8 and 21 fast tests on Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Javadocs, Spotless, pre-commit, CodeQL, PaperLab, documentation/search, and agent validation;
- no reviews or unresolved threads.

The publication-head packaged protocol found one attributable error-taxonomy mismatch: a nonnumeric layer PFD returned `INVALID_INPUT` instead of `INVALID_LAYER`. Exact fast-forward repair `5edce1e7…` makes all layer-local PFD validation consistently return `INVALID_LAYER`; no model, limit, or advisory behavior changed.

The Java 8 Ubuntu and Windows suites have also completed successfully on the repaired exact head.

**READY TO MERGE.**

## Publication boundary

This PR must remain open and draft. Do not merge, enable auto-merge, mark ready for review, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.