### PR TITLE
feat(refinery): qualify Big Hill vacuum scenario screen

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -435,3 +435,62 @@ All DOE assay provenance and the three-cut 650 degF+ normalization remain unchan
 does not add ASTM D1160 or TBP pressure correction, measured vacuum-column data, fitted parameters,
 calibrated VGO/residue yields, optimization, product specifications, hydraulic capacity, or
 plant-agreement evidence.
+
+
+## Combined operating-scenario screening
+
+`DoeBigHillVacuumScenarioScreen.run(...)` independently rebuilds, solves, and evaluates complete
+caller-defined operating scenarios. This is the integration step after the qualified one-factor
+pressure, reflux, feed-temperature, reboiler-temperature, and feed-mass-flow screens. Scenario order
+is preserved; names must be unique, and every scenario supplies its own validated operating inputs
+and positive feed mass flow.
+
+The documented low/base/high scenarios combine only the narrow ranges already exercised by those
+one-factor screens:
+
+```java
+DoeBigHillVacuumScenarioScreen.Scenario[] scenarios = {
+    new DoeBigHillVacuumScenarioScreen.Scenario(
+        "low",
+        980.0,
+        new OperatingInputs(12, 4, 638.0, 0.1176, 0.0784, 0.1568, 698.0, 0.49)),
+    new DoeBigHillVacuumScenarioScreen.Scenario(
+        "base",
+        1000.0,
+        new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.50)),
+    new DoeBigHillVacuumScenarioScreen.Scenario(
+        "high",
+        1020.0,
+        new OperatingInputs(12, 4, 642.0, 0.1224, 0.0816, 0.1632, 702.0, 0.51))
+};
+
+DoeBigHillVacuumScenarioScreen screen =
+    DoeBigHillVacuumScenarioScreen.run("Big Hill vacuum combined screen", scenarios);
+
+for (DoeBigHillVacuumScenarioScreen.PointResult point : screen.getPoints()) {
+  String scenarioName = point.getScenario().getName();
+  double feedMassFlowKgPerHour = point.getScenario().getFeedMassFlowKgPerHour();
+  double overheadMassFraction = point.getOverheadMassFraction();
+  double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+}
+```
+
+All three absolute pressures move together by factors 0.98, 1.00, and 1.02 relative to the base
+0.12/0.08/0.16 bara values. The feed and reboiler temperatures, condenser reflux ratio, and feed mass
+flow simultaneously use the low/base/high values shown above. Tray topology and feed composition
+remain fixed.
+
+Every scenario must pass the qualified MESH-residual, fallback, mass, component, energy,
+material-product, and boiling-point-order gates. The result returns defensive scenario-point arrays,
+the exact immutable scenario definitions and fractionation results, overhead-yield bounds, and the
+worst external mass closure, component closure, column energy error, and final MESH residual. Any
+failed scenario aborts the complete screen.
+
+These three discrete calculations are numerical robustness and interaction-screening evidence only.
+They do not define a continuous or measured operating envelope, response surface, interaction
+correlation, probability distribution, or optimization model. No monotonic trend is required. The
+screen does not establish hydraulic capacity, flooding, weeping, entrainment, pressure drop,
+scale-up, turndown, heat duty, utilities, equipment sizing, calibrated product yield, ASTM D1160 or
+TBP pressure correction, product-specification compliance, or plant agreement. All DOE assay
+provenance, three-cut 650 degF+ normalization, pseudo-component properties, and source-unreported
+engineering-input limitations remain unchanged.

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
@@ -12,10 +12,9 @@ import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult
  * Immutable multivariable scenario screen for the DOE Big Hill vacuum case.
  *
  * <p>
