### PR TITLE
[AI-Assisted] feat(kinetics): invert remaining H2S inventory targets

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -349,6 +349,43 @@ This method dimensionalizes an analytical screening target only. The constant wa
 remains caller-supplied and is not a calculated holdup. The output is not a residence-time design,
 pipeline position, signed H2S source, oxygen demand, product yield, or deposition prediction.
 
+## Absolute remaining-moles target crossing
+
+`AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(...)`
+converts a requested absolute remaining total-sulfide inventory to the fraction required by the
+existing piecewise target-crossing calculation. With initial molality `c_0`, constant water
+inventory `m_w`, and requested remaining amount `n_remaining,target`,
+
+$
+n_0=c_0m_w, \qquad
+f_{\mathrm{target}}=\frac{n_{\mathrm{remaining,target}}}{n_0}, \qquad
+n_{\mathrm{reacted,target}}=n_0-n_{\mathrm{remaining,target}}.
+$
+
+The immutable result records the input molality and water inventory, initial, remaining, and
+complementary reacted amounts, the target fraction, and the existing shortest, nominal, and
+longest crossing times and segment indices. A remaining target equal to half the initial inventory
+maps exactly to a fraction of `0.5`; at the illustrative reference state the nominal crossing is
+`22.4288 h`. It agrees exactly with the reacted-moles inverse when the two dimensional targets
+are complements.
+
+Forward evaluation at each reported fit-scatter crossing recovers the requested remaining amount.
+A smaller remaining target requires a longer time. Scaling both the constant water inventory and
+remaining-moles target by the same factor leaves the target fraction and crossing times unchanged.
+Unchanged-state segment subdivision preserves elapsed times while the source-order crossing index
+continues to describe the supplied segmentation. A target equal to the initial inventory crosses
+at exact time zero.
+
+The target must be finite, strictly positive, and no greater than the initial dimensional inventory;
+exact zero is unreachable in finite time for this first-order model. Non-finite, numerically
+underflowing, overflowing, unrepresentable, or unreachable inputs fail closed. Every lower,
+nominal, and upper fit-scatter path must reach a non-identity target within the supplied finite
+trajectory.
+
+This method is an absolute inventory-threshold screen, not a water-holdup calculation, residence-
+time design, pipeline position, signed H2S source, oxygen demand, product yield, or deposition
+prediction. The water inventory remains an explicit constant caller input.
+
 ## Scientific stop boundary
 
 This capability does not:

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -412,6 +412,45 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.water_inventory_projection_test)
 
