### PR TITLE
feat(refinery): qualify Big Hill vacuum feed-mass-flow sensitivity

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -387,3 +387,51 @@ define heat integration, size equipment, validate product quality, or demonstrat
 All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
 does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
 calibrated VGO/residue yields, optimization, product specifications, or plant-agreement evidence.
+
+## Feed-mass-flow sensitivity screening
+
+`DoeBigHillVacuumFeedMassFlowSensitivity.run(...)` independently rebuilds, solves, and evaluates
+multiple Big Hill vacuum cases while varying only the feed mass flow. Tray count, feed tray, feed and
+reboiler temperatures, all three absolute pressures, condenser reflux ratio, and feed composition
+remain fixed. Mass flows must be finite, positive, unique, and strictly increasing.
+
+The documented three-point screen stays close to the qualified 1000 kg/h base point:
+
+```java
+OperatingInputs baseline =
+    new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+double[] feedMassFlowsKgPerHour = {980.0, 1000.0, 1020.0};
+
+DoeBigHillVacuumFeedMassFlowSensitivity sensitivity =
+    DoeBigHillVacuumFeedMassFlowSensitivity.run(
+        "Big Hill vacuum feed-mass-flow screen",
+        baseline,
+        feedMassFlowsKgPerHour);
+
+for (DoeBigHillVacuumFeedMassFlowSensitivity.PointResult point :
+    sensitivity.getPoints()) {
+  double feedMassFlowKgPerHour = point.getFeedMassFlowKgPerHour();
+  double overheadMassFraction = point.getOverheadMassFraction();
+  double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+}
+```
+
+Every point must pass the already qualified MESH-residual, fallback, mass, component, energy,
+material-product, and boiling-point-order gates. The summary returns a defensive point array, exact
+applied feed mass flows and operating inputs, immutable per-point fractionation results, the observed
+overhead-yield bounds, and the worst external mass closure, component closure, column energy error,
+and final MESH residual. A failed point aborts the complete sensitivity instead of returning a
+partial envelope.
+
+The mass flow is the specified feed-stream throughput in kg/h, not a measured or design column
+capacity. This screen isolates that single numerical input while keeping feed composition and every
+column operating input fixed. The narrow 980/1000/1020 kg/h regression is a convergence and
+conservation test around the documented screening point. It does not establish a measured throughput
+response, require a monotonic yield trend, demonstrate scale-up, quantify flooding, weeping,
+entrainment, pressure drop, heat duty, or utilities, size equipment, validate product quality, or
+demonstrate turndown.
+
+All DOE assay provenance and the three-cut 650 degF+ normalization remain unchanged. The calculation
+does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
+calibrated VGO/residue yields, optimization, product specifications, hydraulic capacity, or
+plant-agreement evidence.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivity.java
@@ -1,0 +1,208 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/**
+ * Immutable feed-mass-flow sensitivity summary for the DOE Big Hill vacuum screening case.
+ *
+ * <p>
+ * Feed mass flow is varied while all explicit column operating inputs and the feed composition
+ * remain fixed. Each point is independently constructed, solved, and evaluated through the
+ * qualified Big Hill case and result contracts. The sensitivity is numerical screening evidence,
+ * not a measured or calibrated vacuum-column throughput envelope.
+ * </p>
+ */
+public final class DoeBigHillVacuumFeedMassFlowSensitivity {
+  private final PointResult[] points;
+  private final double minimumOverheadMassFraction;
+  private final double maximumOverheadMassFraction;
+  private final double maximumMassClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumColumnEnergyBalanceError;
+  private final double maximumMeshResidualNorm;
+
+  private DoeBigHillVacuumFeedMassFlowSensitivity(PointResult[] points) {
+    this.points = points.clone();
+
+    double minimumOverheadFraction = Double.POSITIVE_INFINITY;
+    double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
+    double maximumMassClosure = 0.0;
+    double maximumComponentClosure = 0.0;
+    double maximumEnergyError = 0.0;
+    double maximumMeshResidual = 0.0;
+    for (PointResult point : points) {
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+      minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
+      maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
+      maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumComponentClosure = Math.max(maximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    minimumOverheadMassFraction = minimumOverheadFraction;
+    maximumOverheadMassFraction = maximumOverheadFraction;
+    maximumMassClosureRelativeError = maximumMassClosure;
+    maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumColumnEnergyBalanceError = maximumEnergyError;
+    maximumMeshResidualNorm = maximumMeshResidual;
+  }
+
+  /**
+   * Run an independent feed-mass-flow sensitivity at explicit baseline operating inputs.
+   *
+   * @param caseNamePrefix non-blank prefix used for independently constructed point names
+   * @param baselineInputs explicit source-unreported baseline column inputs
+   * @param feedMassFlowsKgPerHour finite positive strictly increasing feed mass flows in kg/h
+   * @return immutable sensitivity summary
+   * @throws NullPointerException if {@code baselineInputs} or
+   *         {@code feedMassFlowsKgPerHour} is null
+   * @throws IllegalArgumentException if the name or feed mass flows are invalid
+   * @throws IllegalStateException if a point does not solve or pass the qualified result gates
+   */
+  public static DoeBigHillVacuumFeedMassFlowSensitivity run(String caseNamePrefix,
+      OperatingInputs baselineInputs, double[] feedMassFlowsKgPerHour) {
+    if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case-name prefix must be non-blank");
+    }
+    Objects.requireNonNull(baselineInputs, "baselineInputs");
+    Objects.requireNonNull(feedMassFlowsKgPerHour, "feedMassFlowsKgPerHour");
+    if (feedMassFlowsKgPerHour.length < 2) {
+      throw new IllegalArgumentException("Feed-mass-flow sensitivity requires at least two points");
+    }
+
+    double[] massFlows = feedMassFlowsKgPerHour.clone();
+    validateMassFlows(massFlows);
+    PointResult[] evaluatedPoints = new PointResult[massFlows.length];
+    for (int i = 0; i < massFlows.length; i++) {
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
+          .create(caseNamePrefix + " feed-mass-flow point " + (i + 1), massFlows[i],
+              baselineInputs);
+      try {
+        model.getColumn().run(UUID.randomUUID());
+        DoeBigHillVacuumFractionationResult result =
+            DoeBigHillVacuumFractionationResult.evaluate(model);
+        evaluatedPoints[i] = new PointResult(massFlows[i], baselineInputs, result);
+      } catch (RuntimeException exception) {
+        throw new IllegalStateException("Vacuum feed-mass-flow sensitivity failed at point " + i
+            + " with feed mass flow " + massFlows[i] + " kg/h", exception);
+      }
+    }
+    return new DoeBigHillVacuumFeedMassFlowSensitivity(evaluatedPoints);
+  }
+
+  /** @return defensive copy of sensitivity points in increasing mass-flow order */
+  public PointResult[] getPoints() {
+    return points.clone();
+  }
+
+  /**
+   * Return one sensitivity point by zero-based index.
+   *
+   * @param index zero-based point index
+   * @return immutable point result
+   * @throws IndexOutOfBoundsException if {@code index} is outside the sensitivity
+   */
+  public PointResult getPoint(int index) {
+    if (index < 0 || index >= points.length) {
+      throw new IndexOutOfBoundsException(
+          "Feed-mass-flow sensitivity point index is outside the result");
+    }
+    return points[index];
+  }
+
+  /** @return smallest overhead mass fraction across the qualified points */
+  public double getMinimumOverheadMassFraction() {
+    return minimumOverheadMassFraction;
+  }
+
+  /** @return largest overhead mass fraction across the qualified points */
+  public double getMaximumOverheadMassFraction() {
+    return maximumOverheadMassFraction;
+  }
+
+  /** @return largest external mass-closure relative error across the qualified points */
+  public double getMaximumMassClosureRelativeError() {
+    return maximumMassClosureRelativeError;
+  }
+
+  /** @return largest component molar-closure relative error across the qualified points */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest column energy-balance error across the qualified points */
+  public double getMaximumColumnEnergyBalanceError() {
+    return maximumColumnEnergyBalanceError;
+  }
+
+  /** @return largest final MESH residual norm across the qualified points */
+  public double getMaximumMeshResidualNorm() {
+    return maximumMeshResidualNorm;
+  }
+
+  private static void validateMassFlows(double[] massFlows) {
+    double previous = Double.NEGATIVE_INFINITY;
+    for (double massFlow : massFlows) {
+      if (!Double.isFinite(massFlow) || !(massFlow > 0.0)) {
+        throw new IllegalArgumentException("Feed mass flows must be finite and positive");
+      }
+      if (!(massFlow > previous)) {
+        throw new IllegalArgumentException(
+            "Feed mass flows must be strictly increasing and unique");
+      }
+      previous = massFlow;
+    }
+  }
+
+  /** Immutable result for one feed-mass-flow point. */
+  public static final class PointResult {
+    private final double feedMassFlowKgPerHour;
+    private final OperatingInputs operatingInputs;
+    private final DoeBigHillVacuumFractionationResult fractionationResult;
+
+    private PointResult(double feedMassFlowKgPerHour, OperatingInputs operatingInputs,
+        DoeBigHillVacuumFractionationResult fractionationResult) {
+      this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
+      this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
+      this.fractionationResult =
+          Objects.requireNonNull(fractionationResult, "fractionationResult");
+    }
+
+    /** @return feed mass flow applied at this point in kg/h */
+    public double getFeedMassFlowKgPerHour() {
+      return feedMassFlowKgPerHour;
+    }
+
+    /** @return immutable operating inputs applied at this point */
+    public OperatingInputs getOperatingInputs() {
+      return operatingInputs;
+    }
+
+    /** @return qualified immutable fractionation result for this point */
+    public DoeBigHillVacuumFractionationResult getFractionationResult() {
+      return fractionationResult;
+    }
+
+    /** @return overhead mass fraction of feed at this point */
+    public double getOverheadMassFraction() {
+      return fractionationResult.getProduct("Overhead").getMassFractionOfFeed();
+    }
+
+    /**
+     * Return a discrete overhead normal-boiling-point diagnostic.
+     *
+     * @param cumulativeMoleFraction cumulative product mole fraction in (0, 1]
+     * @return overhead pseudo-component quantile in kelvin
+     */
+    public double getOverheadBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      ProductResult overhead = fractionationResult.getProduct("Overhead");
+      return overhead.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivity.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivity.java
@@ -9,10 +9,9 @@ import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult
  * Immutable feed-mass-flow sensitivity summary for the DOE Big Hill vacuum screening case.
  *
  * <p>
- * Feed mass flow is varied while all explicit column operating inputs and the feed composition
- * remain fixed. Each point is independently constructed, solved, and evaluated through the
- * qualified Big Hill case and result contracts. The sensitivity is numerical screening evidence,
- * not a measured or calibrated vacuum-column throughput envelope.
+ * Feed mass flow is varied while all explicit column operating inputs and the feed composition remain fixed. Each point
+ * is independently constructed, solved, and evaluated through the qualified Big Hill case and result contracts. The
+ * sensitivity is numerical screening evidence, not a measured or calibrated vacuum-column throughput envelope.
  * </p>
  */
 public final class DoeBigHillVacuumFeedMassFlowSensitivity {
@@ -60,13 +59,12 @@ public final class DoeBigHillVacuumFeedMassFlowSensitivity {
    * @param baselineInputs explicit source-unreported baseline column inputs
    * @param feedMassFlowsKgPerHour finite positive strictly increasing feed mass flows in kg/h
    * @return immutable sensitivity summary
-   * @throws NullPointerException if {@code baselineInputs} or
-   *         {@code feedMassFlowsKgPerHour} is null
+   * @throws NullPointerException if {@code baselineInputs} or {@code feedMassFlowsKgPerHour} is null
    * @throws IllegalArgumentException if the name or feed mass flows are invalid
    * @throws IllegalStateException if a point does not solve or pass the qualified result gates
    */
-  public static DoeBigHillVacuumFeedMassFlowSensitivity run(String caseNamePrefix,
-      OperatingInputs baselineInputs, double[] feedMassFlowsKgPerHour) {
+  public static DoeBigHillVacuumFeedMassFlowSensitivity run(String caseNamePrefix, OperatingInputs baselineInputs,
+      double[] feedMassFlowsKgPerHour) {
     if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
       throw new IllegalArgumentException("Case-name prefix must be non-blank");
     }
@@ -81,16 +79,15 @@ public final class DoeBigHillVacuumFeedMassFlowSensitivity {
     PointResult[] evaluatedPoints = new PointResult[massFlows.length];
     for (int i = 0; i < massFlows.length; i++) {
       DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
-          .create(caseNamePrefix + " feed-mass-flow point " + (i + 1), massFlows[i],
-              baselineInputs);
+          .create(caseNamePrefix + " feed-mass-flow point " + (i + 1), massFlows[i], baselineInputs);
       try {
         model.getColumn().run(UUID.randomUUID());
-        DoeBigHillVacuumFractionationResult result =
-            DoeBigHillVacuumFractionationResult.evaluate(model);
+        DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
         evaluatedPoints[i] = new PointResult(massFlows[i], baselineInputs, result);
       } catch (RuntimeException exception) {
-        throw new IllegalStateException("Vacuum feed-mass-flow sensitivity failed at point " + i
-            + " with feed mass flow " + massFlows[i] + " kg/h", exception);
+        throw new IllegalStateException(
+            "Vacuum feed-mass-flow sensitivity failed at point " + i + " with feed mass flow " + massFlows[i] + " kg/h",
+            exception);
       }
     }
     return new DoeBigHillVacuumFeedMassFlowSensitivity(evaluatedPoints);
@@ -110,8 +107,7 @@ public final class DoeBigHillVacuumFeedMassFlowSensitivity {
    */
   public PointResult getPoint(int index) {
     if (index < 0 || index >= points.length) {
-      throw new IndexOutOfBoundsException(
-          "Feed-mass-flow sensitivity point index is outside the result");
+      throw new IndexOutOfBoundsException("Feed-mass-flow sensitivity point index is outside the result");
     }
     return points[index];
   }
@@ -153,8 +149,7 @@ public final class DoeBigHillVacuumFeedMassFlowSensitivity {
         throw new IllegalArgumentException("Feed mass flows must be finite and positive");
       }
       if (!(massFlow > previous)) {
-        throw new IllegalArgumentException(
-            "Feed mass flows must be strictly increasing and unique");
+        throw new IllegalArgumentException("Feed mass flows must be strictly increasing and unique");
       }
       previous = massFlow;
     }
@@ -170,8 +165,7 @@ public final class DoeBigHillVacuumFeedMassFlowSensitivity {
         DoeBigHillVacuumFractionationResult fractionationResult) {
       this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
       this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
-      this.fractionationResult =
-          Objects.requireNonNull(fractionationResult, "fractionationResult");
+      this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
     }
 
     /** @return feed mass flow applied at this point in kg/h */

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivityTest.java
@@ -1,0 +1,136 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFeedMassFlowSensitivity.PointResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/** Qualification tests for {@link DoeBigHillVacuumFeedMassFlowSensitivity}. */
+public class DoeBigHillVacuumFeedMassFlowSensitivityTest {
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /** Execute the documented three-point flow screen with every column input held fixed. */
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void feedMassFlowScreenReturnsQualifiedImmutablePoints() {
+    OperatingInputs baseline = baselineInputs();
+    double[] massFlows = { 980.0, 1000.0, 1020.0 };
+
+    DoeBigHillVacuumFeedMassFlowSensitivity sensitivity =
+        DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "Big Hill vacuum feed-mass-flow screen", baseline, massFlows);
+
+    massFlows[0] = 9999.0;
+    PointResult[] points = sensitivity.getPoints();
+    assertEquals(3, points.length);
+    assertNotSame(points, sensitivity.getPoints());
+    assertEquals(980.0, points[0].getFeedMassFlowKgPerHour(), 0.0);
+    assertEquals(1000.0, points[1].getFeedMassFlowKgPerHour(), 0.0);
+    assertEquals(1020.0, points[2].getFeedMassFlowKgPerHour(), 0.0);
+    assertEquals(points[0], sensitivity.getPoint(0));
+    assertEquals(points[2], sensitivity.getPoint(2));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> sensitivity.getPoint(3));
+
+    double expectedMinimumOverhead = Double.POSITIVE_INFINITY;
+    double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
+    double expectedMaximumMassClosure = 0.0;
+    double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumEnergyError = 0.0;
+    double expectedMaximumMeshResidual = 0.0;
+
+    for (PointResult point : points) {
+      double massFlow = point.getFeedMassFlowKgPerHour();
+      OperatingInputs applied = point.getOperatingInputs();
+      assertEquals(baseline.getSimpleTrayCount(), applied.getSimpleTrayCount());
+      assertEquals(baseline.getFeedTrayIndex(), applied.getFeedTrayIndex());
+      assertEquals(baseline.getFeedTemperatureKelvin(), applied.getFeedTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getFeedPressureBara(), applied.getFeedPressureBara(), 0.0);
+      assertEquals(baseline.getTopPressureBara(), applied.getTopPressureBara(), 0.0);
+      assertEquals(baseline.getBottomPressureBara(), applied.getBottomPressureBara(), 0.0);
+      assertEquals(baseline.getReboilerTemperatureKelvin(),
+          applied.getReboilerTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getCondenserRefluxRatio(), applied.getCondenserRefluxRatio(), 0.0);
+
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      assertEquals(massFlow, result.getFeedMassFlowKgPerHour(), massFlow * 1.0e-10);
+      ProductResult overhead = result.getProduct("Overhead");
+      ProductResult bottoms = result.getProduct("Bottoms");
+      assertTrue(overhead.getMassFlowKgPerHour() > 0.0);
+      assertTrue(bottoms.getMassFlowKgPerHour() > 0.0);
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
+          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
+      assertThrows(IllegalArgumentException.class,
+          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
+
+      expectedMinimumOverhead =
+          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead =
+          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure =
+          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumEnergyError =
+          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual =
+          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumMassClosure,
+        sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure,
+        sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
+  }
+
+  /** Require malformed sensitivity definitions to fail before presenting an envelope. */
+  @Test
+  public void invalidSensitivityInputsFailClosed() {
+    OperatingInputs baseline = baselineInputs();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            " ", baseline, new double[] { 980.0, 1020.0 }));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "screen", null, new double[] { 980.0, 1020.0 }));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "screen", baseline, new double[] { 1000.0 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "screen", baseline, new double[] { 1000.0, Double.NaN }));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "screen", baseline, new double[] { 1000.0, 1000.0 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "screen", baseline, new double[] { 1020.0, 980.0 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
+            "screen", baseline, new double[] { 0.0, 1000.0 }));
+  }
+
+  private static OperatingInputs baselineInputs() {
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivityTest.java
@@ -23,9 +23,8 @@ public class DoeBigHillVacuumFeedMassFlowSensitivityTest {
     OperatingInputs baseline = baselineInputs();
     double[] massFlows = { 980.0, 1000.0, 1020.0 };
 
-    DoeBigHillVacuumFeedMassFlowSensitivity sensitivity =
-        DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "Big Hill vacuum feed-mass-flow screen", baseline, massFlows);
+    DoeBigHillVacuumFeedMassFlowSensitivity sensitivity = DoeBigHillVacuumFeedMassFlowSensitivity
+        .run("Big Hill vacuum feed-mass-flow screen", baseline, massFlows);
 
     massFlows[0] = 9999.0;
     PointResult[] points = sensitivity.getPoints();
@@ -55,8 +54,7 @@ public class DoeBigHillVacuumFeedMassFlowSensitivityTest {
       assertEquals(baseline.getFeedPressureBara(), applied.getFeedPressureBara(), 0.0);
       assertEquals(baseline.getTopPressureBara(), applied.getTopPressureBara(), 0.0);
       assertEquals(baseline.getBottomPressureBara(), applied.getBottomPressureBara(), 0.0);
-      assertEquals(baseline.getReboilerTemperatureKelvin(),
-          applied.getReboilerTemperatureKelvin(), 0.0);
+      assertEquals(baseline.getReboilerTemperatureKelvin(), applied.getReboilerTemperatureKelvin(), 0.0);
       assertEquals(baseline.getCondenserRefluxRatio(), applied.getCondenserRefluxRatio(), 0.0);
 
       DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
@@ -65,37 +63,28 @@ public class DoeBigHillVacuumFeedMassFlowSensitivityTest {
       ProductResult bottoms = result.getProduct("Bottoms");
       assertTrue(overhead.getMassFlowKgPerHour() > 0.0);
       assertTrue(bottoms.getMassFlowKgPerHour() > 0.0);
-      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
-          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin() < bottoms.getMeanNormalBoilingPointKelvin());
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
-      assertThrows(IllegalArgumentException.class,
-          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertThrows(IllegalArgumentException.class, () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
       assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
-      expectedMinimumOverhead =
-          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
-      expectedMaximumOverhead =
-          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
-      expectedMaximumMassClosure =
-          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
       expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      expectedMaximumEnergyError =
-          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
-      expectedMaximumMeshResidual =
-          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+      expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
     }
 
     assertEquals(expectedMinimumOverhead, sensitivity.getMinimumOverheadMassFraction(), 0.0);
     assertEquals(expectedMaximumOverhead, sensitivity.getMaximumOverheadMassFraction(), 0.0);
-    assertEquals(expectedMaximumMassClosure,
-        sensitivity.getMaximumMassClosureRelativeError(), 0.0);
-    assertEquals(expectedMaximumComponentClosure,
-        sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumMassClosure, sensitivity.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure, sensitivity.getMaximumComponentMolarClosureRelativeError(), 0.0);
     assertEquals(expectedMaximumEnergyError, sensitivity.getMaximumColumnEnergyBalanceError(), 0.0);
     assertEquals(expectedMaximumMeshResidual, sensitivity.getMaximumMeshResidualNorm(), 0.0);
   }
@@ -106,28 +95,21 @@ public class DoeBigHillVacuumFeedMassFlowSensitivityTest {
     OperatingInputs baseline = baselineInputs();
 
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            " ", baseline, new double[] { 980.0, 1020.0 }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(" ", baseline, new double[] { 980.0, 1020.0 }));
     assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "screen", null, new double[] { 980.0, 1020.0 }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", null, new double[] { 980.0, 1020.0 }));
     assertThrows(NullPointerException.class,
         () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, null));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "screen", baseline, new double[] { 1000.0 }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, new double[] { 1000.0 }));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "screen", baseline, new double[] { 1000.0, Double.NaN }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, new double[] { 1000.0, Double.NaN }));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "screen", baseline, new double[] { 1000.0, 1000.0 }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, new double[] { 1000.0, 1000.0 }));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "screen", baseline, new double[] { 1020.0, 980.0 }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, new double[] { 1020.0, 980.0 }));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run(
-            "screen", baseline, new double[] { 0.0, 1000.0 }));
+        () -> DoeBigHillVacuumFeedMassFlowSensitivity.run("screen", baseline, new double[] { 0.0, 1000.0 }));
   }
 
   private static OperatingInputs baselineInputs() {


### PR DESCRIPTION
Advances #3305.

## Capability

Adds an immutable Java/JPype feed-mass-flow sensitivity runner for the qualified DOE Big Hill 650 degF+ vacuum-screening case.

- independently rebuilds, solves, and evaluates every requested feed-throughput point;
- varies only feed mass flow while tray topology, feed and reboiler temperatures, all three absolute pressures, condenser reflux, and DOE feed composition remain fixed;
- requires finite, positive, unique, strictly increasing flows in kg/h;
- reuses the qualified MESH, fallback, mass, component, energy, material-product, and boiling-range gates;
- fails the complete screen if any point fails;
- returns defensive point arrays, exact applied flows and inputs, overhead-yield bounds, and worst conservation, energy, and MESH diagnostics.

The focused regression qualifies the documented 980/1000/1020 kg/h screen around the existing 1000 kg/h point without asserting a monotonic response or hydraulic capacity.

## Provenance and engineering boundary

The public DOE Big Hill assay, three-cut 650 degF+ normalization, and pseudo-component properties are unchanged. Every column operating value and screen flow remains a source-unreported engineering assumption.

This is numerical throughput-sensitivity evidence only. It does not establish measured capacity or response, hydraulic limits, flooding, weeping, entrainment, pressure drop, scale-up, turndown, heat duty, utilities, equipment sizing, calibrated yield, ASTM D1160/TBP correction, optimization, product specification, or plant agreement.

## Frozen scope and continuity

- Exact base: `e3948d4c45721fe0e1f9b7d8edaaacad8b82322a`
- Exact current head after the sole formatter repair: `d1c63192e132137d2eb9ec934ca8b25d1abba244`
- Changed files: exactly three
  1. `src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivity.java`
  2. `src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumFeedMassFlowSensitivityTest.java`
  3. `docs/thermo/characterization/refinery_big_hill_complete_slate.md`
- Relation to frozen base: 5 commits ahead, zero behind
- No overlap with the 3 other open autonomous PRs
- Portfolio occupancy after reservation: **4/10**

## Validation

Connector-side pre-publication checks confirm the exact three-file scope, frozen-base continuity, Java 8-compatible syntax, defensive inputs and results, explicit failure boundaries, units and fixed-input reconstruction, provenance limits, and no active ownership overlap. Documentation impact is covered in the existing Big Hill guide.

The sole formatter repair used [hosted run 34642894393](https://github.com/equinor/neqsim/actions/runs/34642894393), artifact `10280134392`, with verified digest `sha256:f0a368a57e39afb824e6b548972d22e0cc3261104d0a7cec5d60c92e152260fa`. Its patch contained only the two expected Java files. The resulting blobs exactly match the artifact targets: production `1f0adfe1d7afb500ee58fca023494d1a350f71cc`, test `6acf14e57dee9e0b893cdc86d3da57d0a0dde64e`. No behavior, test intent, API, scientific assumption, provenance, or acceptance criterion changed. The formatter-repair allowance is exhausted.

**VALIDATION COMPLETE — HUMAN REVIEW REQUIRED.**

All exact-head gates pass: Java 8 and 21 on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, and agent-skill checks. The initially cancelled Java workflow was safely retried at job level on the unchanged head; no source change was made. The two newer `master` commits affect only two-fluid and MCP files and do not overlap this three-file refinery scope.

There are no submitted reviews or unresolved review threads. Because this adds public engineering API, subsystem-owner and independent-maintainer reviews remain required before READY TO MERGE.

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.