### PR TITLE
[AI-Assisted] fix(thermo): require qualified Pitzer uncertainties

### DIFF
--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -732,8 +732,14 @@ acceptance limits were fixed before the holdout was evaluated.
 `PitzerBinaryVolumetricDatasetProvenance` records a machine-auditable manifest
 for observations distributed with NeqSim. Each source-lineage record fixes its
 calibration or validation role, full citation and stable URL, license and
-redistribution decision, SHA-256 source-file checksum, uncertainty basis, exact
+redistribution decision, SHA-256 source-file checksum, uncertainty basis and
+explicit qualification, exact
 row count, and molality, temperature and pressure envelope.
+
+Rows are repository-admissible only when the manifest explicitly marks their
+uncertainty mapping as `QUALIFIED_ABSOLUTE_ONE_SIGMA`. Instrument accuracy,
+precision, or repeatability specifications and unresolved empirical error
+envelopes are non-qualified states and fail before fitting or holdout evaluation.
 
 `validateRepositoryDatasets(...)` checks both observation lists against that
 manifest before fitting. It fails closed for an undeclared lineage, role or row

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
@@ -13,7 +13,7 @@ import java.util.TreeMap;
  *
  * <p>
  * The manifest binds every declared source lineage to its calibration or validation role, citation, license,
- * redistribution decision, file checksum, uncertainty basis, row count, and state envelope. It checks
+ * redistribution decision, file checksum, uncertainty basis and qualification, row count, and state envelope. It checks
  * metadata-to-observation consistency before repository-distributed observations are fitted or evaluated. It does not
  * prove experimental independence or calculate a checksum from source bytes.
  * </p>
@@ -37,6 +37,16 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
     RESTRICTED,
     /** Redistribution permission has not been established. */
     UNKNOWN
+  }
+
+  /** Audited suitability of the uncertainty values used for weighted fitting or validation. */
+  public enum UncertaintyQualification {
+    /** Values are documented absolute one-sigma standard uncertainties for the represented rows. */
+    QUALIFIED_ABSOLUTE_ONE_SIGMA,
+    /** Values only repeat an instrument accuracy, precision, or repeatability specification. */
+    INSTRUMENT_SPECIFICATION_ONLY,
+    /** A defensible absolute one-sigma mapping has not been established. */
+    UNRESOLVED
   }
 
   private final List<SourceRecord> sources;
@@ -68,8 +78,9 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
    * Validate repository-distributed observations against one declared role.
    *
    * <p>
-   * Every observation must have a declared source, permitted redistribution, the declared role and molality range. The
-   * common temperature and pressure must lie within each used source envelope, and the number of observations for each
+   * Every observation must have a declared source, permitted redistribution, explicitly qualified absolute one-sigma
+   * uncertainty values, the declared role and molality range. The common temperature and pressure must lie within each
+   * used source envelope, and the number of observations for each
    * source must exactly match its manifest record.
    * </p>
    *
@@ -101,7 +112,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
       if (source.getRole() != role) {
         throw new IllegalArgumentException("Observation source role mismatch for " + observation.getSourceGroup());
       }
