### PR TITLE
[AI-Assisted] docs(pvt): rebuild calibration and validation workflow

### DIFF
--- a/docs/pvtsimulation/pvt_workflow.md
+++ b/docs/pvtsimulation/pvt_workflow.md
@@ -1,519 +1,188 @@
 ---
-title: "PVT Workflow: From Lab Data to Tuned Fluid Model"
-description: This document describes the complete workflow for generating and tuning fluid models from laboratory PVT data in NeqSim.
+title: "PVT Calibration and Validation Workflow"
+description: Source-backed workflow for qualifying reservoir-fluid data, calibrating NeqSim PVT models, validating hold-out experiments, and reporting results with explicit units and evidence boundaries.
 ---
 
-This document describes the complete workflow for generating and tuning fluid models from laboratory PVT data in NeqSim.
-
-## Typical Laboratory PVT Report Data
-
-A standard PVT laboratory report contains the following sections. Below are example data tables showing the format typically received from labs like Core Lab, Schlumberger, or Intertek.
-
-### Sample Information
-```
-Well Name:           A-1
-Sample Type:         Bottom Hole Sample (BHS)
-Sampling Depth:      2850 m TVD
-Sampling Date:       2024-06-15
-Reservoir Pressure:  285 bara
-Reservoir Temp:      98 °C (371.15 K)
-Saturation Pressure: 248 bara (Bubble Point)
-```
-
-### Compositional Analysis (Mole %)
-
-| Component | Mol % | MW (g/mol) | Density (g/cm³) |
-|-----------|-------|------------|-----------------|
-| N₂ | 0.34 | 28.01 | - |
-| CO₂ | 3.53 | 44.01 | - |
-| H₂S | 0.00 | 34.08 | - |
-| C₁ | 70.78 | 16.04 | - |
-| C₂ | 8.94 | 30.07 | - |
-| C₃ | 5.05 | 44.10 | - |
-| i-C₄ | 0.85 | 58.12 | - |
-| n-C₄ | 1.68 | 58.12 | - |
-| i-C₅ | 0.62 | 72.15 | - |
-| n-C₅ | 0.79 | 72.15 | - |
-| C₆ | 0.83 | 86.18 | 0.664 |
-| C₇ | 1.06 | 92.2 | 0.7324 |
-| C₈ | 1.06 | 104.6 | 0.7602 |
-| C₉ | 0.79 | 119.1 | 0.7677 |
-| C₁₀ | 0.57 | 133.0 | 0.790 |
-| C₁₁ | 0.38 | 147.0 | 0.795 |
-| C₁₂+ | 2.73 | 263.0 | 0.854 |
-| **Total** | **100.00** | | |
-
-### Constant Composition Expansion (CCE) at 98°C
-
-| Pressure (bara) | Relative Volume | Y-Factor | Oil Density (kg/m³) | Oil Viscosity (cP) |
-|-----------------|-----------------|----------|---------------------|-------------------|
-| 350 | 0.9521 | - | 612.3 | 0.285 |
-| 300 | 0.9712 | - | 625.1 | 0.312 |
-| 280 | 0.9845 | - | 632.8 | 0.328 |
-| **248** (Psat) | **1.0000** | - | **645.2** | **0.352** |
-| 220 | 1.0523 | 2.145 | 658.4 | 0.385 |
-| 200 | 1.1124 | 2.287 | 670.1 | 0.412 |
-| 180 | 1.1892 | 2.456 | 682.5 | 0.445 |
-| 150 | 1.3245 | 2.712 | 698.2 | 0.498 |
-| 120 | 1.5421 | 3.024 | 715.8 | 0.562 |
-| 100 | 1.7856 | 3.312 | 728.4 | 0.615 |
-
-### Differential Liberation (DLE) at 98°C
-
-| Pressure (bara) | Rs (Sm³/Sm³) | Bo (m³/Sm³) | Oil Density (kg/m³) | Oil Viscosity (cP) | Gas Z-factor | Gas Gravity |
-|-----------------|--------------|-------------|---------------------|-------------------|--------------|-------------|
-| **248** (Psat) | 152.3 | 1.4521 | 645.2 | 0.352 | - | - |
-| 220 | 138.5 | 1.4012 | 658.4 | 0.385 | 0.862 | 0.745 |
-| 200 | 125.2 | 1.3654 | 670.1 | 0.412 | 0.851 | 0.768 |
-| 180 | 112.8 | 1.3285 | 682.5 | 0.445 | 0.838 | 0.792 |
-| 150 | 94.5 | 1.2756 | 698.2 | 0.498 | 0.815 | 0.825 |
-| 120 | 75.2 | 1.2198 | 715.8 | 0.562 | 0.792 | 0.861 |
-| 100 | 61.8 | 1.1812 | 728.4 | 0.615 | 0.775 | 0.892 |
-| 80 | 48.2 | 1.1425 | 742.1 | 0.685 | 0.758 | 0.928 |
-| 50 | 28.5 | 1.0912 | 762.5 | 0.812 | 0.732 | 0.975 |
-| 20 | 8.5 | 1.0385 | 785.2 | 1.025 | 0.712 | 1.045 |
-| 1.01 (STO) | 0.0 | 1.0000 | 825.4 | 2.850 | - | - |
-
-### Constant Volume Depletion (CVD) at 98°C (for Gas Condensates)
-
-| Pressure (bara) | Liquid Dropout (%) | Z-factor | Cumulative Gas Produced (%) | Liquid Density (kg/m³) |
-|-----------------|-------------------|----------|----------------------------|----------------------|
-| **285** (Pdew) | 0.0 | 0.892 | 0.0 | - |
-| 260 | 4.2 | 0.875 | 8.5 | 612.5 |
-| 230 | 8.5 | 0.856 | 18.2 | 628.4 |
-| 200 | 12.8 | 0.838 | 28.5 | 645.2 |
-| 170 | 15.2 | 0.821 | 39.8 | 658.7 |
-| 140 | 14.5 | 0.805 | 51.2 | 672.1 |
-| 110 | 12.1 | 0.792 | 62.8 | 685.4 |
-| 80 | 8.8 | 0.781 | 74.5 | 698.2 |
-| 50 | 5.2 | 0.772 | 86.2 | 712.5 |
-
-### Multi-Stage Separator Test
-
-**Test Conditions:**
-
-| Stage | Pressure (bara) | Temperature (°C) |
-|-------|-----------------|------------------|
-| 1 (HP Sep) | 45.0 | 45.0 |
-| 2 (LP Sep) | 8.0 | 35.0 |
-| 3 (Stock Tank) | 1.01 | 15.0 |
-
-**Results:**
-
-| Property | Stage 1 | Stage 2 | Stage 3 | Total |
-|----------|---------|---------|---------|-------|
-| GOR (Sm³/Sm³) | 95.2 | 18.5 | 8.2 | 121.9 |
-| Gas Gravity | 0.752 | 0.985 | 1.245 | 0.812 |
-| Oil Density (kg/m³) | 712.5 | 758.2 | 825.4 | - |
-| Oil Viscosity (cP) | 0.52 | 0.85 | 2.45 | - |
-
-**Stock Tank Oil Properties:**
-- API Gravity: 39.8 °API
-- Density: 825.4 kg/m³
-- Formation Volume Factor (Bo): 1.385 rm³/Sm³
-- Solution GOR (Rs): 121.9 Sm³/Sm³
-
-### Viscosity Data (Separate Measurements)
-
-| Pressure (bara) | Temperature (°C) | Oil Viscosity (cP) | Gas Viscosity (cP) |
-|-----------------|------------------|-------------------|-------------------|
-| 285 | 98 | 0.285 | 0.0185 |
-| 248 | 98 | 0.352 | 0.0178 |
-| 200 | 98 | 0.412 | 0.0165 |
-| 150 | 98 | 0.498 | 0.0148 |
-| 100 | 98 | 0.615 | 0.0132 |
-| 248 | 80 | 0.425 | 0.0168 |
-| 248 | 60 | 0.585 | 0.0155 |
-
-### Swelling Test (CO₂ Injection)
-
-| Cumulative CO₂ Injected (mol%) | Saturation Pressure (bara) | Relative Swelling Factor | Oil Density (kg/m³) |
-|-------------------------------|---------------------------|-------------------------|---------------------|
-| 0.0 | 248.0 | 1.000 | 645.2 |
-| 5.0 | 268.5 | 1.025 | 638.4 |
-| 10.0 | 292.1 | 1.052 | 630.1 |
-| 15.0 | 318.4 | 1.082 | 620.5 |
-| 20.0 | 348.2 | 1.115 | 608.2 |
-| 25.0 | 382.5 | 1.152 | 594.8 |
-| 30.0 | 421.8 | 1.195 | 578.5 |
-
----
-
-## Overview
-
-```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Lab PVT Data  │───▶│  Initial Fluid  │───▶│  EOS Regression │───▶│  Export Model   │
-│   (CCE,DLE,CVD) │    │  Characterization│    │  (Parameter Fit)│    │  (E300, CSV)    │
-└─────────────────┘    └─────────────────┘    └─────────────────┘    └─────────────────┘
-```
-
-## Step 1: Create Initial Fluid from Composition
-
-Start with laboratory-reported composition and characterize heavy fractions:
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermo.system.SystemInterface;
-
-// Create fluid at reservoir conditions
-SystemInterface fluid = new SystemSrkEos(373.15, 250.0);  // T(K), P(bar)
-
-// Add defined components (from lab composition)
-fluid.addComponent("nitrogen", 0.34);
-fluid.addComponent("CO2", 3.53);
-fluid.addComponent("methane", 70.78);
-fluid.addComponent("ethane", 8.94);
-fluid.addComponent("propane", 5.05);
-fluid.addComponent("i-butane", 0.85);
-fluid.addComponent("n-butane", 1.68);
-fluid.addComponent("i-pentane", 0.62);
-fluid.addComponent("n-pentane", 0.79);
-fluid.addComponent("n-hexane", 0.83);
-
-// Add C7+ fractions (TBP cuts from lab)
-fluid.addTBPfraction("C7", 1.06, 92.2/1000.0, 0.7324);   // name, mole%, MW(kg/mol), SG
-fluid.addTBPfraction("C8", 1.06, 104.6/1000.0, 0.7602);
-fluid.addTBPfraction("C9", 0.79, 119.1/1000.0, 0.7677);
-fluid.addTBPfraction("C10", 0.57, 133.0/1000.0, 0.79);
-
-// Add plus fraction
-fluid.addPlusFraction("C20+", 2.11, 381.0/1000.0, 0.88);
-
-// Characterize plus fraction into pseudo-components
-fluid.getCharacterization().characterisePlusFraction();
-
-// Initialize database and set mixing rule
-fluid.createDatabase(true);
-fluid.setMixingRule(2);  // Classic mixing rule
-```
-
-## Step 2: Add Laboratory PVT Data
-
-Import experimental data from CCE, DLE, CVD, and separator tests:
-
-```java
-import neqsim.pvtsimulation.regression.PVTRegression;
-import neqsim.pvtsimulation.regression.RegressionParameter;
-
-PVTRegression regression = new PVTRegression(fluid);
-
-// CCE (Constant Composition Expansion) data
-double[] ccePressures = {400, 350, 300, 280, 260, 240, 220, 200, 180};  // bara
-double[] cceRelVol = {0.95, 0.97, 0.99, 1.00, 1.02, 1.05, 1.10, 1.18, 1.30};
-double cceTemperature = 373.15;  // K
-regression.addCCEData(ccePressures, cceRelVol, cceTemperature);
-
-// DLE (Differential Liberation) data
-double[] dlePressures = {280, 240, 200, 160, 120, 80, 40, 1.01325};  // bara
-double[] dleRs = {150, 130, 110, 85, 60, 35, 15, 0};  // Sm³/Sm³
-double[] dleBo = {1.45, 1.40, 1.35, 1.28, 1.20, 1.12, 1.06, 1.02};  // m³/Sm³
-double[] dleOilDensity = {650, 680, 710, 740, 770, 800, 830, 850};  // kg/m³
-double dleTemperature = 373.15;  // K
-regression.addDLEData(dlePressures, dleRs, dleBo, dleOilDensity, dleTemperature);
-
-// CVD (Constant Volume Depletion) data - for gas condensates
-double[] cvdPressures = {350, 300, 250, 200, 150, 100};  // bara
-double[] cvdLiquidDropout = {0, 5, 12, 18, 15, 10};  // volume %
-double[] cvdZFactor = {0.85, 0.82, 0.80, 0.78, 0.77, 0.76};
-double cvdTemperature = 373.15;  // K
-regression.addCVDData(cvdPressures, cvdLiquidDropout, cvdZFactor, cvdTemperature);
-
-// Separator test data
-regression.addSeparatorData(
-    125.0,    // GOR (Sm³/Sm³)
-    1.35,     // Bo
-    35.0,     // API gravity
-    50.0,     // separator pressure (bar)
-    313.15,   // separator temperature (K)
-    373.15    // reservoir temperature (K)
-);
-```
-
-## Step 3: Configure Regression Parameters
-
-Select which EOS parameters to tune:
-
-```java
-// Binary Interaction Parameters (BIPs)
-regression.addRegressionParameter(RegressionParameter.BIP_METHANE_C7PLUS);
-regression.addRegressionParameter(RegressionParameter.BIP_C2C6_C7PLUS);
-regression.addRegressionParameter(RegressionParameter.BIP_CO2_HC);
-
-// Critical property multipliers for C7+ pseudo-components
-regression.addRegressionParameter(RegressionParameter.TC_MULTIPLIER_C7PLUS);
-regression.addRegressionParameter(RegressionParameter.PC_MULTIPLIER_C7PLUS);
-regression.addRegressionParameter(RegressionParameter.OMEGA_MULTIPLIER_C7PLUS);
-
-// Volume shift for density matching
-regression.addRegressionParameter(RegressionParameter.VOLUME_SHIFT_C7PLUS);
-
-// Viscosity parameters (if tuning viscosity)
-regression.addRegressionParameter(RegressionParameter.VISCOSITY_LBC_MULTIPLIER);
-regression.addRegressionParameter(RegressionParameter.VISCOSITY_PEDERSEN_ALPHA);
-
-// Custom bounds (optional)
-regression.addRegressionParameter(
-    RegressionParameter.BIP_METHANE_C7PLUS,
-    0.0,    // lower bound
-    0.15,   // upper bound
-    0.05    // initial guess
-);
-
-// Set experiment weights (optional)
-regression.setExperimentWeight(ExperimentType.CCE, 1.0);
-regression.setExperimentWeight(ExperimentType.DLE, 1.5);  // Higher weight for DLE
-regression.setExperimentWeight(ExperimentType.SEPARATOR, 1.0);
-
-// Optimization settings
-regression.setMaxIterations(200);
-regression.setTolerance(1e-8);
-regression.setVerbose(true);
-```
-
-## Step 4: Run Regression
-
-Execute the optimization:
-
-```java
-import neqsim.pvtsimulation.regression.RegressionResult;
-
-RegressionResult result = regression.runRegression();
-
-// Get the tuned fluid
-SystemInterface tunedFluid = result.getTunedFluid();
-
-// Check results
-System.out.println("Final chi-square: " + result.getChiSquare());
-System.out.println("Optimized parameters:");
-double[] params = result.getOptimizedParameters();
-for (int i = 0; i < params.length; i++) {
-    System.out.println("  Parameter " + i + ": " + params[i]);
-}
-```
-
-## Step 5: Validate and Compare with Lab Data
-
-Generate comparison reports:
-
-```java
-import neqsim.pvtsimulation.util.PVTReportGenerator;
-import neqsim.pvtsimulation.simulation.*;
-
-// Run PVT simulations with tuned fluid
-ConstantMassExpansion cce = new ConstantMassExpansion(tunedFluid);
-cce.setTemperature(373.15);
-cce.setPressures(ccePressures);
-cce.runCalc();
-
-DifferentialLiberation dle = new DifferentialLiberation(tunedFluid);
-dle.setTemperature(373.15);
-dle.setPressures(dlePressures);
-dle.runCalc();
-
-// Create report generator
-PVTReportGenerator report = new PVTReportGenerator(tunedFluid);
-report.setProjectInfo("Field X Development", "Well A-1 Sample");
-report.setReservoirConditions(250.0, 100.0);  // P(bar), T(°C)
-
-// Add simulation results
-report.addCCE(cce);
-report.addDLE(dle);
-
-// Add lab data for comparison
-for (int i = 0; i < ccePressures.length; i++) {
-    report.addLabCCEData(ccePressures[i], "RelVol", cceRelVol[i], "");
-}
-for (int i = 0; i < dlePressures.length; i++) {
-    report.addLabDLEData(dlePressures[i], "Bo", dleBo[i], "m³/Sm³");
-    report.addLabDLEData(dlePressures[i], "Rs", dleRs[i], "Sm³/Sm³");
-}
-
-// Generate comparison with statistics
-String comparison = report.generateLabComparison();
-System.out.println(comparison);
-// Output includes AAD (Average Absolute Deviation) and ARE (Average Relative Error)
-
-// Generate full Markdown report
-String fullReport = report.generateMarkdownReport();
-```
-
-## Step 6: Export to Reservoir Simulator
-
-Export the tuned fluid model to Eclipse E300 format:
-
-```java
-import neqsim.blackoil.io.EclipseEOSExporter;
-import java.nio.file.Path;
-
-// Simple export with default settings
-EclipseEOSExporter.toFile(tunedFluid, Path.of("PVT_TUNED.INC"));
-
-// Export with custom configuration
-EclipseEOSExporter.ExportConfig config = new EclipseEOSExporter.ExportConfig()
-    .setUnits(EclipseEOSExporter.Units.FIELD)      // METRIC or FIELD
-    .setReferenceTemperature(373.15)               // Reservoir temp (K)
-    .setIncludePVTO(true)                          // Live oil table
-    .setIncludePVTG(true)                          // Wet gas table
-    .setIncludePVTW(true)                          // Water properties
-    .setIncludeDensity(true)                       // Stock tank densities
-    .setComment("Tuned to Well A-1 PVT data");
-
-EclipseEOSExporter.toFile(tunedFluid, Path.of("PVT_FIELD.INC"), config);
-
-// Or get as string for inspection
-String eclipseContent = EclipseEOSExporter.toString(tunedFluid, config);
-System.out.println(eclipseContent);
-```
-
-### Generated Eclipse Keywords
-
-The exporter produces standard Eclipse keywords:
-
-- **PVTO** - Live oil PVT table (Rs, P, Bo, viscosity)
-- **PVTG** - Wet gas PVT table (Rv, P, Bg, viscosity)
-- **PVTW** - Water PVT properties
-- **DENSITY** - Stock tank densities (oil, water, gas)
-
-### Unit Systems
-
-| Unit System | Pressure | Density | GOR/CGR | Viscosity |
-|-------------|----------|---------|---------|-----------|
-| METRIC | bar | kg/m³ | Sm³/Sm³ | mPa·s |
-| FIELD | psia | lb/ft³ | scf/stb | cp |
-
-### Export Compositional EOS to E300 Format
-
-In addition to black-oil PVT tables, you can export the full compositional EOS model to Eclipse E300 format. This preserves all component properties and binary interaction coefficients:
-
-```java
-import neqsim.thermo.util.readwrite.EclipseFluidReadWrite;
-
-// Export tuned fluid to E300 compositional format
-EclipseFluidReadWrite.write(tunedFluid, "TUNED_FLUID.e300", 100.0);  // reservoir temp in °C
-
-// Or get as string for inspection
-String e300Content = EclipseFluidReadWrite.toE300String(tunedFluid, 100.0);
-System.out.println(e300Content);
-```
-
-The E300 compositional file includes:
-
-| Keyword | Description |
-|---------|-------------|
-| `NCOMPS` | Number of components |
-| `EOS` | Equation of state (SRK, PR) |
-| `RTEMP` | Reservoir temperature |
-| `CNAMES` | Component names |
-| `TCRIT` | Critical temperatures (K) |
-| `PCRIT` | Critical pressures (bar) |
-| `ACF` | Acentric factors |
-| `MW` | Molecular weights (g/mol) |
-| `TBOIL` | Normal boiling points (K) |
-| `VCRIT` | Critical volumes (m³/kmol) |
-| `SSHIFT` | Volume translation parameters |
-| `PARACHOR` | Parachor values for IFT |
-| `ZI` | Mole fractions |
-| `BIC` | Binary interaction coefficients |
-
-### Read E300 File Back into NeqSim
-
-```java
-// Read the E300 file back into a NeqSim fluid
-SystemInterface importedFluid = EclipseFluidReadWrite.read("TUNED_FLUID.e300");
-
-// Set conditions and run flash
-importedFluid.setPressure(200.0, "bara");
-importedFluid.setTemperature(100.0, "C");
-ThermodynamicOperations ops = new ThermodynamicOperations(importedFluid);
-ops.TPflash();
-```
-
-## Step 7: Export CSV for Other Applications
-
-Generate CSV files for spreadsheet analysis or other simulators:
-
-```java
-// CCE data
-String cceCSV = report.generateCCECSV();
-
-// DLE data
-String dleCSV = report.generateDLECSV();
-
-// CVD data
-String cvdCSV = report.generateCVDCSV();
-
-// Viscosity data
-String viscCSV = report.generateViscosityCSV();
-
-// Density data
-String densCSV = report.generateDensityCSV();
-
-// Swelling test
-String swellCSV = report.generateSwellingCSV();
-
-// GOR data
-String gorCSV = report.generateGORCSV();
-
-// MMP data
-String mmpCSV = report.generateMMPCSV();
-```
-
-## Available Regression Parameters
-
-| Parameter | Description | Typical Bounds |
-|-----------|-------------|----------------|
-| `BIP_METHANE_C7PLUS` | BIP between CH₄ and C7+ | 0.0 - 0.10 |
-| `BIP_C2C6_C7PLUS` | BIP between C2-C6 and C7+ | 0.0 - 0.05 |
-| `BIP_CO2_HC` | BIP between CO₂ and hydrocarbons | 0.08 - 0.18 |
-| `BIP_N2_HC` | BIP between N₂ and hydrocarbons | 0.02 - 0.12 |
-| `VOLUME_SHIFT_C7PLUS` | Volume shift multiplier for C7+ | 0.8 - 1.2 |
-| `TC_MULTIPLIER_C7PLUS` | Critical temperature multiplier | 0.95 - 1.05 |
-| `PC_MULTIPLIER_C7PLUS` | Critical pressure multiplier | 0.95 - 1.05 |
-| `OMEGA_MULTIPLIER_C7PLUS` | Acentric factor multiplier | 0.90 - 1.10 |
-| `PLUS_MOLAR_MASS_MULTIPLIER` | Plus fraction MW adjustment | 0.90 - 1.10 |
-| `GAMMA_ALPHA` | Whitson gamma distribution shape | 0.5 - 4.0 |
-| `GAMMA_ETA` | Whitson gamma min MW (η) | 75.0 - 95.0 |
-| `VISCOSITY_LBC_MULTIPLIER` | LBC viscosity correlation factor | 0.8 - 1.5 |
-| `VISCOSITY_PEDERSEN_ALPHA` | Pedersen viscosity parameter | 0.5 - 2.0 |
-
-## Separator Optimization
-
-Find optimal separator conditions:
-
-```java
-import neqsim.pvtsimulation.simulation.MultiStageSeparatorTest;
-
-MultiStageSeparatorTest sepTest = new MultiStageSeparatorTest(tunedFluid);
-sepTest.setReservoirConditions(250.0, 373.15);  // P(bar), T(K)
-
-// Add separator stages
-sepTest.addSeparatorStage(50.0, 40.0, "HP Separator");   // P(bar), T(°C)
-sepTest.addSeparatorStage(10.0, 30.0, "LP Separator");
-sepTest.addSeparatorStage(1.01325, 15.0, "Stock Tank");
-
-// Run simulation
-sepTest.run();
-
-// Optimize first stage pressure/temperature
-MultiStageSeparatorTest.OptimizationResult optResult =
-    sepTest.optimizeFirstStageSeparator(
-        5.0, 80.0, 16,    // pressure: min, max, steps
-        20.0, 60.0, 9     // temperature: min, max, steps
-    );
-
-System.out.println("Optimal P: " + optResult.getOptimalPressure() + " bara");
-System.out.println("Optimal T: " + optResult.getOptimalTemperature() + " °C");
-System.out.println("Max Recovery: " + optResult.getMaximumOilRecovery());
-System.out.println("GOR at optimum: " + optResult.getGorAtOptimum() + " Sm³/Sm³");
-```
-
-## Complete Example
-
-See [PVTRegressionTest.java](https://github.com/equinor/neqsim/blob/master/src/test/java/neqsim/pvtsimulation/regression/PVTRegressionTest.java) for working examples.
-
-## Related Documentation
-
-- [Black Oil PVT Export](blackoil_pvt_export)
-- [Fluid Characterization Mathematics](fluid_characterization_mathematics)
-- [Whitson PVT Reader](whitson_pvt_reader)
+This guide defines an auditable path from laboratory observations to a NeqSim fluid model. It
+does not supply a universal fluid, tuning range, or acceptance limit. Sample identity, laboratory
+conditions, uncertainty, parameter bounds, and acceptance criteria are project-specific and must
+remain traceable to their owners.
+
+For a runnable starting point, use the Java 8/Log4j2
+[`PvtSeparatorQuickStart`](README.md#runnable-java-quick-start) and its enabled
+[documentation regression](../../src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java).
+The enabled [PVT regression tests](../../src/test/java/neqsim/pvtsimulation/regression/PVTRegressionTest.java)
+exercise the current regression surface. This page intentionally contains no second code example.
+
+## Evidence boundary
+
+The workflow is bounded by current repository sources:
+
+| Responsibility | Maintained evidence |
+| --- | --- |
+| Experiment registration, weights, parameters, and optimization | [`PVTRegression`](../../src/main/java/neqsim/pvtsimulation/regression/PVTRegression.java) |
+| Available tuning parameters and library defaults | [`RegressionParameter`](../../src/main/java/neqsim/pvtsimulation/regression/RegressionParameter.java) |
+| Optimized fluid, objectives, parameter values, and uncertainty accessors | [`RegressionResult`](../../src/main/java/neqsim/pvtsimulation/regression/RegressionResult.java) |
+| PVT report assembly and exports | [`PVTReportGenerator`](../../src/main/java/neqsim/pvtsimulation/util/PVTReportGenerator.java) |
+| Laboratory-test model setup | [PVT laboratory-test guide](pvt_lab_tests.md) |
+| Characterization equations and parameter meanings | [Fluid characterization mathematics](fluid_characterization_mathematics.md) |
+
+These sources establish API behavior, not the quality of a particular sample, laboratory campaign,
+equation-of-state choice, tuned parameter set, or field-development decision.
+
+## 1. Freeze the data basis
+
+Before constructing a model, record:
+
+- sample identifier, sampling point, date, and chain of custody;
+- laboratory report revision and the basis for corrected or recombined data;
+- composition units, component slate, plus-fraction definition, and normalization rule;
+- pressure and temperature reference scales;
+- reported uncertainty, detection limits, and rejected observations;
+- experiment sequence, depletion path, separator stages, and stock-tank reference conditions; and
+- the project-specific calibration targets, hold-out observations, and acceptance criteria.
+
+Keep raw observations immutable. Perform unit conversion, filtering, and derived-property
+calculation in a traceable preparation layer. Do not silently replace missing observations with
+illustrative values.
+
+## 2. Construct and qualify the base fluid
+
+Build the untuned fluid from the approved composition and characterization basis. Document the
+thermodynamic model, mixing rule, component mapping, plus-fraction splitting, and every externally
+supplied property. The [Whitson reader](whitson_pvt_reader.md), [JSON fluid
+format](json_fluid_format.md), and [Eclipse E300 import guide](eclipse_e300_fluid_import.md)
+describe dedicated input routes.
+
+Qualify the base fluid before regression. At minimum, check material normalization, component
+identity, critical-property plausibility, phase behavior near the laboratory path, and whether each
+laboratory experiment can run independently. Preserve the untuned result as the comparison
+baseline. The `PVTRegression` constructor clones the supplied system for its base and tuned
+states; subsequent project records should still identify the exact input revision.
+
+## 3. Reproduce experiments independently
+
+Configure only experiments represented by traceable observations. Run the corresponding NeqSim
+laboratory-test models before assembling a multi-experiment objective. This separates model-setup
+failures from regression behavior and exposes unit or phase-selection mistakes early.
+
+Compare predictions and observations using the laboratory's definitions. A relative volume, liquid
+dropout, solution gas-oil ratio, formation volume factor, density, and viscosity are different
+observables; do not combine them merely because they share a pressure point. Record both absolute
+and normalized residuals and explain the weighting basis.
+
+## 4. Register data with explicit units
+
+The current `PVTRegression` methods accept the following quantities:
+
+| Method | Required quantities |
+| --- | --- |
+| `addCCEData` | pressure in bar, relative volume as (V/V_{sat}), optional Y-factor, temperature in K |
+| `addCVDData` | pressure in bar, liquid dropout in volume %, gas compressibility factor, temperature in K |
+| `addDLEData` | pressure in bar, solution GOR in Sm³/Sm³, oil FVF in m³/Sm³, oil density in kg/m³, temperature in K |
+| `addSeparatorData` | GOR in Sm³/Sm³, oil FVF, API gravity, separator pressure in bar, separator temperature in K, reservoir temperature in K |
+| `addViscosityData` | pressure in bara, dynamic viscosity in Pa s, temperature in K, and phase name `gas`, `oil`, `liquid`, `aqueous`, or `water` |
+
+The array-taking methods iterate from the pressure-array length and do not perform a visible
+equal-length, non-empty, finite-value, or ordering check before indexing the companion arrays.
+Validate those properties before calling the API. Also retain the original observation order or an
+explicit sort record; do not infer a depletion path from an unordered table.
+
+Pressure conventions differ across the surface: most regression experiment Javadocs say bar,
+viscosity uses bara, and report metadata uses bara. Treat the laboratory pressure basis as an input
+contract and convert deliberately.
+
+## 5. Select bounded regression parameters
+
+Choose only parameters with a defensible physical relationship to the observed residuals. Record
+for every parameter:
+
+- lower bound, upper bound, initial guess, and units where applicable;
+- the source or engineering rationale for each bound;
+- which experiments constrain it;
+- known correlations or identifiability concerns; and
+- the sensitivity and hold-out checks required for acceptance.
+
+`RegressionParameter.getDefaultBounds()` returns library defaults, and
+`addRegressionParameter(parameter)` uses them. Defaults are not project approval. Prefer explicit,
+project-specific bounds when the data basis requires them. Avoid adding many weakly identifiable
+parameters solely to reduce the calibration objective.
+
+## 6. Configure and run regression
+
+Set experiment weights only after documenting the residual normalization and the relative
+importance of each data type. `setExperimentWeight`, `setMaxIterations`, `setTolerance`, and
+`setVerbose` configure the current framework. `runRegression()` rejects an empty parameter set
+and a run with no experimental data.
+
+Keep the base-fluid revision, data-preparation revision, parameter configuration, optimizer
+settings, software revision, and execution log together. Logging in maintained Java examples must
+remain Java 8 compatible and use Log4j2; console printing is not an accepted publication pattern.
+
+## 7. Review calibration diagnostics
+
+`RegressionResult` exposes the tuned fluid, objective values by experiment type, total objective,
+parameter configurations and optimized values, uncertainty information, confidence intervals, and
+the final chi-square value. Treat these as diagnostics of the configured optimization problem.
+
+Calibration is not independent validation. A low objective value does not establish uniqueness,
+predictive accuracy outside the fitted observations, representative sampling, or fitness for a
+facility or reservoir decision. Examine residual structure, parameter-bound hits, parameter
+correlation, experiment balance, and sensitivity to initial guesses.
+
+## 8. Validate before acceptance
+
+Reserve hold-out observations or a separate experiment that was not used to tune the model. Apply
+the tuned fluid without changing parameters, then compare predictions using predeclared
+project-specific criteria. Where no independent data exist, state that limitation and use
+cross-validation or sensitivity cases as weaker evidence rather than calling the model validated.
+
+Challenge the model across the intended pressure, temperature, composition, and depletion envelope.
+Investigate discontinuities, phase-identity changes, extrapolation, and sensitivity to laboratory
+uncertainty. Any engineering use must carry the validation range and unresolved limitations
+forward.
+
+## 9. Report and hand off
+
+`PVTReportGenerator` accepts a fluid in its constructor. Its current metadata methods include
+`setProjectInfo`, `setLabInfo`, and `setReservoirConditions`; the latter takes reservoir
+pressure in bara and temperature in °C. Simulation results can be attached with `addCCE`,
+`addDLE`, `addCVD`, `addSeparatorTest`, and the other source-listed adders.
+`generateMarkdownReport()` produces the Markdown report, while dedicated CSV methods export
+supported result tables.
+
+A handoff package should contain:
+
+- raw and prepared data with provenance and units;
+- base and tuned fluid definitions with repository revision;
+- parameter bounds, initial and optimized values;
+- residuals, objectives, uncertainty, and sensitivity results;
+- hold-out predictions and acceptance decisions;
+- validity envelope, exclusions, and accountable reviewer; and
+- report output plus a machine-readable execution manifest.
+
+Use the dedicated [black-oil PVT export guide](blackoil_pvt_export.md) or
+[Eclipse E300 import guide](eclipse_e300_fluid_import.md) for supported file workflows. The
+regression package does not provide an `EclipseEOSExporter` API.
+
+## Review checklist
+
+- [ ] Sample and laboratory revisions are traceable.
+- [ ] Every observation has an explicit quantity, unit, uncertainty, and pressure basis.
+- [ ] Equal-length arrays are non-empty, finite, ordered, and reviewed before API calls.
+- [ ] Base experiments run independently before regression.
+- [ ] Parameters and bounds have project-specific justification.
+- [ ] Calibration residuals and parameter correlations are reviewed.
+- [ ] Hold-out validation covers the intended operating envelope.
+- [ ] Reporting uses the current source-backed API and preserves limitations.
+- [ ] No result is presented as an engineering qualification without accountable project review.
+
+## Related documentation
+
+- [PVT simulation package](README.md)
+- [PVT laboratory-test guide](pvt_lab_tests.md)
+- [Fluid characterization mathematics](fluid_characterization_mathematics.md)
+- [Whitson PVT reader](whitson_pvt_reader.md)
+- [JSON fluid format](json_fluid_format.md)
+- [Eclipse E300 fluid import](eclipse_e300_fluid_import.md)
+- [Black-oil PVT export](blackoil_pvt_export.md)

--- a/docs/pvtsimulation/pvt_workflow.md
+++ b/docs/pvtsimulation/pvt_workflow.md
@@ -9,7 +9,7 @@ conditions, uncertainty, parameter bounds, and acceptance criteria are project-s
 remain traceable to their owners.
 
 For a runnable starting point, use the Java 8/Log4j2
-[`PvtSeparatorQuickStart`](README.md#runnable-java-quick-start) and its enabled
+[`PvtSeparatorQuickStart`](README.md#runnable-multi-stage-separator-example) and its enabled
 [documentation regression](../../src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java).
 The enabled [PVT regression tests](../../src/test/java/neqsim/pvtsimulation/regression/PVTRegressionTest.java)
 exercise the current regression surface. This page intentionally contains no second code example.

--- a/docs/pvtsimulation/pvt_workflow.md
+++ b/docs/pvtsimulation/pvt_workflow.md
@@ -77,7 +77,7 @@ The current `PVTRegression` methods accept the following quantities:
 
 | Method | Required quantities |
 | --- | --- |
-| `addCCEData` | pressure in bar, relative volume as (V/V_{sat}), optional Y-factor, temperature in K |
+| `addCCEData` | pressure in bar, relative volume as $V/V_{sat}$, optional Y-factor, temperature in K |
 | `addCVDData` | pressure in bar, liquid dropout in volume %, gas compressibility factor, temperature in K |
 | `addDLEData` | pressure in bar, solution GOR in Sm³/Sm³, oil FVF in m³/Sm³, oil density in kg/m³, temperature in K |
 | `addSeparatorData` | GOR in Sm³/Sm³, oil FVF, API gravity, separator pressure in bar, separator temperature in K, reservoir temperature in K |

--- a/docs/test_pvt_workflow_documentation.py
+++ b/docs/test_pvt_workflow_documentation.py
@@ -11,11 +11,19 @@ DOCS = ROOT / "docs"
 GUIDE = DOCS / "pvtsimulation" / "pvt_workflow.md"
 INDEX = DOCS / "REFERENCE_MANUAL_INDEX.md"
 REGRESSION = ROOT / "src/main/java/neqsim/pvtsimulation/regression/PVTRegression.java"
-PARAMETER = ROOT / "src/main/java/neqsim/pvtsimulation/regression/RegressionParameter.java"
+PARAMETER = (
+    ROOT / "src/main/java/neqsim/pvtsimulation/regression/RegressionParameter.java"
+)
 RESULT = ROOT / "src/main/java/neqsim/pvtsimulation/regression/RegressionResult.java"
 REPORT = ROOT / "src/main/java/neqsim/pvtsimulation/util/PVTReportGenerator.java"
-REGRESSION_TEST = ROOT / "src/test/java/neqsim/pvtsimulation/regression/PVTRegressionTest.java"
-DOCUMENTATION_TEST = ROOT / "src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java"
+REGRESSION_TEST = (
+    ROOT
+    / "src/test/java/neqsim/pvtsimulation/regression/PVTRegressionTest.java"
+)
+DOCUMENTATION_TEST = (
+    ROOT
+    / "src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java"
+)
 PVT_OVERVIEW = DOCS / "pvtsimulation" / "README.md"
 
 
@@ -88,12 +96,31 @@ class PvtWorkflowDocumentationTest(unittest.TestCase):
             "public PVTRegression(SystemInterface fluid)",
             "this.baseFluid = fluid.clone();",
             "this.tunedFluid = fluid.clone();",
-            "public void addCCEData(double[] pressures, double[] relativeVolumes, double temperature)",
-            "public void addCVDData(double[] pressures, double[] liquidDropout, double[] zFactors, double temperature)",
-            "public void addDLEData(double[] pressures, double[] rs, double[] bo, double[] oilDensity, double temperature)",
-            "public void addSeparatorData(double gor, double bo, double apiGravity, double separatorPressure, double separatorTemperature, double reservoirTemperature)",
-            "public void addViscosityData(double[] pressures, double[] viscosities, double temperature, String phaseName)",
-            "public void addRegressionParameter(RegressionParameter parameter, double lowerBound, double upperBound, double initialGuess)",
+            (
+                "public void addCCEData(double[] pressures, "
+                "double[] relativeVolumes, double temperature)"
+            ),
+            (
+                "public void addCVDData(double[] pressures, "
+                "double[] liquidDropout, double[] zFactors, double temperature)"
+            ),
+            (
+                "public void addDLEData(double[] pressures, double[] rs, "
+                "double[] bo, double[] oilDensity, double temperature)"
+            ),
+            (
+                "public void addSeparatorData(double gor, double bo, "
+                "double apiGravity, double separatorPressure, "
+                "double separatorTemperature, double reservoirTemperature)"
+            ),
+            (
+                "public void addViscosityData(double[] pressures, "
+                "double[] viscosities, double temperature, String phaseName)"
+            ),
+            (
+                "public void addRegressionParameter(RegressionParameter parameter, "
+                "double lowerBound, double upperBound, double initialGuess)"
+            ),
             "public void setExperimentWeight(ExperimentType type, double weight)",
             "public void setMaxIterations(int maxIterations)",
             "public void setTolerance(double tolerance)",
@@ -123,13 +150,22 @@ class PvtWorkflowDocumentationTest(unittest.TestCase):
 
         for signature in [
             "public PVTReportGenerator(SystemInterface fluid)",
-            "public PVTReportGenerator setProjectInfo(String projectName, String fluidName)",
+            (
+                "public PVTReportGenerator setProjectInfo("
+                "String projectName, String fluidName)"
+            ),
             "public PVTReportGenerator setLabInfo(String labName, String sampleDate)",
-            "public PVTReportGenerator setReservoirConditions(double pressure, double temperatureCelsius)",
+            (
+                "public PVTReportGenerator setReservoirConditions("
+                "double pressure, double temperatureCelsius)"
+            ),
             "public PVTReportGenerator addCCE(ConstantMassExpansion cce)",
             "public PVTReportGenerator addDLE(DifferentialLiberation dle)",
             "public PVTReportGenerator addCVD(ConstantVolumeDepletion cvd)",
-            "public PVTReportGenerator addSeparatorTest(MultiStageSeparatorTest sepTest)",
+            (
+                "public PVTReportGenerator addSeparatorTest("
+                "MultiStageSeparatorTest sepTest)"
+            ),
             "public String generateMarkdownReport()",
         ]:
             self.assertIn(normalized(signature), self.report_normalized)
@@ -138,9 +174,14 @@ class PvtWorkflowDocumentationTest(unittest.TestCase):
         for source in [self.regression_test, self.documentation_test]:
             self.assertIn("@Test", source)
             self.assertNotIn("@Disabled", source)
-        self.assertIn("testRegressionFitsSingleCspViscosityParameter", self.regression_test)
+        self.assertIn(
+            "testRegressionFitsSingleCspViscosityParameter", self.regression_test
+        )
         self.assertIn("PvtSeparatorQuickStart", self.pvt_overview)
-        self.assertIn("LogManager.getLogger(PvtSeparatorQuickStart.class)", self.pvt_overview)
+        self.assertIn(
+            "LogManager.getLogger(PvtSeparatorQuickStart.class)",
+            self.pvt_overview,
+        )
         self.assertIn("MultiStageSeparatorTest", self.documentation_test)
 
     def test_engineering_boundaries_and_units_are_explicit(self):

--- a/docs/test_pvt_workflow_documentation.py
+++ b/docs/test_pvt_workflow_documentation.py
@@ -1,0 +1,195 @@
+"""Contracts for the source-backed PVT calibration and validation workflow."""
+
+from pathlib import Path
+import re
+import unittest
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+GUIDE = DOCS / "pvtsimulation" / "pvt_workflow.md"
+INDEX = DOCS / "REFERENCE_MANUAL_INDEX.md"
+REGRESSION = ROOT / "src/main/java/neqsim/pvtsimulation/regression/PVTRegression.java"
+PARAMETER = ROOT / "src/main/java/neqsim/pvtsimulation/regression/RegressionParameter.java"
+RESULT = ROOT / "src/main/java/neqsim/pvtsimulation/regression/RegressionResult.java"
+REPORT = ROOT / "src/main/java/neqsim/pvtsimulation/util/PVTReportGenerator.java"
+REGRESSION_TEST = ROOT / "src/test/java/neqsim/pvtsimulation/regression/PVTRegressionTest.java"
+DOCUMENTATION_TEST = ROOT / "src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java"
+PVT_OVERVIEW = DOCS / "pvtsimulation" / "README.md"
+
+
+def normalized(text):
+    """Collapse whitespace so source signatures remain formatting-independent."""
+    return " ".join(text.split())
+
+
+def heading_anchors(markdown):
+    """Return the GitHub-style anchors needed by links in this guide."""
+    anchors = set()
+    for line in markdown.splitlines():
+        match = re.match(r"^#{1,6}\s+(.+?)\s*$", line)
+        if not match:
+            continue
+        heading = re.sub(r"<[^>]+>", "", match.group(1)).lower()
+        heading = re.sub(r"[^\w\- ]", "", heading)
+        anchors.add(re.sub(r"-+", "-", heading.replace(" ", "-")).strip("-"))
+    return anchors
+
+
+class PvtWorkflowDocumentationTest(unittest.TestCase):
+    """Protect the D148 PVT workflow evidence boundary."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.guide_normalized = normalized(cls.guide)
+        cls.regression = REGRESSION.read_text(encoding="utf-8")
+        cls.regression_normalized = normalized(cls.regression)
+        cls.parameter = PARAMETER.read_text(encoding="utf-8")
+        cls.result = RESULT.read_text(encoding="utf-8")
+        cls.result_normalized = normalized(cls.result)
+        cls.report = REPORT.read_text(encoding="utf-8")
+        cls.report_normalized = normalized(cls.report)
+        cls.regression_test = REGRESSION_TEST.read_text(encoding="utf-8")
+        cls.documentation_test = DOCUMENTATION_TEST.read_text(encoding="utf-8")
+        cls.pvt_overview = PVT_OVERVIEW.read_text(encoding="utf-8")
+
+    def test_front_matter_heading_and_code_policy(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        closing = self.guide.find("\n---\n", 4)
+        self.assertGreater(closing, 4)
+        front_matter = self.guide[4:closing]
+        body = self.guide[closing + 5 :]
+        self.assertRegex(front_matter, r"(?m)^title:\s*.+$")
+        self.assertRegex(front_matter, r"(?m)^description:\s*.+$")
+        self.assertNotRegex(body, r"(?m)^#\s+")
+        self.assertNotIn("```", body)
+        self.assertNotIn("System.out", body)
+        self.assertNotIn("System.err", body)
+        self.assertNotIn("Path.of", body)
+
+    def test_relative_links_and_fragments_resolve(self):
+        links = re.findall(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", self.guide)
+        self.assertGreaterEqual(len(links), 15)
+        for raw_target in links:
+            target = unquote(raw_target.strip().split()[0].strip("<>"))
+            if target.startswith(("http://", "https://", "mailto:")):
+                continue
+            path_text, _, fragment = target.partition("#")
+            destination = (GUIDE.parent / path_text).resolve() if path_text else GUIDE
+            self.assertTrue(destination.is_file(), target)
+            if fragment:
+                anchors = heading_anchors(destination.read_text(encoding="utf-8"))
+                self.assertIn(fragment.lower(), anchors, target)
+
+    def test_regression_source_contract(self):
+        required = [
+            "public PVTRegression(SystemInterface fluid)",
+            "this.baseFluid = fluid.clone();",
+            "this.tunedFluid = fluid.clone();",
+            "public void addCCEData(double[] pressures, double[] relativeVolumes, double temperature)",
+            "public void addCVDData(double[] pressures, double[] liquidDropout, double[] zFactors, double temperature)",
+            "public void addDLEData(double[] pressures, double[] rs, double[] bo, double[] oilDensity, double temperature)",
+            "public void addSeparatorData(double gor, double bo, double apiGravity, double separatorPressure, double separatorTemperature, double reservoirTemperature)",
+            "public void addViscosityData(double[] pressures, double[] viscosities, double temperature, String phaseName)",
+            "public void addRegressionParameter(RegressionParameter parameter, double lowerBound, double upperBound, double initialGuess)",
+            "public void setExperimentWeight(ExperimentType type, double weight)",
+            "public void setMaxIterations(int maxIterations)",
+            "public void setTolerance(double tolerance)",
+            "public void setVerbose(boolean verbose)",
+            "public RegressionResult runRegression()",
+            'throw new IllegalStateException("No regression parameters defined")',
+            'throw new IllegalStateException("No experimental data provided")',
+        ]
+        for signature in required:
+            self.assertIn(normalized(signature), self.regression_normalized)
+
+    def test_parameter_result_and_report_source_contracts(self):
+        self.assertIn("public double[] getDefaultBounds()", self.parameter)
+
+        for signature in [
+            "public SystemInterface getTunedFluid()",
+            "public Map<ExperimentType, Double> getObjectiveValues()",
+            "public double getTotalObjective()",
+            "public double getObjectiveValue(ExperimentType type)",
+            "public List<RegressionParameterConfig> getParameterConfigs()",
+            "public double getOptimizedValue(RegressionParameter parameter)",
+            "public UncertaintyAnalysis getUncertainty()",
+            "public double[] getConfidenceInterval(RegressionParameter parameter)",
+            "public double getFinalChiSquare()",
+        ]:
+            self.assertIn(normalized(signature), self.result_normalized)
+
+        for signature in [
+            "public PVTReportGenerator(SystemInterface fluid)",
+            "public PVTReportGenerator setProjectInfo(String projectName, String fluidName)",
+            "public PVTReportGenerator setLabInfo(String labName, String sampleDate)",
+            "public PVTReportGenerator setReservoirConditions(double pressure, double temperatureCelsius)",
+            "public PVTReportGenerator addCCE(ConstantMassExpansion cce)",
+            "public PVTReportGenerator addDLE(DifferentialLiberation dle)",
+            "public PVTReportGenerator addCVD(ConstantVolumeDepletion cvd)",
+            "public PVTReportGenerator addSeparatorTest(MultiStageSeparatorTest sepTest)",
+            "public String generateMarkdownReport()",
+        ]:
+            self.assertIn(normalized(signature), self.report_normalized)
+
+    def test_executable_evidence_remains_enabled(self):
+        for source in [self.regression_test, self.documentation_test]:
+            self.assertIn("@Test", source)
+            self.assertNotIn("@Disabled", source)
+        self.assertIn("testRegressionFitsSingleCspViscosityParameter", self.regression_test)
+        self.assertIn("PvtSeparatorQuickStart", self.pvt_overview)
+        self.assertIn("LogManager.getLogger(PvtSeparatorQuickStart.class)", self.pvt_overview)
+        self.assertIn("MultiStageSeparatorTest", self.documentation_test)
+
+    def test_engineering_boundaries_and_units_are_explicit(self):
+        required_phrases = [
+            "calibration is not independent validation",
+            "project-specific",
+            "equal-length",
+            "non-empty",
+            "finite",
+            "hold-out",
+            "java 8/log4j2",
+            "pressure in bar",
+            "pressure in bara",
+            "temperature in k",
+            "temperature in °c",
+            "volume %",
+            "sm³/sm³",
+            "m³/sm³",
+            "kg/m³",
+            "pa s",
+            "does not provide an eclipseeosexporter api",
+        ]
+        lower_guide = self.guide_normalized.lower().replace("`", "")
+        for phrase in required_phrases:
+            self.assertIn(phrase, lower_guide)
+
+    def test_stale_workflow_claims_do_not_return(self):
+        rejected = [
+            "import neqsim.blackoil.io.EclipseEOSExporter",
+            "PVT_TUNED.INC",
+            "PVT_FIELD.INC",
+            "Typical Bounds",
+            "Field X Development",
+            "Well A-1 Sample",
+            "Core Lab",
+            "Schlumberger",
+            "Intertek",
+            "Complete Example",
+        ]
+        for phrase in rejected:
+            self.assertNotIn(phrase, self.guide)
+
+    def test_navigation_route_is_preserved(self):
+        index = INDEX.read_text(encoding="utf-8")
+        self.assertIn(
+            "[docs/pvtsimulation/pvt_workflow.md](pvtsimulation/pvt_workflow.md)",
+            index,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Advances documentation campaign #2499 as **D148, rotation scope 5**.

- replace the synthetic, fragment-heavy PVT workflow with a source-backed calibration and independent-validation process
- document the current `PVTRegression`, `RegressionParameter`, `RegressionResult`, and `PVTReportGenerator` units and responsibilities
- make sample provenance, array validation, project-specific bounds, hold-out evidence, and reporting limitations explicit
- remove the nonexistent `neqsim.blackoil.io.EclipseEOSExporter`, Java 11 `Path.of`, console output, generic tuning tables, invented lab data, and unsupported completeness claims
- add a dependency-free contract for front matter, links, navigation, source signatures, enabled executable evidence, engineering boundaries, and rejected stale APIs

## Frozen scope

Exactly two files:

- `docs/pvtsimulation/pvt_workflow.md`
- `docs/test_pvt_workflow_documentation.py`

Exact base: `4e8ef12407afed4de6255dfc71e97efda8bc1964`  
Exact head: `24e02b83770e5b64b5168f5c536c76621dad5bd4`

The batch is five ordered commits, zero commits behind its exact base, with 411 additions and 506 deletions.

## Evidence

Prepublication connector-side checks pass for:

- all current source signatures and documented units
- enabled `PVTRegressionTest` and `PvtSimulationDocumentationTest`
- maintained Java 8/Log4j2 `PvtSeparatorQuickStart`
- front matter, heading, no-fence, and rejected-output policies
- all 21 Markdown links across 13 repository files
- the maintained reference-manual route
- Python syntax and 88-column formatting

Hosted validation is complete on exact head `24e02b83770e5b64b5168f5c536c76621dad5bd4`:

- Run build, test and javadoc: pass
- Documentation search coverage, including the focused contract and complete site build: pass
- Pre-commit checks: pass
- Spotless format patch: pass
- CodeQL Security Analysis: pass

The frozen draft is **READY TO MERGE** pending independent merge and current-`master` byte verification.

## Engineering boundary

This is documentation and source-contract work only. No PVT example or regression was executed and no fluid, parameter set, laboratory observation, numerical result, engineering decision, production Java, EOS/regression behavior, notebook, generated export, two-fluid work, MCP surface, optimization, refinery, release, or Huldra artifact was changed or qualified.

## Continuity

This PR must remain draft-only at its exact head. Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, close, replace, or abandon it for capacity. Independent merge and current-`master` byte verification are required after exact-head validation.