+    def test_absolute_remaining_moles_target_is_documented_and_executable(self):
+        for token in (
+            "Absolute remaining-moles target crossing",
+            "`AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(...)`",
+            r"n_0=c_0m_w",
+            r"f_{\mathrm{target}}=\frac{n_{\mathrm{remaining,target}}}{n_0}",
+            r"n_{\mathrm{reacted,target}}=n_0-n_{\mathrm{remaining,target}}",
+            "shortest, nominal, and longest crossing times and segment indices",
+            "nominal crossing is `22.4288 h`",
+            "reacted-moles inverse when the two dimensional targets are complements",
+            "Scaling both the constant water inventory and remaining-moles target",
+            "target equal to the initial inventory crosses at exact time zero",
+            "strictly positive, and no greater than the initial dimensional inventory",
+            "not a water-holdup calculation",
+            "not a water-holdup calculation, residence- time design",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static RemainingMolesTargetResult timeToRemainingMolesRange(",
+            "public static final class RemainingMolesTargetResult",
+            "getInitialTotalSulfideMoles()",
+            "getTargetRemainingMoles()",
+            "getTargetReactedMoles()",
+            "getTargetRemainingFraction()",
+            "getCrossingRange()",
+            "cannot be represented at this inventory scale",
+        ):
+            self.assertIn(token, self.water_inventory_projection)
+
+        for token in (
+            "testRemainingMolesTargetReproducesHalfInventoryAndAgreesWithComplement",
+            "testRemainingMolesTargetIsMonotonicAndPreservesLinearWaterScaling",
+            "testRemainingMolesTargetIsSplitInvariantAndIdentityIsExact",
+            "testRemainingMolesTargetInvalidInputsAndUnreachableTrajectoryFailClosed",
+            "assertTargetRemaining(",
+        ):
+            self.assertIn(token, self.water_inventory_projection_test)
+
     def test_piecewise_target_crossing_contract_is_documented_and_executable(self):
         for token in (
             "Piecewise target crossing",

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -112,8 +112,8 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
    * Locate when an absolute remaining total-sulfide target is reached at constant water inventory.
    *
    * <p>
-   * The dimensional threshold is converted to a remaining fraction and delegated to the existing piecewise
-   * analytical crossing calculation. No product identity, oxygen demand, or process source term is inferred.
+   * The dimensional threshold is converted to a remaining fraction and delegated to the existing piecewise analytical
+   * crossing calculation. No product identity, oxygen demand, or process source term is inferred.
    * </p>
    *
    * @param initialTotalSulfideMolality initial total-sulfide molality [mol/kg water]
@@ -145,16 +145,16 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     double targetReactedMoles = finiteDifference(initialTotalSulfideMoles, targetRemainingMoles,
         "Target reacted total sulfide");
     if (targetRemainingMoles < initialTotalSulfideMoles && targetReactedMoles == 0.0) {
-      throw new IllegalArgumentException("Target remaining total sulfide cannot be represented at this inventory scale");
+      throw new IllegalArgumentException(
+          "Target remaining total sulfide cannot be represented at this inventory scale");
     }
     double targetRemainingFraction = targetRemainingMoles / initialTotalSulfideMoles;
-    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0
-        || targetRemainingFraction > 1.0) {
+    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0 || targetRemainingFraction > 1.0) {
       throw new IllegalArgumentException("Target remaining fraction must be finite and in the interval (0, 1]");
     }
 
-    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange =
-        AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(targetRemainingFraction, segments);
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange = AqueousHydrogenSulfideOxidationTrajectory
+        .timeToRemainingFractionRange(targetRemainingFraction, segments);
     return new RemainingMolesTargetResult(initialTotalSulfideMolality, waterInventoryKg, initialTotalSulfideMoles,
         targetRemainingMoles, targetReactedMoles, targetRemainingFraction, crossingRange);
   }

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -109,6 +109,57 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
   }
 
   /**
+   * Locate when an absolute remaining total-sulfide target is reached at constant water inventory.
+   *
+   * <p>
+   * The dimensional threshold is converted to a remaining fraction and delegated to the existing piecewise
+   * analytical crossing calculation. No product identity, oxygen demand, or process source term is inferred.
+   * </p>
+   *
+   * @param initialTotalSulfideMolality initial total-sulfide molality [mol/kg water]
+   * @param targetRemainingMoles requested remaining total sulfide [mol]
+   * @param waterInventoryKg constant liquid-water inventory [kg]
+   * @param segments non-empty ordered exposure segments
+   * @return immutable dimensional threshold and piecewise crossing evidence
+   * @throws IllegalArgumentException when inputs are outside the source or numerical domain, the target exceeds the
+   * initial dimensional inventory, or every fit-scatter path cannot reach the target
+   */
+  public static RemainingMolesTargetResult timeToRemainingMolesRange(double initialTotalSulfideMolality,
+      double targetRemainingMoles, double waterInventoryKg,
+      List<AqueousHydrogenSulfideOxidationTrajectory.Segment> segments) {
+    if (!Double.isFinite(initialTotalSulfideMolality)
+        || initialTotalSulfideMolality < AqueousHydrogenSulfideOxidationTrajectory.MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY
+        || initialTotalSulfideMolality > AqueousHydrogenSulfideOxidationTrajectory.MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY) {
+      throw new IllegalArgumentException("Initial total-sulfide molality must be within the source experiment range");
+    }
+    requirePositiveFinite(waterInventoryKg, "Water inventory");
+
+    double initialTotalSulfideMoles = finiteProduct(initialTotalSulfideMolality, waterInventoryKg,
+        "Initial total sulfide");
+    if (!Double.isFinite(targetRemainingMoles) || targetRemainingMoles <= 0.0
+        || targetRemainingMoles > initialTotalSulfideMoles) {
+      throw new IllegalArgumentException(
+          "Target remaining total sulfide must be finite, positive, and no greater than the initial inventory");
+    }
+
+    double targetReactedMoles = finiteDifference(initialTotalSulfideMoles, targetRemainingMoles,
+        "Target reacted total sulfide");
+    if (targetRemainingMoles < initialTotalSulfideMoles && targetReactedMoles == 0.0) {
+      throw new IllegalArgumentException("Target remaining total sulfide cannot be represented at this inventory scale");
+    }
+    double targetRemainingFraction = targetRemainingMoles / initialTotalSulfideMoles;
+    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0
+        || targetRemainingFraction > 1.0) {
+      throw new IllegalArgumentException("Target remaining fraction must be finite and in the interval (0, 1]");
+    }
+
+    AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange =
+        AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(targetRemainingFraction, segments);
+    return new RemainingMolesTargetResult(initialTotalSulfideMolality, waterInventoryKg, initialTotalSulfideMoles,
+        targetRemainingMoles, targetReactedMoles, targetRemainingFraction, crossingRange);
+  }
+
+  /**
    * Locate when an absolute reacted total-sulfide target is reached at constant water inventory.
    *
    * <p>
@@ -186,6 +237,67 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
       throw new IllegalArgumentException(name + " is not finite");
     }
     return difference;
+  }
+
+  /** Immutable dimensional remaining-moles target and piecewise crossing evidence. */
+  public static final class RemainingMolesTargetResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double initialTotalSulfideMolality;
+    private final double waterInventoryKg;
+    private final double initialTotalSulfideMoles;
+    private final double targetRemainingMoles;
+    private final double targetReactedMoles;
+    private final double targetRemainingFraction;
+    private final AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange;
+
+    private RemainingMolesTargetResult(double initialTotalSulfideMolality, double waterInventoryKg,
+        double initialTotalSulfideMoles, double targetRemainingMoles, double targetReactedMoles,
+        double targetRemainingFraction,
+        AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult crossingRange) {
+      this.initialTotalSulfideMolality = initialTotalSulfideMolality;
+      this.waterInventoryKg = waterInventoryKg;
+      this.initialTotalSulfideMoles = initialTotalSulfideMoles;
+      this.targetRemainingMoles = targetRemainingMoles;
+      this.targetReactedMoles = targetReactedMoles;
+      this.targetRemainingFraction = targetRemainingFraction;
+      this.crossingRange = crossingRange;
+    }
+
+    /** @return initial total-sulfide molality [mol/kg water]. */
+    public double getInitialTotalSulfideMolality() {
+      return initialTotalSulfideMolality;
+    }
+
+    /** @return caller-supplied constant liquid-water inventory [kg]. */
+    public double getWaterInventoryKg() {
+      return waterInventoryKg;
+    }
+
+    /** @return initial total-sulfide inventory [mol]. */
+    public double getInitialTotalSulfideMoles() {
+      return initialTotalSulfideMoles;
+    }
+
+    /** @return requested remaining total sulfide [mol]. */
+    public double getTargetRemainingMoles() {
+      return targetRemainingMoles;
+    }
+
+    /** @return reacted total sulfide at the requested target [mol]. */
+    public double getTargetReactedMoles() {
+      return targetReactedMoles;
+    }
+
+    /** @return remaining fraction corresponding to the requested dimensional threshold. */
+    public double getTargetRemainingFraction() {
+      return targetRemainingFraction;
+    }
+
+    /** @return immutable lower, nominal, and upper piecewise crossing evidence. */
+    public AqueousHydrogenSulfideOxidationTrajectory.TargetCrossingRangeResult getCrossingRange() {
+      return crossingRange;
+    }
   }
 
   /** Immutable dimensional reacted-moles target and piecewise crossing evidence. */

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -295,6 +295,141 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
         .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.0, WATER_INVENTORY_KG, null));
   }
 