-      source.requireRepositoryRedistributable();
+      source.requireRepositoryAdmissible();
       if (!source.containsState(observation.getMolality(), temperatureK, pressurePa)) {
         throw new IllegalArgumentException(
             "Observation is outside the declared source envelope: " + observation.getSourceGroup());
@@ -176,6 +187,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
     private final RedistributionStatus redistributionStatus;
     private final String sha256;
     private final String uncertaintyBasis;
+    private final UncertaintyQualification uncertaintyQualification;
     private final int observationCount;
     private final double minimumMolality;
     private final double maximumMolality;
@@ -183,6 +195,22 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
     private final double maximumTemperatureK;
     private final double minimumPressurePa;
     private final double maximumPressurePa;
+
+    /**
+     * Construct a source-lineage record without a machine-qualified uncertainty decision.
+     *
+     * @deprecated Repository validation rejects the unresolved uncertainty status assigned by this constructor. Use the
+     *             constructor that accepts {@link UncertaintyQualification}.
+     */
+    @Deprecated
+    public SourceRecord(String sourceGroup, DatasetRole role, String citation, String sourceUrl, String licenseId,
+        String licenseUrl, RedistributionStatus redistributionStatus, String sha256, String uncertaintyBasis,
+        int observationCount, double minimumMolality, double maximumMolality, double minimumTemperatureK,
+        double maximumTemperatureK, double minimumPressurePa, double maximumPressurePa) {
+      this(sourceGroup, role, citation, sourceUrl, licenseId, licenseUrl, redistributionStatus, sha256, uncertaintyBasis,
+          UncertaintyQualification.UNRESOLVED, observationCount, minimumMolality, maximumMolality, minimumTemperatureK,
+          maximumTemperatureK, minimumPressurePa, maximumPressurePa);
+    }
 
     /**
      * Construct a source-lineage record.
@@ -196,6 +224,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
      * @param redistributionStatus audited redistribution decision
      * @param sha256 lowercase or uppercase SHA-256 of the distributed source file
      * @param uncertaintyBasis description of the absolute one-sigma uncertainty mapping
+     * @param uncertaintyQualification audited suitability of that mapping for weighted repository use
      * @param observationCount exact number of represented observations
      * @param minimumMolality minimum formula-unit molality in mol/kg solvent
      * @param maximumMolality maximum formula-unit molality in mol/kg solvent
@@ -206,8 +235,9 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
      */
     public SourceRecord(String sourceGroup, DatasetRole role, String citation, String sourceUrl, String licenseId,
         String licenseUrl, RedistributionStatus redistributionStatus, String sha256, String uncertaintyBasis,
-        int observationCount, double minimumMolality, double maximumMolality, double minimumTemperatureK,
-        double maximumTemperatureK, double minimumPressurePa, double maximumPressurePa) {
+        UncertaintyQualification uncertaintyQualification, int observationCount, double minimumMolality,
+        double maximumMolality, double minimumTemperatureK, double maximumTemperatureK, double minimumPressurePa,
+        double maximumPressurePa) {
       this.sourceGroup = requireText(sourceGroup, "Source group");
       if (role == null) {
         throw new IllegalArgumentException("Dataset role must not be null");
@@ -227,6 +257,10 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
       }
       this.sha256 = normalizedChecksum;
       this.uncertaintyBasis = requireText(uncertaintyBasis, "Uncertainty basis");
+      if (uncertaintyQualification == null) {
+        throw new IllegalArgumentException("Uncertainty qualification must not be null");
+      }
+      this.uncertaintyQualification = uncertaintyQualification;
       if (observationCount <= 0) {
         throw new IllegalArgumentException("Source observation count must be positive");
       }
@@ -251,9 +285,13 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
           && temperatureK <= maximumTemperatureK && pressurePa >= minimumPressurePa && pressurePa <= maximumPressurePa;
     }
 
-    private void requireRepositoryRedistributable() {
+    private void requireRepositoryAdmissible() {
       if (redistributionStatus != RedistributionStatus.PERMITTED) {
         throw new IllegalArgumentException("Repository redistribution is not permitted for " + sourceGroup);
+      }
+      if (uncertaintyQualification != UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA) {
+        throw new IllegalArgumentException("Repository uncertainty is not qualified as absolute one-sigma for "
+            + sourceGroup + ": " + uncertaintyQualification);
       }
     }
 
@@ -300,6 +338,11 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
     /** @return description of the absolute one-sigma uncertainty mapping */
     public String getUncertaintyBasis() {
       return uncertaintyBasis;
+    }
+
+    /** @return audited suitability of the uncertainty mapping for weighted repository use */
+    public UncertaintyQualification getUncertaintyQualification() {
+      return uncertaintyQualification;
     }
 
     /** @return exact number of represented observations */

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
@@ -207,8 +207,9 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
         String licenseUrl, RedistributionStatus redistributionStatus, String sha256, String uncertaintyBasis,
         int observationCount, double minimumMolality, double maximumMolality, double minimumTemperatureK,
         double maximumTemperatureK, double minimumPressurePa, double maximumPressurePa) {
-      this(sourceGroup, role, citation, sourceUrl, licenseId, licenseUrl, redistributionStatus, sha256, uncertaintyBasis,
-          UncertaintyQualification.UNRESOLVED, observationCount, minimumMolality, maximumMolality, minimumTemperatureK,
+      this(sourceGroup, role, citation, sourceUrl, licenseId, licenseUrl, redistributionStatus, sha256,
+          uncertaintyBasis, UncertaintyQualification.UNRESOLVED, observationCount, minimumMolality, maximumMolality,
+          minimumTemperatureK,
           maximumTemperatureK, minimumPressurePa, maximumPressurePa);
     }
 

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenance.java
@@ -80,8 +80,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
    * <p>
    * Every observation must have a declared source, permitted redistribution, explicitly qualified absolute one-sigma
    * uncertainty values, the declared role and molality range. The common temperature and pressure must lie within each
-   * used source envelope, and the number of observations for each
-   * source must exactly match its manifest record.
+   * used source envelope, and the number of observations for each source must exactly match its manifest record.
    * </p>
    *
    * @param observations observations to validate
@@ -200,7 +199,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
      * Construct a source-lineage record without a machine-qualified uncertainty decision.
      *
      * @deprecated Repository validation rejects the unresolved uncertainty status assigned by this constructor. Use the
-     *             constructor that accepts {@link UncertaintyQualification}.
+     * constructor that accepts {@link UncertaintyQualification}.
      */
     @Deprecated
     public SourceRecord(String sourceGroup, DatasetRole role, String citation, String sourceUrl, String licenseId,
@@ -209,8 +208,7 @@ public final class PitzerBinaryVolumetricDatasetProvenance implements Serializab
         double maximumTemperatureK, double minimumPressurePa, double maximumPressurePa) {
       this(sourceGroup, role, citation, sourceUrl, licenseId, licenseUrl, redistributionStatus, sha256,
           uncertaintyBasis, UncertaintyQualification.UNRESOLVED, observationCount, minimumMolality, maximumMolality,
-          minimumTemperatureK,
-          maximumTemperatureK, minimumPressurePa, maximumPressurePa);
+          minimumTemperatureK, maximumTemperatureK, minimumPressurePa, maximumPressurePa);
     }
 
     /**

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
@@ -47,7 +47,8 @@ public final class PitzerBinaryVolumetricGroupedValidation implements Serializab
    *
    * <p>
    * The provenance manifest must assign every observation to its declared calibration or validation role and establish
-   * repository redistribution permission, file checksum, uncertainty basis, row count, and state envelope. The original
+   * repository redistribution permission, file checksum, explicit absolute-one-sigma uncertainty qualification, row
+   * count, and state envelope. The original
    * caller-supplied {@link #validate(List, List, double, double, double)} path remains available for private or
    * in-memory data that are not distributed with NeqSim.
    * </p>

--- a/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerBinaryVolumetricGroupedValidation.java
@@ -48,9 +48,8 @@ public final class PitzerBinaryVolumetricGroupedValidation implements Serializab
    * <p>
    * The provenance manifest must assign every observation to its declared calibration or validation role and establish
    * repository redistribution permission, file checksum, explicit absolute-one-sigma uncertainty qualification, row
-   * count, and state envelope. The original
-   * caller-supplied {@link #validate(List, List, double, double, double)} path remains available for private or
-   * in-memory data that are not distributed with NeqSim.
+   * count, and state envelope. The original caller-supplied {@link #validate(List, List, double, double, double)} path
+   * remains available for private or in-memory data that are not distributed with NeqSim.
    * </p>
    *
    * @param provenance repository dataset provenance manifest

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
@@ -69,14 +69,12 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
     for (PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification qualification : Arrays.asList(
         PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.INSTRUMENT_SPECIFICATION_ONLY,
         PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.UNRESOLVED)) {
-      PitzerBinaryVolumetricDatasetProvenance.SourceRecord source =
-          new PitzerBinaryVolumetricDatasetProvenance.SourceRecord("uncertainty-source",
-              PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
-              "https://example.test/uncertainty-source", "CC-BY-4.0",
-              "https://creativecommons.org/licenses/by/4.0/",
-              PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('9'),
-              "Instrument precision without a combined uncertainty budget", qualification,
-              CALIBRATION_MOLALITIES.length, 0.02, 6.0, TEMPERATURE_K, TEMPERATURE_K, PRESSURE_PA, PRESSURE_PA);
+      PitzerBinaryVolumetricDatasetProvenance.SourceRecord source = new PitzerBinaryVolumetricDatasetProvenance.SourceRecord(
+          "uncertainty-source", PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
+          "https://example.test/uncertainty-source", "CC-BY-4.0", "https://creativecommons.org/licenses/by/4.0/",
+          PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('9'),
+          "Instrument precision without a combined uncertainty budget", qualification, CALIBRATION_MOLALITIES.length,
+          0.02, 6.0, TEMPERATURE_K, TEMPERATURE_K, PRESSURE_PA, PRESSURE_PA);
       PitzerBinaryVolumetricDatasetProvenance provenance = manifest(source);
 
       IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
@@ -126,8 +124,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
             "https://example.test/source", "CC-BY-4.0", "https://creativecommons.org/licenses/by/4.0/",
             PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, "not-a-checksum",
             "Absolute one-sigma synthetic uncertainty",
-            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0,
-            1.0, 298.15, 323.15, 1.0e5, 20.0e6));
+            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0, 1.0,
+            298.15, 323.15, 1.0e5, 20.0e6));
 
     PitzerBinaryVolumetricDatasetProvenance.SourceRecord duplicate = source("duplicate",
         PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
@@ -141,8 +139,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
             "https://example.test/source", "CC-BY-4.0", "",
             PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('2'),
             "Absolute one-sigma synthetic uncertainty",
-            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0,
-            1.0, 298.15, 323.15, 1.0e5, 20.0e6));
+            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0, 1.0,
+            298.15, 323.15, 1.0e5, 20.0e6));
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
@@ -62,6 +62,31 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void rejectsUnresolvedOrInstrumentOnlyUncertaintyBeforeFitting() {
+    List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(calciumChlorideModel(),
+        CALIBRATION_MOLALITIES, "uncertainty-source");
+
+    for (PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification qualification : Arrays.asList(
+        PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.INSTRUMENT_SPECIFICATION_ONLY,
+        PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.UNRESOLVED)) {
+      PitzerBinaryVolumetricDatasetProvenance.SourceRecord source =
+          new PitzerBinaryVolumetricDatasetProvenance.SourceRecord("uncertainty-source",
+              PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
+              "https://example.test/uncertainty-source", "CC-BY-4.0",
+              "https://creativecommons.org/licenses/by/4.0/",
+              PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('9'),
+              "Instrument precision without a combined uncertainty budget", qualification,
+              CALIBRATION_MOLALITIES.length, 0.02, 6.0, TEMPERATURE_K, TEMPERATURE_K, PRESSURE_PA, PRESSURE_PA);
+      PitzerBinaryVolumetricDatasetProvenance provenance = manifest(source);
+
+      IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> provenance.validateRepositoryObservations(calibration,
+              PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, TEMPERATURE_K, PRESSURE_PA));
+      assertTrue(exception.getMessage().contains("not qualified as absolute one-sigma"));
+    }
+  }
+
+  @Test
   void rejectsUndeclaredRoleCountAndEnvelopeMismatches() {
     PitzerBinaryVolumetricModel model = calciumChlorideModel();
     List<PitzerBinaryVolumetricRegression.Observation> calibration = observations(model, CALIBRATION_MOLALITIES,
@@ -100,7 +125,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
             PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
             "https://example.test/source", "CC-BY-4.0", "https://creativecommons.org/licenses/by/4.0/",
             PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, "not-a-checksum",
-            "Absolute one-sigma synthetic uncertainty", 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
+            "Absolute one-sigma synthetic uncertainty",
+            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
 
     PitzerBinaryVolumetricDatasetProvenance.SourceRecord duplicate = source("duplicate",
         PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
@@ -113,7 +139,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
             PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION, "Synthetic source",
             "https://example.test/source", "CC-BY-4.0", "",
             PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('2'),
-            "Absolute one-sigma synthetic uncertainty", 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
+            "Absolute one-sigma synthetic uncertainty",
+            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
   }
 
   @Test
@@ -126,6 +153,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
 
     assertEquals("a-source", provenance.getSources().get(0).getSourceGroup());
     assertEquals(checksum('b'), provenance.getSource("a-source").getSha256());
+    assertEquals(PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA,
+        provenance.getSource("a-source").getUncertaintyQualification());
     assertNotSame(provenance.getSources(), provenance.getSources());
     assertThrows(UnsupportedOperationException.class,
         () -> provenance.getSources()
@@ -148,7 +177,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
         status == PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED
             ? "https://creativecommons.org/licenses/by/4.0/"
             : "",
-        status, checksum(checksumCharacter), "Absolute one-sigma synthetic uncertainty", observationCount,
+        status, checksum(checksumCharacter), "Absolute one-sigma synthetic uncertainty",
+        PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, observationCount,
         minimumMolality, maximumMolality, TEMPERATURE_K, TEMPERATURE_K, PRESSURE_PA, PRESSURE_PA);
   }
 

--- a/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerBinaryVolumetricDatasetProvenanceTest.java
@@ -126,7 +126,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
             "https://example.test/source", "CC-BY-4.0", "https://creativecommons.org/licenses/by/4.0/",
             PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, "not-a-checksum",
             "Absolute one-sigma synthetic uncertainty",
-            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
+            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0,
+            1.0, 298.15, 323.15, 1.0e5, 20.0e6));
 
     PitzerBinaryVolumetricDatasetProvenance.SourceRecord duplicate = source("duplicate",
         PitzerBinaryVolumetricDatasetProvenance.DatasetRole.CALIBRATION,
@@ -140,7 +141,8 @@ class PitzerBinaryVolumetricDatasetProvenanceTest extends neqsim.NeqSimTest {
             "https://example.test/source", "CC-BY-4.0", "",
             PitzerBinaryVolumetricDatasetProvenance.RedistributionStatus.PERMITTED, checksum('2'),
             "Absolute one-sigma synthetic uncertainty",
-            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0, 1.0, 298.15, 323.15, 1.0e5, 20.0e6));
+            PitzerBinaryVolumetricDatasetProvenance.UncertaintyQualification.QUALIFIED_ABSOLUTE_ONE_SIGMA, 1, 0.0,
+            1.0, 298.15, 323.15, 1.0e5, 20.0e6));
   }
 
   @Test


### PR DESCRIPTION
Advances #3144.

## Summary

Repository-distributed volumetric Pitzer observations previously required only a non-empty uncertainty-description string. That allowed instrument precision, repeatability, or an unresolved empirical envelope to satisfy the metadata shape even though those values are not a qualified absolute one-sigma mapping.

This draft adds a machine-auditable `UncertaintyQualification` decision and requires `QUALIFIED_ABSOLUTE_ONE_SIGMA` before repository fitting or holdout evaluation. Instrument-specification-only and unresolved states fail closed. The existing constructor remains source-compatible but is deprecated and assigns `UNRESOLVED`, so it cannot silently bypass the new gate.

## Scientific boundary

- No dataset, coefficient, parameter, regression result, default, or thermodynamic model behavior is added or changed.
- The audited GFZ CaCl2 density package remains calibration-candidate only; this guard does not qualify its missing combined per-row uncertainty.
- The independent high-pressure series remains reserved for validation.
- Compressed-CaCl2 activation and calcium-sulfate qualification remain fail-closed.

## Exact continuity

- Exact base: `1e248a9753d8bf6398b4a06ddd10e6606dcec860`
- Publication is draft-only and must remain on its exact head.
- No existing PR head was modified, rebased, replaced, or closed.
- Occupancy before publication: 3/10; after publication: 4/10.

## Validation

Focused rejection and admitted-path tests are included, with documentation of the repository gate. **VALIDATION PENDING EXACT-HEAD CI.**

Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon this draft.