### PR TITLE
[AI-Assisted] fix(mechanical-design): qualify JSON for geometry and design calculations

### DIFF
--- a/.github/workflows/devtools_tests.yml
+++ b/.github/workflows/devtools_tests.yml
@@ -7,11 +7,13 @@ on:
   pull_request:
     paths:
       - "devtools/**"
+      - "examples/mechanical_design_json_to_mesh.py"
       - ".github/workflows/devtools_tests.yml"
   push:
     branches: [master]
     paths:
       - "devtools/**"
+      - "examples/mechanical_design_json_to_mesh.py"
 
 jobs:
   devtools-tests:
@@ -30,7 +32,7 @@ jobs:
           # pytest for the hermetic suites; python-docx + matplotlib for the
           # report-generator tests; scikit-learn so discovery uses the TF-IDF
           # path (it also has a pure-python fallback).
-          python -m pip install pytest python-docx matplotlib scikit-learn
+          python -m pip install pytest python-docx matplotlib scikit-learn trimesh
 
       - name: Run hermetic pytest suites
         run: |
@@ -42,6 +44,9 @@ jobs:
             devtools/test_verify_agent_skill_refs.py \
             devtools/test_report_workflow.py \
             devtools/test_unisim_outputs.py
+
+      - name: Run mechanical design mesh contract tests
+        run: python -m unittest discover -s devtools -p test_mechanical_design_json_to_mesh.py -v
 
       - name: Run report generator integration test (script)
         run: python devtools/test_report_gen.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,6 +590,13 @@ design.calcDesign();
 String json = design.toJson();
 ```
 
+For JSON-driven CAD or external design calculations, use `design.toDesignDataJson()`
+after running the process and `calcDesign()`. Read each quantity's unit, source and
+availability; legacy wall-thickness getters use m for vessels/compressors but mm
+for pumps/pipelines/columns. Check `geometryConsistency`, and keep compressor
+envelope dimensions separate from pressure-casing calculation results. See
+`docs/process/mechanical_design.md` and `MechanicalDesignJsonContractTest`.
+
 **Internals classes** (`mechanicaldesign.separator.internals`):
 - `DemistingInternal` — Eu-number pressure drop, Souders-Brown max velocity,
   carry-over model for wire mesh / vane pack / cyclone demisting devices

--- a/devtools/test_mechanical_design_json_to_mesh.py
+++ b/devtools/test_mechanical_design_json_to_mesh.py
@@ -1,0 +1,71 @@
+"""Geometry-contract tests for the runnable JSON-to-mesh example."""
+
+import copy
+import importlib.util
+import math
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "design_mesh_example", ROOT / "examples/mechanical_design_json_to_mesh.py"
+)
+EXAMPLE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(EXAMPLE)
+
+
+class DesignMeshTest(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+            "schemaVersion": "1.0",
+            "geometryKind": "cylindrical_shell",
+            "geometryConsistency": "consistent",
+            "orientation": "horizontal",
+            "geometry": {
+                name: {"value": value, "unit": "m", "status": "available"}
+                for name, value in {
+                    "innerDiameter": 1.0,
+                    "outerDiameter": 1.04,
+                    "wallThickness": 0.02,
+                    "tangentLength": 3.0,
+                    "moduleLength": 5.0,
+                    "moduleWidth": 2.0,
+                    "moduleHeight": 2.0,
+                }.items()
+            },
+        }
+
+    def test_shell_bounds_and_volume(self):
+        mesh, report = EXAMPLE.build_mesh(self.data)
+        for actual, expected in zip(mesh.extents, [3.0, 1.04, 1.04]):
+            self.assertAlmostEqual(actual, expected, places=10)
+        self.assertTrue(mesh.is_watertight)
+        self.assertAlmostEqual(report["analyticVolume_m3"], math.pi * 0.0204 * 3.0)
+        self.assertLess(report["relativeVolumeError"], 0.00011)
+        self.assertFalse(report["fabricationReady"])
+
+    def test_rejects_units_missing_values_and_inconsistent_geometry(self):
+        for changed in [
+            {"unit": "mm"},
+            {"value": None, "status": "unavailable"},
+            {"value": 20.0},
+            {"value": float("nan")},
+        ]:
+            with self.subTest(changed=changed):
+                data = copy.deepcopy(self.data)
+                data["geometry"]["wallThickness"].update(changed)
+                with self.assertRaises(ValueError):
+                    EXAMPLE.build_mesh(data)
+
+    def test_envelope_is_separate_from_pressure_shell(self):
+        self.data["geometryKind"] = "compressor_envelope"
+        with self.assertRaises(ValueError):
+            EXAMPLE.build_mesh(self.data)
+        mesh, report = EXAMPLE.build_mesh({"designData": self.data}, mode="envelope")
+        self.assertAlmostEqual(mesh.volume, 20.0)
+        self.assertIn("plot-space", report["representation"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -134,7 +134,7 @@ mecDesign.calcDesign();
 
 // Access results
 double weight = mecDesign.getWeightTotal();           // kg
-double wallThickness = mecDesign.getWallThickness();  // mm
+double wallThickness = mecDesign.getWallThickness();  // m for this separator
 double innerDiameter = mecDesign.getInnerDiameter();  // m
 double length = mecDesign.getTantanLength();          // m
 double designPressure = mecDesign.getMaxDesignPressure(); // bara
@@ -278,7 +278,8 @@ String json = separator.getMechanicalDesign().toJson();
   "maxDesignTemperature": 80.0,
   "innerDiameter": 2.4,
   "tangentLength": 7.2,
-  "wallThickness": 28.5,
+  "wallThickness": 0.0285,
+  "wallThicknessUnit": "m",
   "moduleLength": 10.0,
   "moduleWidth": 5.0,
   "moduleHeight": 4.5,
@@ -286,6 +287,102 @@ String json = separator.getMechanicalDesign().toJson();
 }
 */
 ```
+
+### JSON for 3D geometry and design calculations
+
+Use `toDesignDataJson()` on any mechanical design for the versioned, unit-labelled
+contract. The same snapshot is included as `designData` in response-based
+`toJson()` exports. The dedicated method also works for equipment with its own
+legacy exporter. Run the process and `calcDesign()` after changing inputs, then
+export; exporting does not run calculations or change the equipment.
+
+```java
+// After running the process:
+MechanicalDesign design = separator.getMechanicalDesign();
+design.calcDesign();
+String designDataJson = design.toDesignDataJson();
+java.nio.file.Files.write(java.nio.file.Paths.get("separator-design.json"),
+    designDataJson.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+```
+
+The contract has `schemaVersion: "1.0"`. Every numeric quantity inside `geometry`,
+`operatingConditions` and `designBasis` has `value`, `unit`, `source` and `status`.
+Lengths use **m**, absolute pressures **Pa**, temperatures **K**, power/duty **W**,
+mass flow **kg/s**, area **m2**, conductance **W/K**, and efficiency **1**.
+Unavailable or non-finite values are JSON `null` with status `unavailable`.
+`available` means a finite getter value is present; it does **not** establish
+calculation completion, freshness, compliance or fabrication readiness.
+`calculationStatus` is explicitly `not_tracked`. Configured operating/design limits
+are marked `configured_or_default` and kept separate from live stream conditions.
+
+| Equipment | Legacy `getWallThickness()` / JSON unit | Normalized geometry and calculation interpretation |
+|---|---|---|
+| Separator, absorber | m | Sized cylindrical shell; orientation from process owner; head type/profile unavailable |
+| Compressor | m | Envelope gap, **not pressure-casing thickness**; `pressureCasingWallThickness` and `pressureCasingInnerDiameter` come separately from the casing calculator |
+| Heat exchanger, heater/cooler | m | Selected sizing envelope; an equivalent diameter does not imply a cylindrical exchanger |
+| Pump | mm | Casing envelope, impeller and shaft sizes converted to m |
+| Pipeline/riser | mm | Geometry uses the pipe's specified ID/thickness/length; `designBasis.designWallThickness` preserves the design getter separately (minimum sizing result after `calcDesign`) |
+| Valve | m | Envelope; face-to-face, body thickness and stem getters use mm where documented |
+| Distillation column | mm | Column envelope; height exported separately |
+| Filter, adsorber | m | Getter dimensions exported with the diameter/thickness consistency check |
+| Membrane | mm | Getter dimensions converted; detailed housing layout is not inferred |
+| Other design classes | Unqualified | Thickness is unavailable in normalized output until its unit contract is qualified |
+
+Existing getter numeric units remain unchanged. Legacy response JSON now declares
+`wallThicknessUnit`; for example separator `wallThickness = 0.0285 m`, whereas
+its explicitly millimetre-valued `shellThickness = 28.5 mm`. Compressor and pump
+impeller/shaft legacy fields remain mm. Previously unpopulated floating-point
+response fields use `Double.NaN` in the Java DTO and now serialize as `null`, and non-finite nested calculator values
+also become `null` in response-based exports. Compact and pretty response exports
+have the same fields. Legacy zero counts/false flags are not a completeness test;
+consume the versioned contract for geometry automation.
+
+Compressor inlet/outlet pressures and efficiencies come from the live compressor,
+not the design envelope defaults. Compressor, pump and valve maximum design
+pressure/temperature fields use their own calculation results. Heat-exchanger
+exports now use their specialized response, selected type, required area and
+thermal coefficient. Shell dimensions are populated only for a shell-and-tube
+selection. No head thickness or product geometry is invented when its source is
+absent.
+
+`geometryConsistency` checks whether positive finite ID, OD and thickness satisfy
+`OD = ID + 2t`. It is `consistent`, `inconsistent` or `incomplete`. This checks
+geometric arithmetic only, not pressure-code adequacy. Correct an inconsistent
+source design before meshing it. A missing head type is expected: the separator
+model does not specify a fabrication head profile.
+
+The runnable [JSON-to-mesh example](../../examples/mechanical_design_json_to_mesh.py)
+uses `trimesh` and rejects missing units, unavailable dimensions and inconsistent
+shell geometry. With the JSON above saved as `separator-design.json`:
+
+```bash
+python -m pip install trimesh numpy
+python examples/mechanical_design_json_to_mesh.py separator-design.json separator-shell.stl
+# For a compressor, pump or exchanger plot-space envelope:
+python examples/mechanical_design_json_to_mesh.py compressor-design.json compressor-skid.glb --mode envelope
+```
+
+The shell mesh is an **open-ended tube wall**, without heads, nozzles or supports.
+Horizontal vessels have their axis along X; vertical vessels along Z. The example
+checks watertightness of the wall solid and its mesh volume against
+`pi * (OD^2 - ID^2) * tangentLength / 4`. The STL/GLB sidecar retains metre units,
+source design data, bounds, representation and the volume error. STL itself does
+not encode units. Envelope mode creates a plot-space box including access
+allowances, so its volume must not be interpreted as metal volume or used for mass.
+
+For design calculations, retain the JSON's sources and statuses alongside each
+result. Wall-metal volume times a separately specified material density gives a
+shell-only mass estimate. Pressure-thickness or hoop-stress calculations also need
+an explicitly selected pressure differential, material allowable stress, joint
+factor, corrosion allowance and applicable design method. Absolute operating
+pressure is not automatically the pressure differential across a wall. Existing
+mechanical/casing calculators remain the source of their design results; a CAD
+mesh is not a substitute for those calculations or a fabrication drawing.
+
+The regression test `MechanicalDesignJsonContractTest` runs the equipment, checks
+getter/JSON values and unit conversions, preserves configured limits across
+reruns, checks missing values, and writes separator/compressor JSON fixtures for
+the mesh example under `target/design-json/`.
 
 ### Exporting System-Wide Design
 
@@ -399,7 +496,8 @@ mechReport.writeJsonReport("mechanical_design_report.json");
       "mechanicalDesign": {
         "designPressure": 55.0,
         "designTemperature": 80.0,
-        "wallThickness": 28.5,
+        "wallThickness": 0.0285,
+        "wallThicknessUnit": "m",
         "weight": 15420.5,
         ...
       }