+  @Test
+  void testRemainingMolesTargetReproducesHalfInventoryAndAgreesWithComplement() {
+    AqueousHydrogenSulfideOxidationTrajectory.Segment segment = referenceSegment(100.0);
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentEvidence = segmentResult(segment);
+    double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
+    double targetRemainingMoles = 0.5 * initialMoles;
+
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult remainingTarget =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, targetRemainingMoles, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult reactedTarget =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles - targetRemainingMoles, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+
+    assertEquals(initialMoles, remainingTarget.getInitialTotalSulfideMoles(), 0.0);
+    assertEquals(targetRemainingMoles, remainingTarget.getTargetRemainingMoles(), 0.0);
+    assertEquals(0.5 * initialMoles, remainingTarget.getTargetReactedMoles(), 0.0);
+    assertEquals(0.5, remainingTarget.getTargetRemainingFraction(), 0.0);
+    assertEquals(22.4288, remainingTarget.getCrossingRange().getNominalTimeHours(), 1.0e-4);
+    assertEquals(reactedTarget.getCrossingRange().getShortestTimeHours(),
+        remainingTarget.getCrossingRange().getShortestTimeHours(), 0.0);
+    assertEquals(reactedTarget.getCrossingRange().getNominalTimeHours(),
+        remainingTarget.getCrossingRange().getNominalTimeHours(), 0.0);
+    assertEquals(reactedTarget.getCrossingRange().getLongestTimeHours(),
+        remainingTarget.getCrossingRange().getLongestTimeHours(), 0.0);
+
+    assertTargetRemaining(targetRemainingMoles, initialMoles, segmentEvidence.getUpperPseudoFirstOrderRate(),
+        remainingTarget.getCrossingRange().getShortestTimeHours());
+    assertTargetRemaining(targetRemainingMoles, initialMoles, segmentEvidence.getNominalPseudoFirstOrderRate(),
+        remainingTarget.getCrossingRange().getNominalTimeHours());
+    assertTargetRemaining(targetRemainingMoles, initialMoles, segmentEvidence.getLowerPseudoFirstOrderRate(),
+        remainingTarget.getCrossingRange().getLongestTimeHours());
+  }
+
+  @Test
+  void testRemainingMolesTargetIsMonotonicAndPreservesLinearWaterScaling() {
+    AqueousHydrogenSulfideOxidationTrajectory.Segment segment = referenceSegment(100.0);
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult largerRemaining =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.018, WATER_INVENTORY_KG, Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult smallerRemaining =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.009, WATER_INVENTORY_KG, Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult scaled =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.036, 2.0 * WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+
+    assertTrue(largerRemaining.getCrossingRange().getShortestTimeHours()
+        < smallerRemaining.getCrossingRange().getShortestTimeHours());
+    assertTrue(largerRemaining.getCrossingRange().getNominalTimeHours()
+        < smallerRemaining.getCrossingRange().getNominalTimeHours());
+    assertTrue(largerRemaining.getCrossingRange().getLongestTimeHours()
+        < smallerRemaining.getCrossingRange().getLongestTimeHours());
+    assertEquals(largerRemaining.getCrossingRange().getShortestTimeHours(),
+        scaled.getCrossingRange().getShortestTimeHours(), NUMERICAL_TOLERANCE);
+    assertEquals(largerRemaining.getCrossingRange().getNominalTimeHours(),
+        scaled.getCrossingRange().getNominalTimeHours(), NUMERICAL_TOLERANCE);
+    assertEquals(largerRemaining.getCrossingRange().getLongestTimeHours(),
+        scaled.getCrossingRange().getLongestTimeHours(), NUMERICAL_TOLERANCE);
+  }
+
+  @Test
+  void testRemainingMolesTargetIsSplitInvariantAndIdentityIsExact() {
+    double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult unsplit =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult split =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+            Arrays.asList(referenceSegment(10.0), referenceSegment(90.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult identity =
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(0.0)));
+
+    assertEquals(unsplit.getCrossingRange().getShortestTimeHours(),
+        split.getCrossingRange().getShortestTimeHours(), NUMERICAL_TOLERANCE);
+    assertEquals(unsplit.getCrossingRange().getNominalTimeHours(), split.getCrossingRange().getNominalTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(unsplit.getCrossingRange().getLongestTimeHours(), split.getCrossingRange().getLongestTimeHours(),
+        NUMERICAL_TOLERANCE);
+    assertEquals(0, unsplit.getCrossingRange().getNominalCrossingSegmentIndex());
+    assertEquals(1, split.getCrossingRange().getNominalCrossingSegmentIndex());
+    assertEquals(0.0, identity.getTargetReactedMoles(), 0.0);
+    assertEquals(1.0, identity.getTargetRemainingFraction(), 0.0);
+    assertEquals(0.0, identity.getCrossingRange().getShortestTimeHours(), 0.0);
+    assertEquals(0.0, identity.getCrossingRange().getNominalTimeHours(), 0.0);
+    assertEquals(0.0, identity.getCrossingRange().getLongestTimeHours(), 0.0);
+  }
+
+  @Test
+  void testRemainingMolesTargetInvalidInputsAndUnreachableTrajectoryFailClosed() {
+    double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(19.0e-6, 0.01,
+            WATER_INVENTORY_KG, Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.0, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles + 0.001, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Double.NaN, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Double.MIN_VALUE, 1.0e300,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, Double.POSITIVE_INFINITY,
+            Collections.singletonList(referenceSegment(100.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+            Collections.singletonList(referenceSegment(1.0))));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles, WATER_INVENTORY_KG, null));
+  }
+
+  private static void assertTargetRemaining(double targetRemainingMoles, double initialMoles,
+      double pseudoFirstOrderRate, double crossingTimeHours) {
+    double remainingMoles = initialMoles * Math.exp(-pseudoFirstOrderRate * crossingTimeHours);
+    assertEquals(targetRemainingMoles, remainingMoles, NUMERICAL_TOLERANCE);
+  }
+
   private static void assertTargetReaction(double targetReactedMoles, double initialMoles, double pseudoFirstOrderRate,
       double crossingTimeHours) {
     double reactedMoles = initialMoles * -Math.expm1(-pseudoFirstOrderRate * crossingTimeHours);

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -302,14 +302,12 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
     double targetRemainingMoles = 0.5 * initialMoles;
 
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult remainingTarget =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, targetRemainingMoles, WATER_INVENTORY_KG,
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult remainingTarget = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, targetRemainingMoles, WATER_INVENTORY_KG,
             Collections.singletonList(segment));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult reactedTarget =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToReactedMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles - targetRemainingMoles, WATER_INVENTORY_KG,
