### PR TITLE
[AI-Assisted] feat(kinetics): add sulfur-equivalent H2S loss budget

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -284,6 +284,45 @@ total-sulfide-loss evidence. They do not consume O2, assign sulfur products, cal
 phase transfer, create signed component sources, mutate pipeline/transient state, or update S8,
 FeS, wall, or sulfur-deposition inventories.
 
+## Product-agnostic sulfur-equivalent budget
+
+The segment and constant-water trajectory results also expose the sulfur-element mass equivalent
+of the qualified total-sulfide loss. One mole of total sulfide contains one mole of sulfur atoms,
+so the conversion is
+
+$
+\dot m_{S,\mathrm{equiv},r,i}
+=\dot n_{r,i}M_S, \qquad
+m_{S,\mathrm{equiv},r,i}
+=n_{r,i,\mathrm{reacted}}M_S.
+$
+
+where `M_S = 0.032065 kg/mol` reuses
+`IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL`. Segment results report lower-rate,
+nominal, and upper-rate mean sulfur-equivalent loss in kg/h and kg/s, plus reacted
+sulfur-equivalent mass in kg. The trajectory result reports cumulative reacted
+sulfur-equivalent mass and the corresponding mass-basis closure residual for every fit-scatter
+path.
+
+For positive duration, the mass-rate integral closes exactly:
+
+$
+\dot m_{S,\mathrm{equiv},r,i}\Delta t_i
+=m_{S,\mathrm{equiv},r,i}.
+$
+
+Zero duration gives exactly zero reacted sulfur-equivalent mass while preserving the finite
+analytical mean-rate limit. The segment sums telescope to the trajectory cumulative mass,
+unchanged-state subdivision is invariant, and all values scale linearly with the caller-supplied
+water inventory. Non-finite or unrepresentable derived mass fails closed.
+
+This is a sulfur-atom conservation view, not an elemental-sulfur or S8 yield. It does not identify
+S8, sulfate, thiosulfate, polysulfides, FeS, or any other product; prescribe selectivity or oxygen
+demand; calculate reaction heat; or update a stream, wall, deposit, filter, or pipeline state.
+Product and deposition calculations require separately qualified stoichiometry and selectivity
+and must compose with the existing sulfur analyser, wall inventory, oxidation source, solid
+flash, and filter implementations.
+
 ## Piecewise target crossing
 
 `AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a
@@ -402,4 +441,3 @@ Electrolyte pH/speciation remains owned by issue #3144. TP flash, dynamics, pipe
 MCP publication remain coordinated with #2937, #2911, the pipeline roadmap, and #3153. Applying
 this atmospheric aqueous correlation to a Northern-Lights-type high-pressure CO2 pipeline requires
 separate phase, pressure, mass-transfer, and composition evidence.
-

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -373,6 +373,41 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         ):
             self.assertIn(token, self.water_inventory_projection_test)
 
+    def test_sulfur_equivalent_budget_is_documented_and_executable(self):
+        for token in (
+            "Product-agnostic sulfur-equivalent budget",
+            "one mole of sulfur atoms",
+            r"\dot m_{S,\mathrm{equiv},r,i}",
+            r"n_{r,i,\mathrm{reacted}}M_S",
+            "M_S = 0.032065 kg/mol",
+            "IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL",
+            "mean sulfur-equivalent loss in kg/h and kg/s",
+            "mass-basis closure residual",
+            "not an elemental-sulfur or S8 yield",
+            "separately qualified stoichiometry and selectivity",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL",
+            "sulfurEquivalentMassKg(",
+            "getLowerRateMeanSulfurEquivalentMassRateKgPerHour()",
+            "getNominalMeanSulfurEquivalentMassRateKgPerSecond()",
+            "getUpperRateReactedSulfurEquivalentMassKg()",
+            "getLowerRateSulfurEquivalentClosureResidualKg()",
+            "getNominalReactedSulfurEquivalentMassKg()",
+            "getUpperRateSulfurEquivalentClosureResidualKg()",
+        ):
+            self.assertIn(token, self.water_inventory_projection)
+
+        for token in (
+            "testSegmentSulfurEquivalentMassUsesSharedAuthorityAndClosesRateIntegral",
+            "testTrajectorySulfurEquivalentMassClosesAllPathsAndSegmentSums",
+            "assertSulfurEquivalentPath(",
+            "IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL",
+        ):
+            self.assertIn(token, self.water_inventory_projection_test)
+
 
     def test_absolute_reacted_moles_target_is_documented_and_executable(self):
         for token in (
@@ -512,4 +547,3 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjection.java
@@ -11,7 +11,8 @@ import java.util.List;
  * <p>
  * The projection multiplies the existing molality-basis mean total-sulfide loss rates and reacted molalities by a
  * caller-supplied liquid-water inventory. It does not derive water holdup, assign reaction products, consume oxygen, or
- * mutate a process or thermodynamic system.
+ * mutate a process or thermodynamic system. Product-agnostic sulfur-equivalent mass views use the shared sulfur atomic
+ * molar mass from {@link IronSulfideWallInventory}; they are elemental bookkeeping, not an elemental-sulfur yield.
  * </p>
  *
  * @author esol
@@ -239,6 +240,15 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     return difference;
   }
 
+  private static double sulfurEquivalentMassKg(double sulfurAtomMoles, String name) {
+    double mass = sulfurAtomMoles * IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL;
+    if (!Double.isFinite(mass)
+        || (sulfurAtomMoles != 0.0 && IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL != 0.0 && mass == 0.0)) {
+      throw new IllegalArgumentException(name + " is not finite or representable");
+    }
+    return mass;
+  }
+
   /** Immutable dimensional remaining-moles target and piecewise crossing evidence. */
   public static final class RemainingMolesTargetResult implements Serializable {
     private static final long serialVersionUID = 1000L;
@@ -420,6 +430,29 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
       return upperRateReactedMoles;
     }
 
+    /**
+     * Return cumulative lower-rate sulfur-equivalent loss.
+     *
+     * <p>
+     * This is sulfur-atom accounting, not an S8 or other product yield.
+     * </p>
+     *
+     * @return cumulative lower-rate reacted sulfur equivalent [kg S-equivalent]
+     */
+    public double getLowerRateReactedSulfurEquivalentMassKg() {
+      return sulfurEquivalentMassKg(lowerRateReactedMoles, "Lower-rate reacted sulfur-equivalent mass");
+    }
+
+    /** @return cumulative nominal reacted sulfur equivalent [kg S-equivalent]. */
+    public double getNominalReactedSulfurEquivalentMassKg() {
+      return sulfurEquivalentMassKg(nominalReactedMoles, "Nominal reacted sulfur-equivalent mass");
+    }
+
+    /** @return cumulative upper-rate reacted sulfur equivalent [kg S-equivalent]. */
+    public double getUpperRateReactedSulfurEquivalentMassKg() {
+      return sulfurEquivalentMassKg(upperRateReactedMoles, "Upper-rate reacted sulfur-equivalent mass");
+    }
+
     /** @return lower-rate constant-water inventory closure residual [mol]. */
     public double getLowerRateClosureResidualMoles() {
       return lowerRateClosureResidualMoles;
@@ -433,6 +466,24 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     /** @return upper-rate constant-water inventory closure residual [mol]. */
     public double getUpperRateClosureResidualMoles() {
       return upperRateClosureResidualMoles;
+    }
+
+    /** @return lower-rate sulfur-equivalent trajectory closure residual [kg S-equivalent]. */
+    public double getLowerRateSulfurEquivalentClosureResidualKg() {
+      return sulfurEquivalentMassKg(lowerRateClosureResidualMoles,
+          "Lower-rate sulfur-equivalent trajectory closure residual");
+    }
+
+    /** @return nominal sulfur-equivalent trajectory closure residual [kg S-equivalent]. */
+    public double getNominalSulfurEquivalentClosureResidualKg() {
+      return sulfurEquivalentMassKg(nominalClosureResidualMoles,
+          "Nominal sulfur-equivalent trajectory closure residual");
+    }
+
+    /** @return upper-rate sulfur-equivalent trajectory closure residual [kg S-equivalent]. */
+    public double getUpperRateSulfurEquivalentClosureResidualKg() {
+      return sulfurEquivalentMassKg(upperRateClosureResidualMoles,
+          "Upper-rate sulfur-equivalent trajectory closure residual");
     }
   }
 
@@ -509,6 +560,44 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
       return upperRateMeanLossMolesPerHour / SECONDS_PER_HOUR;
     }
 
+    /**
+     * Return the lower-rate mean sulfur-equivalent loss rate.
+     *
+     * <p>
+     * This is sulfur-atom accounting, not an S8 or other product rate.
+     * </p>
+     *
+     * @return lower-rate mean sulfur-equivalent loss [kg S-equivalent/h]
+     */
+    public double getLowerRateMeanSulfurEquivalentMassRateKgPerHour() {
+      return sulfurEquivalentMassKg(lowerRateMeanLossMolesPerHour, "Lower-rate mean sulfur-equivalent loss rate");
+    }
+
+    /** @return nominal mean sulfur-equivalent loss [kg S-equivalent/h]. */
+    public double getNominalMeanSulfurEquivalentMassRateKgPerHour() {
+      return sulfurEquivalentMassKg(nominalMeanLossMolesPerHour, "Nominal mean sulfur-equivalent loss rate");
+    }
+
+    /** @return upper-rate mean sulfur-equivalent loss [kg S-equivalent/h]. */
+    public double getUpperRateMeanSulfurEquivalentMassRateKgPerHour() {
+      return sulfurEquivalentMassKg(upperRateMeanLossMolesPerHour, "Upper-rate mean sulfur-equivalent loss rate");
+    }
+
+    /** @return lower-rate mean sulfur-equivalent loss [kg S-equivalent/s]. */
+    public double getLowerRateMeanSulfurEquivalentMassRateKgPerSecond() {
+      return getLowerRateMeanSulfurEquivalentMassRateKgPerHour() / SECONDS_PER_HOUR;
+    }
+
+    /** @return nominal mean sulfur-equivalent loss [kg S-equivalent/s]. */
+    public double getNominalMeanSulfurEquivalentMassRateKgPerSecond() {
+      return getNominalMeanSulfurEquivalentMassRateKgPerHour() / SECONDS_PER_HOUR;
+    }
+
+    /** @return upper-rate mean sulfur-equivalent loss [kg S-equivalent/s]. */
+    public double getUpperRateMeanSulfurEquivalentMassRateKgPerSecond() {
+      return getUpperRateMeanSulfurEquivalentMassRateKgPerHour() / SECONDS_PER_HOUR;
+    }
+
     /** @return reacted total sulfide for the lower-rate path [mol]. */
     public double getLowerRateReactedMoles() {
       return lowerRateReactedMoles;
@@ -522,6 +611,21 @@ public final class AqueousHydrogenSulfideOxidationWaterInventoryProjection {
     /** @return reacted total sulfide for the upper-rate path [mol]. */
     public double getUpperRateReactedMoles() {
       return upperRateReactedMoles;
+    }
+
+    /** @return lower-rate reacted sulfur equivalent [kg S-equivalent]. */
+    public double getLowerRateReactedSulfurEquivalentMassKg() {
+      return sulfurEquivalentMassKg(lowerRateReactedMoles, "Lower-rate reacted sulfur-equivalent mass");
+    }
+
+    /** @return nominal reacted sulfur equivalent [kg S-equivalent]. */
+    public double getNominalReactedSulfurEquivalentMassKg() {
+      return sulfurEquivalentMassKg(nominalReactedMoles, "Nominal reacted sulfur-equivalent mass");
+    }
+
+    /** @return upper-rate reacted sulfur equivalent [kg S-equivalent]. */
+    public double getUpperRateReactedSulfurEquivalentMassKg() {
+      return sulfurEquivalentMassKg(upperRateReactedMoles, "Upper-rate reacted sulfur-equivalent mass");
     }
   }
 }

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java
@@ -36,6 +36,30 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
   }
 
   @Test
+  void testSegmentSulfurEquivalentMassUsesSharedAuthorityAndClosesRateIntegral() {
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(segmentResult(referenceSegment(10.0)), WATER_INVENTORY_KG);
+
+    assertSulfurEquivalentPath(projection.getLowerRateMeanLossMolesPerHour(),
+        projection.getLowerRateMeanSulfurEquivalentMassRateKgPerHour(),
+        projection.getLowerRateMeanSulfurEquivalentMassRateKgPerSecond(), projection.getLowerRateReactedMoles(),
+        projection.getLowerRateReactedSulfurEquivalentMassKg(), projection.getDurationHours());
+    assertSulfurEquivalentPath(projection.getNominalMeanLossMolesPerHour(),
+        projection.getNominalMeanSulfurEquivalentMassRateKgPerHour(),
+        projection.getNominalMeanSulfurEquivalentMassRateKgPerSecond(), projection.getNominalReactedMoles(),
+        projection.getNominalReactedSulfurEquivalentMassKg(), projection.getDurationHours());
+    assertSulfurEquivalentPath(projection.getUpperRateMeanLossMolesPerHour(),
+        projection.getUpperRateMeanSulfurEquivalentMassRateKgPerHour(),
+        projection.getUpperRateMeanSulfurEquivalentMassRateKgPerSecond(), projection.getUpperRateReactedMoles(),
+        projection.getUpperRateReactedSulfurEquivalentMassKg(), projection.getDurationHours());
+
+    assertTrue(
+        projection.getLowerRateReactedSulfurEquivalentMassKg() < projection.getNominalReactedSulfurEquivalentMassKg());
+    assertTrue(
+        projection.getNominalReactedSulfurEquivalentMassKg() < projection.getUpperRateReactedSulfurEquivalentMassKg());
+  }
+
+  @Test
   void testZeroDurationPreservesDifferentialLimitAndZeroReaction() {
     AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment = segmentResult(referenceSegment(0.0));
     AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
@@ -52,6 +76,10 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     assertEquals(0.0, projection.getLowerRateReactedMoles(), 0.0);
     assertEquals(0.0, projection.getNominalReactedMoles(), 0.0);
     assertEquals(0.0, projection.getUpperRateReactedMoles(), 0.0);
+    assertTrue(Double.isFinite(projection.getNominalMeanSulfurEquivalentMassRateKgPerSecond()));
+    assertEquals(0.0, projection.getLowerRateReactedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(0.0, projection.getNominalReactedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(0.0, projection.getUpperRateReactedSulfurEquivalentMassKg(), 0.0);
   }
 
   @Test
@@ -134,6 +162,36 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     assertEquals(0.0, projection.getUpperRateClosureResidualMoles(), NUMERICAL_TOLERANCE);
     assertTrue(projection.getLowerRateReactedMoles() < projection.getNominalReactedMoles());
     assertTrue(projection.getNominalReactedMoles() < projection.getUpperRateReactedMoles());
+  }
+
+  @Test
+  void testTrajectorySulfurEquivalentMassClosesAllPathsAndSegmentSums() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result trajectory = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.TrajectoryResult projection = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+        .project(trajectory, WATER_INVENTORY_KG);
+
+    double lowerSegmentMass = 0.0;
+    double nominalSegmentMass = 0.0;
+    double upperSegmentMass = 0.0;
+    for (AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result segment : projection.getSegmentProjections()) {
+      lowerSegmentMass += segment.getLowerRateReactedSulfurEquivalentMassKg();
+      nominalSegmentMass += segment.getNominalReactedSulfurEquivalentMassKg();
+      upperSegmentMass += segment.getUpperRateReactedSulfurEquivalentMassKg();
+    }
+
+    assertEquals(projection.getLowerRateReactedMoles() * IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL,
+        projection.getLowerRateReactedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(projection.getNominalReactedMoles() * IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL,
+        projection.getNominalReactedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(projection.getUpperRateReactedMoles() * IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL,
+        projection.getUpperRateReactedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(lowerSegmentMass, projection.getLowerRateReactedSulfurEquivalentMassKg(), NUMERICAL_TOLERANCE);
+    assertEquals(nominalSegmentMass, projection.getNominalReactedSulfurEquivalentMassKg(), NUMERICAL_TOLERANCE);
+    assertEquals(upperSegmentMass, projection.getUpperRateReactedSulfurEquivalentMassKg(), NUMERICAL_TOLERANCE);
+    assertEquals(0.0, projection.getLowerRateSulfurEquivalentClosureResidualKg(), NUMERICAL_TOLERANCE);
+    assertEquals(0.0, projection.getNominalSulfurEquivalentClosureResidualKg(), NUMERICAL_TOLERANCE);
+    assertEquals(0.0, projection.getUpperRateSulfurEquivalentClosureResidualKg(), NUMERICAL_TOLERANCE);
   }
 
   @Test
@@ -436,6 +494,17 @@ public class AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest extends
     assertEquals(meanLossMolesPerHour / 3600.0, meanLossMolesPerSecond, 0.0);
     assertEquals(reactedMolality * WATER_INVENTORY_KG, reactedMoles, 0.0);
     assertEquals(reactedMoles, meanLossMolesPerHour * durationHours, NUMERICAL_TOLERANCE);
+  }
+
+  private static void assertSulfurEquivalentPath(double meanLossMolesPerHour,
+      double meanSulfurEquivalentMassRateKgPerHour, double meanSulfurEquivalentMassRateKgPerSecond, double reactedMoles,
+      double reactedSulfurEquivalentMassKg, double durationHours) {
+    double sulfurMolarMass = IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL;
+    assertEquals(meanLossMolesPerHour * sulfurMolarMass, meanSulfurEquivalentMassRateKgPerHour, 0.0);
+    assertEquals(meanSulfurEquivalentMassRateKgPerHour / 3600.0, meanSulfurEquivalentMassRateKgPerSecond, 0.0);
+    assertEquals(reactedMoles * sulfurMolarMass, reactedSulfurEquivalentMassKg, 0.0);
+    assertEquals(reactedSulfurEquivalentMassKg, meanSulfurEquivalentMassRateKgPerHour * durationHours,
+        NUMERICAL_TOLERANCE);
   }
 
   private static AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult(


### PR DESCRIPTION
Refs #3318.

Adds a product-agnostic sulfur-element-equivalent mass budget to the existing qualified aqueous H2S/O2 water-inventory projection.

## Capability

- Adds lower, nominal, and upper segment mean sulfur-equivalent loss rates in kg/h and kg/s.
- Adds lower, nominal, and upper reacted sulfur-equivalent mass in kg for each segment.
- Adds cumulative reacted sulfur-equivalent mass and mass-basis closure residuals for a constant-water trajectory.
- Reuses the repository's existing `IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL` authority.
- Keeps all result types immutable and Java 8 compatible.

## Numerical gates

- Every mass quantity equals the corresponding qualified total-sulfide mole quantity times 0.032065 kg/mol.
- Positive-duration mass rate multiplied by duration recovers reacted sulfur-equivalent mass.
- Zero-duration reacted mass is exactly zero while the analytical mean-rate limit stays finite.
- Segment sums telescope to cumulative trajectory mass for all three fit paths.
- Mass-basis closure residuals correspond exactly to the existing mole-basis residuals.
- Unchanged-state segment subdivision and linear water-inventory scaling remain invariant.
- Non-finite or unrepresentable derived mass fails closed.

At the existing 298.15 K, pH 8, ionic-strength 0.723 mol/kg-water, O2 250 micromol/kg-water, initial total sulfide 25 micromol/kg-water, 1200 kg water, and 10 h reference, the nominal sulfur-equivalent mean loss rate is `2.557357706657525e-5 kg/h` and reacted sulfur equivalent is `2.557357706657525e-4 kg`.

## Scientific basis and boundary

Kinetics remain Millero et al. (1987), https://doi.org/10.1021/es00159a003, including the existing published domain and 0.18 log10(k) fit scatter. One mole of total sulfide contributes one mole of sulfur atoms to this bookkeeping conversion.

This is sulfur-atom accounting, **not** elemental-sulfur or S8 yield. It does not identify S8, sulfate, thiosulfate, polysulfides, FeS, or any other product; prescribe selectivity or O2 demand; calculate reaction heat, water holdup/dropout, phase transfer, or pressure effects; create a signed component source; mutate a thermodynamic/process/pipeline/transient state; or update corrosion, wall, solid-flash, filter, or deposition inventories. Later product/deposition coupling still requires separately qualified stoichiometry/selectivity and must compose with existing sulfur implementations.

Coordination remains with #3144, #2937, #2911, pipeline work, #3153, `SulfurDepositionAnalyser`, `IronSulfideWallInventory`, oxidation-source, solid-flash, and filter implementations.

## Documentation impact

Updates the primary H2S/O2 guide and executable documentation contract with equations, units, numerical invariants, and the product/deposition stop boundary.

## Validation

Passed on the exact local validation tree:

- repository Spotless 3.10.1/Eclipse 4.35 apply and repeat check;
- Java 8 ECJ 3.41.0 compilation of the complete focused chain and shared sulfur-mass authority;
- 19 focused JUnit methods through the Java 8 reflection harness;
- executable documentation contract: 18/18;
- Python byte compilation of the documentation contract;
- exact local/remote blob equality for all four changed files.

Full repository Maven matrix, pre-commit/pre-push, documentation search, Javadocs, security, and hosted checks are deferred to exact-head CI.

## Exact continuity and publication

- Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5644849335
- Exact base: `1e248a9753d8bf6398b4a06ddd10e6606dcec860`
- Exact head: `70c0ee2dd75568725e4e30a87f00bbd1ed0eee69`
- Scope: exactly four existing files (production, focused JUnit, guide, documentation contract).
- Portfolio occupancy after publication: **6/10** autonomous implementation capabilities.
- No overlap with active PRs #3653, #3664, #3667, #3668, or #3669.
- Draft-only.
- **VALIDATION PENDING EXACT-HEAD CI.**

AI-assisted implementation. Subject to CI and the subsystem-owner plus independent review required by repository governance.