- * Every scenario supplies a complete set of explicit engineering inputs and a feed mass flow. Each
- * scenario is independently constructed, solved, and evaluated through the qualified Big Hill case
- * and result contracts. This class reports discrete numerical scenarios; it does not define a
- * measured or continuous vacuum-column operating envelope.
+ * Every scenario supplies a complete set of explicit engineering inputs and a feed mass flow. Each scenario is
+ * independently constructed, solved, and evaluated through the qualified Big Hill case and result contracts. This class
+ * reports discrete numerical scenarios; it does not define a measured or continuous vacuum-column operating envelope.
  * </p>
  */
 public final class DoeBigHillVacuumScenarioScreen {
@@ -44,8 +43,7 @@ public final class DoeBigHillVacuumScenarioScreen {
       maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
       maximumComponentClosure = Math.max(maximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      maximumEnergyError =
-          Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
       maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
     }
 
@@ -67,8 +65,7 @@ public final class DoeBigHillVacuumScenarioScreen {
    * @throws IllegalArgumentException if the name, scenario count, or scenario names are invalid
    * @throws IllegalStateException if a scenario does not solve or pass the qualified result gates
    */
-  public static DoeBigHillVacuumScenarioScreen run(String caseNamePrefix,
-      Scenario[] scenarios) {
+  public static DoeBigHillVacuumScenarioScreen run(String caseNamePrefix, Scenario[] scenarios) {
     if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
       throw new IllegalArgumentException("Case-name prefix must be non-blank");
     }
@@ -82,17 +79,15 @@ public final class DoeBigHillVacuumScenarioScreen {
     PointResult[] evaluatedPoints = new PointResult[requestedScenarios.length];
     for (int i = 0; i < requestedScenarios.length; i++) {
       Scenario scenario = requestedScenarios[i];
-      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
-          .create(caseNamePrefix + " scenario " + scenario.getName(),
-              scenario.getFeedMassFlowKgPerHour(), scenario.getOperatingInputs());
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase.create(
+          caseNamePrefix + " scenario " + scenario.getName(), scenario.getFeedMassFlowKgPerHour(),
+          scenario.getOperatingInputs());
       try {
         model.getColumn().run(UUID.randomUUID());
-        DoeBigHillVacuumFractionationResult result =
-            DoeBigHillVacuumFractionationResult.evaluate(model);
+        DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
         evaluatedPoints[i] = new PointResult(scenario, result);
       } catch (RuntimeException exception) {
-        throw new IllegalStateException(
-            "Vacuum scenario screen failed at point " + i + " (" + scenario.getName() + ")",
+        throw new IllegalStateException("Vacuum scenario screen failed at point " + i + " (" + scenario.getName() + ")",
             exception);
       }
     }
@@ -174,13 +169,11 @@ public final class DoeBigHillVacuumScenarioScreen {
      * @throws NullPointerException if {@code operatingInputs} is null
      * @throws IllegalArgumentException if the name or feed mass flow is invalid
      */
-    public Scenario(String name, double feedMassFlowKgPerHour,
-        OperatingInputs operatingInputs) {
+    public Scenario(String name, double feedMassFlowKgPerHour, OperatingInputs operatingInputs) {
       if (name == null || name.trim().isEmpty()) {
         throw new IllegalArgumentException("Scenario name must be non-blank");
       }
-      if (!Double.isFinite(feedMassFlowKgPerHour)
-          || !(feedMassFlowKgPerHour > 0.0)) {
+      if (!Double.isFinite(feedMassFlowKgPerHour) || !(feedMassFlowKgPerHour > 0.0)) {
         throw new IllegalArgumentException("Feed mass flow must be finite and positive");
       }
       this.name = name.trim();
@@ -209,11 +202,9 @@ public final class DoeBigHillVacuumScenarioScreen {
     private final Scenario scenario;
     private final DoeBigHillVacuumFractionationResult fractionationResult;
 
-    private PointResult(Scenario scenario,
-        DoeBigHillVacuumFractionationResult fractionationResult) {
+    private PointResult(Scenario scenario, DoeBigHillVacuumFractionationResult fractionationResult) {
       this.scenario = Objects.requireNonNull(scenario, "scenario");
-      this.fractionationResult =
-          Objects.requireNonNull(fractionationResult, "fractionationResult");
+      this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
     }
 
     /** @return immutable scenario definition applied at this point */
@@ -243,3 +234,4 @@ public final class DoeBigHillVacuumScenarioScreen {
     }
   }
 }
+

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
@@ -234,4 +234,3 @@ public final class DoeBigHillVacuumScenarioScreen {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
@@ -1,0 +1,245 @@
+package neqsim.process.equipment.distillation;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+
+/**
+ * Immutable multivariable scenario screen for the DOE Big Hill vacuum case.
+ *
+ * <p>
+ * Every scenario supplies a complete set of explicit engineering inputs and a feed mass flow. Each
+ * scenario is independently constructed, solved, and evaluated through the qualified Big Hill case
+ * and result contracts. This class reports discrete numerical scenarios; it does not define a
+ * measured or continuous vacuum-column operating envelope.
+ * </p>
+ */
+public final class DoeBigHillVacuumScenarioScreen {
+  private final PointResult[] points;
+  private final double minimumOverheadMassFraction;
+  private final double maximumOverheadMassFraction;
+  private final double maximumMassClosureRelativeError;
+  private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumColumnEnergyBalanceError;
+  private final double maximumMeshResidualNorm;
+
+  private DoeBigHillVacuumScenarioScreen(PointResult[] points) {
+    this.points = points.clone();
+
+    double minimumOverheadFraction = Double.POSITIVE_INFINITY;
+    double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
+    double maximumMassClosure = 0.0;
+    double maximumComponentClosure = 0.0;
+    double maximumEnergyError = 0.0;
+    double maximumMeshResidual = 0.0;
+    for (PointResult point : points) {
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      double overheadFraction = result.getProduct("Overhead").getMassFractionOfFeed();
+      minimumOverheadFraction = Math.min(minimumOverheadFraction, overheadFraction);
+      maximumOverheadFraction = Math.max(maximumOverheadFraction, overheadFraction);
+      maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
+      maximumComponentClosure = Math.max(maximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      maximumEnergyError =
+          Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
+      maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    minimumOverheadMassFraction = minimumOverheadFraction;
+    maximumOverheadMassFraction = maximumOverheadFraction;
+    maximumMassClosureRelativeError = maximumMassClosure;
+    maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumColumnEnergyBalanceError = maximumEnergyError;
+    maximumMeshResidualNorm = maximumMeshResidual;
+  }
+
+  /**
+   * Run independently constructed cases for explicit multivariable scenarios.
+   *
+   * @param caseNamePrefix non-blank prefix used for independently constructed case names
+   * @param scenarios at least two uniquely named scenarios in caller-defined order
+   * @return immutable scenario-screen summary
+   * @throws NullPointerException if {@code scenarios} or one scenario is null
+   * @throws IllegalArgumentException if the name, scenario count, or scenario names are invalid
+   * @throws IllegalStateException if a scenario does not solve or pass the qualified result gates
+   */
+  public static DoeBigHillVacuumScenarioScreen run(String caseNamePrefix,
+      Scenario[] scenarios) {
+    if (caseNamePrefix == null || caseNamePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case-name prefix must be non-blank");
+    }
+    Objects.requireNonNull(scenarios, "scenarios");
+    if (scenarios.length < 2) {
+      throw new IllegalArgumentException("Scenario screen requires at least two points");
+    }
+
+    Scenario[] requestedScenarios = scenarios.clone();
+    validateUniqueNames(requestedScenarios);
+    PointResult[] evaluatedPoints = new PointResult[requestedScenarios.length];
+    for (int i = 0; i < requestedScenarios.length; i++) {
+      Scenario scenario = requestedScenarios[i];
+      DoeBigHillVacuumFractionationCase model = DoeBigHillVacuumFractionationCase
+          .create(caseNamePrefix + " scenario " + scenario.getName(),
+              scenario.getFeedMassFlowKgPerHour(), scenario.getOperatingInputs());
+      try {
+        model.getColumn().run(UUID.randomUUID());
+        DoeBigHillVacuumFractionationResult result =
+            DoeBigHillVacuumFractionationResult.evaluate(model);
+        evaluatedPoints[i] = new PointResult(scenario, result);
+      } catch (RuntimeException exception) {
+        throw new IllegalStateException(
+            "Vacuum scenario screen failed at point " + i + " (" + scenario.getName() + ")",
+            exception);
+      }
+    }
+    return new DoeBigHillVacuumScenarioScreen(evaluatedPoints);
+  }
+
+  /** @return defensive copy of scenario points in caller-defined order */
+  public PointResult[] getPoints() {
+    return points.clone();
+  }
+
+  /**
+   * Return one scenario point by zero-based index.
+   *
+   * @param index zero-based point index
+   * @return immutable point result
+   * @throws IndexOutOfBoundsException if {@code index} is outside the screen
+   */
+  public PointResult getPoint(int index) {
+    if (index < 0 || index >= points.length) {
+      throw new IndexOutOfBoundsException("Scenario-screen point index is outside the result");
+    }
+    return points[index];
+  }
+
+  /** @return smallest overhead mass fraction across the qualified scenarios */
+  public double getMinimumOverheadMassFraction() {
+    return minimumOverheadMassFraction;
+  }
+
+  /** @return largest overhead mass fraction across the qualified scenarios */
+  public double getMaximumOverheadMassFraction() {
+    return maximumOverheadMassFraction;
+  }
+
+  /** @return largest external mass-closure relative error across the qualified scenarios */
+  public double getMaximumMassClosureRelativeError() {
+    return maximumMassClosureRelativeError;
+  }
+
+  /** @return largest component molar-closure relative error across the qualified scenarios */
+  public double getMaximumComponentMolarClosureRelativeError() {
+    return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest column energy-balance error across the qualified scenarios */
+  public double getMaximumColumnEnergyBalanceError() {
+    return maximumColumnEnergyBalanceError;
+  }
+
+  /** @return largest final MESH residual norm across the qualified scenarios */
+  public double getMaximumMeshResidualNorm() {
+    return maximumMeshResidualNorm;
+  }
+
+  private static void validateUniqueNames(Scenario[] scenarios) {
+    Set<String> normalizedNames = new HashSet<String>();
+    for (Scenario scenario : scenarios) {
+      Objects.requireNonNull(scenario, "scenario");
+      String normalizedName = scenario.getName().toLowerCase(Locale.ROOT);
+      if (!normalizedNames.add(normalizedName)) {
+        throw new IllegalArgumentException("Scenario names must be unique");
+      }
+    }
+  }
+
+  /** Immutable complete input definition for one numerical scenario. */
+  public static final class Scenario {
+    private final String name;
+    private final double feedMassFlowKgPerHour;
+    private final OperatingInputs operatingInputs;
+
+    /**
+     * Create one explicit scenario.
+     *
+     * @param name non-blank unique scenario name
+     * @param feedMassFlowKgPerHour finite positive feed mass flow in kg/h
+     * @param operatingInputs complete immutable column operating inputs
+     * @throws NullPointerException if {@code operatingInputs} is null
+     * @throws IllegalArgumentException if the name or feed mass flow is invalid
+     */
+    public Scenario(String name, double feedMassFlowKgPerHour,
+        OperatingInputs operatingInputs) {
+      if (name == null || name.trim().isEmpty()) {
+        throw new IllegalArgumentException("Scenario name must be non-blank");
+      }
+      if (!Double.isFinite(feedMassFlowKgPerHour)
+          || !(feedMassFlowKgPerHour > 0.0)) {
+        throw new IllegalArgumentException("Feed mass flow must be finite and positive");
+      }
+      this.name = name.trim();
+      this.feedMassFlowKgPerHour = feedMassFlowKgPerHour;
+      this.operatingInputs = Objects.requireNonNull(operatingInputs, "operatingInputs");
+    }
+
+    /** @return trimmed scenario name */
+    public String getName() {
+      return name;
+    }
+
+    /** @return feed mass flow in kg/h */
+    public double getFeedMassFlowKgPerHour() {
+      return feedMassFlowKgPerHour;
+    }
+
+    /** @return immutable explicit column operating inputs */
+    public OperatingInputs getOperatingInputs() {
+      return operatingInputs;
+    }
+  }
+
+  /** Immutable result for one independently solved scenario. */
+  public static final class PointResult {
+    private final Scenario scenario;
+    private final DoeBigHillVacuumFractionationResult fractionationResult;
+
+    private PointResult(Scenario scenario,
+        DoeBigHillVacuumFractionationResult fractionationResult) {
+      this.scenario = Objects.requireNonNull(scenario, "scenario");
+      this.fractionationResult =
+          Objects.requireNonNull(fractionationResult, "fractionationResult");
+    }
+
+    /** @return immutable scenario definition applied at this point */
+    public Scenario getScenario() {
+      return scenario;
+    }
+
+    /** @return qualified immutable fractionation result for this scenario */
+    public DoeBigHillVacuumFractionationResult getFractionationResult() {
+      return fractionationResult;
+    }
+
+    /** @return overhead mass fraction of feed for this scenario */
+    public double getOverheadMassFraction() {
+      return fractionationResult.getProduct("Overhead").getMassFractionOfFeed();
+    }
+
+    /**
+     * Return a discrete overhead normal-boiling-point diagnostic.
+     *
+     * @param cumulativeMoleFraction cumulative product mole fraction in (0, 1]
+     * @return overhead pseudo-component quantile in kelvin
+     */
+    public double getOverheadBoilingPointQuantileKelvin(double cumulativeMoleFraction) {
+      ProductResult overhead = fractionationResult.getProduct("Overhead");
+      return overhead.getNormalBoilingPointQuantileKelvin(cumulativeMoleFraction);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
@@ -1,0 +1,146 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumScenarioScreen.PointResult;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumScenarioScreen.Scenario;
+
+/** Qualification tests for {@link DoeBigHillVacuumScenarioScreen}. */
+public class DoeBigHillVacuumScenarioScreenTest {
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /** Execute documented combined scenarios without assuming a response trend. */
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void combinedScenarioScreenReturnsQualifiedImmutablePoints() {
+    Scenario[] scenarios = documentedScenarios();
+
+    DoeBigHillVacuumScenarioScreen screen = DoeBigHillVacuumScenarioScreen
+        .run("Big Hill vacuum combined screen", scenarios);
+
+    scenarios[0] = scenarios[2];
+    PointResult[] points = screen.getPoints();
+    assertEquals(3, points.length);
+    assertNotSame(points, screen.getPoints());
+    assertEquals("low", points[0].getScenario().getName());
+    assertEquals("base", points[1].getScenario().getName());
+    assertEquals("high", points[2].getScenario().getName());
+    assertEquals(points[0], screen.getPoint(0));
+    assertEquals(points[2], screen.getPoint(2));
+    assertThrows(IndexOutOfBoundsException.class, () -> screen.getPoint(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> screen.getPoint(3));
+
+    double expectedMinimumOverhead = Double.POSITIVE_INFINITY;
+    double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
+    double expectedMaximumMassClosure = 0.0;
+    double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumEnergyError = 0.0;
+    double expectedMaximumMeshResidual = 0.0;
+
+    for (PointResult point : points) {
+      Scenario scenario = point.getScenario();
+      OperatingInputs applied = scenario.getOperatingInputs();
+      DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+
+      assertEquals(12, applied.getSimpleTrayCount());
+      assertEquals(4, applied.getFeedTrayIndex());
+      assertEquals(scenario.getFeedMassFlowKgPerHour(),
+          result.getFeedMassFlowKgPerHour(),
+          scenario.getFeedMassFlowKgPerHour() * 1.0e-10);
+
+      ProductResult overhead = result.getProduct("Overhead");
+      ProductResult bottoms = result.getProduct("Bottoms");
+      assertTrue(overhead.getMassFlowKgPerHour() > 0.0);
+      assertTrue(bottoms.getMassFlowKgPerHour() > 0.0);
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
+          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
+      assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
+      assertThrows(IllegalArgumentException.class,
+          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError()
+          <= BALANCE_TOLERANCE);
+      assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
+
+      expectedMinimumOverhead =
+          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead =
+          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure =
+          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
+          result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumEnergyError =
+          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual =
+          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+    }
+
+    assertEquals(expectedMinimumOverhead, screen.getMinimumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumOverhead, screen.getMaximumOverheadMassFraction(), 0.0);
+    assertEquals(expectedMaximumMassClosure,
+        screen.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure,
+        screen.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError,
+        screen.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMeshResidual, screen.getMaximumMeshResidualNorm(), 0.0);
+  }
+
+  /** Require malformed scenario definitions to fail before presenting results. */
+  @Test
+  public void invalidScenarioDefinitionsFailClosed() {
+    Scenario[] scenarios = documentedScenarios();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumScenarioScreen.run(" ", scenarios));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumScenarioScreen.run("screen", null));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumScenarioScreen.run("screen",
+            new Scenario[] {scenarios[0]}));
+    assertThrows(NullPointerException.class,
+        () -> DoeBigHillVacuumScenarioScreen.run("screen",
+            new Scenario[] {scenarios[0], null}));
+    assertThrows(IllegalArgumentException.class,
+        () -> DoeBigHillVacuumScenarioScreen.run("screen",
+            new Scenario[] {scenarios[0],
+                new Scenario("LOW", 1000.0, baselineInputs())}));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new Scenario(" ", 1000.0, baselineInputs()));
+    assertThrows(IllegalArgumentException.class,
+        () -> new Scenario("invalid", 0.0, baselineInputs()));
+    assertThrows(IllegalArgumentException.class,
+        () -> new Scenario("invalid", Double.NaN, baselineInputs()));
+    assertThrows(NullPointerException.class,
+        () -> new Scenario("invalid", 1000.0, null));
+  }
+
+  private static Scenario[] documentedScenarios() {
+    OperatingInputs low =
+        new OperatingInputs(12, 4, 638.0, 0.1176, 0.0784, 0.1568, 698.0, 0.49);
+    OperatingInputs base = baselineInputs();
+    OperatingInputs high =
+        new OperatingInputs(12, 4, 642.0, 0.1224, 0.0816, 0.1632, 702.0, 0.51);
+    return new Scenario[] {
+        new Scenario("low", 980.0, low),
+        new Scenario("base", 1000.0, base),
+        new Scenario("high", 1020.0, high)
+    };
+  }
+
+  private static OperatingInputs baselineInputs() {
+    return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
@@ -23,8 +23,8 @@ public class DoeBigHillVacuumScenarioScreenTest {
   public void combinedScenarioScreenReturnsQualifiedImmutablePoints() {
     Scenario[] scenarios = documentedScenarios();
 
-    DoeBigHillVacuumScenarioScreen screen = DoeBigHillVacuumScenarioScreen
-        .run("Big Hill vacuum combined screen", scenarios);
+    DoeBigHillVacuumScenarioScreen screen = DoeBigHillVacuumScenarioScreen.run("Big Hill vacuum combined screen",
+        scenarios);
 
     scenarios[0] = scenarios[2];
     PointResult[] points = screen.getPoints();
@@ -52,48 +52,36 @@ public class DoeBigHillVacuumScenarioScreenTest {
 
       assertEquals(12, applied.getSimpleTrayCount());
       assertEquals(4, applied.getFeedTrayIndex());
-      assertEquals(scenario.getFeedMassFlowKgPerHour(),
-          result.getFeedMassFlowKgPerHour(),
+      assertEquals(scenario.getFeedMassFlowKgPerHour(), result.getFeedMassFlowKgPerHour(),
           scenario.getFeedMassFlowKgPerHour() * 1.0e-10);
 
       ProductResult overhead = result.getProduct("Overhead");
       ProductResult bottoms = result.getProduct("Bottoms");
       assertTrue(overhead.getMassFlowKgPerHour() > 0.0);
       assertTrue(bottoms.getMassFlowKgPerHour() > 0.0);
-      assertTrue(overhead.getMeanNormalBoilingPointKelvin()
-          < bottoms.getMeanNormalBoilingPointKelvin());
+      assertTrue(overhead.getMeanNormalBoilingPointKelvin() < bottoms.getMeanNormalBoilingPointKelvin());
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.10)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.50)));
       assertTrue(Double.isFinite(point.getOverheadBoilingPointQuantileKelvin(0.90)));
-      assertThrows(IllegalArgumentException.class,
-          () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
+      assertThrows(IllegalArgumentException.class, () -> point.getOverheadBoilingPointQuantileKelvin(0.0));
       assertTrue(result.getMassClosureRelativeError() <= BALANCE_TOLERANCE);
-      assertTrue(result.getMaximumComponentMolarClosureRelativeError()
-          <= BALANCE_TOLERANCE);
+      assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
-      expectedMinimumOverhead =
-          Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
-      expectedMaximumOverhead =
-          Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
-      expectedMaximumMassClosure =
-          Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
+      expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
+      expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
+      expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
       expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
-      expectedMaximumEnergyError =
-          Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
-      expectedMaximumMeshResidual =
-          Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
+      expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
+      expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
     }
 
     assertEquals(expectedMinimumOverhead, screen.getMinimumOverheadMassFraction(), 0.0);
     assertEquals(expectedMaximumOverhead, screen.getMaximumOverheadMassFraction(), 0.0);
-    assertEquals(expectedMaximumMassClosure,
-        screen.getMaximumMassClosureRelativeError(), 0.0);
-    assertEquals(expectedMaximumComponentClosure,
-        screen.getMaximumComponentMolarClosureRelativeError(), 0.0);
-    assertEquals(expectedMaximumEnergyError,
-        screen.getMaximumColumnEnergyBalanceError(), 0.0);
+    assertEquals(expectedMaximumMassClosure, screen.getMaximumMassClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumComponentClosure, screen.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumEnergyError, screen.getMaximumColumnEnergyBalanceError(), 0.0);
     assertEquals(expectedMaximumMeshResidual, screen.getMaximumMeshResidualNorm(), 0.0);
   }
 
@@ -102,45 +90,31 @@ public class DoeBigHillVacuumScenarioScreenTest {
   public void invalidScenarioDefinitionsFailClosed() {
     Scenario[] scenarios = documentedScenarios();
 
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumScenarioScreen.run(" ", scenarios));
+    assertThrows(NullPointerException.class, () -> DoeBigHillVacuumScenarioScreen.run("screen", null));
     assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumScenarioScreen.run(" ", scenarios));
+        () -> DoeBigHillVacuumScenarioScreen.run("screen", new Scenario[] { scenarios[0] }));
     assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumScenarioScreen.run("screen", null));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumScenarioScreen.run("screen",
-            new Scenario[] {scenarios[0]}));
-    assertThrows(NullPointerException.class,
-        () -> DoeBigHillVacuumScenarioScreen.run("screen",
-            new Scenario[] {scenarios[0], null}));
-    assertThrows(IllegalArgumentException.class,
-        () -> DoeBigHillVacuumScenarioScreen.run("screen",
-            new Scenario[] {scenarios[0],
-                new Scenario("LOW", 1000.0, baselineInputs())}));
+        () -> DoeBigHillVacuumScenarioScreen.run("screen", new Scenario[] { scenarios[0], null }));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillVacuumScenarioScreen.run("screen",
+        new Scenario[] { scenarios[0], new Scenario("LOW", 1000.0, baselineInputs()) }));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> new Scenario(" ", 1000.0, baselineInputs()));
-    assertThrows(IllegalArgumentException.class,
-        () -> new Scenario("invalid", 0.0, baselineInputs()));
-    assertThrows(IllegalArgumentException.class,
-        () -> new Scenario("invalid", Double.NaN, baselineInputs()));
-    assertThrows(NullPointerException.class,
-        () -> new Scenario("invalid", 1000.0, null));
+    assertThrows(IllegalArgumentException.class, () -> new Scenario(" ", 1000.0, baselineInputs()));
+    assertThrows(IllegalArgumentException.class, () -> new Scenario("invalid", 0.0, baselineInputs()));
+    assertThrows(IllegalArgumentException.class, () -> new Scenario("invalid", Double.NaN, baselineInputs()));
+    assertThrows(NullPointerException.class, () -> new Scenario("invalid", 1000.0, null));
   }
 
   private static Scenario[] documentedScenarios() {
-    OperatingInputs low =
-        new OperatingInputs(12, 4, 638.0, 0.1176, 0.0784, 0.1568, 698.0, 0.49);
+    OperatingInputs low = new OperatingInputs(12, 4, 638.0, 0.1176, 0.0784, 0.1568, 698.0, 0.49);
     OperatingInputs base = baselineInputs();
-    OperatingInputs high =
-        new OperatingInputs(12, 4, 642.0, 0.1224, 0.0816, 0.1632, 702.0, 0.51);
-    return new Scenario[] {
-        new Scenario("low", 980.0, low),
-        new Scenario("base", 1000.0, base),
-        new Scenario("high", 1020.0, high)
-    };
+    OperatingInputs high = new OperatingInputs(12, 4, 642.0, 0.1224, 0.0816, 0.1632, 702.0, 0.51);
+    return new Scenario[] { new Scenario("low", 980.0, low), new Scenario("base", 1000.0, base),
+        new Scenario("high", 1020.0, high) };
   }
 
   private static OperatingInputs baselineInputs() {
     return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
   }
 }
+

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
@@ -117,4 +117,3 @@ public class DoeBigHillVacuumScenarioScreenTest {
     return new OperatingInputs(12, 4, 640.0, 0.12, 0.08, 0.16, 700.0, 0.5);
   }
 }
-


### PR DESCRIPTION
Advances #3305.

## Capability

Adds an immutable Java/JPype multivariable scenario screen for the qualified DOE Big Hill 650 degF+ vacuum case.

- accepts at least two uniquely named complete scenarios;
- preserves caller order and rejects null, blank, duplicate, non-finite, or non-positive definitions before calculation;
- independently rebuilds, solves, and evaluates every scenario;
- reuses the qualified MESH, fallback, mass, component, energy, material-product, and boiling-range gates;
- fails the complete screen if any scenario fails;
- returns defensive scenario-point arrays, exact applied inputs, overhead-yield bounds, and worst conservation, energy, and MESH diagnostics.

The focused regression combines only previously qualified narrow one-factor ranges into explicit low/base/high numerical scenarios: 980/1000/1020 kg/h feed, 638/640/642 K feed temperature, 698/700/702 K reboiler temperature, 0.49/0.50/0.51 reflux, and 0.98/1.00/1.02 common absolute-pressure factors. Tray topology and feed composition remain fixed. No monotonic response is asserted.

## Provenance and engineering boundary

The public DOE Big Hill assay, qualified three-cut 650 degF+ normalization, pseudo-component properties, and all existing source provenance are unchanged. Every operating value remains a source-unreported engineering assumption.

This is discrete combined-scenario numerical screening only. It does not establish a measured or continuous operating envelope, response surface, interaction correlation, uncertainty distribution, hydraulic capacity, flooding, weeping, entrainment, pressure drop, scale-up, turndown, heat duty, utilities, equipment sizing, calibrated yield, ASTM D1160/TBP correction, optimization, product specification, or plant agreement.

## Frozen scope and continuity

- Exact base: `1e248a9753d8bf6398b4a06ddd10e6606dcec860`
- Initial publication head: `46c358ec916729aced30ded0575974a786fa7205`
- Exact repaired head: `1d4fadb3b0e743a79ea372a4eb01ec2b3537eddc`
- Changed files: exactly three
  1. `src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java`
  2. `src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java`
  3. `docs/thermo/characterization/refinery_big_hill_complete_slate.md`
- Relation to frozen base: 7 commits ahead, zero behind
- No overlap with open autonomous PRs #3653, #3664, or #3667
- Portfolio occupancy after reservation: **4/10**
- Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5644634608

## Validation

Connector-side pre-publication checks confirm the exact three-file scope, frozen-base continuity, Java 8-compatible language constructs, defensive scenario and result arrays, explicit units and failure boundaries, existing provenance, documentation impact, and no active ownership overlap.

The sole formatter-repair sequence used [hosted run 34682565449](https://github.com/equinor/neqsim/actions/runs/34682565449), artifact `10294471559` (`sha256:279dac889cb8d4c7a2a8930b50478ce82a985bcc41af744270dbe031c6d8fcd2`), followed by the exact fresh-head completion artifact `10294716401` (`sha256:dd08a214d2c598d6ea3ec64c3ac590b3e0906d3226095827d7c05a36cb6fbb4e`). Both patches contained only the two new Java files; the completion patch removed only one accidental terminal blank line from each transported file. Final blobs exactly match the hosted targets: production `3ed7693c2d7d6c7418c69250a89a00741c512e63`, test `5ea7ad538ee534b24d15cfb50df3b0224c2e2559`. No behavior, test intent, API, scientific assumption, provenance, or acceptance criterion changed. The formatter-repair allowance is exhausted.

Hosted exact-head validation is authoritative for compilation, execution of the three combined scenarios, regression behavior, Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, agent checks, cross-platform Java tests, and slow-test shards.

**VALIDATION COMPLETE — HUMAN REVIEW REQUIRED.**

At preserved exact head `1d4fadb3b0e743a79ea372a4eb01ec2b3537eddc`, Java 8 and Java 21 tests pass on Ubuntu and Windows, all four Java 21 slow-test shards pass, and Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, and agent-skill cross-reference checks pass. All seven pull-request workflow runs completed successfully. Current `master` is three commits ahead of the frozen base and does not touch any of this PR's three refinery files.

Because this adds public engineering API, subsystem-owner and independent-maintainer reviews are required before READY TO MERGE.

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.