-            Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.ReactedMolesTargetResult reactedTarget = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToReactedMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles - targetRemainingMoles,
+            WATER_INVENTORY_KG, Collections.singletonList(segment));
 
     assertEquals(initialMoles, remainingTarget.getInitialTotalSulfideMoles(), 0.0);
     assertEquals(targetRemainingMoles, remainingTarget.getTargetRemainingMoles(), 0.0);
@@ -334,23 +332,22 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
   @Test
   void testRemainingMolesTargetIsMonotonicAndPreservesLinearWaterScaling() {
     AqueousHydrogenSulfideOxidationTrajectory.Segment segment = referenceSegment(100.0);
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult largerRemaining =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.018, WATER_INVENTORY_KG, Collections.singletonList(segment));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult smallerRemaining =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.009, WATER_INVENTORY_KG, Collections.singletonList(segment));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult scaled =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.036, 2.0 * WATER_INVENTORY_KG,
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult largerRemaining = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.018, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult smallerRemaining = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.009, WATER_INVENTORY_KG,
+            Collections.singletonList(segment));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult scaled = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.036, 2.0 * WATER_INVENTORY_KG,
             Collections.singletonList(segment));
 
-    assertTrue(largerRemaining.getCrossingRange().getShortestTimeHours()
-        < smallerRemaining.getCrossingRange().getShortestTimeHours());
-    assertTrue(largerRemaining.getCrossingRange().getNominalTimeHours()
-        < smallerRemaining.getCrossingRange().getNominalTimeHours());
-    assertTrue(largerRemaining.getCrossingRange().getLongestTimeHours()
-        < smallerRemaining.getCrossingRange().getLongestTimeHours());
+    assertTrue(largerRemaining.getCrossingRange().getShortestTimeHours() < smallerRemaining.getCrossingRange()
+        .getShortestTimeHours());
+    assertTrue(largerRemaining.getCrossingRange().getNominalTimeHours() < smallerRemaining.getCrossingRange()
+        .getNominalTimeHours());
+    assertTrue(largerRemaining.getCrossingRange().getLongestTimeHours() < smallerRemaining.getCrossingRange()
+        .getLongestTimeHours());
     assertEquals(largerRemaining.getCrossingRange().getShortestTimeHours(),
         scaled.getCrossingRange().getShortestTimeHours(), NUMERICAL_TOLERANCE);
     assertEquals(largerRemaining.getCrossingRange().getNominalTimeHours(),
@@ -362,21 +359,18 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
   @Test
   void testRemainingMolesTargetIsSplitInvariantAndIdentityIsExact() {
     double initialMoles = INITIAL_TOTAL_SULFIDE_MOLALITY * WATER_INVENTORY_KG;
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult unsplit =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult unsplit = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
             Collections.singletonList(referenceSegment(100.0)));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult split =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult split = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, 0.015, WATER_INVENTORY_KG,
             Arrays.asList(referenceSegment(10.0), referenceSegment(90.0)));