--- a/examples/mechanical_design_json_to_mesh.py
+++ b/examples/mechanical_design_json_to_mesh.py
@@ -1,0 +1,111 @@
+"""Convert NeqSim design-data JSON to a preliminary shell or plot-space mesh.
+
+Run the process and mechanical design first, then save design.toDesignDataJson().
+This example uses metres throughout. An STL has no unit metadata, so a JSON sidecar
+retains the units, source snapshot, representation and independent volume check.
+No heads, nozzles, internals, welds or supports are inferred.
+
+Example:
+    python examples/mechanical_design_json_to_mesh.py design.json shell.stl
+    python examples/mechanical_design_json_to_mesh.py compressor.json skid.glb --mode envelope
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import trimesh
+
+
+def quantity(data, section, name, unit):
+    """Read an available positive finite quantity in the declared unit."""
+    entry = data[section][name]
+    value = entry.get("value")
+    if entry.get("status") != "available" or entry.get("unit") != unit:
+        raise ValueError(f"{section}.{name} is unavailable or is not in {unit}")
+    if isinstance(value, bool) or not isinstance(value, (float, int)):
+        raise ValueError(f"{section}.{name} must be numeric")
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{section}.{name} must be finite and positive")
+    return value
+
+
+def build_mesh(document, mode="shell", sections=256):
+    """Build a mesh and independently check its dimensions and enclosed solid volume."""
+    data = document.get("designData", document)
+    if data.get("schemaVersion") != "1.0":
+        raise ValueError("Expected NeqSim design-data schema 1.0")
+    if sections < 32:
+        raise ValueError("Use at least 32 circumferential sections")
+    if mode == "shell":
+        kind = data.get("geometryKind")
+        if kind not in ("cylindrical_shell", "straight_pipe_section"):
+            raise ValueError("This equipment has no qualified cylindrical shell; use envelope mode")
+        if data.get("geometryConsistency") != "consistent":
+            raise ValueError("Shell diameters and thickness are incomplete or inconsistent")
+        inner = quantity(data, "geometry", "innerDiameter", "m")
+        outer = quantity(data, "geometry", "outerDiameter", "m")
+        thickness = quantity(data, "geometry", "wallThickness", "m")
+        length_key = "length" if kind == "straight_pipe_section" else "tangentLength"
+        length = quantity(data, "geometry", length_key, "m")
+        if outer <= inner or not math.isclose(outer - inner, 2 * thickness, rel_tol=1e-7):
+            raise ValueError("Outer diameter must equal inner diameter plus twice the wall thickness")
+        mesh = trimesh.creation.annulus(
+            r_min=inner / 2,
+            r_max=outer / 2,
+            height=length,
+            sections=sections,
+        )
+        orientation = data.get("orientation")
+        if kind == "cylindrical_shell" and orientation not in ("horizontal", "vertical"):
+            raise ValueError("Specify a horizontal or vertical vessel orientation")
+        if orientation == "horizontal":
+            mesh.apply_transform(trimesh.transformations.rotation_matrix(math.pi / 2, [0, 1, 0]))
+        analytic_volume = math.pi * (outer**2 - inner**2) * length / 4
+        representation = "open-ended shell wall only; annular ends close the wall solid, not the vessel bore"
+    elif mode == "envelope":
+        length = quantity(data, "geometry", "moduleLength", "m")
+        width = quantity(data, "geometry", "moduleWidth", "m")
+        height = quantity(data, "geometry", "moduleHeight", "m")
+        mesh = trimesh.creation.box(extents=[length, width, height])
+        analytic_volume = length * width * height
+        representation = "plot-space box including access allowances; not equipment metal or pressure boundary"
+    else:
+        raise ValueError("Mode must be shell or envelope")
+    relative_error = abs(mesh.volume - analytic_volume) / analytic_volume
+    if not mesh.is_watertight or mesh.volume <= 0 or relative_error > 0.007:
+        raise ValueError("Mesh failed topology or independent volume verification")
+    report = {
+        "lengthUnit": "m",
+        "representation": representation,
+        "analyticVolume_m3": analytic_volume,
+        "meshVolume_m3": float(mesh.volume),
+        "relativeVolumeError": float(relative_error),
+        "bounds_m": mesh.bounds.tolist(),
+        "watertightSolid": bool(mesh.is_watertight),
+        "fabricationReady": False,
+        "sourceDesignData": data,
+    }
+    return mesh, report
+
+
+def main():
+    """Write the mesh together with its unit and provenance sidecar."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--mode", choices=("shell", "envelope"), default="shell")
+    args = parser.parse_args()
+    if args.output.suffix.lower() not in (".stl", ".glb"):
+        parser.error("Output must end in .stl or .glb")
+    document = json.loads(args.input.read_text(encoding="utf-8"))
+    mesh, report = build_mesh(document, mode=args.mode)
+    mesh.export(args.output)
+    sidecar = args.output.with_suffix(args.output.suffix + ".json")
+    sidecar.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(json.dumps({key: value for key, value in report.items() if key != "sourceDesignData"}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
@@ -1356,7 +1356,8 @@ public class MechanicalDesign implements java.io.Serializable {
   /**
    * Getter for the field <code>wallThickness</code>.
    *
-   * @return the wallThickness
+   * @return wall thickness in the equipment-specific legacy unit (m for separators/compressors/heat exchangers; mm for
+   * pumps/pipelines/columns). Use toDesignDataJson for an explicit metre contract.
    */
   public double getWallThickness() {
     return wallThickness;
@@ -1884,7 +1885,7 @@ public class MechanicalDesign implements java.io.Serializable {
    * @return JSON string representation of the mechanical design
    */
   public String toJson() {
-    MechanicalDesignResponse response = new MechanicalDesignResponse(this);
+    MechanicalDesignResponse response = getResponse();
     return response.toJson();
   }
 
@@ -1894,7 +1895,7 @@ public class MechanicalDesign implements java.io.Serializable {
    * @return compact JSON string
    */
   public String toCompactJson() {
-    MechanicalDesignResponse response = new MechanicalDesignResponse(this);
+    MechanicalDesignResponse response = getResponse();
     return response.toCompactJson();
   }
 
@@ -1910,6 +1911,16 @@ public class MechanicalDesign implements java.io.Serializable {
    */
   public MechanicalDesignResponse getResponse() {
     return new MechanicalDesignResponse(this);
+  }
+
+  /**
+   * Export a versioned, unit-labelled snapshot for preliminary geometry and design calculations. Run the process and
+   * calcDesign first. Export does not run, certify or track calculation freshness.
+   *
+   * @return strict JSON with explicit unavailable values and source getters
+   */
+  public final String toDesignDataJson() {
+    return new MechanicalDesignData(this).toJson();
   }
 
   // ============================================================================

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignData.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignData.java
@@ -1,0 +1,285 @@
+package neqsim.process.mechanicaldesign;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.TwoPortInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.pipeline.PipeLineInterface;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.adsorber.AdsorberMechanicalDesign;
+import neqsim.process.mechanicaldesign.compressor.CompressorMechanicalDesign;
+import neqsim.process.mechanicaldesign.compressor.CompressorCasingDesignCalculator;
+import neqsim.process.mechanicaldesign.distillation.DistillationColumnMechanicalDesign;
+import neqsim.process.mechanicaldesign.filter.FilterMechanicalDesign;
+import neqsim.process.mechanicaldesign.heatexchanger.HeatExchangerMechanicalDesign;
+import neqsim.process.mechanicaldesign.heatexchanger.HeatExchangerSizingResult;
+import neqsim.process.mechanicaldesign.membrane.MembraneMechanicalDesign;
+import neqsim.process.mechanicaldesign.pipeline.PipelineMechanicalDesign;
+import neqsim.process.mechanicaldesign.pump.PumpMechanicalDesign;
+import neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign;
+import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
+
+/**
+ * Versioned snapshot for preliminary geometry and downstream design calculations.
+ *
+ * <p>
+ * Every quantity declares its unit, source and availability. Geometry is in metres, pressures are absolute Pa,
+ * temperatures are K and powers are W. Availability does not assert that a design was run, is current, meets a
+ * standard, or is fabrication-ready. The caller must run the process and design calculation after changing inputs.
+ * Export is side-effect free.
+ * </p>
+ */
+public final class MechanicalDesignData implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String schemaVersion = "1.0";
+  private final String intendedUse = "preliminary_geometry_and_design_review";
+  private final String calculationStatus = "not_tracked";
+  private String equipmentName;
+  private String equipmentClass;
+  private String designClass;
+  private String selectedEquipmentType;
+  private String geometryKind = "unspecified";
+  private String geometryConsistency = "incomplete";
+  private String orientation;
+  private String headType;
+  private final Map<String, Quantity> geometry = new LinkedHashMap<String, Quantity>();
+  private final Map<String, Quantity> operatingConditions = new LinkedHashMap<String, Quantity>();
+  private final Map<String, Quantity> designBasis = new LinkedHashMap<String, Quantity>();
+  private final List<String> limitations = new ArrayList<String>();
+
+  /** A numeric value together with its dimensional and availability contract. */
+  public static final class Quantity implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Double value;
+    private final String unit;
+    private final String source;
+    private final String status;
+
+    private Quantity(double value, String unit, String source, boolean positive, String availableStatus) {
+      boolean available = unit != null && Double.isFinite(value) && (!positive || value > 0.0);
+      this.value = available ? value : null;
+      this.unit = unit;
+      this.source = source;
+      this.status = available ? availableStatus : "unavailable";
+    }
+  }
+
+  /**
+   * Capture current values without running or mutating the equipment.
+   *
+   * @param design mechanical design to export
+   */
+  public MechanicalDesignData(MechanicalDesign design) {
+    if (design == null) {
+      throw new IllegalArgumentException("Mechanical design is required");
+    }
+    designClass = design.getClass().getSimpleName();
+    ProcessEquipmentInterface equipment = design.getProcessEquipment();
+    if (equipment != null) {
+      equipmentName = equipment.getName();
+      equipmentClass = equipment.getClass().getSimpleName();
+    }
+    limitations.add("Run process and calcDesign after every input change; calculation freshness is not tracked.");
+    limitations.add(
+        "Getter snapshots may contain configured defaults or empirical estimates; availability is not design approval.");
+    limitations
+        .add("No nozzle positions, head profile, supports, weld details or fabrication tolerances are inferred.");
+    double thickness = design.getWallThickness();
+    String thicknessUnit = wallThicknessUnit(design);
+    if ("mm".equals(thicknessUnit)) {
+      thickness /= 1000.0;
+    }
+    put(geometry, "innerDiameter", design.getInnerDiameter(), "m", "getInnerDiameter", true);
+    put(geometry, "outerDiameter", design.getOuterDiameter(), "m", "getOuterDiameter", true);
+    put(geometry, "wallThickness", thickness, thicknessUnit == null ? null : "m", "getWallThickness", true);
+    put(geometry, "tangentLength", design.getTantanLength(), "m", "getTantanLength", true);
+    put(geometry, "moduleLength", design.getModuleLength(), "m", "getModuleLength", true);
+    put(geometry, "moduleWidth", design.getModuleWidth(), "m", "getModuleWidth", true);
+    put(geometry, "moduleHeight", design.getModuleHeight(), "m", "getModuleHeight", true);
+    designBasis.put("maximumOperatingPressure", new Quantity(design.getMaxOperationPressure() * 1e5, "Pa",
+        "getMaxOperationPressure (bara)", true, "configured_or_default"));
+    designBasis.put("maximumDesignPressure", new Quantity(design.getMaxDesignPressure() * 1e5, "Pa",
+        "getMaxDesignPressure (bara)", true, "configured_or_default"));
+    designBasis.put("maximumDesignTemperature", new Quantity(design.getDesignMaxTemperatureLimit("K"), "K",
+        "getDesignMaxTemperatureLimit(K)", true, "configured_or_default"));
+    put(designBasis, "corrosionAllowance", design.getCorrosionAllowance() / 1000.0, "m", "getCorrosionAllowance (mm)",
+        false);
+
+    if (equipment instanceof TwoPortInterface) {
+      TwoPortInterface ports = (TwoPortInterface) equipment;
+      stream("inlet", ports.getInletStream());
+      stream("outlet", ports.getOutletStream());
+    } else if (equipment instanceof Separator) {
+      Separator separator = (Separator) equipment;
+      int index = 0;
+      for (StreamInterface inlet : separator.getInletStreams()) {
+        stream("inlet" + index++, inlet);
+      }
+      stream("gasOutlet", separator.getGasOutStream());
+    } else if (equipment instanceof HeatExchanger) {
+      HeatExchanger exchanger = (HeatExchanger) equipment;
+      for (int i = 0; i < 2; i++) {
+        stream("inlet" + i, exchanger.getInStream(i));
+        stream("outlet" + i, exchanger.getOutStream(i));
+      }
+    }
+
+    if (design instanceof SeparatorMechanicalDesign) {
+      geometryKind = "cylindrical_shell";
+      put(geometry, "headThickness", Double.NaN, "m", "not specified by the separator design model", true);
+      if (equipment instanceof Separator) {
+        orientation = ((Separator) equipment).getOrientation();
+      }
+      SeparatorMechanicalDesign separatorDesign = (SeparatorMechanicalDesign) design;
+      put(geometry, "inletNozzleInnerDiameter", separatorDesign.getInletNozzleID(), "m", "getInletNozzleID", true);
+      put(geometry, "gasOutletNozzleInnerDiameter", separatorDesign.getGasOutletNozzleID(), "m", "getGasOutletNozzleID",
+          true);
+      put(geometry, "liquidOutletNozzleInnerDiameter", separatorDesign.getOilOutletNozzleID(), "m",
+          "getOilOutletNozzleID", true);
+      put(geometry, "normalLiquidLevel", separatorDesign.getNLL(), "m", "getNLL", false);
+    } else if (design instanceof CompressorMechanicalDesign) {
+      geometryKind = "compressor_envelope";
+      CompressorMechanicalDesign compressorDesign = (CompressorMechanicalDesign) design;
+      put(geometry, "impellerDiameter", compressorDesign.getImpellerDiameter() / 1000.0, "m",
+          "getImpellerDiameter (mm)", true);
+      put(geometry, "shaftDiameter", compressorDesign.getShaftDiameter() / 1000.0, "m", "getShaftDiameter (mm)", true);
+      put(geometry, "bearingSpan", compressorDesign.getBearingSpan() / 1000.0, "m", "getBearingSpan (mm)", true);
+      pressureAndTemperature(compressorDesign.getDesignPressure(), compressorDesign.getDesignTemperature());
+      CompressorCasingDesignCalculator casing = compressorDesign.getCasingDesignCalculator();
+      if (casing != null) {
+        put(geometry, "pressureCasingInnerDiameter", casing.getCasingInnerDiameterMm() / 1000.0, "m",
+            "getCasingDesignCalculator.getCasingInnerDiameterMm", true);
+        put(geometry, "pressureCasingWallThickness", casing.getSelectedWallThicknessMm() / 1000.0, "m",
+            "getCasingDesignCalculator.getSelectedWallThicknessMm", true);
+      }
+      if (equipment instanceof Compressor) {
+        Compressor compressor = (Compressor) equipment;
+        put(operatingConditions, "polytropicEfficiency", compressor.getPolytropicEfficiency(), "1",
+            "Compressor.getPolytropicEfficiency", true);
+        put(operatingConditions, "power", compressor.getPower("W"), "W", "Compressor.getPower(W)", false);
+      }
+      limitations.add(
+          "Compressor wallThickness is an envelope gap; use pressureCasingWallThickness for the casing calculation result.");
+    } else if (design instanceof PumpMechanicalDesign) {
+      geometryKind = "pump_envelope";
+      PumpMechanicalDesign pump = (PumpMechanicalDesign) design;
+      put(geometry, "impellerDiameter", pump.getImpellerDiameter() / 1000.0, "m", "getImpellerDiameter (mm)", true);
+      put(geometry, "shaftDiameter", pump.getShaftDiameter() / 1000.0, "m", "getShaftDiameter (mm)", true);
+      pressureAndTemperature(pump.getDesignPressure(), pump.getDesignTemperature());
+    } else if (design instanceof PipelineMechanicalDesign) {
+      geometryKind = "straight_pipe_section";
+      put(designBasis, "designWallThickness", thickness, "m", "getWallThickness (mm), sizing result after calcDesign",
+          true);
+      if (equipment instanceof PipeLineInterface) {
+        PipeLineInterface pipe = (PipeLineInterface) equipment;
+        put(geometry, "innerDiameter", pipe.getDiameter(), "m", "PipeLineInterface.getDiameter", true);
+        put(geometry, "wallThickness", pipe.getWallThickness(), "m", "PipeLineInterface.getWallThickness", true);
+        put(geometry, "outerDiameter",
+            pipe.getWallThickness() > 0.0 ? pipe.getDiameter() + 2.0 * pipe.getWallThickness() : Double.NaN, "m",
+            "PipeLineInterface.getDiameter + 2 * getWallThickness", true);
+        put(geometry, "length", pipe.getLength(), "m", "PipeLineInterface.getLength", true);
+      }
+      limitations.add("Pipeline routing, bends and elevation are not represented by a straight section.");
+    } else if (design instanceof ValveMechanicalDesign) {
+      geometryKind = "valve_envelope";
+      ValveMechanicalDesign valve = (ValveMechanicalDesign) design;
+      put(geometry, "faceToFace", valve.getFaceToFace() / 1000.0, "m", "getFaceToFace (mm)", true);
+      put(geometry, "stemDiameter", valve.getStemDiameter() / 1000.0, "m", "getStemDiameter (mm)", true);
+      pressureAndTemperature(valve.getDesignPressure(), valve.getDesignTemperature());
+    } else if (design instanceof HeatExchangerMechanicalDesign) {
+      geometryKind = "heat_exchanger_envelope";
+      HeatExchangerSizingResult sizing = ((HeatExchangerMechanicalDesign) design).getSelectedSizingResult();
+      if (sizing != null) {
+        selectedEquipmentType = sizing.getType().name();
+        put(designBasis, "requiredArea", sizing.getRequiredArea(), "m2", "getSelectedSizingResult.getRequiredArea",
+            true);
+        put(designBasis, "requiredUA", sizing.getRequiredUA(), "W/K", "getSelectedSizingResult.getRequiredUA", true);
+      }
+      limitations.add(
+          "Exchanger dimensions may be equivalent envelope dimensions; consult the selected exchanger type before meshing.");
+    } else if (design instanceof DistillationColumnMechanicalDesign) {
+      geometryKind = "column_envelope";
+      put(geometry, "height", ((DistillationColumnMechanicalDesign) design).getColumnHeight(), "m", "getColumnHeight",
+          true);
+    }
+    if (equipment instanceof Heater) {
+      put(operatingConditions, "duty", ((Heater) equipment).getDuty("W"), "W", "Heater.getDuty(W)", false);
+    } else if (equipment instanceof HeatExchanger) {
+      put(operatingConditions, "duty", ((HeatExchanger) equipment).getDuty(), "W", "HeatExchanger.getDuty", false);
+    }
+    Quantity inner = geometry.get("innerDiameter");
+    Quantity outer = geometry.get("outerDiameter");
+    Quantity wall = geometry.get("wallThickness");
+    if (inner.value != null && outer.value != null && wall.value != null) {
+      double error = Math.abs(outer.value - inner.value - 2.0 * wall.value);
+      geometryConsistency = outer.value > inner.value && error <= 1e-8 * Math.max(1.0, outer.value) ? "consistent"
+          : "inconsistent";
+      if ("inconsistent".equals(geometryConsistency)) {
+        limitations.add(
+            "Inner diameter, outer diameter and wall thickness are inconsistent; do not construct a pressure shell from them.");
+      }
+    }
+    if (thicknessUnit == null) {
+      limitations.add(
+          "Legacy wall-thickness unit is not qualified for this design class; normalized thickness is unavailable.");
+    }
+  }
+
+  private void stream(String prefix, StreamInterface stream) {
+    put(operatingConditions, prefix + "Pressure", stream == null ? Double.NaN : stream.getPressure("Pa"), "Pa",
+        prefix + "Stream.getPressure(Pa), absolute", true);
+    put(operatingConditions, prefix + "Temperature", stream == null ? Double.NaN : stream.getTemperature("K"), "K",
+        prefix + "Stream.getTemperature(K)", true);
+    put(operatingConditions, prefix + "MassFlow", stream == null ? Double.NaN : stream.getFlowRate("kg/sec"), "kg/s",
+        prefix + "Stream.getFlowRate(kg/sec)", false);
+  }
+
+  private void pressureAndTemperature(double pressureBara, double temperatureC) {
+    // Keep the normalized pressure field in SI while preserving its source unit in the provenance.
+    put(designBasis, "maximumDesignPressure", pressureBara > 0.0 ? pressureBara * 1e5 : Double.NaN, "Pa",
+        "getDesignPressure (bara)", true);
+    put(designBasis, "maximumDesignTemperature", pressureBara > 0.0 ? temperatureC + 273.15 : Double.NaN, "K",
+        "getDesignTemperature (C)", true);
+  }
+
+  private static void put(Map<String, Quantity> fields, String name, double value, String unit, String source,
+      boolean positive) {
+    fields.put(name, new Quantity(value, unit, source, positive, "available"));
+  }
+
+  /**
+   * Identify the verified unit of the existing, unmodified wall-thickness getter.
+   *
+   * @param design mechanical design
+   * @return m, mm, or null when the unit is not qualified
+   */
+  public static String wallThicknessUnit(MechanicalDesign design) {
+    if (design instanceof PumpMechanicalDesign || design instanceof PipelineMechanicalDesign
+        || design instanceof DistillationColumnMechanicalDesign || design instanceof MembraneMechanicalDesign) {
+      return "mm";
+    }
+    if (design instanceof SeparatorMechanicalDesign || design instanceof CompressorMechanicalDesign
+        || design instanceof HeatExchangerMechanicalDesign || design instanceof ValveMechanicalDesign
+        || design instanceof FilterMechanicalDesign || design instanceof AdsorberMechanicalDesign) {
+      return "m";
+    }
+    return null;
+  }
+
+  /**
+   * Serialize the snapshot using strict JSON, retaining explicit nulls.
+   *
+   * @return versioned JSON snapshot
+   */
+  public String toJson() {
+    return new GsonBuilder().serializeNulls().setPrettyPrinting().create().toJson(this);
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignData.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignData.java
@@ -113,23 +113,23 @@ public final class MechanicalDesignData implements Serializable {
     put(designBasis, "corrosionAllowance", design.getCorrosionAllowance() / 1000.0, "m", "getCorrosionAllowance (mm)",
         false);
 
-    if (equipment instanceof TwoPortInterface) {
-      TwoPortInterface ports = (TwoPortInterface) equipment;
-      stream("inlet", ports.getInletStream());
-      stream("outlet", ports.getOutletStream());
+    if (equipment instanceof HeatExchanger) {
+      HeatExchanger exchanger = (HeatExchanger) equipment;
+      for (int i = 0; i < 2; i++) {
+        stream("inlet" + i, exchanger.getInStream(i));
+        stream("outlet" + i, exchanger.getOutStream(i));
+      }
     } else if (equipment instanceof Separator) {
       Separator separator = (Separator) equipment;
       int index = 0;
       for (StreamInterface inlet : separator.getInletStreams()) {
         stream("inlet" + index++, inlet);
       }
-      stream("gasOutlet", separator.getGasOutStream());
-    } else if (equipment instanceof HeatExchanger) {
-      HeatExchanger exchanger = (HeatExchanger) equipment;
-      for (int i = 0; i < 2; i++) {
-        stream("inlet" + i, exchanger.getInStream(i));
-        stream("outlet" + i, exchanger.getOutStream(i));
-      }
+      stream("gasOutlet", index == 0 ? null : separator.getGasOutStream());
+    } else if (equipment instanceof TwoPortInterface) {
+      TwoPortInterface ports = (TwoPortInterface) equipment;
+      stream("inlet", ports.getInletStream());
+      stream("outlet", ports.getOutletStream());
     }
 
     if (design instanceof SeparatorMechanicalDesign) {
@@ -210,10 +210,10 @@ public final class MechanicalDesignData implements Serializable {
       put(geometry, "height", ((DistillationColumnMechanicalDesign) design).getColumnHeight(), "m", "getColumnHeight",
           true);
     }
-    if (equipment instanceof Heater) {
-      put(operatingConditions, "duty", ((Heater) equipment).getDuty("W"), "W", "Heater.getDuty(W)", false);
-    } else if (equipment instanceof HeatExchanger) {
+    if (equipment instanceof HeatExchanger) {
       put(operatingConditions, "duty", ((HeatExchanger) equipment).getDuty(), "W", "HeatExchanger.getDuty", false);
+    } else if (equipment instanceof Heater) {
+      put(operatingConditions, "duty", ((Heater) equipment).getDuty("W"), "W", "Heater.getDuty(W)", false);
     }
     Quantity inner = geometry.get("innerDiameter");
     Quantity outer = geometry.get("outerDiameter");

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignResponse.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonParser;
 
 /**
@@ -75,78 +77,84 @@ public class MechanicalDesignResponse implements java.io.Serializable {
   // ============================================================================
 
   /** Total weight in kg. */
-  private double totalWeight;
+  private double totalWeight = Double.NaN;
 
   /** Vessel shell weight in kg. */
-  private double vesselWeight;
+  private double vesselWeight = Double.NaN;
 
   /** Internals weight in kg. */
-  private double internalsWeight;
+  private double internalsWeight = Double.NaN;
 
   /** Piping weight in kg. */
-  private double pipingWeight;
+  private double pipingWeight = Double.NaN;
 
   /** Nozzles weight in kg. */
-  private double nozzlesWeight;
+  private double nozzlesWeight = Double.NaN;
 
   /** Electrical and instrumentation weight in kg. */
-  private double eiWeight;
+  private double eiWeight = Double.NaN;
 
   /** Structural steel weight in kg. */
-  private double structuralWeight;
+  private double structuralWeight = Double.NaN;
 
   /** Operating weight (with contents) in kg. */
-  private double operatingWeight;
+  private double operatingWeight = Double.NaN;
 
   // ============================================================================
   // Design Conditions
   // ============================================================================
 
   /** Maximum design pressure in bara. */
-  private double maxDesignPressure;
+  private double maxDesignPressure = Double.NaN;
 
   /** Minimum design pressure in bara. */
-  private double minDesignPressure;
+  private double minDesignPressure = Double.NaN;
 
   /** Maximum design temperature in °C. */
-  private double maxDesignTemperature;
+  private double maxDesignTemperature = Double.NaN;
 
   /** Minimum design temperature in °C. */
-  private double minDesignTemperature;
+  private double minDesignTemperature = Double.NaN;
 
   /** Maximum operating pressure in bara. */
-  private double maxOperatingPressure;
+  private double maxOperatingPressure = Double.NaN;
 
   /** Maximum operating temperature in °C. */
-  private double maxOperatingTemperature;
+  private double maxOperatingTemperature = Double.NaN;
 
   // ============================================================================
   // Dimensions
   // ============================================================================
 
   /** Inner diameter in meters. */
-  private double innerDiameter;
+  private double innerDiameter = Double.NaN;
 
   /** Outer diameter in meters. */
-  private double outerDiameter;
+  private double outerDiameter = Double.NaN;
 
   /** Tangent-to-tangent length in meters. */
-  private double tangentLength;
+  private double tangentLength = Double.NaN;
 
-  /** Wall thickness in mm. */
-  private double wallThickness;
+  /** Wall thickness in the legacy getter unit, declared by wallThicknessUnit. */
+  private double wallThickness = Double.NaN;
+
+  /** Unit of the legacy wallThickness field; null if the equipment has no verified unit contract. */
+  private String wallThicknessUnit;
+
+  /** Unit-labelled snapshot for geometry and downstream design calculations. */
+  private MechanicalDesignData designData;
 
   /** Module length (plot space) in meters. */
-  private double moduleLength;
+  private double moduleLength = Double.NaN;
 
   /** Module width (plot space) in meters. */
-  private double moduleWidth;
+  private double moduleWidth = Double.NaN;
 
   /** Module height in meters. */
-  private double moduleHeight;
+  private double moduleHeight = Double.NaN;
 
   /** Total volume in m3. */
-  private double totalVolume;
+  private double totalVolume = Double.NaN;
 
   // ============================================================================
   // Materials
@@ -159,17 +167,17 @@ public class MechanicalDesignResponse implements java.io.Serializable {
   private String headMaterial;
 
   /** Corrosion allowance in mm. */
-  private double corrosionAllowance;
+  private double corrosionAllowance = Double.NaN;
 
   // ============================================================================
   // Utility Requirements
   // ============================================================================
 
   /** Power requirement in kW (positive = consumed, negative = produced). */
-  private double power;
+  private double power = Double.NaN;
 
   /** Heating/Cooling duty in kW (positive = heating, negative = cooling). */
-  private double duty;
+  private double duty = Double.NaN;
 
   // ============================================================================
   // Equipment-Specific Data
@@ -192,31 +200,31 @@ public class MechanicalDesignResponse implements java.io.Serializable {
   private int equipmentCount;
 
   /** Total power required in kW. */
-  private double totalPowerRequired;
+  private double totalPowerRequired = Double.NaN;
 
   /** Total power recovered in kW. */
-  private double totalPowerRecovered;
+  private double totalPowerRecovered = Double.NaN;
 
   /** Net power requirement in kW. */
-  private double netPower;
+  private double netPower = Double.NaN;
 
   /** Total heating duty in kW. */
-  private double totalHeatingDuty;
+  private double totalHeatingDuty = Double.NaN;
 
   /** Total cooling duty in kW. */
-  private double totalCoolingDuty;
+  private double totalCoolingDuty = Double.NaN;
 
   /** Total plot space in m2. */
-  private double totalPlotSpace;
+  private double totalPlotSpace = Double.NaN;
 
   /** Footprint length in m. */
-  private double footprintLength;
+  private double footprintLength = Double.NaN;
 
   /** Footprint width in m. */
-  private double footprintWidth;
+  private double footprintWidth = Double.NaN;
 
   /** Maximum height in m. */
-  private double maxHeight;
+  private double maxHeight = Double.NaN;
 
   /** Weight breakdown by equipment type. */
   private Map<String, Double> weightByType = new LinkedHashMap<String, Double>();
@@ -242,11 +250,11 @@ public class MechanicalDesignResponse implements java.io.Serializable {
 
     private String name;
     private String type;
-    private double weight;
-    private double designPressure;
-    private double designTemperature;
-    private double power;
-    private double duty;
+    private double weight = Double.NaN;
+    private double designPressure = Double.NaN;
+    private double designTemperature = Double.NaN;
+    private double power = Double.NaN;
+    private double duty = Double.NaN;
     private String dimensions;
 
     /**
@@ -379,6 +387,7 @@ public class MechanicalDesignResponse implements java.io.Serializable {
 
     // Design conditions
     this.maxDesignPressure = mecDesign.getMaxDesignPressure();
+    this.minDesignPressure = mecDesign.getMinDesignPressure();
     this.maxDesignTemperature = mecDesign.getDesignMaxTemperatureLimit("C");
     this.minDesignTemperature = mecDesign.getDesignMinTemperatureLimit("C");
     this.maxOperatingPressure = mecDesign.getMaxOperationPressure();
@@ -389,6 +398,8 @@ public class MechanicalDesignResponse implements java.io.Serializable {
     this.outerDiameter = mecDesign.getOuterDiameter();
     this.tangentLength = mecDesign.getTantanLength();
     this.wallThickness = mecDesign.getWallThickness();
+    this.wallThicknessUnit = MechanicalDesignData.wallThicknessUnit(mecDesign);
+    this.designData = new MechanicalDesignData(mecDesign);
     this.moduleLength = mecDesign.getModuleLength();
     this.moduleWidth = mecDesign.getModuleWidth();
     this.moduleHeight = mecDesign.getModuleHeight();
@@ -462,7 +473,7 @@ public class MechanicalDesignResponse implements java.io.Serializable {
    */
   public String toJson() {
     Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().serializeNulls().create();
-    return gson.toJson(this);
+    return gson.toJson(finiteJson(gson.toJsonTree(this)));
   }
 
   /**
@@ -471,8 +482,30 @@ public class MechanicalDesignResponse implements java.io.Serializable {
    * @return compact JSON representation
    */
   public String toCompactJson() {
-    Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
-    return gson.toJson(this);
+    Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().serializeNulls().create();
+    return gson.toJson(finiteJson(gson.toJsonTree(this)));
+  }
+
+  /**
+   * Replace non-finite numeric values with explicit JSON nulls, including nested calculator results.
+   *
+   * @param element response tree
+   * @return strict JSON tree
+   */
+  private static JsonElement finiteJson(JsonElement element) {
+    if (element.isJsonObject()) {
+      for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+        entry.setValue(finiteJson(entry.getValue()));
+      }
+    } else if (element.isJsonArray()) {
+      for (int i = 0; i < element.getAsJsonArray().size(); i++) {
+        element.getAsJsonArray().set(i, finiteJson(element.getAsJsonArray().get(i)));
+      }
+    } else if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isNumber()
+        && !Double.isFinite(element.getAsDouble())) {
+      return JsonNull.INSTANCE;
+    }
+    return element;
   }
 
   /**
@@ -498,7 +531,7 @@ public class MechanicalDesignResponse implements java.io.Serializable {
     }
 
     try {
-      Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create();
+      Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().serializeNulls().setPrettyPrinting().create();
 
       // Parse both JSONs
       JsonObject mecDesignJson = JsonParser.parseString(toJson()).getAsJsonObject();

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignResponse.java
@@ -1,6 +1,7 @@
 package neqsim.process.mechanicaldesign.compressor;
 
 import java.util.Map;
+import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.mechanicaldesign.MechanicalDesignResponse;
 
 /**
@@ -32,77 +33,77 @@ public class CompressorMechanicalDesignResponse extends MechanicalDesignResponse
   private int numberOfStages;
 
   /** Polytropic head per stage [kJ/kg]. */
-  private double headPerStage;
+  private double headPerStage = Double.NaN;
 
   /** Total polytropic head [kJ/kg]. */
-  private double totalHead;
+  private double totalHead = Double.NaN;
 
   /** Impeller diameter [mm]. */
-  private double impellerDiameter;
+  private double impellerDiameter = Double.NaN;
 
   /** Shaft diameter [mm]. */
-  private double shaftDiameter;
+  private double shaftDiameter = Double.NaN;
 
   /** Impeller tip speed [m/s]. */
-  private double tipSpeed;
+  private double tipSpeed = Double.NaN;
 
   /** Maximum continuous speed [rpm]. */
-  private double maxContinuousSpeed;
+  private double maxContinuousSpeed = Double.NaN;
 
   /** Trip speed [rpm]. */
-  private double tripSpeed;
+  private double tripSpeed = Double.NaN;
 
   /** First lateral critical speed [rpm]. */
-  private double firstCriticalSpeed;
+  private double firstCriticalSpeed = Double.NaN;
 
   /** Required driver power [kW]. */
-  private double driverPower;
+  private double driverPower = Double.NaN;
 
   /** Driver power margin factor. */
-  private double driverMargin;
+  private double driverMargin = Double.NaN;
 
   /** Casing weight [kg]. */
-  private double casingWeight;
+  private double casingWeight = Double.NaN;
 
   /** Rotor weight [kg]. */
-  private double rotorWeight;
+  private double rotorWeight = Double.NaN;
 
   /** Bundle weight [kg]. */
-  private double bundleWeight;
+  private double bundleWeight = Double.NaN;
 
   /** Bearing span [mm]. */
-  private double bearingSpan;
+  private double bearingSpan = Double.NaN;
 
   /** Inlet pressure [bara]. */
-  private double inletPressure;
+  private double inletPressure = Double.NaN;
 
   /** Outlet pressure [bara]. */
-  private double outletPressure;
+  private double outletPressure = Double.NaN;
 
   /** Pressure ratio. */
-  private double pressureRatio;
+  private double pressureRatio = Double.NaN;
 
   /** Polytropic efficiency. */
-  private double polytropicEfficiency;
+  private double polytropicEfficiency = Double.NaN;
 
   /** Isentropic efficiency. */
-  private double isentropicEfficiency;
+  private double isentropicEfficiency = Double.NaN;
 
   // ============================================================================
   // Process Design Parameters (added for TR3500 compliance)
   // ============================================================================
 
   /** Surge margin percentage. */
-  private double surgeMarginPercent;
+  private double surgeMarginPercent = Double.NaN;
 
   /** Stonewall margin percentage. */
-  private double stonewallMarginPercent;
+  private double stonewallMarginPercent = Double.NaN;
 
   /** Minimum turndown percentage. */
-  private double minTurndownPercent;
+  private double minTurndownPercent = Double.NaN;
 
   /** Target polytropic efficiency. */
-  private double targetPolytropicEfficiency;
+  private double targetPolytropicEfficiency = Double.NaN;
 
   /** Seal type (dry gas, oil film, labyrinth). */
   private String sealType;
@@ -114,13 +115,13 @@ public class CompressorMechanicalDesignResponse extends MechanicalDesignResponse
   private boolean naceCompliance;
 
   /** Maximum discharge temperature [°C]. */
-  private double maxDischargeTemperature;
+  private double maxDischargeTemperature = Double.NaN;
 
   /** Maximum pressure ratio per stage. */
-  private double maxPressureRatioPerStage;
+  private double maxPressureRatioPerStage = Double.NaN;
 
   /** Maximum unfiltered vibration [mm/s]. */
-  private double maxVibrationUnfiltered;
+  private double maxVibrationUnfiltered = Double.NaN;
 
   // ============================================================================
   // Casing Design Parameters (API 617 / ASME VIII)
@@ -177,8 +178,22 @@ public class CompressorMechanicalDesignResponse extends MechanicalDesignResponse
     this.rotorWeight = mecDesign.getRotorWeight();
     this.bundleWeight = mecDesign.getBundleWeight();
     this.bearingSpan = mecDesign.getBearingSpan();
-    this.inletPressure = mecDesign.getMinOperationPressure();
-    this.outletPressure = mecDesign.getMaxOperationPressure();
+    this.inletPressure = Double.NaN;
+    this.outletPressure = Double.NaN;
+    this.pressureRatio = Double.NaN;
+    if (mecDesign.getProcessEquipment() instanceof Compressor) {
+      Compressor compressor = (Compressor) mecDesign.getProcessEquipment();
+      if (compressor.getInletStream() != null && compressor.getOutletStream() != null) {
+        this.inletPressure = compressor.getInletStream().getPressure("bara");
+        this.outletPressure = compressor.getOutletStream().getPressure("bara");
+      }
+      this.polytropicEfficiency = compressor.getPolytropicEfficiency();
+      this.isentropicEfficiency = compressor.getIsentropicEfficiency();
+      this.totalHead = compressor.getPolytropicFluidHead();
+      setPower(compressor.getPower("kW"));
+    }
+    setMaxDesignPressure(mecDesign.getDesignPressure() > 0.0 ? mecDesign.getDesignPressure() : Double.NaN);
+    setMaxDesignTemperature(mecDesign.getDesignPressure() > 0.0 ? mecDesign.getDesignTemperature() : Double.NaN);
 
     if (mecDesign.getCasingType() != null) {
       this.casingType = mecDesign.getCasingType().name();

--- a/src/main/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesign.java
@@ -184,6 +184,12 @@ public class HeatExchangerMechanicalDesign extends MechanicalDesign {
 
   /** {@inheritDoc} */
   @Override
+  public HeatExchangerMechanicalDesignResponse getResponse() {
+    return new HeatExchangerMechanicalDesignResponse(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public void calcDesign() {
     super.calcDesign();
     ProcessEquipmentInterface equipment = getProcessEquipment();

--- a/src/main/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesignResponse.java
@@ -40,16 +40,16 @@ public class HeatExchangerMechanicalDesignResponse extends MechanicalDesignRespo
   private int numberOfTubes;
 
   /** Tube outer diameter [mm]. */
-  private double tubeOuterDiameter;
+  private double tubeOuterDiameter = Double.NaN;
 
   /** Tube wall thickness [mm]. */
-  private double tubeWallThickness;
+  private double tubeWallThickness = Double.NaN;
 
   /** Tube length [m]. */
-  private double tubeLength;
+  private double tubeLength = Double.NaN;
 
   /** Tube pitch [mm]. */
-  private double tubePitch;
+  private double tubePitch = Double.NaN;
 
   /** Tube layout angle (30°, 45°, 60°, 90°). */
   private int tubeLayoutAngle;
@@ -58,113 +58,110 @@ public class HeatExchangerMechanicalDesignResponse extends MechanicalDesignRespo
   private String tubeMaterial;
 
   /** Shell inner diameter [mm]. */
-  private double shellInnerDiameter;
+  private double shellInnerDiameter = Double.NaN;
 
   /** Shell wall thickness [mm]. */
-  private double shellWallThickness;
-
-  /** Shell material. */
-  private String shellMaterial;
+  private double shellWallThickness = Double.NaN;
 
   /** Baffle type (single segmental, double segmental, no-tubes-in-window). */
   private String baffleType;
 
   /** Baffle cut [%]. */
-  private double baffleCut;
+  private double baffleCut = Double.NaN;
 
   /** Baffle spacing [mm]. */
-  private double baffleSpacing;
+  private double baffleSpacing = Double.NaN;
 
   /** Number of baffles. */
   private int numberOfBaffles;
 
   /** Baffle thickness [mm]. */
-  private double baffleThickness;
+  private double baffleThickness = Double.NaN;
 
   /** Heat transfer area [m²]. */
-  private double heatTransferArea;
+  private double heatTransferArea = Double.NaN;
 
   /** Required heat transfer area [m²]. */
-  private double requiredArea;
+  private double requiredArea = Double.NaN;
 
   /** Area margin [%]. */
-  private double areaMargin;
+  private double areaMargin = Double.NaN;
 
   /** Overall heat transfer coefficient [W/m²K]. */
-  private double overallHeatTransferCoeff;
+  private double overallHeatTransferCoeff = Double.NaN;
 
   /** Heat duty [kW]. */
-  private double heatDuty;
+  private double heatDuty = Double.NaN;
 
   /** Log mean temperature difference [K]. */
-  private double lmtd;
+  private double lmtd = Double.NaN;
 
   /** LMTD correction factor (F). */
-  private double lmtdCorrectionFactor;
+  private double lmtdCorrectionFactor = Double.NaN;
 
   /** Shell-side design pressure [bara]. */
-  private double shellDesignPressure;
+  private double shellDesignPressure = Double.NaN;
 
   /** Shell-side design temperature [°C]. */
-  private double shellDesignTemperature;
+  private double shellDesignTemperature = Double.NaN;
 
   /** Tube-side design pressure [bara]. */
-  private double tubeDesignPressure;
+  private double tubeDesignPressure = Double.NaN;
 
   /** Tube-side design temperature [°C]. */
-  private double tubeDesignTemperature;
+  private double tubeDesignTemperature = Double.NaN;
 
   /** Shell-side pressure drop [bar]. */
-  private double shellPressureDrop;
+  private double shellPressureDrop = Double.NaN;
 
   /** Tube-side pressure drop [bar]. */
-  private double tubePressureDrop;
+  private double tubePressureDrop = Double.NaN;
 
   /** Shell-side fouling resistance [m²K/W]. */
-  private double shellFoulingResistance;
+  private double shellFoulingResistance = Double.NaN;
 
   /** Tube-side fouling resistance [m²K/W]. */
-  private double tubeFoulingResistance;
+  private double tubeFoulingResistance = Double.NaN;
 
   /** Bundle weight [kg]. */
-  private double bundleWeight;
+  private double bundleWeight = Double.NaN;
 
   /** Channel weight [kg]. */
-  private double channelWeight;
+  private double channelWeight = Double.NaN;
 
   // ============================================================================
   // Process Design Parameters (added for TR3500 compliance)
   // ============================================================================
 
   /** Shell-side fouling resistance (design value) [m²K/W]. */
-  private double designShellFoulingResistance;
+  private double designShellFoulingResistance = Double.NaN;
 
   /** Tube-side fouling resistance (design value) [m²K/W]. */
-  private double designTubeFoulingResistance;
+  private double designTubeFoulingResistance = Double.NaN;
 
   /** TEMA equipment class (R, C, or B). */
   private String temaClass;
 
   /** Maximum tube velocity [m/s]. */
-  private double maxTubeVelocity;
+  private double maxTubeVelocity = Double.NaN;
 
   /** Maximum shell velocity [m/s]. */
-  private double maxShellVelocity;
+  private double maxShellVelocity = Double.NaN;
 
   /** Minimum approach temperature [°C]. */
-  private double minApproachTemperature;
+  private double minApproachTemperature = Double.NaN;
 
   /** Maximum tube length [m]. */
-  private double maxTubeLength;
+  private double maxTubeLength = Double.NaN;
 
   /** Vibration analysis required flag. */
   private boolean vibrationAnalysisRequired;
 
   /** Clean overall heat transfer coefficient [W/m²K]. */
-  private double cleanOverallHeatTransferCoeff;
+  private double cleanOverallHeatTransferCoeff = Double.NaN;
 
   /** Fouled overall heat transfer coefficient [W/m²K]. */
-  private double fouledOverallHeatTransferCoeff;
+  private double fouledOverallHeatTransferCoeff = Double.NaN;
 
   // ============================================================================
   // ASME VIII and NACE Parameters
@@ -177,16 +174,16 @@ public class HeatExchangerMechanicalDesignResponse extends MechanicalDesignRespo
   private String tubeMaterialGrade;
 
   /** MAWP shell side [bara] per ASME UG-27. */
-  private double mawpShellSide;
+  private double mawpShellSide = Double.NaN;
 
   /** MAWP tube side [bara] per ASME UG-27. */
-  private double mawpTubeSide;
+  private double mawpTubeSide = Double.NaN;
 
   /** Hydro test pressure shell [bara] per ASME UG-99. */
-  private double hydroTestPressureShell;
+  private double hydroTestPressureShell = Double.NaN;
 
   /** Hydro test pressure tube [bara] per ASME UG-99. */
-  private double hydroTestPressureTube;
+  private double hydroTestPressureTube = Double.NaN;
 
   /** NACE MR0175 sour service required flag. */
   private boolean sourServiceRequired;
@@ -229,6 +226,20 @@ public class HeatExchangerMechanicalDesignResponse extends MechanicalDesignRespo
   public void populateFromHeatExchangerDesign(HeatExchangerMechanicalDesign mecDesign) {
     if (mecDesign == null) {
       return;
+    }
+
+    HeatExchangerSizingResult sizing = mecDesign.getSelectedSizingResult();
+    if (sizing != null) {
+      this.heatExchangerType = sizing.getType().name();
+      this.requiredArea = sizing.getRequiredArea();
+      this.overallHeatTransferCoeff = sizing.getOverallHeatTransferCoefficient();
+      this.lmtd = mecDesign.getLogMeanTemperatureDifference();
+      if (sizing.getType() == HeatExchangerType.SHELL_AND_TUBE) {
+        this.shellInnerDiameter = sizing.getInnerDiameter() * 1000.0;
+        this.shellWallThickness = sizing.getWallThickness() * 1000.0;
+        this.numberOfTubes = sizing.getTubeCount();
+        this.numberOfTubePasses = sizing.getTubePasses();
+      }
     }
 
     // Populate process design parameters
@@ -379,12 +390,12 @@ public class HeatExchangerMechanicalDesignResponse extends MechanicalDesignRespo
 
   @Override
   public String getShellMaterial() {
-    return shellMaterial;
+    return super.getShellMaterial();
   }
 
   @Override
   public void setShellMaterial(String shellMaterial) {
-    this.shellMaterial = shellMaterial;
+    super.setShellMaterial(shellMaterial);
   }
 
   public String getBaffleType() {

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignResponse.java
@@ -35,119 +35,119 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
   private int numberOfStages;
 
   /** Impeller diameter [mm]. */
-  private double impellerDiameter;
+  private double impellerDiameter = Double.NaN;
 
   /** Impeller width [mm]. */
-  private double impellerWidth;
+  private double impellerWidth = Double.NaN;
 
   /** Shaft diameter at impeller [mm]. */
-  private double shaftDiameter;
+  private double shaftDiameter = Double.NaN;
 
   /** Rated speed [rpm]. */
-  private double ratedSpeed;
+  private double ratedSpeed = Double.NaN;
 
   /** Specific speed (Ns). */
-  private double specificSpeed;
+  private double specificSpeed = Double.NaN;
 
   /** Suction specific speed (Nss). */
-  private double suctionSpecificSpeed;
+  private double suctionSpecificSpeed = Double.NaN;
 
   /** Required driver power [kW]. */
-  private double driverPower;
+  private double driverPower = Double.NaN;
 
   /** Driver power margin factor. */
-  private double driverMargin;
+  private double driverMargin = Double.NaN;
 
   /** Rated flow [m³/h]. */
-  private double ratedFlow;
+  private double ratedFlow = Double.NaN;
 
   /** Rated head [m]. */
-  private double ratedHead;
+  private double ratedHead = Double.NaN;
 
   /** Best efficiency point flow [m³/h]. */
-  private double bepFlow;
+  private double bepFlow = Double.NaN;
 
   /** Best efficiency point head [m]. */
-  private double bepHead;
+  private double bepHead = Double.NaN;
 
   /** Pump efficiency at rated point. */
-  private double efficiency;
+  private double efficiency = Double.NaN;
 
   /** Net positive suction head required [m]. */
-  private double npshr;
+  private double npshr = Double.NaN;
 
   /** Net positive suction head available [m]. */
-  private double npsha;
+  private double npsha = Double.NaN;
 
   /** NPSH margin [m]. */
-  private double npshMargin;
+  private double npshMargin = Double.NaN;
 
   /** NPSH margin ratio [NPSHa/NPSHr]. */
-  private double npshMarginRatio;
+  private double npshMarginRatio = Double.NaN;
 
   /** Absorbed pump shaft power [kW]. */
-  private double absorbedPower;
+  private double absorbedPower = Double.NaN;
 
   /** Hydraulic liquid power [kW]. */
-  private double hydraulicPower;
+  private double hydraulicPower = Double.NaN;
 
   /** Casing wall thickness [mm]. */
-  private double casingWallThickness;
+  private double casingWallThickness = Double.NaN;
 
   /** Suction nozzle size [inches]. */
-  private double suctionNozzleSize;
+  private double suctionNozzleSize = Double.NaN;
 
   /** Discharge nozzle size [inches]. */
-  private double dischargeNozzleSize;
+  private double dischargeNozzleSize = Double.NaN;
 
   /** Minimum continuous flow [m³/h]. */
-  private double minimumContinuousFlow;
+  private double minimumContinuousFlow = Double.NaN;
 
   /** Suction pressure [bara]. */
-  private double suctionPressure;
+  private double suctionPressure = Double.NaN;
 
   /** Discharge pressure [bara]. */
-  private double dischargePressure;
+  private double dischargePressure = Double.NaN;
 
   /** Differential pressure [bar]. */
-  private double differentialPressure;
+  private double differentialPressure = Double.NaN;
 
   /** Fluid temperature [°C]. */
-  private double fluidTemperature;
+  private double fluidTemperature = Double.NaN;
 
   /** Fluid density [kg/m³]. */
-  private double fluidDensity;
+  private double fluidDensity = Double.NaN;
 
   /** Fluid viscosity [cP]. */
-  private double fluidViscosity;
+  private double fluidViscosity = Double.NaN;
 
   // ============================================================================
   // Process Design Parameters (added for TR3500 compliance)
   // ============================================================================
 
   /** NPSH margin factor. */
-  private double npshMarginFactor;
+  private double npshMarginFactor = Double.NaN;
 
   /** Hydraulic power margin factor. */
-  private double hydraulicPowerMargin;
+  private double hydraulicPowerMargin = Double.NaN;
 
   /** Preferred Operating Region low boundary fraction of BEP. */
-  private double porLowFraction;
+  private double porLowFraction = Double.NaN;
 
   /** Preferred Operating Region high boundary fraction of BEP. */
-  private double porHighFraction;
+  private double porHighFraction = Double.NaN;
 
   /** Allowable Operating Region low boundary fraction of BEP. */
-  private double aorLowFraction;
+  private double aorLowFraction = Double.NaN;
 
   /** Allowable Operating Region high boundary fraction of BEP. */
-  private double aorHighFraction;
+  private double aorHighFraction = Double.NaN;
 
   /** Maximum suction specific speed. */
-  private double maxSuctionSpecificSpeed;
+  private double maxSuctionSpecificSpeed = Double.NaN;
 
   /** Head margin factor. */
-  private double headMarginFactor;
+  private double headMarginFactor = Double.NaN;
 
   /** Structured API 610 screening result with pass/fail/data-gap checks. */
   private PumpApi610DesignCalculator api610Screening;
@@ -186,6 +186,8 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
       return;
     }
 
+    setMaxDesignPressure(mecDesign.getDesignPressure() > 0.0 ? mecDesign.getDesignPressure() : Double.NaN);
+    setMaxDesignTemperature(mecDesign.getDesignPressure() > 0.0 ? mecDesign.getDesignTemperature() : Double.NaN);
     this.numberOfStages = mecDesign.getNumberOfStages();
     this.impellerDiameter = mecDesign.getImpellerDiameter();
     this.impellerWidth = mecDesign.getImpellerWidth();

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesignResponse.java
@@ -1,6 +1,8 @@
 package neqsim.process.mechanicaldesign.separator;
 
 import neqsim.process.mechanicaldesign.MechanicalDesignResponse;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
 
 /**
  * Response class for separator mechanical design JSON export.
@@ -28,172 +30,172 @@ public class SeparatorMechanicalDesignResponse extends MechanicalDesignResponse 
   private String separatorType;
 
   /** Gas load factor (K-factor). */
-  private double gasLoadFactor;
+  private double gasLoadFactor = Double.NaN;
 
   /** Volumetric design safety factor. */
-  private double volumeSafetyFactor;
+  private double volumeSafetyFactor = Double.NaN;
 
   /** Liquid level fraction (Fg). */
-  private double liquidLevelFraction;
+  private double liquidLevelFraction = Double.NaN;
 
   /** Liquid retention time [s]. */
-  private double retentionTime;
+  private double retentionTime = Double.NaN;
 
   /** Demister type (wire mesh, vane, cyclone). */
   private String demisterType;
 
   /** Demister efficiency. */
-  private double demisterEfficiency;
+  private double demisterEfficiency = Double.NaN;
 
   /** Number of inlet nozzles. */
   private int numberOfInletNozzles;
 
   /** Inlet nozzle diameter [mm]. */
-  private double inletNozzleDiameter;
+  private double inletNozzleDiameter = Double.NaN;
 
   /** Gas outlet nozzle diameter [mm]. */
-  private double gasOutletNozzleDiameter;
+  private double gasOutletNozzleDiameter = Double.NaN;
 
   /** Liquid outlet nozzle diameter [mm]. */
-  private double liquidOutletNozzleDiameter;
+  private double liquidOutletNozzleDiameter = Double.NaN;
 
   /** Water outlet nozzle diameter (for 3-phase) [mm]. */
-  private double waterOutletNozzleDiameter;
+  private double waterOutletNozzleDiameter = Double.NaN;
 
   /** Head type (hemispherical, 2:1 ellipsoidal, torispherical). */
   private String headType;
 
   /** Head thickness [mm]. */
-  private double headThickness;
+  private double headThickness = Double.NaN;
 
   /** Shell course thickness [mm]. */
-  private double shellThickness;
+  private double shellThickness = Double.NaN;
 
   /** Design code (ASME VIII Div 1, Div 2). */
   private String designCode;
 
   /** Gas design velocity [m/s]. */
-  private double gasDesignVelocity;
+  private double gasDesignVelocity = Double.NaN;
 
   /** Actual gas velocity [m/s]. */
-  private double actualGasVelocity;
+  private double actualGasVelocity = Double.NaN;
 
   /** Allowable gas velocity [m/s]. */
-  private double allowableGasVelocity;
+  private double allowableGasVelocity = Double.NaN;
 
   /** Design gas flow [Am³/h]. */
-  private double designGasFlow;
+  private double designGasFlow = Double.NaN;
 
   /** Design liquid flow [m³/h]. */
-  private double designLiquidFlow;
+  private double designLiquidFlow = Double.NaN;
 
   /** Design water flow (for 3-phase) [m³/h]. */
-  private double designWaterFlow;
+  private double designWaterFlow = Double.NaN;
 
   /** Normal liquid level [m]. */
-  private double normalLiquidLevel;
+  private double normalLiquidLevel = Double.NaN;
 
   /** High liquid level [m]. */
-  private double highLiquidLevel;
+  private double highLiquidLevel = Double.NaN;
 
   /** Low liquid level [m]. */
-  private double lowLiquidLevel;
+  private double lowLiquidLevel = Double.NaN;
 
   /** Oil-water interface level (for 3-phase) [m]. */
-  private double interfaceLevel;
+  private double interfaceLevel = Double.NaN;
 
   /** Liquid surge volume [m³]. */
-  private double surgeVolume;
+  private double surgeVolume = Double.NaN;
 
   /** Liquid holdup volume [m³]. */
-  private double holdupVolume;
+  private double holdupVolume = Double.NaN;
 
   /** Empty vessel weight [kg]. */
-  private double emptyVesselWeight;
+  private double emptyVesselWeight = Double.NaN;
 
   /** Operating liquid volume [m³]. */
-  private double operatingLiquidVolume;
+  private double operatingLiquidVolume = Double.NaN;
 
   /** Liquid density [kg/m³]. */
-  private double liquidDensity;
+  private double liquidDensity = Double.NaN;
 
   /** Gas density [kg/m³]. */
-  private double gasDensity;
+  private double gasDensity = Double.NaN;
 
   // ============================================================================
   // Liquid Level Design Parameters (added January 2026)
   // ============================================================================
 
   /** Effective length for liquid separation [m]. */
-  private double effectiveLengthLiquid;
+  private double effectiveLengthLiquid = Double.NaN;
 
   /** Effective length for gas separation [m]. */
-  private double effectiveLengthGas;
+  private double effectiveLengthGas = Double.NaN;
 
   // ============================================================================
   // Process Design Parameters (added for TR3500 compliance)
   // ============================================================================
 
   /** Foam allowance factor. */
-  private double foamAllowanceFactor;
+  private double foamAllowanceFactor = Double.NaN;
 
   /** Design droplet diameter for gas-liquid separation [um]. */
-  private double dropletDiameterGasLiquid;
+  private double dropletDiameterGasLiquid = Double.NaN;
 
   /** Design droplet diameter for liquid-liquid separation [um]. */
-  private double dropletDiameterLiquidLiquid;
+  private double dropletDiameterLiquidLiquid = Double.NaN;
 
   /** Design pressure margin factor. */
-  private double designPressureMarginFactor;
+  private double designPressureMarginFactor = Double.NaN;
 
   /** Design temperature margin [C]. */
-  private double designTemperatureMarginC;
+  private double designTemperatureMarginC = Double.NaN;
 
   /** Maximum gas velocity [m/s]. */
-  private double maxGasVelocity;
+  private double maxGasVelocity = Double.NaN;
 
   /** Maximum liquid velocity [m/s]. */
-  private double maxLiquidVelocity;
+  private double maxLiquidVelocity = Double.NaN;
 
   /** Demister pressure drop [mbar]. */
-  private double demisterPressureDrop;
+  private double demisterPressureDrop = Double.NaN;
 
   /** Demister void fraction. */
-  private double demisterVoidFraction;
+  private double demisterVoidFraction = Double.NaN;
 
   /** Minimum oil retention time [min]. */
-  private double minOilRetentionTime;
+  private double minOilRetentionTime = Double.NaN;
 
   /** Minimum water retention time [min]. */
-  private double minWaterRetentionTime;
+  private double minWaterRetentionTime = Double.NaN;
 
   // ============================================================================
   // Liquid Level Design Parameters (added January 2026)
   // ============================================================================
 
   /** High-High Liquid Level fraction of ID. */
-  private double hhllFraction;
+  private double hhllFraction = Double.NaN;
 
   /** High Liquid Level fraction of ID. */
-  private double hllFraction;
+  private double hllFraction = Double.NaN;
 
   /** Normal Liquid Level fraction of ID. */
-  private double nllFraction;
+  private double nllFraction = Double.NaN;
 
   /** Low Liquid Level fraction of ID. */
-  private double lllFraction;
+  private double lllFraction = Double.NaN;
 
   /** Weir height fraction of ID. */
-  private double weirFraction;
+  private double weirFraction = Double.NaN;
 
   /** High Interface Level fraction of ID. */
-  private double hilFraction;
+  private double hilFraction = Double.NaN;
 
   /** Normal Interface Level fraction of ID. */
-  private double nilFraction;
+  private double nilFraction = Double.NaN;
 
   /** Low Interface Level fraction of ID. */
-  private double lilFraction;
+  private double lilFraction = Double.NaN;
 
   // ============================================================================
   // Entrainment Performance Results
@@ -202,23 +204,23 @@ public class SeparatorMechanicalDesignResponse extends MechanicalDesignResponse 
   /** Whether detailed entrainment calculation was used. */
   private boolean detailedEntrainmentUsed;
   /** Oil-in-gas entrainment fraction [0-1]. */
-  private double oilInGasFraction;
+  private double oilInGasFraction = Double.NaN;
   /** Water-in-gas entrainment fraction [0-1]. */
-  private double waterInGasFraction;
+  private double waterInGasFraction = Double.NaN;
   /** Gas-in-oil carry-under fraction [0-1]. */
-  private double gasInOilFraction;
+  private double gasInOilFraction = Double.NaN;
   /** Gas-in-water carry-under fraction [0-1]. */
-  private double gasInWaterFraction;
+  private double gasInWaterFraction = Double.NaN;
   /** Oil-in-water entrainment fraction [0-1]. */
-  private double oilInWaterFraction;
+  private double oilInWaterFraction = Double.NaN;
   /** Water-in-oil entrainment fraction [0-1]. */
-  private double waterInOilFraction;
+  private double waterInOilFraction = Double.NaN;
   /** Overall gas-liquid separation efficiency [0-1]. */
-  private double overallGasLiquidEfficiency;
+  private double overallGasLiquidEfficiency = Double.NaN;
   /** Mist eliminator efficiency [0-1]. */
-  private double mistEliminatorEfficiency;
+  private double mistEliminatorEfficiency = Double.NaN;
   /** K-factor utilization (actual/design) [0-1]. */
-  private double kFactorUtilization;
+  private double kFactorUtilization = Double.NaN;
   /** Whether the mist eliminator is flooded. */
   private boolean mistEliminatorFlooded;
   /** Liquid-in-gas calibration factor. */
@@ -231,28 +233,28 @@ public class SeparatorMechanicalDesignResponse extends MechanicalDesignResponse 
   private transient String entrainmentDetailJson;
 
   /** High-High Liquid Level [m]. */
-  private double hhll;
+  private double hhll = Double.NaN;
 
   /** High Liquid Level [m] - duplicate for explicit naming. */
-  private double hll;
+  private double hll = Double.NaN;
 
   /** Normal Liquid Level [m] - duplicate for explicit naming. */
-  private double nll;
+  private double nll = Double.NaN;
 
   /** Low Liquid Level [m] - duplicate for explicit naming. */
-  private double lll;
+  private double lll = Double.NaN;
 
   /** Weir height [m]. */
-  private double weirHeight;
+  private double weirHeight = Double.NaN;
 
   /** High Interface Level [m]. */
-  private double hil;
+  private double hil = Double.NaN;
 
   /** Normal Interface Level [m]. */
-  private double nil;
+  private double nil = Double.NaN;
 
   /** Low Interface Level [m]. */
-  private double lil;
+  private double lil = Double.NaN;
 
   // ============================================================================
   // Constructors
@@ -288,6 +290,14 @@ public class SeparatorMechanicalDesignResponse extends MechanicalDesignResponse 
       return;
     }
 
+    if (mecDesign.getProcessEquipment() instanceof Separator) {
+      Separator separator = (Separator) mecDesign.getProcessEquipment();
+      this.orientation = separator.getOrientation();
+      this.separatorType = separator instanceof ThreePhaseSeparator ? "three-phase" : "two-phase";
+    }
+    this.shellThickness = mecDesign.getWallThickness() > 0.0 ? mecDesign.getWallThickness() * 1000.0 : Double.NaN;
+    this.demisterType = mecDesign.getDemisterType();
+    // Head geometry has no authoritative owner in this model and remains unavailable.
     this.gasLoadFactor = mecDesign.getGasLoadFactor();
     this.volumeSafetyFactor = mecDesign.getVolumeSafetyFactor();
     this.liquidLevelFraction = mecDesign.getFg();

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignResponse.java
@@ -35,13 +35,13 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
   private int ansiPressureClass;
 
   /** Nominal valve size [inches]. */
-  private double nominalSizeInches;
+  private double nominalSizeInches = Double.NaN;
 
   /** Required valve Cv. */
-  private double cvRequired;
+  private double cvRequired = Double.NaN;
 
   /** Selected/limiting trim maximum Cv, or legacy required Cv when no catalog is evaluated. */
-  private double cvMax;
+  private double cvMax = Double.NaN;
 
   /** Available vendor trim capacity options. */
   private List<ValveTrimOption> availableTrimOptions = new ArrayList<ValveTrimOption>();
@@ -53,22 +53,22 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
   private String selectedTrimIdentifier;
 
   /** Relative size of the selected or limiting trim [%]. */
-  private double relativeTrimSizePercent;
+  private double relativeTrimSizePercent = Double.NaN;
 
   /** Maximum design Cv of the selected or limiting trim. */
-  private double selectedTrimMaximumCv;
+  private double selectedTrimMaximumCv = Double.NaN;
 
   /** Largest maximum design Cv in the supplied trim catalog. */
-  private double maximumAvailableTrimCv;
+  private double maximumAvailableTrimCv = Double.NaN;
 
   /** Required-Cv utilization of the selected or limiting trim. */
-  private double trimCvUtilization;
+  private double trimCvUtilization = Double.NaN;
 
   /** Remaining Cv capacity of the selected or limiting trim. */
-  private double trimCvCapacityMargin;
+  private double trimCvCapacityMargin = Double.NaN;
 
   /** Maximum allowed trim utilization used for selection. */
-  private double maximumAllowedTrimUtilization;
+  private double maximumAllowedTrimUtilization = Double.NaN;
 
   /** Whether a feasible trim was selected. */
   private boolean trimFeasible;
@@ -83,64 +83,64 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
   private String trimRecommendation;
 
   /** Valve opening percentage at design point. */
-  private double valveOpening;
+  private double valveOpening = Double.NaN;
 
   /** Calculated Kv (metric flow coefficient). */
-  private double kv;
+  private double kv = Double.NaN;
 
   /** Face-to-face dimension [mm]. */
-  private double faceToFace;
+  private double faceToFace = Double.NaN;
 
   /** Body wall thickness [mm]. */
-  private double bodyWallThickness;
+  private double bodyWallThickness = Double.NaN;
 
   /** Body weight [kg]. */
-  private double bodyWeight;
+  private double bodyWeight = Double.NaN;
 
   /** Actuator weight [kg]. */
-  private double actuatorWeight;
+  private double actuatorWeight = Double.NaN;
 
   /** Actuator type (pneumatic, electric, hydraulic, manual). */
   private String actuatorType;
 
   /** Required actuator thrust [N]. */
-  private double requiredActuatorThrust;
+  private double requiredActuatorThrust = Double.NaN;
 
   /** Stem diameter [mm]. */
-  private double stemDiameter;
+  private double stemDiameter = Double.NaN;
 
   /** Flange type (RF, RTJ, FF). */
   private String flangeType;
 
   /** Inlet pressure [bara]. */
-  private double inletPressure;
+  private double inletPressure = Double.NaN;
 
   /** Outlet pressure [bara]. */
-  private double outletPressure;
+  private double outletPressure = Double.NaN;
 
   /** Pressure drop [bar]. */
-  private double pressureDrop;
+  private double pressureDrop = Double.NaN;
 
   /** Pressure recovery factor (FL). */
-  private double flFactor;
+  private double flFactor = Double.NaN;
 
   /** Pressure ratio factor (xT). */
-  private double xtFactor;
+  private double xtFactor = Double.NaN;
 
   /** Flow regime (subcritical, critical, choked). */
   private String flowRegime;
 
   /** Mass flow rate [kg/h]. */
-  private double massFlowRate;
+  private double massFlowRate = Double.NaN;
 
   /** Volumetric flow rate [m³/h]. */
-  private double volumetricFlowRate;
+  private double volumetricFlowRate = Double.NaN;
 
   /** Noise level [dBA]. */
-  private double noiseLevel;
+  private double noiseLevel = Double.NaN;
 
   /** Cavitation index. */
-  private double cavitationIndex;
+  private double cavitationIndex = Double.NaN;
 
   /** Is flow choked? */
   private boolean isChoked;
@@ -179,11 +179,13 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
       return;
     }
 
+    setMaxDesignPressure(mecDesign.getDesignPressure() > 0.0 ? mecDesign.getDesignPressure() : Double.NaN);
+    setMaxDesignTemperature(mecDesign.getDesignPressure() > 0.0 ? mecDesign.getDesignTemperature() : Double.NaN);
     this.valveType = mecDesign.getValveType();
     this.valveCharacteristic = mecDesign.getValveCharacterization();
     this.ansiPressureClass = mecDesign.getAnsiPressureClass();
     this.nominalSizeInches = mecDesign.getNominalSizeInches();
-    this.cvRequired = Double.isFinite(mecDesign.getRequiredCv()) ? mecDesign.getRequiredCv() : 0.0;
+    this.cvRequired = mecDesign.getRequiredCv();
     this.cvMax = mecDesign.getValveCvMax();
     this.availableTrimOptions = new ArrayList<ValveTrimOption>(mecDesign.getAvailableTrimOptions());
     this.faceToFace = mecDesign.getFaceToFace();

--- a/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignJsonContractTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignJsonContractTest.java
@@ -1,0 +1,237 @@
+package neqsim.process.mechanicaldesign;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.mechanicaldesign.compressor.CompressorMechanicalDesignResponse;
+import neqsim.process.mechanicaldesign.heatexchanger.HeatExchangerMechanicalDesignResponse;
+import neqsim.process.mechanicaldesign.heatexchanger.HeatExchangerType;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for issue #3678 and downstream design consumers. */
+class MechanicalDesignJsonContractTest {
+  private Stream feed() {
+    SystemSrkEos fluid = new SystemSrkEos(313.15, 20.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-decane", 0.1);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+    return feed;
+  }
+
+  @Test
+  void compressorExportsLiveOperatingConditions() throws Exception {
+    Separator separator = new Separator("separator", feed());
+    separator.run();
+    Compressor compressor = new Compressor("compressor", separator.getGasOutStream());
+    compressor.setOutletPressure(80.0, "bara");
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicEfficiency(0.78);
+    compressor.setSpeed(6000.0);
+    compressor.run();
+    compressor.getMechanicalDesign().calcDesign();
+    JsonObject json = JsonParser.parseString(compressor.getMechanicalDesign().toJson()).getAsJsonObject();
+    assertEquals(20.0, json.get("inletPressure").getAsDouble(), 1e-9);
+    JsonObject data = JsonParser.parseString(compressor.getMechanicalDesign().toDesignDataJson()).getAsJsonObject();
+    assertEquals(2e6, value(data, "operatingConditions", "inletPressure"), 1e-6);
+    assertEquals(8e6, value(data, "operatingConditions", "outletPressure"), 1e-6);
+    assertEquals(compressor.getMechanicalDesign().getImpellerDiameter() / 1000.0,
+        value(data, "geometry", "impellerDiameter"), 1e-12);
+    assertEquals(compressor.getMechanicalDesign().getCasingDesignCalculator().getSelectedWallThicknessMm() / 1000.0,
+        value(data, "geometry", "pressureCasingWallThickness"), 1e-12);
+    assertEquals(JsonParser.parseString(compressor.getMechanicalDesign().toJson()),
+        JsonParser.parseString(compressor.getMechanicalDesign().toCompactJson()));
+    Files.createDirectories(Paths.get("target/design-json"));
+    Files.write(Paths.get("target/design-json/compressor.json"),
+        compressor.getMechanicalDesign().toDesignDataJson().getBytes(StandardCharsets.UTF_8));
+    assertEquals(80.0, json.get("outletPressure").getAsDouble(), 1e-9);
+    assertEquals(4.0, json.get("pressureRatio").getAsDouble(), 1e-9);
+    assertEquals(0.78, json.get("polytropicEfficiency").getAsDouble(), 1e-9);
+    assertEquals(compressor.getMechanicalDesign().getDesignPressure(), json.get("maxDesignPressure").getAsDouble(),
+        1e-9);
+  }
+
+  @Test
+  void separatorExportsGeometryWithCorrectScale() throws Exception {
+    Separator separator = new Separator("separator", feed());
+    separator.setOrientation("horizontal");
+    separator.run();
+    MechanicalDesign design = separator.getMechanicalDesign();
+    design.calcDesign();
+    JsonObject json = JsonParser.parseString(design.toJson()).getAsJsonObject();
+    assertEquals("horizontal", json.get("orientation").getAsString());
+    assertEquals("m", json.get("wallThicknessUnit").getAsString());
+    JsonObject data = JsonParser.parseString(design.toDesignDataJson()).getAsJsonObject();
+    assertEquals(data, json.getAsJsonObject("designData"));
+    assertEquals("consistent", data.get("geometryConsistency").getAsString());
+    assertEquals(design.getWallThickness(), value(data, "geometry", "wallThickness"), 1e-12);
+    Files.createDirectories(Paths.get("target/design-json"));
+    Files.write(Paths.get("target/design-json/separator.json"),
+        design.toDesignDataJson().getBytes(StandardCharsets.UTF_8));
+    assertEquals(design.getWallThickness() * 1000.0, json.get("shellThickness").getAsDouble(), 1e-9);
+    assertTrue(json.get("headType").isJsonNull(), "No head specification exists; do not invent one");
+    assertTrue(json.get("headThickness").isJsonNull(), "Uncalculated thickness must be unavailable");
+  }
+
+  @Test
+  void heaterDesignSerializesSelectedSizing() {
+    Heater heater = new Heater("heater", feed());
+    heater.setOutTemperature(353.15);
+    heater.run();
+    heater.getMechanicalDesign().calcDesign();
+    JsonObject json = JsonParser.parseString(heater.getMechanicalDesign().toJson()).getAsJsonObject();
+    assertTrue(json.get("requiredArea").getAsDouble() > 0.0);
+    assertFalse(json.get("heatExchangerType").isJsonNull());
+  }
+
+  private double value(JsonObject data, String section, String field) {
+    return data.getAsJsonObject(section).getAsJsonObject(field).get("value").getAsDouble();
+  }
+
+  @Test
+  void unpopulatedResponsesUseNullAndStrictJson() {
+    JsonObject empty = JsonParser.parseString(new CompressorMechanicalDesignResponse().toJson()).getAsJsonObject();
+    assertTrue(empty.get("inletPressure").isJsonNull());
+    assertTrue(empty.get("polytropicEfficiency").isJsonNull());
+    MechanicalDesignResponse response = new MechanicalDesignResponse();
+    response.setWallThickness(Double.POSITIVE_INFINITY);
+    response.addSpecificParameter("nonfinite", Double.NaN);
+    assertEquals(JsonParser.parseString(response.toJson()), JsonParser.parseString(response.toCompactJson()));
+    assertFalse(response.toJson().contains("NaN"));
+    assertFalse(response.toJson().contains("Infinity"));
+    assertTrue(JsonParser.parseString(response.toJson()).getAsJsonObject().get("wallThickness").isJsonNull());
+    assertDoesNotThrow(() -> new HeatExchangerMechanicalDesignResponse().toJson());
+    MechanicalDesign unknown = new MechanicalDesign(null);
+    unknown.setWallThickness(8.0);
+    JsonObject data = JsonParser.parseString(unknown.toDesignDataJson()).getAsJsonObject();
+    assertTrue(data.getAsJsonObject("geometry").getAsJsonObject("wallThickness").get("value").isJsonNull());
+    assertEquals("unavailable",
+        data.getAsJsonObject("geometry").getAsJsonObject("wallThickness").get("status").getAsString());
+  }
+
+  @Test
+  void repeatedExportTracksCurrentCompressorWithoutOverwritingDesignEnvelope() {
+    Compressor compressor = new Compressor("compressor", feed());
+    compressor.setOutletPressure(60.0, "bara");
+    compressor.run();
+    compressor.getMechanicalDesign().setMaxOperationPressure(125.0);
+    compressor.getMechanicalDesign().calcDesign();
+    JsonObject first = JsonParser.parseString(compressor.getMechanicalDesign().toJson()).getAsJsonObject();
+    compressor.setOutletPressure(80.0, "bara");
+    compressor.run();
+    compressor.getMechanicalDesign().calcDesign();
+    JsonObject second = JsonParser.parseString(compressor.getMechanicalDesign().toJson()).getAsJsonObject();
+    assertEquals(60.0, first.get("outletPressure").getAsDouble(), 1e-9);
+    assertEquals(80.0, second.get("outletPressure").getAsDouble(), 1e-9);
+    assertEquals(125.0, compressor.getMechanicalDesign().getMaxOperationPressure(), 1e-9);
+    assertEquals("configured_or_default", second.getAsJsonObject("designData").getAsJsonObject("designBasis")
+        .getAsJsonObject("maximumOperatingPressure").get("status").getAsString());
+  }
+
+  @Test
+  void pumpConvertsMillimetresAndUsesCalculatedPressure() {
+    SystemSrkEos water = new SystemSrkEos(298.15, 2.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule("classic");
+    Stream inlet = new Stream("water", water);
+    inlet.setFlowRate(1000.0, "kg/hr");
+    inlet.run();
+    Pump pump = new Pump("pump", inlet);
+    pump.setOutletPressure(10.0, "bara");
+    pump.run();
+    pump.getMechanicalDesign().calcDesign();
+    JsonObject legacy = JsonParser.parseString(pump.getMechanicalDesign().toJson()).getAsJsonObject();
+    JsonObject data = legacy.getAsJsonObject("designData");
+    assertEquals("mm", legacy.get("wallThicknessUnit").getAsString());
+    assertEquals(pump.getMechanicalDesign().getCasingWallThickness() / 1000.0, value(data, "geometry", "wallThickness"),
+        1e-12);
+    assertEquals("consistent", data.get("geometryConsistency").getAsString());
+    assertEquals(2.0, legacy.get("suctionPressure").getAsDouble(), 1e-9);
+    assertEquals(pump.getMechanicalDesign().getDesignPressure(), legacy.get("maxDesignPressure").getAsDouble(), 1e-9);
+  }
+
+  @Test
+  void valveUsesMetresForShellAndMillimetresForFaceToFace() {
+    ThrottlingValve valve = new ThrottlingValve("valve", feed());
+    valve.setOutletPressure(10.0, "bara");
+    valve.run();
+    valve.getMechanicalDesign().calcDesign();
+    JsonObject legacy = JsonParser.parseString(valve.getMechanicalDesign().toJson()).getAsJsonObject();
+    JsonObject data = legacy.getAsJsonObject("designData");
+    assertEquals("m", legacy.get("wallThicknessUnit").getAsString());
+    assertEquals(valve.getMechanicalDesign().getFaceToFace() / 1000.0, value(data, "geometry", "faceToFace"), 1e-12);
+    assertEquals(2e6, value(data, "operatingConditions", "inletPressure"), 1e-6);
+    assertEquals(valve.getMechanicalDesign().getDesignPressure(), legacy.get("maxDesignPressure").getAsDouble(), 1e-9);
+  }
+
+  @Test
+  void pipelineSeparatesSpecifiedGeometryFromSizingThickness() {
+    PipeBeggsAndBrills pipe = new PipeBeggsAndBrills("pipe", feed());
+    pipe.setLength(100.0);
+    pipe.setDiameter(0.3);
+    pipe.setWallThickness(0.012);
+    pipe.run();
+    pipe.initMechanicalDesign();
+    pipe.getMechanicalDesign().calcDesign();
+    JsonObject data = JsonParser.parseString(pipe.getMechanicalDesign().toDesignDataJson()).getAsJsonObject();
+    assertEquals(0.3, value(data, "geometry", "innerDiameter"), 1e-12);
+    assertEquals(0.324, value(data, "geometry", "outerDiameter"), 1e-12);
+    assertEquals(0.012, value(data, "geometry", "wallThickness"), 1e-12);
+    assertEquals("consistent", data.get("geometryConsistency").getAsString());
+    assertEquals(pipe.getMechanicalDesign().getWallThickness() / 1000.0,
+        value(data, "designBasis", "designWallThickness"), 1e-12);
+  }
+
+  @Test
+  void heatExchangerExportsSelectedTypeWithoutInventingShellForPlate() {
+    Stream hot = feed();
+    Stream cold = feed();
+    cold.setTemperature(293.15);
+    cold.run();
+    HeatExchanger exchanger = new HeatExchanger("exchanger", hot, cold);
+    exchanger.setUAvalue(1000.0);
+    exchanger.run();
+    exchanger.getMechanicalDesign().setManualSelection(HeatExchangerType.PLATE_AND_FRAME);
+    exchanger.getMechanicalDesign().calcDesign();
+    JsonObject plate = JsonParser.parseString(exchanger.getMechanicalDesign().toJson()).getAsJsonObject();
+    assertEquals("PLATE_AND_FRAME", plate.get("heatExchangerType").getAsString());
+    assertTrue(plate.get("shellInnerDiameter").isJsonNull());
+    assertEquals(exchanger.getMechanicalDesign().getSelectedSizingResult().getRequiredArea(),
+        plate.get("requiredArea").getAsDouble(), 1e-12);
+    exchanger.getMechanicalDesign().setManualSelection(HeatExchangerType.SHELL_AND_TUBE);
+    exchanger.getMechanicalDesign().calcDesign();
+    JsonObject shell = JsonParser.parseString(exchanger.getMechanicalDesign().toJson()).getAsJsonObject();
+    assertEquals(exchanger.getMechanicalDesign().getInnerDiameter() * 1000.0,
+        shell.get("shellInnerDiameter").getAsDouble(), 1e-9);
+    assertEquals(exchanger.getMechanicalDesign().getWallThickness() * 1000.0,
+        shell.get("shellWallThickness").getAsDouble(), 1e-9);
+  }
+
+  @Test
+  void inconsistentGeometryIsReported() {
+    Separator separator = new Separator("separator", feed());
+    MechanicalDesign design = separator.getMechanicalDesign();
+    design.setInnerDiameter(1.0);
+    design.setOuterDiameter(0.5);
+    design.setWallThickness(0.02);
+    JsonObject data = JsonParser.parseString(design.toDesignDataJson()).getAsJsonObject();
+    assertEquals("inconsistent", data.get("geometryConsistency").getAsString());
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignJsonContractTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignJsonContractTest.java
@@ -91,6 +91,15 @@ class MechanicalDesignJsonContractTest {
   }
 
   @Test
+  void unconnectedSeparatorKeepsDesignResponseAvailable() {
+    MechanicalDesign design = new MechanicalDesign(new Separator("unit test separator"));
+    assertDoesNotThrow(() -> new MechanicalDesignResponse(design));
+    JsonObject data = JsonParser.parseString(design.toDesignDataJson()).getAsJsonObject();
+    assertTrue(data.getAsJsonObject("operatingConditions").getAsJsonObject("gasOutletPressure").get("value")
+        .isJsonNull());
+  }
+
+  @Test
   void heaterDesignSerializesSelectedSizing() {
     Heater heater = new Heater("heater", feed());
     heater.setOutTemperature(353.15);
@@ -208,6 +217,10 @@ class MechanicalDesignJsonContractTest {
     HeatExchanger exchanger = new HeatExchanger("exchanger", hot, cold);
     exchanger.setUAvalue(1000.0);
     exchanger.run();
+    JsonObject data = JsonParser.parseString(exchanger.getMechanicalDesign().toDesignDataJson()).getAsJsonObject();
+    assertEquals(hot.getPressure("Pa"), value(data, "operatingConditions", "inlet0Pressure"), 1e-6);
+    assertEquals(cold.getPressure("Pa"), value(data, "operatingConditions", "inlet1Pressure"), 1e-6);
+    assertEquals(exchanger.getDuty(), value(data, "operatingConditions", "duty"), 1e-9);
     exchanger.getMechanicalDesign().setManualSelection(HeatExchangerType.PLATE_AND_FRAME);
     exchanger.getMechanicalDesign().calcDesign();
     JsonObject plate = JsonParser.parseString(exchanger.getMechanicalDesign().toJson()).getAsJsonObject();

--- a/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignJsonContractTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignJsonContractTest.java
@@ -95,8 +95,8 @@ class MechanicalDesignJsonContractTest {
     MechanicalDesign design = new MechanicalDesign(new Separator("unit test separator"));
     assertDoesNotThrow(() -> new MechanicalDesignResponse(design));
     JsonObject data = JsonParser.parseString(design.toDesignDataJson()).getAsJsonObject();
-    assertTrue(data.getAsJsonObject("operatingConditions").getAsJsonObject("gasOutletPressure").get("value")
-        .isJsonNull());
+    assertTrue(
+        data.getAsJsonObject("operatingConditions").getAsJsonObject("gasOutletPressure").get("value").isJsonNull());
   }
 
   @Test

--- a/src/test/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignTest.java
@@ -146,7 +146,10 @@ public class ValveMechanicalDesignTest {
 
     ValveMechanicalDesignResponse response = valve.getMechanicalDesign().getResponse();
 
-    assertEquals(0.0, response.getCvRequired(), 1.0e-12);
+    assertTrue(Double.isNaN(response.getCvRequired()));
+    assertTrue(
+        com.google.gson.JsonParser.parseString(response.toJson()).getAsJsonObject().get("cvRequired").isJsonNull());
+    assertFalse(response.toJson().contains("NaN"));
     assertTrue(response.toJson().contains("NOT_EVALUATED"));
   }
 


### PR DESCRIPTION
Closes #3678.

Mechanical-design JSON could report a compressor operating at 20/80 bara as 1/100 bara, leave separator geometry at defaults, and conceal heat-exchanger sizing behind the generic response. Mixed wall-thickness units made these values unsafe to consume as geometry inputs.

This PR:
- Reads compressor inlet/outlet pressure, efficiencies, head and power from the process owner; compressor, pump and valve design pressure/temperature come from their calculation getters.
- Populates separator orientation and shell thickness with the correct metre-to-millimetre conversion. Unspecified head geometry remains unavailable.
- Routes heat-exchanger/heater exports through the specialized response, removes a duplicate Gson field, and exports selected sizing/type/area. Plate exchangers do not acquire fictitious shell dimensions.
- Adds `MechanicalDesign.toDesignDataJson()`, plus `designData` in response-based JSON: versioned quantities with units, source getters and availability; SI geometry/pressure/temperature; separate operating conditions and design basis; explicit geometric consistency checks.
- Preserves legacy getter units and declares `wallThicknessUnit`. Unknown floating-point DTO fields use NaN internally and serialize as null; non-finite nested response values also become null. Pretty and compact response exports retain the same fields.
- Separates compressor envelope thickness from the casing calculator's pressure-boundary thickness, and specified pipeline geometry from the design thickness result.
- Runs the mesh contract tests in CI, installs trimesh in that job, and triggers it for changes to the example.
- Adds a runnable trimesh example exporting STL/GLB with unit/provenance sidecars, independent volume verification, and rejection of missing or inconsistent inputs.

Coverage includes executed separators, compressors, pumps, valves, pipelines, heaters, and plate/shell-and-tube exchanger selections. Additional wall-unit mappings were inspected for absorbers, adsorbers, filters, membranes and distillation columns; this is not a claim of full design qualification for those models. Unqualified classes expose unavailable normalized thickness.

The contract is a snapshot for preliminary geometry and design review. It explicitly reports `calculationStatus: not_tracked`: callers must rerun the process and design after input changes. Availability is not certification or freshness evidence. No head profiles, nozzle locations, supports, welds or fabrication tolerances are invented. The shell example models only an open-ended tube wall; envelope mode models plot space.

Documentation impact: updated the mechanical-design guide, incorrect wall-unit examples, compatibility/missing-value semantics, JSON-to-geometry/calculation workflow, and AGENTS.md guidance.

Validation on source baseline `7cdaa4d7259ee7b8d3d8c0db5d927270a1bef107` plus this change:
- Reproduced the three initial regressions before implementation.
- `./mvnw -q -DskipTests compile`: exit 0.
- `./mvnw -q -Dtest=MechanicalDesignJsonContractTest,MechanicalDesignJsonExportTest,HeatExchangerMechanicalDesignTest,PumpMechanicalDesignTest,ValveMechanicalDesignTest test`: exit 0, 77 tests passed.
- `python devtools/run_spotless.py apply`: exit 0; repeated successfully without changes.
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0, 696 Markdown pages and one standalone HTML page.
- `python -m unittest discover -s devtools -p test_mechanical_design_json_to_mesh.py -v`: exit 0, 3 tests passed.
- Both documented mesh CLI modes executed successfully against JSON generated by the Java regression. Separator wall volume: analytical 0.39240617 m3 versus mesh 0.39236678 m3 (0.01004% error); STL reload remained watertight. Compressor plot-space GLB matched the box volume.
- `git diff --check`: exit 0. The implementation commit's 15 published blob hashes match the locally validated files; the follow-up adds the CI wiring as file 16.

Python commands used the provided Python 3.12 runtime; trimesh 5.1.0. Maven was bootstrapped with the NeqSim skill helper. The pre-commit executable was unavailable; the direct formatting and documentation hooks passed. Full repository test matrix was not run.

VALIDATION PENDING CI. Draft for engineering/API review; no merge or auto-merge requested.