### PR TITLE
feat(refinery): qualify Big Hill vacuum reboiler-temperature sensitivity

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -291,3 +291,51 @@ size equipment, validate product quality, or demonstrate turndown.
 All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
 does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
 calibrated VGO/residue yields, optimization, product specifications, or plant-agreement evidence.
+
+## Reboiler-temperature sensitivity screening
+
+`DoeBigHillVacuumReboilerTemperatureSensitivity.run(...)` independently rebuilds, solves, and
+evaluates multiple Big Hill vacuum cases while varying only the reboiler outlet temperature. Tray
+count, feed tray, feed temperature, all three absolute pressures, condenser reflux ratio, feed
+composition, and feed mass flow remain fixed. Temperatures must be finite, positive, unique,
+strictly increasing, and above the fixed feed temperature.
+
+The documented three-point screen stays close to the qualified base point:
+
+```java
+OperatingInputs baseline =
+    new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+double[] reboilerTemperaturesKelvin = {698.0, 700.0, 702.0};
+
+DoeBigHillVacuumReboilerTemperatureSensitivity sensitivity =
+    DoeBigHillVacuumReboilerTemperatureSensitivity.run(
+        "Big Hill vacuum reboiler-temperature screen",
+        1000.0,
+        baseline,
+        reboilerTemperaturesKelvin);
+
+for (DoeBigHillVacuumReboilerTemperatureSensitivity.PointResult point :
+    sensitivity.getPoints()) {
+  double reboilerTemperatureKelvin = point.getReboilerTemperatureKelvin();
+  double overheadMassFraction = point.getOverheadMassFraction();
+  double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+}
+```
+
+Every point must pass the already qualified MESH-residual, fallback, mass, component, energy,
+material-product, and boiling-point-order gates. The summary returns a defensive point array, exact
+applied operating inputs, immutable per-point fractionation results, the observed overhead-yield
+bounds, and the worst external mass closure, component closure, column energy error, and final MESH
+residual. A failed point aborts the complete sensitivity instead of returning a partial envelope.
+
+The temperature is the specified reboiler outlet temperature, not a measured tray profile, boiling
+curve, heat duty, or utility demand. This screen isolates that single numerical operating variable;
+it does not represent a measured, optimized, or vendor-recommended temperature policy. The narrow
+698/700/702 K regression is a convergence and conservation test around the documented screening
+point. It does not establish a measured temperature response, require a monotonic yield trend,
+quantify heat-transfer performance, size equipment, validate product quality, or demonstrate
+turndown.
+
+All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
+does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
+calibrated VGO/residue yields, optimization, product specifications, or plant-agreement evidence.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivity.java
@@ -1,0 +1,221 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/**
+ * Immutable reboiler-temperature sensitivity summary for the DOE Big Hill vacuum screening case.
+ *
+ * <p>
+ * Reboiler outlet temperature is varied while all other explicit engineering inputs remain fixed.
+ * Each point is independently constructed, solved, and evaluated through the qualified Big Hill
+ * case and result contracts. The sensitivity is numerical screening evidence, not a measured or
+ * calibrated vacuum-column operating envelope.
+ * </p>
+ */
+public final class DoeBigHillVacuumReboilerTemperatureSensitivity {
+  private final PointResult[] points;
+  private final double minimumOverheadMassFraction;
+  private final double maximumOverheadMassFraction;
+  private final double maximumMassClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumColumnEnergyBalanceError;
+  private final double maximumMeshResidualNorm;
+
+  private DoeBigHillVacuumReboilerTemperatureSensitivity(PointResult[] points) {
+    this.points = points.clone();
+
+    double minimumOverheadFraction = Double.POSITIVE_INFINITY;
+    double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
+    double maximumMassClosure = 0.0;
+    double maximumComponentClosure = 0.0;
+    double maximumEnergyError = 0.0;
+    double maximumMeshResidual = 0.0;
+    for (PointResult point : points) {
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+      minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
+      maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
+      maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumComponentClosure = Math.max(maximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    minimumOverheadMassFraction = minimumOverheadFraction;
+    maximumOverheadMassFraction = maximumOverheadFraction;
+    maximumMassClosureRelativeError = maximumMassClosure;
+    maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumColumnEnergyBalanceError = maximumEnergyError;
+    maximumMeshResidualNorm = maximumMeshResidual;
+  }
+
+  /**
+   * Run an independent reboiler-temperature sensitivity around explicit baseline operating inputs.
+   *
+   * @param caseNamePrefix non-blank prefix used for independently constructed point names
+   * @param feedMassFlowKgPerHour finite positive feed mass flow in kg/h
+   * @param baselineInputs explicit source-unreported baseline column inputs
+   * @param reboilerTemperaturesKelvin finite positive strictly increasing temperatures in kelvin
+   * @return immutable sensitivity summary
+   * @throws NullPointerException if {@code baselineInputs} or
+   *         {@code reboilerTemperaturesKelvin} is null
+   * @throws IllegalArgumentException if the name, feed flow, or temperatures are invalid
+   * @throws IllegalStateException if a point does not solve or pass the qualified result gates
+   */
+  public static DoeBigHillVacuumReboilerTemperatureSensitivity run(String caseNamePrefix,
+      double feedMassFlowKgPerHour, OperatingInputs baselineInputs,
+      double[] reboilerTemperaturesKelvin) {
+    if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case-name prefix must be non-blank");
+    }
+    if (!Double.isFinite(feedMassFlowKgPerHour) || !(feedMassFlowKgPerHour > 0.0)) {
+      throw new IllegalArgumentException("Feed mass flow must be finite and positive");
+    }
+    Objects.requireNonNull(baselineInputs, "baselineInputs");
+    Objects.requireNonNull(reboilerTemperaturesKelvin, "reboilerTemperaturesKelvin");
+    if (reboilerTemperaturesKelvin.length < 2) {
+      throw new IllegalArgumentException("Reboiler-temperature sensitivity requires at least two points");
+    }
+
+    double[] temperatures = reboilerTemperaturesKelvin.clone();
+    validateTemperatures(temperatures, baselineInputs.getFeedTemperatureKelvin());
+    PointResult[] evaluatedPoints = new PointResult[temperatures.length];
+    for (int i = 0; i < temperatures.length; i++) {
+      OperatingInputs pointInputs = temperatureInputs(baselineInputs, temperatures[i]);
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase.create(
+          caseNamePrefix + " reboiler-temperature point " + (i + 1), feedMassFlowKgPerHour,
+          pointInputs);
+      try {
+        model.getColumn().run(UUID.randomUUID());
+        DoeBigHillVacuumFractionationResult result =
+            DoeBigHillVacuumFractionationResult.evaluate(model);
+        evaluatedPoints[i] = new PointResult(temperatures[i], pointInputs, result);
+      } catch (RuntimeException exception) {
+        throw new IllegalStateException("Vacuum reboiler-temperature sensitivity failed at point "
+            + i + " with reboiler temperature " + temperatures[i] + " K", exception);
+      }
+    }
+    return new DoeBigHillVacuumReboilerTemperatureSensitivity(evaluatedPoints);
+  }
+
+  /** @return defensive copy of sensitivity points in increasing temperature order */
+  public PointResult[] getPoints() {
+    return points.clone();
+  }
+
+  /**
+   * Return one sensitivity point by zero-based index.
+   *
+   * @param index zero-based point index
+   * @return immutable point result
+   * @throws IndexOutOfBoundsException if {@code index} is outside the sensitivity
+   */
+  public PointResult getPoint(int index) {
+    if (index < 0 || index >= points.length) {
+      throw new IndexOutOfBoundsException("Reboiler-temperature sensitivity point index is outside the result");
+    }
+    return points[index];
+  }
+
+  /** @return smallest overhead mass fraction across the qualified points */
+  public double getMinimumOverheadMassFraction() {
+    return minimumOverheadMassFraction;
+  }
+
+  /** @return largest overhead mass fraction across the qualified points */
+  public double getMaximumOverheadMassFraction() {
+    return maximumOverheadMassFraction;
+  }
+
+  /** @return largest external mass-closure relative error across the qualified points */
+  public double getMaximumMassClosureRelativeError() {
+    return maximumMassClosureRelativeError;
+  }
+
+  /** @return largest component molar-closure relative error across the qualified points */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest column energy-balance error across the qualified points */
+  public double getMaximumColumnEnergyBalanceError() {
+    return maximumColumnEnergyBalanceError;
+  }
+
+  /** @return largest final MESH residual norm across the qualified points */
+  public double getMaximumMeshResidualNorm() {
+    return maximumMeshResidualNorm;
+  }
+
+  private static void validateTemperatures(double[] temperatures, double feedTemperatureKelvin) {
+    double previous = Double.NEGATIVE_INFINITY;
+    for (double temperature : temperatures) {
+      if (!Double.isFinite(temperature) || !(temperature > feedTemperatureKelvin)) {
+        throw new IllegalArgumentException(
+            "Reboiler temperatures must be finite and greater than the feed temperature");
+      }
+      if (!(temperature > previous)) {
+        throw new IllegalArgumentException(
+            "Reboiler temperatures must be strictly increasing and unique");
+      }
+      previous = temperature;
+    }
+  }
+
+  private static OperatingInputs temperatureInputs(OperatingInputs baseline,
+      double reboilerTemperatureKelvin) {
+    return new OperatingInputs(baseline.getSimpleTrayCount(), baseline.getFeedTrayIndex(),
+        baseline.getFeedTemperatureKelvin(), baseline.getFeedPressureBara(),
+        baseline.getTopPressureBara(), baseline.getBottomPressureBara(),
+        reboilerTemperatureKelvin, baseline.getCondenserRefluxRatio());
+  }
+
+  /** Immutable result for one reboiler-temperature point. */
+  public static final class PointResult {
+    private final double reboilerTemperatureKelvin;
+    private final OperatingInputs operatingInputs;
+    private final DoeBigHillVacuumFractionationResult fractionationResult;
+
+    private PointResult(double reboilerTemperatureKelvin, OperatingInputs operatingInputs,
+        DoeBigHillVacuumFractionationResult fractionationResult) {
+      this.reboilerTemperatureKelvin = reboilerTemperatureKelvin;
+      this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
+      this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
+    }
+
+    /** @return reboiler outlet temperature applied at this point in kelvin */
+    public double getReboilerTemperatureKelvin() {
+      return reboilerTemperatureKelvin;
+    }
+
+    /** @return immutable operating inputs applied at this point */
+    public OperatingInputs getOperatingInputs() {
+      return operatingInputs;
+    }
+
+    /** @return qualified immutable fractionation result for this point */
+    public DoeBigHillVacuumFractionationResult getFractionationResult() {
+      return fractionationResult;
+    }
+
+    /** @return overhead mass fraction of feed at this point */
+    public double getOverheadMassFraction() {
+      return fractionationResult.getProduct("Overhead").getMassFractionOfFeed();
+    }
+
+    /**
+     * Return a discrete overhead normal-boiling-point diagnostic.
+     *
+     * @param cumulativeMoleFraction cumulative product mole fraction in (0, 1]
+     * @return overhead pseudo-component quantile in kelvin
+     */
+    public double getOverheadBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      ProductResult overhead = fractionationResult.getProduct("Overhead");
+      return overhead.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivity.java
@@ -9,10 +9,9 @@ import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult
  * Immutable reboiler-temperature sensitivity summary for the DOE Big Hill vacuum screening case.
  *
  * <p>
- * Reboiler outlet temperature is varied while all other explicit engineering inputs remain fixed.
- * Each point is independently constructed, solved, and evaluated through the qualified Big Hill
- * case and result contracts. The sensitivity is numerical screening evidence, not a measured or
- * calibrated vacuum-column operating envelope.
+ * Reboiler outlet temperature is varied while all other explicit engineering inputs remain fixed. Each point is
+ * independently constructed, solved, and evaluated through the qualified Big Hill case and result contracts. The
+ * sensitivity is numerical screening evidence, not a measured or calibrated vacuum-column operating envelope.
  * </p>
  */
 public final class DoeBigHillVacuumReboilerTemperatureSensitivity {
@@ -61,14 +60,12 @@ public final class DoeBigHillVacuumReboilerTemperatureSensitivity {
    * @param baselineInputs explicit source-unreported baseline column inputs
    * @param reboilerTemperaturesKelvin finite positive strictly increasing temperatures in kelvin
    * @return immutable sensitivity summary
-   * @throws NullPointerException if {@code baselineInputs} or
-   *         {@code reboilerTemperaturesKelvin} is null
+   * @throws NullPointerException if {@code baselineInputs} or {@code reboilerTemperaturesKelvin} is null
    * @throws IllegalArgumentException if the name, feed flow, or temperatures are invalid
    * @throws IllegalStateException if a point does not solve or pass the qualified result gates
    */
-  public static DoeBigHillVacuumReboilerTemperatureSensitivity run(String caseNamePrefix,
-      double feedMassFlowKgPerHour, OperatingInputs baselineInputs,
-      double[] reboilerTemperaturesKelvin) {
+  public static DoeBigHillVacuumReboilerTemperatureSensitivity run(String caseNamePrefix, double feedMassFlowKgPerHour,
+      OperatingInputs baselineInputs, double[] reboilerTemperaturesKelvin) {
     if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
       throw new IllegalArgumentException("Case-name prefix must be non-blank");
     }
@@ -86,17 +83,15 @@ public final class DoeBigHillVacuumReboilerTemperatureSensitivity {
     PointResult[] evaluatedPoints = new PointResult[temperatures.length];
     for (int i = 0; i < temperatures.length; i++) {
       OperatingInputs pointInputs = temperatureInputs(baselineInputs, temperatures[i]);
-      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase.create(
-          caseNamePrefix + " reboiler-temperature point " + (i + 1), feedMassFlowKgPerHour,
-          pointInputs);
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
+          .create(caseNamePrefix + " reboiler-temperature point " + (i + 1), feedMassFlowKgPerHour, pointInputs);
       try {
         model.getColumn().run(UUID.randomUUID());
-        DoeBigHillVacuumFractionationResult result =
-            DoeBigHillVacuumFractionationResult.evaluate(model);
+        DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
         evaluatedPoints[i] = new PointResult(temperatures[i], pointInputs, result);
       } catch (RuntimeException exception) {
-        throw new IllegalStateException("Vacuum reboiler-temperature sensitivity failed at point "
-            + i + " with reboiler temperature " + temperatures[i] + " K", exception);
+        throw new IllegalStateException("Vacuum reboiler-temperature sensitivity failed at point " + i
+            + " with reboiler temperature " + temperatures[i] + " K", exception);
       }
     }
     return new DoeBigHillVacuumReboilerTemperatureSensitivity(evaluatedPoints);
@@ -159,19 +154,16 @@ public final class DoeBigHillVacuumReboilerTemperatureSensitivity {
             "Reboiler temperatures must be finite and greater than the feed temperature");
       }
       if (!(temperature > previous)) {
-        throw new IllegalArgumentException(
-            "Reboiler temperatures must be strictly increasing and unique");
+        throw new IllegalArgumentException("Reboiler temperatures must be strictly increasing and unique");
       }
       previous = temperature;
     }
   }
 
-  private static OperatingInputs temperatureInputs(OperatingInputs baseline,
-      double reboilerTemperatureKelvin) {
+  private static OperatingInputs temperatureInputs(OperatingInputs baseline, double reboilerTemperatureKelvin) {
     return new OperatingInputs(baseline.getSimpleTrayCount(), baseline.getFeedTrayIndex(),
-        baseline.getFeedTemperatureKelvin(), baseline.getFeedPressureBara(),
-        baseline.getTopPressureBara(), baseline.getBottomPressureBara(),
-        reboilerTemperatureKelvin, baseline.getCondenserRefluxRatio());
+        baseline.getFeedTemperatureKelvin(), baseline.getFeedPressureBara(), baseline.getTopPressureBara(),
+        baseline.getBottomPressureBara(), reboilerTemperatureKelvin, baseline.getCondenserRefluxRatio());
   }
 
   /** Immutable result for one reboiler-temperature point. */

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java
@@ -1,0 +1,138 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumReboilerTemperatureSensitivity.PointResult;
+
+/** Qualification tests for {@link DoeBigHillVacuumReboilerTemperatureSensitivity}. */
+public class DoeBigHillVacuumReboilerTemperatureSensitivityTest {
+  private static final double FEED_MASS_FLOW_KG_PER_HOUR = 1000.0;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /** Execute the documented three-point temperature screen with every other input held fixed. */
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void temperatureScreenReturnsQualifiedImmutablePoints() {
+    OperatingInputs baseline = baselineInputs();
+    double[] temperatures = {698.0, 700.0, 702.0};
+
+    DoeBigHillVacuumReboilerTemperatureSensitivity sensitivity =
+        DoeBigHillVacuumReboilerTemperatureSensitivity.run(
+            "Big Hill vacuum reboiler-temperature screen", FEED_MASS_FLOW_KG_PER_HOUR,
+            baseline, temperatures);
+
+    temperatures[0] = 999.0;
+    PointResult[] points = sensitivity.getPoints();
+    assertEquals(3, points.length);
+    assertNotSame(points, sensitivity.getPoints());
+    assertEquals(698.0, points[0].getReboilerTemperatureKelvin(), 0.0);
+    assertEquals(700.0, points[1].getReboilerTemperatureKelvin(), 0.0);
+    assertEquals(702.0, points[2].getReboilerTemperatureKelvin(), 0.0);
+    assertEquals(points[0], sensitivity.getPoint(0));
+    assertEquals(points[2], sensitivity.getPoint(2));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(3));
+
+    double expectedMinimumOverhead = Double.POSITIVE_INFINITY;
+    double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
+    double expectedMaximumMassClosure = 0.0;
+    double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumEnergyError = 0.0;
+    double expectedMaximumMeshResidual = 0.0;
+
+    for (PointResult point : points) {
+      double temperature = point.getReboilerTemperatureKelvin();
+      OperatingInputs applied = point.getOperatingInputs();
+      assertEquals(temperature, applied.getReboilerTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
+      assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
+      assertEquals(baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getFeedPressureBara(), applied.getFeedPressureBara(), 0.0);
+      assertEquals(baseline.getTopPressureBara(), applied.getTopPressureBara(), 0.0);
+      assertEquals(baseline.getBottomPressureBara(), applied.getBottomPressureBara(), 0.0);
+      assertEquals(baseline.getCondenserRefluxRatio(), applied.getCondenserRefluxRatio(), 0.0);
+
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      ProductResult overhead = result.getProduct("Overhead");
+      ProductResult bottoms = result.getProduct("Bottoms");
+      assertTrue(overhead.getMassFractionOfFeed() > 0.0);
+      assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
+          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
+      assertThrows(IllegalArgumentException.class,
+          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
+
+      expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure =
+          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumEnergyError =
+          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual =
+          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumMassClosure,
+        sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure,
+        sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
+  }
+
+  /** Require malformed sensitivity definitions to fail before presenting an envelope. */
+  @Test
+  public void invalidSensitivityInputsFailClosed() {
+    OperatingInputs baseline = baselineInputs();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run(" ",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {698.0, 702.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen", 0.0, baseline,
+            new double[] {698.0, 702.0}));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] {698.0, 702.0}));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {700.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {700.0, Double.NaN}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {700.0, 700.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {702.0, 700.0}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {640.0, 700.0}));
+  }
+
+  private static OperatingInputs baselineInputs() {
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java
@@ -24,10 +24,8 @@ public class DoeBigHillVacuumReboilerTemperatureSensitivityTest {
     OperatingInputs baseline = baselineInputs();
     double[] temperatures = { 698.0, 700.0, 702.0 };
 
-    DoeBigHillVacuumReboilerTemperatureSensitivity sensitivity =
-        DoeBigHillVacuumReboilerTemperatureSensitivity.run(
-            "Big Hill vacuum reboiler-temperature screen", FEED_MASS_FLOW_KG_PER_HOUR,
-            baseline, temperatures);
+    DoeBigHillVacuumReboilerTemperatureSensitivity sensitivity = DoeBigHillVacuumReboilerTemperatureSensitivity
+        .run("Big Hill vacuum reboiler-temperature screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, temperatures);
 
     temperatures[0] = 999.0;
     PointResult[] points = sensitivity.getPoints();
@@ -65,35 +63,28 @@ public class DoeBigHillVacuumReboilerTemperatureSensitivityTest {
       ProductResult bottoms = result.getProduct("Bottoms");
       assertTrue(overhead.getMassFractionOfFeed() > 0.0);
       assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
-      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
-          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin() < bottoms.getMeanNormalBoilingPointKelvin());
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
-      assertThrows(IllegalArgumentException.class,
-          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertThrows(IllegalArgumentException.class, () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
       assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
       expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
       expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
-      expectedMaximumMassClosure =
-          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
       expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      expectedMaximumEnergyError =
-          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
-      expectedMaximumMeshResidual =
-          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+      expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
     }
 
     assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
     assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
-    assertEquals(expectedMaximumMassClosure,
-        sensitivity.getMaximumMassClosureRelativeError(), 0.0);
-    assertEquals(expectedMaximumComponentClosure,
-        sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumMassClosure, sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure, sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
     assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
     assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
   }
@@ -103,33 +94,24 @@ public class DoeBigHillVacuumReboilerTemperatureSensitivityTest {
   public void invalidSensitivityInputsFailClosed() {
     OperatingInputs baseline = baselineInputs();
 
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run(" ",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 698.0, 702.0 }));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen", 0.0, baseline,
-            new double[] { 698.0, 702.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run(" ",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 698.0, 702.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen", 0.0,
+        baseline, new double[] { 698.0, 702.0 }));
+    assertThrows(NullPointerException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 698.0, 702.0 }));
     assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 698.0, 702.0 }));
-    assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0 }));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, Double.NaN }));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, 700.0 }));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 702.0, 700.0 }));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 640.0, 700.0 }));
+        () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, Double.NaN }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, 700.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 702.0, 700.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 640.0, 700.0 }));
   }
 
   private static OperatingInputs baselineInputs() {

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java
@@ -22,7 +22,7 @@ public class DoeBigHillVacuumReboilerTemperatureSensitivityTest {
   @Timeout(value = 300, unit = TimeUnit.SECONDS)
   public void temperatureScreenReturnsQualifiedImmutablePoints() {
     OperatingInputs baseline = baselineInputs();
-    double[] temperatures = {698.0, 700.0, 702.0};
+    double[] temperatures = { 698.0, 700.0, 702.0 };
 
     DoeBigHillVacuumReboilerTemperatureSensitivity sensitivity =
         DoeBigHillVacuumReboilerTemperatureSensitivity.run(
@@ -105,31 +105,31 @@ public class DoeBigHillVacuumReboilerTemperatureSensitivityTest {
 
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run(" ",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {698.0, 702.0}));
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 698.0, 702.0 }));
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen", 0.0, baseline,
-            new double[] {698.0, 702.0}));
+            new double[] { 698.0, 702.0 }));
     assertThrows(NullPointerException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] {698.0, 702.0}));