-    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult identity =
-        AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles, WATER_INVENTORY_KG,
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.RemainingMolesTargetResult identity = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .timeToRemainingMolesRange(INITIAL_TOTAL_SULFIDE_MOLALITY, initialMoles, WATER_INVENTORY_KG,
             Collections.singletonList(referenceSegment(0.0)));
 
-    assertEquals(unsplit.getCrossingRange().getShortestTimeHours(),
-        split.getCrossingRange().getShortestTimeHours(), NUMERICAL_TOLERANCE);
+    assertEquals(unsplit.getCrossingRange().getShortestTimeHours(), split.getCrossingRange().getShortestTimeHours(),
+        NUMERICAL_TOLERANCE);
     assertEquals(unsplit.getCrossingRange().getNominalTimeHours(), split.getCrossingRange().getNominalTimeHours(),
         NUMERICAL_TOLERANCE);
     assertEquals(unsplit.getCrossingRange().getLongestTimeHours(), split.getCrossingRange().getLongestTimeHours(),


### PR DESCRIPTION
Refs #3318.

Adds a direct absolute remaining-inventory inverse for the qualified aqueous H2S/O2 Millero screening path.

## Capability

- Adds `AqueousHydrogenSulfideOxidationWaterInventoryProjection.timeToRemainingMolesRange(...)`.
- Converts a caller-requested remaining total-sulfide amount, explicit constant liquid-water inventory, and source-range initial molality into the existing analytical piecewise crossing.
- Returns immutable initial, remaining, and complementary reacted dimensional evidence plus the established shortest, nominal, and longest crossing times and source-order segment indices.
- Reuses the existing lower/nominal/upper Millero fit-scatter paths without introducing a kinetic parameter.

## Numerical gates

- a remaining target equal to the initial inventory crosses at exact time zero;
- half the initial dimensional inventory maps to a remaining fraction of 0.5 and reproduces the nominal 22.4288 h reference half-life;
- forward evaluation of every returned crossing recovers the requested remaining amount;
- smaller remaining targets require longer times;
- proportional water-inventory and target scaling preserves crossing times;
- unchanged-state segment subdivision preserves elapsed crossing times;
- complementary remaining- and reacted-moles targets return identical crossings;
- invalid, above-initial, unreachable, unrepresentable, underflowing, overflowing, or non-finite inputs fail closed.

## Scientific basis and boundary

The rate basis remains Millero et al. (1987), [doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003). The implementation remains atmospheric aqueous total-sulfide-loss screening. It does not calculate water holdup/dropout, H2S/HS- speciation, oxygen solubility or consumption, products/selectivity, reaction heat, pressure or phase transfer, signed component sources, equipment sizing, pipeline position or transient mutation, or S8/FeS/wall/deposition inventories.

Coordination remains with #3144, #2937, #2911, the pipeline roadmap, #3153, and the existing sulfur/solid-flash implementations. The four changed paths do not overlap the four other open autonomous PRs identified at publication.

## Documentation impact

Updates the primary H2S/O2 guide and executable documentation contract with the absolute remaining-inventory equations, validity rules, numerical invariants, and stop boundary.

## Validation

- Repository Spotless 3.10.1/Eclipse 4.35 apply and repeat check passed for the exact local validation tree.
- Java 8 ECJ 3.41.0 compilation passed for the complete three-class kinetics/projection chain.
- 17 focused JUnit methods passed through the local Java 8 reflection harness.
- Documentation contract: 17/17 tests passed.
- Python byte compilation of the documentation contract passed.
- Full repository Maven matrix, pre-commit/pre-push, documentation search, Javadocs, security, and hosted checks are deferred to exact-head CI.

## Publication

- Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5640478445
- Exact base: `e3948d4c45721fe0e1f9b7d8edaaacad8b82322a`
- Exact head: `b4466cbce5fc7b6f06d2db926587526d3808f132`
- Changed files: exactly four (production, JUnit, guide, documentation contract).
- Portfolio occupancy after publication: **5/10** autonomous implementation capabilities.
- Draft-only.
- **VALIDATION PENDING EXACT-HEAD CI.**

AI-assisted implementation. Subject to CI and the subsystem-owner plus independent review required by repository governance.