### PR TITLE
feat(refinery): qualify Big Hill vacuum feed-temperature sensitivity

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -339,3 +339,51 @@ turndown.
 All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
 does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
 calibrated VGO/residue yields, optimization, product specifications, or plant-agreement evidence.
+
+## Feed-temperature sensitivity screening
+
+`DoeBigHillVacuumFeedTemperatureSensitivity.run(...)` independently rebuilds, solves, and evaluates
+multiple Big Hill vacuum cases while varying only the feed temperature. Tray count, feed tray, all
+three absolute pressures, reboiler outlet temperature, condenser reflux ratio, feed composition, and
+feed mass flow remain fixed. Temperatures must be finite, positive, unique, strictly increasing, and
+below the fixed reboiler temperature.
+
+The documented three-point screen stays close to the qualified base point:
+
+```java
+OperatingInputs baseline =
+    new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+double[] feedTemperaturesKelvin = {638.0, 640.0, 642.0};
+
+DoeBigHillVacuumFeedTemperatureSensitivity sensitivity =
+    DoeBigHillVacuumFeedTemperatureSensitivity.run(
+        "Big Hill vacuum feed-temperature screen",
+        1000.0,
+        baseline,
+        feedTemperaturesKelvin);
+
+for (DoeBigHillVacuumFeedTemperatureSensitivity.PointResult point :
+    sensitivity.getPoints()) {
+  double feedTemperatureKelvin = point.getFeedTemperatureKelvin();
+  double overheadMassFraction = point.getOverheadMassFraction();
+  double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+}
+```
+
+Every point must pass the already qualified MESH-residual, fallback, mass, component, energy,
+material-product, and boiling-point-order gates. The summary returns a defensive point array, exact
+applied operating inputs, immutable per-point fractionation results, the observed overhead-yield
+bounds, and the worst external mass closure, component closure, column energy error, and final MESH
+residual. A failed point aborts the complete sensitivity instead of returning a partial envelope.
+
+The temperature is the specified feed-stream temperature at the fixed feed pressure, not a measured
+preheat-train profile, furnace outlet temperature, flash-zone temperature, or heat duty. This screen
+isolates that single numerical operating variable; it does not represent a measured, optimized, or
+vendor-recommended preheat policy. The narrow 638/640/642 K regression is a convergence and
+conservation test around the documented screening point. It does not establish a measured
+temperature response, require a monotonic yield trend, quantify furnace or exchanger performance,
+define heat integration, size equipment, validate product quality, or demonstrate turndown.
+
+All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
+does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
+calibrated VGO/residue yields, optimization, product specifications, or plant-agreement evidence.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java
@@ -180,7 +180,7 @@ public final class DoeBigHillVacuumFeedTemperatureSensitivity {
     }
 
     /** @return feed temperature applied at this point in kelvin */
