### PR TITLE
[AI-Assisted] feat(twofluid): add transactional unsplit adapter

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1320,12 +1320,19 @@ one Jacobian and refresh them between Newton iterations. Every model evaluation 
 transactional: trial calls must start from the same accepted state and must not accumulate accepted
 mass, component, thermal, limiter, or rejection ledgers.
 
-This class is not yet selected by `TwoFluidPipe.runTransient`. It does not change a default or
-qualify severe slugging. Integration still requires a transactional adapter for the complete
-finite-volume flux/source operator, pressure-dependent phase properties, and the fixed-pressure
-outlet face. The existing 5 s mesh matrix and the 180/600 s public Tengesdal gates must pass before
-the path can be exposed as a pipe option. Energy, named-component transport, and phase change are
-outside the initial isothermal solve and remain separate unsupported intersections.
+`TwoFluidUnsplitModelAdapter` now supplies the transactional finite-volume bridge. It clones
+accepted section templates for every residual probe, evaluates pressure-dependent phase densities
+at the midpoint and closure pressures, restores evaluator-owned diagnostics after every trial, and
+applies a prescribed pressure only to the external outlet momentum traction. Advective phase mass
+and energy fluxes keep the existing signed or one-way outlet policy, and the final cell retains its
+own volume-closure equation.
+
+The adapter is not yet selected by `TwoFluidPipe.runTransient`; it does not change a default or
+qualify severe slugging. Integration still requires an opt-in pipe route, accepted-state commit and
+rollback wiring, and active-set ownership for donor and regime choices. The existing 5 s mesh matrix
+and the 180/600 s public Tengesdal gates must pass before the path can be exposed as a pipe option.
+Energy, named-component transport, and phase change are outside the initial isothermal solve and
+remain separate unsupported intersections.
 
 ### Standing benchmark acceptance metrics
 

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -873,10 +873,17 @@ search, fraction-to-boundary mass/pressure limits, and hooks that freeze and ref
 active sets. Its model callback must be transactional so Jacobian probes cannot advance accepted
 diagnostics or state.
 
-This is a solver foundation, not a selectable `TwoFluidPipe` mode or a severe-slugging claim. The
-full finite-volume flux/source adapter, pressure-dependent properties, conservative outlet-face
-transport, and 5/180/600 s qualification sequence remain required. Energy, named-component
-transport, and phase change are outside the initial isothermal system.
+`TwoFluidUnsplitModelAdapter` connects this kernel to the finite-volume flux/source operator
+transactionally. It reconstructs trial sections from accepted clones, evaluates phase densities at
+both midpoint and closure pressure, restores retained equation diagnostics after each probe, and
+uses a prescribed pressure only in the external outlet momentum traction. The last cell still owns
+its volume-closure equation, while outlet phase mass and energy remain conservative advective
+fluxes.
+
+This is still not a selectable `TwoFluidPipe` mode or a severe-slugging claim. Opt-in pipe routing,
+accepted-state commit/rollback, donor/regime active-set ownership, and the 5/180/600 s qualification
+sequence remain required. Energy, named-component transport, and phase change are outside the
+initial isothermal system.
 
 ### Public severe-slugging qualification
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -823,8 +823,6 @@ public class TwoFluidConservationEquations implements Serializable {
     }
     double[] flux = new double[NUM_EQUATIONS];
     double A = sec.getArea();
-    double facePressure =
-        Double.isNaN(outletBoundaryPressure) ? sec.getPressure() : outletBoundaryPressure;
 
     // Gas flux (positive velocity means flow INTO domain)
     // Use the stored gas holdup directly, not derived from mass
@@ -835,7 +833,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double alphaG = sec.getGasHoldup();
     alphaG = Math.max(0.0, Math.min(1.0, alphaG));
     flux[IDX_GAS_MASS] = alphaG * rhoG * vG * A;