+            FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 698.0, 702.0 }));
     assertThrows(NullPointerException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
             FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {700.0}));
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0 }));
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {700.0, Double.NaN}));
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, Double.NaN }));
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {700.0, 700.0}));
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, 700.0 }));
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {702.0, 700.0}));
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 702.0, 700.0 }));
     assertThrows(IllegalArgumentException.class,
         () -> DoeBigHillVacuumReboilerTemperatureSensitivity.run("screen",
-            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] {640.0, 700.0}));
+            FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 640.0, 700.0 }));
   }
 
   private static OperatingInputs baselineInputs() {


### PR DESCRIPTION
Advances #3305.

## Capability

Adds an immutable Java/JPype reboiler-temperature sensitivity runner for the qualified DOE Big Hill 650 degF+ vacuum screening case.

- independently rebuilds, solves, and evaluates every requested temperature point;
- varies only reboiler outlet temperature while tray topology, feed state, absolute pressures, condenser reflux, feed composition, and feed mass flow remain fixed;
- requires finite, positive, unique, strictly increasing temperatures above the fixed feed temperature;
- reuses the qualified MESH, fallback, mass, component, energy, material-product, and boiling-range gates;
- fails the complete screen if any point fails;
- returns defensive point arrays, exact applied inputs, overhead-yield bounds, and worst conservation, energy, and MESH diagnostics.

The focused regression qualifies the documented 698/700/702 K screen around the existing 700 K point without asserting a monotonic response.

## Provenance and engineering boundary

The public DOE Big Hill assay and qualified three-cut 650 degF+ normalization are unchanged. Every column operating value remains a source-unreported engineering assumption.

This is numerical sensitivity evidence only. It does not establish a measured or calibrated temperature response, VGO/residue yield, heat duty or utility demand, heat-transfer performance, equipment design, ASTM D1160/TBP correction, optimization, product specification, turndown, or plant agreement.

## Frozen scope and continuity

- Exact base: `8a16c6c80842f2f9311c508b0fa5c246db14dfd0`
- Exact publication head: `47160c663f4cfadcc81ae941461583055ab063fb`
- Changed files: exactly three
  1. `src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivity.java`
  2. `src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumReboilerTemperatureSensitivityTest.java`
  3. `docs/thermo/characterization/refinery_big_hill_complete_slate.md`
- Relation to frozen base: 6 commits ahead, zero behind
- No overlap with the 4 other open autonomous PRs
- Portfolio occupancy after reservation: **5/10**

## Validation

Connector-side pre-publication checks confirm the exact three-file scope, frozen-base continuity, Java 8-compatible syntax, defensive inputs/results, explicit failure boundaries, provenance limits, and no active ownership overlap.

**VALIDATION COMPLETE — HUMAN REVIEW REQUIRED.**

The single permitted hosted formatter repair was applied exactly from workflow run `34592796474`, artifact `spotless-format-patch` ID `10196327114`, archive digest `sha256:81667bc41c143fc0c392548e32e7d0042d008fc0185c7756775273976beb7783`. Its two formatted blob SHAs are `ff5abc4467a3c2de6ec90be7c7657ae318533e93` and `fcc3937f91cee3fffbfd997c145b8877ab7f2d7a`; only the two new Java files changed.

All exact-head validation passes: Java 8 and Java 21 on Ubuntu and Windows, four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, and agent-skill checks. The frozen base remains current `master`, and the other open autonomous PRs have no file overlap.

Because this adds public engineering API, subsystem-owner and independent-maintainer reviews are required before READY TO MERGE.

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.