-    public double getReboilerTemperatureKelvin() {
+    public double getFeedTemperatureKelvin() {
       return feedTemperatureKelvin;
     }
 

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java
@@ -1,0 +1,214 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/**
+ * Immutable feed-temperature sensitivity summary for the DOE Big Hill vacuum screening case.
+ *
+ * <p>
+ * Feed temperature is varied while all other explicit engineering inputs remain fixed. Each point is
+ * independently constructed, solved, and evaluated through the qualified Big Hill case and result contracts. The
+ * sensitivity is numerical screening evidence, not a measured or calibrated vacuum-column operating envelope.
+ * </p>
+ */
+public final class DoeBigHillVacuumFeedTemperatureSensitivity {
+  private final PointResult[] points;
+  private final double minimumOverheadMassFraction;
+  private final double maximumOverheadMassFraction;
+  private final double maximumMassClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumColumnEnergyBalanceError;
+  private final double maximumMeshResidualNorm;
+
+  private DoeBigHillVacuumFeedTemperatureSensitivity(PointResult[] points) {
+    this.points = points.clone();
+
+    double minimumOverheadFraction = Double.POSITIVE_INFINITY;
+    double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
+    double maximumMassClosure = 0.0;
+    double maximumComponentClosure = 0.0;
+    double maximumEnergyError = 0.0;
+    double maximumMeshResidual = 0.0;
+    for (PointResult point : points) {
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+      minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
+      maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
+      maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumComponentClosure = Math.max(maximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    minimumOverheadMassFraction = minimumOverheadFraction;
+    maximumOverheadMassFraction = maximumOverheadFraction;
+    maximumMassClosureRelativeError = maximumMassClosure;
+    maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumColumnEnergyBalanceError = maximumEnergyError;
+    maximumMeshResidualNorm = maximumMeshResidual;
+  }
+
+  /**
+   * Run an independent feed-temperature sensitivity around explicit baseline operating inputs.
+   *
+   * @param caseNamePrefix non-blank prefix used for independently constructed point names
+   * @param feedMassFlowKgPerHour finite positive feed mass flow in kg/h
+   * @param baselineInputs explicit source-unreported baseline column inputs
+   * @param feedTemperaturesKelvin finite positive strictly increasing temperatures in kelvin
+   * @return immutable sensitivity summary
+   * @throws NullPointerException if {@code baselineInputs} or {@code feedTemperaturesKelvin} is null
+   * @throws IllegalArgumentException if the name, feed flow, or temperatures are invalid
+   * @throws IllegalStateException if a point does not solve or pass the qualified result gates
+   */
+  public static DoeBigHillVacuumFeedTemperatureSensitivity run(String caseNamePrefix, double feedMassFlowKgPerHour,
+      OperatingInputs baselineInputs, double[] feedTemperaturesKelvin) {
+    if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case-name prefix must be non-blank");
+    }
+    if (!Double.isFinite(feedMassFlowKgPerHour) || !(feedMassFlowKgPerHour > 0.0)) {
+      throw new IllegalArgumentException("Feed mass flow must be finite and positive");
+    }
+    Objects.requireNonNull(baselineInputs, "baselineInputs");
+    Objects.requireNonNull(feedTemperaturesKelvin, "feedTemperaturesKelvin");
+    if (feedTemperaturesKelvin.length < 2) {
+      throw new IllegalArgumentException("Feed-temperature sensitivity requires at least two points");
+    }
+
+    double[] temperatures = feedTemperaturesKelvin.clone();
+    validateTemperatures(temperatures, baselineInputs.getReboilerTemperatureKelvin());
+    PointResult[] evaluatedPoints = new PointResult[temperatures.length];
+    for (int i = 0; i < temperatures.length; i++) {
+      OperatingInputs pointInputs = temperatureInputs(baselineInputs, temperatures[i]);
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
+          .create(caseNamePrefix + " feed-temperature point " + (i + 1), feedMassFlowKgPerHour, pointInputs);
+      try {
+        model.getColumn().run(UUID.randomUUID());
+        DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
+        evaluatedPoints[i] = new PointResult(temperatures[i], pointInputs, result);
+      } catch (RuntimeException exception) {
+        throw new IllegalStateException("Vacuum feed-temperature sensitivity failed at point " + i
+            + " with reboiler temperature " + temperatures[i] + " K", exception);
+      }
+    }
+    return new DoeBigHillVacuumFeedTemperatureSensitivity(evaluatedPoints);
+  }
+
+  /** @return defensive copy of sensitivity points in increasing temperature order */
+  public PointResult[] getPoints() {
+    return points.clone();
+  }
+
+  /**
+   * Return one sensitivity point by zero-based index.
+   *
+   * @param index zero-based point index
+   * @return immutable point result
+   * @throws IndexOutOfBoundsException if {@code index} is outside the sensitivity
+   */
+  public PointResult getPoint(int index) {
+    if (index < 0 || index >= points.length) {
+      throw new IndexOutOfBoundsException("Feed-temperature sensitivity point index is outside the result");
+    }
+    return points[index];
+  }
+
+  /** @return smallest overhead mass fraction across the qualified points */
+  public double getMinimumOverheadMassFraction() {
+    return minimumOverheadMassFraction;
+  }
+
+  /** @return largest overhead mass fraction across the qualified points */
+  public double getMaximumOverheadMassFraction() {
+    return maximumOverheadMassFraction;
+  }
+
+  /** @return largest external mass-closure relative error across the qualified points */
+  public double getMaximumMassClosureRelativeError() {
+    return maximumMassClosureRelativeError;
+  }
+
+  /** @return largest component molar-closure relative error across the qualified points */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest column energy-balance error across the qualified points */
+  public double getMaximumColumnEnergyBalanceError() {
+    return maximumColumnEnergyBalanceError;
+  }
+
+  /** @return largest final MESH residual norm across the qualified points */
+  public double getMaximumMeshResidualNorm() {
+    return maximumMeshResidualNorm;
+  }
+
+  private static void validateTemperatures(double[] temperatures, double reboilerTemperatureKelvin) {
+    double previous = Double.NEGATIVE_INFINITY;
+    for (double temperature : temperatures) {
+      if (!Double.isFinite(temperature) || !(temperature > 0.0)
+          || !(temperature < reboilerTemperatureKelvin)) {
+        throw new IllegalArgumentException(
+            "Feed temperatures must be finite, positive, and below the reboiler temperature");
+      }
+      if (!(temperature > previous)) {
+        throw new IllegalArgumentException("Feed temperatures must be strictly increasing and unique");
+      }
+      previous = temperature;
+    }
+  }
+
+  private static OperatingInputs temperatureInputs(OperatingInputs baseline, double feedTemperatureKelvin) {
+    return new OperatingInputs(baseline.getSimpleTrayCount(), baseline.getFeedTrayIndex(), feedTemperatureKelvin,
+        baseline.getFeedPressureBara(), baseline.getTopPressureBara(), baseline.getBottomPressureBara(),
+        baseline.getReboilerTemperatureKelvin(), baseline.getCondenserRefluxRatio());
+  }
+
+  /** Immutable result for one feed-temperature point. */
+  public static final class PointResult {
+    private final double feedTemperatureKelvin;
+    private final OperatingInputs operatingInputs;
+    private final DoeBigHillVacuumFractionationResult fractionationResult;
+
+    private PointResult(double feedTemperatureKelvin, OperatingInputs operatingInputs,
+        DoeBigHillVacuumFractionationResult fractionationResult) {
+      this.feedTemperatureKelvin = feedTemperatureKelvin;
+      this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
+      this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
+    }
+
+    /** @return feed temperature applied at this point in kelvin */
+    public double getReboilerTemperatureKelvin() {
+      return feedTemperatureKelvin;
+    }
+
+    /** @return immutable operating inputs applied at this point */
+    public OperatingInputs getOperatingInputs() {
+      return operatingInputs;
+    }
+
+    /** @return qualified immutable fractionation result for this point */
+    public DoeBigHillVacuumFractionationResult getFractionationResult() {
+      return fractionationResult;
+    }
+
+    /** @return overhead mass fraction of feed at this point */
+    public double getOverheadMassFraction() {
+      return fractionationResult.getProduct("Overhead").getMassFractionOfFeed();
+    }
+
+    /**
+     * Return a discrete overhead normal-boiling-point diagnostic.
+     *
+     * @param cumulativeMoleFraction cumulative product mole fraction in (0, 1]
+     * @return overhead pseudo-component quantile in kelvin
+     */
+    public double getOverheadBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      ProductResult overhead = fractionationResult.getProduct("Overhead");
+      return overhead.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java
@@ -9,9 +9,9 @@ import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult
  * Immutable feed-temperature sensitivity summary for the DOE Big Hill vacuum screening case.
  *
  * <p>
- * Feed temperature is varied while all other explicit engineering inputs remain fixed. Each point is
- * independently constructed, solved, and evaluated through the qualified Big Hill case and result contracts. The
- * sensitivity is numerical screening evidence, not a measured or calibrated vacuum-column operating envelope.
+ * Feed temperature is varied while all other explicit engineering inputs remain fixed. Each point is independently
+ * constructed, solved, and evaluated through the qualified Big Hill case and result contracts. The sensitivity is
+ * numerical screening evidence, not a measured or calibrated vacuum-column operating envelope.
  * </p>
  */
 public final class DoeBigHillVacuumFeedTemperatureSensitivity {
@@ -149,8 +149,7 @@ public final class DoeBigHillVacuumFeedTemperatureSensitivity {
   private static void validateTemperatures(double[] temperatures, double reboilerTemperatureKelvin) {
     double previous = Double.NEGATIVE_INFINITY;
     for (double temperature : temperatures) {
-      if (!Double.isFinite(temperature) || !(temperature > 0.0)
-          || !(temperature < reboilerTemperatureKelvin)) {
+      if (!Double.isFinite(temperature) || !(temperature > 0.0) || !(temperature < reboilerTemperatureKelvin)) {
         throw new IllegalArgumentException(
             "Feed temperatures must be finite, positive, and below the reboiler temperature");
       }

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java
@@ -115,6 +115,6 @@ public class DoeBigHillVacuumFeedTemperatureSensitivityTest {
   }
 
   private static OperatingInputs baselineInputs() {
-    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 640.0, 0.5);
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
   }
 }

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java
@@ -96,8 +96,8 @@ public class DoeBigHillVacuumFeedTemperatureSensitivityTest {
 
     assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run(" ",
         FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 638.0, 642.0 }));
-    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen", 0.0,
-        baseline, new double[] { 638.0, 642.0 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen", 0.0, baseline, new double[] { 638.0, 642.0 }));
     assertThrows(NullPointerException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
         FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 638.0, 642.0 }));
     assertThrows(NullPointerException.class,

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java
@@ -1,0 +1,120 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFeedTemperatureSensitivity.PointResult;
+
+/** Qualification tests for {@link DoeBigHillVacuumFeedTemperatureSensitivity}. */
+public class DoeBigHillVacuumFeedTemperatureSensitivityTest {
+  private static final double FEED_MASS_FLOW_KG_PER_HOUR = 1000.0;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /** Execute the documented three-point temperature screen with every other input held fixed. */
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void temperatureScreenReturnsQualifiedImmutablePoints() {
+    OperatingInputs baseline = baselineInputs();
+    double[] temperatures = { 638.0, 640.0, 642.0 };
+
+    DoeBigHillVacuumFeedTemperatureSensitivity sensitivity = DoeBigHillVacuumFeedTemperatureSensitivity
+        .run("Big Hill vacuum feed-temperature screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, temperatures);
+
+    temperatures[0] = 999.0;
+    PointResult[] points = sensitivity.getPoints();
+    assertEquals(3, points.length);
+    assertNotSame(points, sensitivity.getPoints());
+    assertEquals(638.0, points[0].getFeedTemperatureKelvin(), 0.0);
+    assertEquals(640.0, points[1].getFeedTemperatureKelvin(), 0.0);
+    assertEquals(642.0, points[2].getFeedTemperatureKelvin(), 0.0);
+    assertEquals(points[0], sensitivity.getPoint(0));
+    assertEquals(points[2], sensitivity.getPoint(2));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(3));
+
+    double expectedMinimumOverhead = Double.POSITIVE_INFINITY;
+    double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
+    double expectedMaximumMassClosure = 0.0;
+    double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumEnergyError = 0.0;
+    double expectedMaximumMeshResidual = 0.0;
+
+    for (PointResult point : points) {
+      double temperature = point.getFeedTemperatureKelvin();
+      OperatingInputs applied = point.getOperatingInputs();
+      assertEquals(temperature, applied.getFeedTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
+      assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
+      assertEquals(baseline.getReboilerTemperatureKelvin(), applied.getReboilerTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getFeedPressureBara(), applied.getFeedPressureBara(), 0.0);
+      assertEquals(baseline.getTopPressureBara(), applied.getTopPressureBara(), 0.0);
+      assertEquals(baseline.getBottomPressureBara(), applied.getBottomPressureBara(), 0.0);
+      assertEquals(baseline.getCondenserRefluxRatio(), applied.getCondenserRefluxRatio(), 0.0);
+
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      ProductResult overhead = result.getProduct("Overhead");
+      ProductResult bottoms = result.getProduct("Bottoms");
+      assertTrue(overhead.getMassFractionOfFeed() > 0.0);
+      assertTrue(bottoms.getMassFractionOfFeed() > 0.0);
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin() < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
+      assertThrows(IllegalArgumentException.class, () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
+
+      expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumMassClosure, sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure, sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
+  }
+
+  /** Require malformed sensitivity definitions to fail before presenting an envelope. */
+  @Test
+  public void invalidSensitivityInputsFailClosed() {
+    OperatingInputs baseline = baselineInputs();
+
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run(" ",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 638.0, 642.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen", 0.0,
+        baseline, new double[] { 638.0, 642.0 }));
+    assertThrows(NullPointerException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, null, new double[] { 638.0, 642.0 }));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen", FEED_MASS_FLOW_KG_PER_HOUR, baseline, null));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 640.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 640.0, Double.NaN }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 640.0, 640.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 642.0, 640.0 }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumFeedTemperatureSensitivity.run("screen",
+        FEED_MASS_FLOW_KG_PER_HOUR, baseline, new double[] { 700.0, 702.0 }));
+  }
+
+  private static OperatingInputs baselineInputs() {
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 640.0, 0.5);
+  }
+}


### PR DESCRIPTION
Advances #3305.

## Capability

Adds an immutable Java/JPype feed-temperature sensitivity runner for the qualified DOE Big Hill 650 degF+ vacuum screening case.

- independently rebuilds, solves, and evaluates every requested temperature point;
- varies only feed temperature while tray topology, absolute pressures, reboiler temperature, condenser reflux, feed composition, and feed mass flow remain fixed;
- requires finite, positive, unique, strictly increasing temperatures below the fixed reboiler temperature;
- reuses the qualified MESH, fallback, mass, component, energy, material-product, and boiling-range gates;
- fails the complete screen if any point fails;
- returns defensive point arrays, exact applied inputs, overhead-yield bounds, and worst conservation, energy, and MESH diagnostics.

The focused regression qualifies the documented 638/640/642 K screen around the existing 640 K feed point without asserting a monotonic response.

## Provenance and engineering boundary

The public DOE Big Hill assay and qualified three-cut 650 degF+ normalization are unchanged. Every column operating value remains a source-unreported engineering assumption.

This is numerical sensitivity evidence only. It does not establish a measured or calibrated feed-temperature response, VGO/residue yield, furnace or exchanger duty, heat integration, equipment design, ASTM D1160/TBP correction, optimization, product specification, turndown, or plant agreement.

## Frozen scope and continuity

- Exact base: `65bdebae0b606b6d6458bc25fbe14965236ff53e`
- Exact current head: `017e94e1226ecc32df714d1e45925e4b02a62bab`
- Changed files: exactly three
  1. `src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivity.java`
  2. `src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedTemperatureSensitivityTest.java`
  3. `docs/thermo/characterization/refinery_big_hill_complete_slate.md`
- Relation to frozen base: 7 commits ahead, zero behind
- No overlap with the 2 other open autonomous PRs
- Portfolio occupancy after reservation: **3/10**

## Validation

Connector-side pre-publication checks confirm the exact three-file scope, frozen-base continuity, fixed-input reconstruction, Java 8-compatible source, defensive input/result handling, explicit failure boundaries, provenance limits, and no active ownership overlap.

The sole initial failure was Spotless wrapping in the two new Java files. The hosted Spotless artifact from workflow run `34625947235`, artifact `10274168732`, archive digest `sha256:68daf12e6551b48ead3547132ceb168032b7db7520e8e0662b4741ed16998732`, was audited and applied exactly. The exact artifact produced blobs `c35ba175de4c6ee4535fce7baf1b188c5e8908bd` (production, before the subsequent accessor correction) and `a5d19cd05df637204965ab8f0e08918f0d044208` (test, current). This repair changes formatting only; behavior, tests, API, scientific assumptions, provenance, and acceptance criteria are unchanged. The single formatter-repair allowance is exhausted.

The first post-format Java matrix failed at test compilation because the point-result implementation retained the inherited name `getReboilerTemperatureKelvin()`, while the frozen feed-temperature contract, Javadoc, documentation, and tests require `getFeedTemperatureKelvin()`. The one-symbol correction changes the production blob to `cb7484c07c5644ff2edc3302e6a822c49b4d0145`; it changes no calculation, operating input, result value, physics, provenance, engineering boundary, or acceptance criterion.

Fresh exact-head validation now passes Java 21 on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, and agent-skill checks. Only Java 8 on Ubuntu and Windows remains running.

**VALIDATION PENDING EXACT-HEAD JAVA 8 MATRIX.**

Because this adds public engineering API, subsystem-owner and independent-maintainer reviews are required before READY TO MERGE.

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.