-    flux[IDX_GAS_MOMENTUM] = alphaG * rhoG * vG * vG * A + alphaG * facePressure * A;
+    flux[IDX_GAS_MOMENTUM] = alphaG * rhoG * vG * vG * A + alphaG * sec.getPressure() * A;
 
     // Oil flux - use holdup directly for inlet BC stability
     double rhoO = sec.getOilDensity();
@@ -847,7 +845,7 @@ public class TwoFluidConservationEquations implements Serializable {
     // smaller than the rounding error in gas holdup.
     alphaO = Math.max(0, Math.min(1.0, alphaO));
     flux[IDX_OIL_MASS] = alphaO * rhoO * vO * A;
-    flux[IDX_OIL_MOMENTUM] = alphaO * rhoO * vO * vO * A + alphaO * facePressure * A;
+    flux[IDX_OIL_MOMENTUM] = alphaO * rhoO * vO * vO * A + alphaO * sec.getPressure() * A;
 
     // Water flux - use holdup directly for inlet BC stability
     double rhoW = sec.getWaterDensity();
@@ -858,7 +856,7 @@ public class TwoFluidConservationEquations implements Serializable {
     // Do not subtract other phase holdups to recover this phase's availability.
     alphaW = Math.max(0, Math.min(1.0, alphaW));
     flux[IDX_WATER_MASS] = alphaW * rhoW * vW * A;
-    flux[IDX_WATER_MOMENTUM] = alphaW * rhoW * vW * vW * A + alphaW * facePressure * A;
+    flux[IDX_WATER_MOMENTUM] = alphaW * rhoW * vW * vW * A + alphaW * sec.getPressure() * A;
 
     // Energy flux
     if (includeEnergyEquation) {
@@ -890,6 +888,7 @@ public class TwoFluidConservationEquations implements Serializable {
     }
     double[] flux = new double[NUM_EQUATIONS];
     double A = sec.getArea();
+    double facePressure = Double.isNaN(outletBoundaryPressure) ? sec.getPressure() : outletBoundaryPressure;
 
     if (!allowOutletPhaseBackflow
         && (sec.getGasVelocity() < 0.0 || sec.getOilVelocity() < 0.0 || sec.getWaterVelocity() < 0.0)) {
@@ -904,7 +903,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double alphaG = sec.getGasMassPerLength() / (rhoG * A);
     alphaG = Math.max(0, Math.min(1, alphaG));
     flux[IDX_GAS_MASS] = alphaG * rhoG * vG * A;
-    flux[IDX_GAS_MOMENTUM] = alphaG * rhoG * vG * vG * A + alphaG * sec.getPressure() * A;
+    flux[IDX_GAS_MOMENTUM] = alphaG * rhoG * vG * vG * A + alphaG * facePressure * A;
 
     // Oil flux - use default density if not set
     double rhoO = sec.getOilDensity();
@@ -917,7 +916,7 @@ public class TwoFluidConservationEquations implements Serializable {
     // artificial priority at the outlet.
     alphaO = Math.max(0, Math.min(1.0, alphaO));
     flux[IDX_OIL_MASS] = alphaO * rhoO * vO * A;
-    flux[IDX_OIL_MOMENTUM] = alphaO * rhoO * vO * vO * A + alphaO * sec.getPressure() * A;
+    flux[IDX_OIL_MOMENTUM] = alphaO * rhoO * vO * vO * A + alphaO * facePressure * A;
 
     // Water flux - use default density if not set
     double rhoW = sec.getWaterDensity();
@@ -927,7 +926,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double alphaW = sec.getWaterMassPerLength() / (rhoW * A);
     alphaW = Math.max(0, Math.min(1.0, alphaW));
     flux[IDX_WATER_MASS] = alphaW * rhoW * vW * A;
-    flux[IDX_WATER_MOMENTUM] = alphaW * rhoW * vW * vW * A + alphaW * sec.getPressure() * A;
+    flux[IDX_WATER_MOMENTUM] = alphaW * rhoW * vW * vW * A + alphaW * facePressure * A;
 
     // Energy flux
     if (includeEnergyEquation) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -108,6 +108,9 @@ public class TwoFluidConservationEquations implements Serializable {
   private boolean inletClosed;
   private boolean outletClosed;
 
+  /** Prescribed pressure at the external outlet face in Pa; NaN uses the outlet-cell pressure. */
+  private double outletBoundaryPressure = Double.NaN;
+
   /**
    * Impose impermeable external faces independently of reconstructed subcell velocities.
    *
@@ -117,6 +120,34 @@ public class TwoFluidConservationEquations implements Serializable {
   public void setClosedBoundaries(boolean closeInlet, boolean closeOutlet) {
     inletClosed = closeInlet;
     outletClosed = closeOutlet;
+  }
+
+  /**
+   * Prescribe pressure at the external outlet face without replacing the final cell pressure.
+   *
+   * <p>
+   * The value contributes only to the outlet momentum traction. Phase mass and energy remain the signed or one-way
+   * advective fluxes selected by the existing outlet policy. Pass {@link Double#NaN} to restore the cell-based
+   * zero-gradient pressure.
+   * </p>
+   *
+   * @param pressure positive finite outlet-face pressure in Pa, or NaN for the cell-based pressure
+   * @throws IllegalArgumentException if a finite pressure is not positive
+   */
+  public void setOutletBoundaryPressure(double pressure) {
+    if (!Double.isNaN(pressure) && (!(pressure > 0.0) || !Double.isFinite(pressure))) {
+      throw new IllegalArgumentException("Outlet boundary pressure must be positive and finite, or NaN");
+    }
+    outletBoundaryPressure = pressure;
+  }
+
+  /**
+   * Get the prescribed external outlet-face pressure.
+   *
+   * @return pressure in Pa, or NaN when the outlet-cell pressure is used
+   */
+  public double getOutletBoundaryPressure() {
+    return outletBoundaryPressure;
   }
 
   /**
@@ -581,6 +612,60 @@ public class TwoFluidConservationEquations implements Serializable {
   }
 
   /**
+   * Evaluate the finite-volume operator without committing its retained diagnostics.
+   *
+   * <p>
+   * The supplied sections are trial objects and may be updated by closure evaluation. Callers that own accepted
+   * sections must therefore pass clones. All evaluator-owned interface reconstructions, boundary diagnostics, phase
+   * rates, and momentum-force ledgers are restored even if evaluation fails. This contract makes repeated residual and
+   * finite-difference Jacobian probes deterministic.
+   * </p>
+   *
+   * @param sections trial pipe sections
+   * @param dx representative cell size in m
+   * @return time derivatives with the same shape as {@link #calcRHS(TwoFluidSection[], double)}
+   */
+  public double[][] calcRHSTransactional(TwoFluidSection[] sections, double dx) {
+    double[] savedInterfaceGasHoldup = interfaceGasHoldup.clone();
+    double[] savedInterfaceLiquidHoldup = interfaceLiquidHoldup.clone();
+    double[] savedInterfacePressure = interfacePressure.clone();
+    double[][] savedInterfacePhaseHoldup = copyMatrix(interfacePhaseHoldup);
+    double[][] savedInterfacePhasePressure = copyMatrix(interfacePhasePressure);
+    TwoFluidSection savedReconstructedOutlet = reconstructedOutlet;
+    boolean savedOutletBackflowClamped = outletBackflowClamped;
+    MassBalanceRate savedMassBalanceRate = lastMassBalanceRate;
+    double[][] savedPhaseMassFaceFluxes = copyMatrix(lastPhaseMassFaceFluxes);
+    double[][] savedPhaseMassSourcesPerLength = copyMatrix(lastPhaseMassSourcesPerLength);
+    double[][] savedMomentumSourceForcesPerLength = copyMatrix(lastMomentumSourceForcesPerLength);
+    try {
+      return calcRHS(sections, dx);
+    } finally {
+      interfaceGasHoldup = savedInterfaceGasHoldup;
+      interfaceLiquidHoldup = savedInterfaceLiquidHoldup;
+      interfacePressure = savedInterfacePressure;
+      interfacePhaseHoldup = savedInterfacePhaseHoldup;
+      interfacePhasePressure = savedInterfacePhasePressure;
+      reconstructedOutlet = savedReconstructedOutlet;
+      outletBackflowClamped = savedOutletBackflowClamped;
+      lastMassBalanceRate = savedMassBalanceRate;
+      lastPhaseMassFaceFluxes = savedPhaseMassFaceFluxes;
+      lastPhaseMassSourcesPerLength = savedPhaseMassSourcesPerLength;
+      lastMomentumSourceForcesPerLength = savedMomentumSourceForcesPerLength;
+    }
+  }
+
+  private static double[][] copyMatrix(double[][] source) {
+    if (source == null) {
+      return null;
+    }
+    double[][] copy = new double[source.length][];
+    for (int row = 0; row < source.length; row++) {
+      copy[row] = source[row] == null ? null : source[row].clone();
+    }
+    return copy;
+  }
+
+  /**
    * Get the phase-resolved boundary and source rates from the most recent right-hand-side evaluation.
    *
    * @return immutable mass-balance rate snapshot
@@ -738,6 +823,8 @@ public class TwoFluidConservationEquations implements Serializable {
     }
     double[] flux = new double[NUM_EQUATIONS];
     double A = sec.getArea();
+    double facePressure =
+        Double.isNaN(outletBoundaryPressure) ? sec.getPressure() : outletBoundaryPressure;
 
     // Gas flux (positive velocity means flow INTO domain)
     // Use the stored gas holdup directly, not derived from mass
@@ -748,7 +835,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double alphaG = sec.getGasHoldup();
     alphaG = Math.max(0.0, Math.min(1.0, alphaG));
     flux[IDX_GAS_MASS] = alphaG * rhoG * vG * A;
-    flux[IDX_GAS_MOMENTUM] = alphaG * rhoG * vG * vG * A + alphaG * sec.getPressure() * A;
+    flux[IDX_GAS_MOMENTUM] = alphaG * rhoG * vG * vG * A + alphaG * facePressure * A;
 
     // Oil flux - use holdup directly for inlet BC stability
     double rhoO = sec.getOilDensity();
@@ -760,7 +847,7 @@ public class TwoFluidConservationEquations implements Serializable {
     // smaller than the rounding error in gas holdup.
     alphaO = Math.max(0, Math.min(1.0, alphaO));
     flux[IDX_OIL_MASS] = alphaO * rhoO * vO * A;
-    flux[IDX_OIL_MOMENTUM] = alphaO * rhoO * vO * vO * A + alphaO * sec.getPressure() * A;
+    flux[IDX_OIL_MOMENTUM] = alphaO * rhoO * vO * vO * A + alphaO * facePressure * A;
 
     // Water flux - use holdup directly for inlet BC stability
     double rhoW = sec.getWaterDensity();
@@ -771,7 +858,7 @@ public class TwoFluidConservationEquations implements Serializable {
     // Do not subtract other phase holdups to recover this phase's availability.
     alphaW = Math.max(0, Math.min(1.0, alphaW));
     flux[IDX_WATER_MASS] = alphaW * rhoW * vW * A;
-    flux[IDX_WATER_MOMENTUM] = alphaW * rhoW * vW * vW * A + alphaW * sec.getPressure() * A;
+    flux[IDX_WATER_MOMENTUM] = alphaW * rhoW * vW * vW * A + alphaW * facePressure * A;
 
     // Energy flux
     if (includeEnergyEquation) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TwoFluidUnsplitModelAdapter.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TwoFluidUnsplitModelAdapter.java
@@ -1,0 +1,151 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import java.io.Serializable;
+import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidConservationEquations;
+import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidSection;
+
+/**
+ * Transactional bridge between {@link UnsplitTransientSolver} and the two-fluid finite-volume operator.
+ *
+ * <p>
+ * Every residual probe starts from cloned accepted section templates. Trial pressure-dependent densities are installed
+ * before conservative variables are recovered, and the closure densities are evaluated at the end-state pressure used
+ * by the solver's volume equation. A prescribed outlet pressure is applied at the external boundary face only.
+ * </p>
+ *
+ * <p>
+ * This adapter is intentionally not selected by {@code TwoFluidPipe.runTransient}. It establishes the evaluator
+ * contract needed for subsequent pipe integration and severe-slugging qualification without changing a production
+ * default.
+ * </p>
+ */
+public final class TwoFluidUnsplitModelAdapter implements UnsplitTransientSolver.Model, Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final int PHASE_COUNT = 3;
+  private static final int STATE_SIZE = 7;
+
+  /** Pressure-dependent gas, oil, and water density closure. */
+  @FunctionalInterface
+  public interface PhaseDensityModel extends Serializable {
+    /**
+     * Evaluate phase densities for one cell.
+     *
+     * @param cell cell index
+     * @param conservativeState seven-column conservative state
+     * @param pressure cell pressure in Pa
+     * @param time evaluation time in s
+     * @return gas, oil, and water densities in kg/m3
+     */
+    double[] calculate(int cell, double[] conservativeState, double pressure, double time);
+  }
+
+  private final TwoFluidConservationEquations equations;
+  private final TwoFluidSection[] acceptedTemplates;
+  private final double spatialStep;
+  private final PhaseDensityModel densityModel;
+
+  /**
+   * Create a transactional adapter.
+   *
+   * @param equations configured finite-volume operator
+   * @param acceptedTemplates accepted section state used as the trial template
+   * @param spatialStep representative cell size in m
+   * @param densityModel pressure-dependent phase density model
+   */
+  public TwoFluidUnsplitModelAdapter(TwoFluidConservationEquations equations, TwoFluidSection[] acceptedTemplates,
+      double spatialStep, PhaseDensityModel densityModel) {
+    if (equations == null || densityModel == null) {
+      throw new IllegalArgumentException("Equations and density model cannot be null");
+    }
+    if (acceptedTemplates == null || acceptedTemplates.length == 0) {
+      throw new IllegalArgumentException("At least one accepted section template is required");
+    }
+    if (!(spatialStep > 0.0) || !Double.isFinite(spatialStep)) {
+      throw new IllegalArgumentException("Spatial step must be positive and finite");
+    }
+    this.equations = equations;
+    this.acceptedTemplates = cloneSections(acceptedTemplates);
+    this.spatialStep = spatialStep;
+    this.densityModel = densityModel;
+  }
+
+  @Override
+  public synchronized UnsplitTransientSolver.Evaluation evaluate(double[][] state, double[] pressure,
+      double[][] closureState, double[] closurePressure, double time, double outletPressure,
+      boolean outletPressureFixed) {
+    validateShape(state, pressure, "midpoint");
+    validateShape(closureState, closurePressure, "closure");
+    if (outletPressureFixed && (!(outletPressure > 0.0) || !Double.isFinite(outletPressure))) {
+      throw new IllegalArgumentException("A fixed outlet pressure must be positive and finite");
+    }
+
+    TwoFluidSection[] trialSections = cloneSections(acceptedTemplates);
+    for (int cell = 0; cell < trialSections.length; cell++) {
+      double[] densities = densities(cell, state[cell], pressure[cell], time);
+      trialSections[cell].setPressure(pressure[cell]);
+      trialSections[cell].setGasDensity(densities[0]);
+      trialSections[cell].setOilDensity(densities[1]);
+      trialSections[cell].setWaterDensity(densities[2]);
+    }
+    equations.applyState(trialSections, state);
+
+    double[][] closureDensities = new double[PHASE_COUNT][trialSections.length];
+    for (int cell = 0; cell < trialSections.length; cell++) {
+      double[] densities = densities(cell, closureState[cell], closurePressure[cell], time);
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        closureDensities[phase][cell] = densities[phase];
+      }
+    }
+
+    double savedOutletPressure = equations.getOutletBoundaryPressure();
+    double[][] rates;
+    synchronized (equations) {
+      try {
+        equations.setOutletBoundaryPressure(outletPressureFixed ? outletPressure : Double.NaN);
+        rates = equations.calcRHSTransactional(trialSections, spatialStep);
+      } finally {
+        equations.setOutletBoundaryPressure(savedOutletPressure);
+      }
+    }
+    return new UnsplitTransientSolver.Evaluation(rates, closureDensities);
+  }
+
+  private double[] densities(int cell, double[] state, double pressure, double time) {
+    double[] values = densityModel.calculate(cell, state.clone(), pressure, time);
+    if (values == null || values.length != PHASE_COUNT) {
+      throw new IllegalArgumentException("Density model must return gas, oil, and water densities");
+    }
+    for (double value : values) {
+      if (!(value > 0.0) || !Double.isFinite(value)) {
+        throw new IllegalArgumentException("Phase densities must be positive and finite");
+      }
+    }
+    return values.clone();
+  }
+
+  private void validateShape(double[][] state, double[] pressure, String label) {
+    if (state == null || pressure == null || state.length != acceptedTemplates.length
+        || pressure.length != acceptedTemplates.length) {
+      throw new IllegalArgumentException(label + " arrays must match the accepted section count");
+    }
+    for (int cell = 0; cell < state.length; cell++) {
+      if (state[cell] == null || state[cell].length < STATE_SIZE) {
+        throw new IllegalArgumentException(label + " state requires seven variables per cell");
+      }
+      if (!(pressure[cell] > 0.0) || !Double.isFinite(pressure[cell])) {
+        throw new IllegalArgumentException(label + " pressures must be positive and finite");
+      }
+    }
+  }
+
+  private static TwoFluidSection[] cloneSections(TwoFluidSection[] sections) {
+    TwoFluidSection[] copy = new TwoFluidSection[sections.length];
+    for (int cell = 0; cell < sections.length; cell++) {
+      if (sections[cell] == null) {
+        throw new IllegalArgumentException("Section templates cannot contain null entries");
+      }
+      copy[cell] = sections[cell].clone();
+    }
+    return copy;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/UnsplitTransientSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/UnsplitTransientSolver.java
@@ -234,7 +234,6 @@ public final class UnsplitTransientSolver implements Serializable {
       double startTime, double outletPressure, boolean outletPressureFixed, Model model) {
     validateInputs(previousState, previousPressure, cellAreas, timeStep, startTime, outletPressure, outletPressureFixed,
         model);
-    int cellCount = previousState.length;
     double[][] state = copy(previousState);
     double[] pressure = previousPressure.clone();
     double[] variableScale = createVariableScale(previousState, previousPressure);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TwoFluidUnsplitModelAdapterTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TwoFluidUnsplitModelAdapterTest.java
@@ -1,0 +1,96 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidConservationEquations;
+import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidSection;
+import org.junit.jupiter.api.Test;
+
+class TwoFluidUnsplitModelAdapterTest {
+  @Test
+  void repeatedResidualProbesAreTransactionalAndUseTheOutletFacePressure() {
+    TwoFluidSection[] accepted = { section(0.0), section(10.0) };
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    equations.setIncludeEnergyEquation(false);
+    equations.setIncludeMassTransfer(false);
+
+    equations.calcRHS(cloneSections(accepted), 10.0);
+    TwoFluidConservationEquations.MassBalanceRate acceptedBalance = equations.getLastMassBalanceRate();
+    double[][] acceptedFaces = equations.getLastPhaseMassFaceFluxes();
+    boolean acceptedBackflow = equations.isOutletBackflowClamped();
+
+    double[][] state = { accepted[0].getStateVector(), accepted[1].getStateVector() };
+    double[][] acceptedState = { state[0].clone(), state[1].clone() };
+    double[] pressure = { accepted[0].getPressure(), accepted[1].getPressure() };
+    double[] area = { accepted[0].getArea(), accepted[1].getArea() };
+    TwoFluidUnsplitModelAdapter adapter = new TwoFluidUnsplitModelAdapter(equations, accepted, 10.0,
+        (cell, conservativeState, cellPressure, time) ->
+            new double[] { 40.0 + 1.0e-6 * (cellPressure - 5.0e6), 700.0, 1000.0 });
+    UnsplitTransientSolver solver = new UnsplitTransientSolver();
+
+    double[] free = solver.residual(state, pressure, state, pressure, area, 0.05, 0.0, Double.NaN, false, adapter);
+    double[] repeated = solver.residual(state, pressure, state, pressure, area, 0.05, 0.0, Double.NaN, false, adapter);
+    double[] fixed = solver.residual(state, pressure, state, pressure, area, 0.05, 0.0, 4.0e6, true, adapter);
+
+    assertArrayEquals(free, repeated, 0.0);
+    assertNotEquals(free[10], fixed[10], "Outlet gas momentum must use the prescribed face pressure");
+    assertNotEquals(free[11], fixed[11], "Outlet oil momentum must use the prescribed face pressure");
+    assertSame(acceptedBalance, equations.getLastMassBalanceRate());
+    assertMatrixEquals(acceptedFaces, equations.getLastPhaseMassFaceFluxes());
+    if (acceptedBackflow) {
+      assertSame(Boolean.TRUE, Boolean.valueOf(equations.isOutletBackflowClamped()));
+    } else {
+      assertSame(Boolean.FALSE, Boolean.valueOf(equations.isOutletBackflowClamped()));
+    }
+    assertArrayEquals(acceptedState[0], accepted[0].getStateVector(), 0.0);
+    assertArrayEquals(acceptedState[1], accepted[1].getStateVector(), 0.0);
+    assertArrayEquals(pressure, new double[] { accepted[0].getPressure(), accepted[1].getPressure() }, 0.0);
+  }
+
+  private static TwoFluidSection section(double position) {
+    TwoFluidSection section = new TwoFluidSection(position, 10.0, 0.1, 0.0);
+    section.setPressure(5.0e6);
+    section.setTemperature(300.0);
+    section.setGasDensity(40.0);
+    section.setOilDensity(700.0);
+    section.setWaterDensity(1000.0);
+    section.setLiquidDensity(850.0);
+    section.setGasViscosity(1.2e-5);
+    section.setOilViscosity(1.0e-3);
+    section.setWaterViscosity(1.0e-3);
+    section.setLiquidViscosity(1.0e-3);
+    section.setGasSoundSpeed(300.0);
+    section.setLiquidSoundSpeed(1200.0);
+    section.setSurfaceTension(0.02);
+    section.setGasHoldup(0.6);
+    section.setLiquidHoldup(0.4);
+    section.setOilHoldup(0.2);
+    section.setWaterHoldup(0.2);
+    section.setWaterCut(0.5);
+    section.setOilFractionInLiquid(0.5);
+    section.setGasVelocity(3.0);
+    section.setLiquidVelocity(0.5);
+    section.setOilVelocity(0.55);
+    section.setWaterVelocity(0.45);
+    section.updateConservativeVariables();
+    section.updateDerivedQuantities();
+    return section;
+  }
+
+  private static TwoFluidSection[] cloneSections(TwoFluidSection[] sections) {
+    TwoFluidSection[] copy = new TwoFluidSection[sections.length];
+    for (int cell = 0; cell < sections.length; cell++) {
+      copy[cell] = sections[cell].clone();
+    }
+    return copy;
+  }
+
+  private static void assertMatrixEquals(double[][] expected, double[][] actual) {
+    org.junit.jupiter.api.Assertions.assertEquals(expected.length, actual.length);
+    for (int row = 0; row < expected.length; row++) {
+      assertArrayEquals(expected[row], actual[row], 0.0);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TwoFluidUnsplitModelAdapterTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TwoFluidUnsplitModelAdapterTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.pipeline.twophasepipe.numerics;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -26,8 +27,8 @@ class TwoFluidUnsplitModelAdapterTest {
     double[] pressure = { accepted[0].getPressure(), accepted[1].getPressure() };
     double[] area = { accepted[0].getArea(), accepted[1].getArea() };
     TwoFluidUnsplitModelAdapter adapter = new TwoFluidUnsplitModelAdapter(equations, accepted, 10.0,
-        (cell, conservativeState, cellPressure, time) ->
-            new double[] { 40.0 + 1.0e-6 * (cellPressure - 5.0e6), 700.0, 1000.0 });
+        (cell, conservativeState, cellPressure,
+            time) -> new double[] { 40.0 + 1.0e-6 * (cellPressure - 5.0e6), 700.0, 1000.0 });
     UnsplitTransientSolver solver = new UnsplitTransientSolver();
 
     double[] free = solver.residual(state, pressure, state, pressure, area, 0.05, 0.0, Double.NaN, false, adapter);
@@ -39,11 +40,7 @@ class TwoFluidUnsplitModelAdapterTest {
     assertNotEquals(free[11], fixed[11], "Outlet oil momentum must use the prescribed face pressure");
     assertSame(acceptedBalance, equations.getLastMassBalanceRate());
     assertMatrixEquals(acceptedFaces, equations.getLastPhaseMassFaceFluxes());
-    if (acceptedBackflow) {
-      assertSame(Boolean.TRUE, Boolean.valueOf(equations.isOutletBackflowClamped()));
-    } else {
-      assertSame(Boolean.FALSE, Boolean.valueOf(equations.isOutletBackflowClamped()));
-    }
+    assertEquals(acceptedBackflow, equations.isOutletBackflowClamped());
     assertArrayEquals(acceptedState[0], accepted[0].getStateVector(), 0.0);
     assertArrayEquals(acceptedState[1], accepted[1].getStateVector(), 0.0);
     assertArrayEquals(pressure, new double[] { accepted[0].getPressure(), accepted[1].getPressure() }, 0.0);


### PR DESCRIPTION
## Summary

- add a transactional adapter from `UnsplitTransientSolver` to the existing two-fluid finite-volume operator
- evaluate pressure-dependent gas/oil/water density at both midpoint and end-state closure pressure
- prescribe pressure at the external outlet momentum face without replacing the final-cell volume equation or altering advective phase transport
- restore interface reconstruction, mass-balance, momentum-force, and outlet-backflow diagnostics after every residual/Jacobian probe
- add deterministic exact-state regression coverage and document the remaining capability boundary
- remove the unused local identified after merged PR #3652

## Campaign contract

This is the next WS1 dependency increment for #3298 and is based exactly on master `65bdebae0b606b6d6458bc25fbe14965236ff53e`.

The adapter is deliberately **not** wired into `TwoFluidPipe.runTransient`. No default changes, severe-slugging qualification, energy coupling, named-component transport, or phase-change support are claimed here. The next ordered increment remains opt-in pipe routing with transactional accepted-state commit/rollback and donor/regime active-set ownership, followed by the established 5 s mesh, 180 s characterization, and 600 s Tengesdal gates.

## Validation

The disposable workspace was unavailable after maintenance, so publication followed the campaign's resilient draft policy. The first hosted pre-commit run identified an outlet/inlet replacement error and two formatting deltas; exact-head commit `47e0014` corrects them.

Passing on the corrected exact head: Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, production-optimization documentation, and agent/skill validation. The three automated review threads concern deliberately broad density-callback inputs needed for cell-local composition and time-dependent property models; each has an engineering response and is resolved.

The Java 8 Ubuntu and Windows jobs remain in progress. **VALIDATION PENDING EXACT-HEAD JAVA 8 MATRIX.**

Exact head: `47e001486c457ba0dd613b1e3778e9d1c8b9bff2`

## Documentation impact

Both the process model reference and wiki model page now describe the transactional adapter, fixed outlet-face pressure semantics, and the unsupported/qualification boundary.

Closes no issue; advances #3298.
