### PR TITLE
[AI-Assisted] test(flash): qualify locked water-rich phase-slot rollback

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1549,15 +1549,21 @@ by volatile screening components.
 Directly appending a gas phase is not used because `SystemInterface.addPhase()` can expose a stale phase slot whose
 requested type need not survive initialization. Instead, the algorithm snapshots the converged endpoint, clones it,
 resets the clone to a fresh two-phase GAS/liquid estimate, calls `init(0)` and `init(1)`, and runs one nested
-`TPmultiflash`. A thread-local guard and a per-operation one-shot flag prevent reciprocal recursion.
+`TPmultiflash`. The snapshot retains both logical phase roles and their physical phase-array slots. A thread-local guard
+and a per-operation one-shot flag prevent reciprocal recursion.
 
 The trial replaces the retained endpoint only if it preserves every original phase role, adds GAS, stays within the
 configured phase-count limit, and lowers extensive Gibbs energy. An exception, missing phase, non-improving Gibbs
 energy, or rejected trial leaves the snapshot in place; beta, phase compositions, K-values, and initialized properties
-are restored. Thus the Wilson screen triggers an equilibrium calculation but does not itself decide phase stability.
+are restored on their original physical phase-array slots. If phase shifting is disabled, the restart is skipped because
+the trial cannot reliably adopt or restore phase roles. Thus the Wilson screen triggers an equilibrium calculation but
+does not itself decide phase stability.
 
 ```java
 if (oilAndAqueousWithoutGas && neutral && wilsonSubmixtureBracketsTwoPhases) {
+    if (!system.allowPhaseShift()) {
+        return;
+    }
     PhaseSplitSnapshot retained = snapshot(system);
     SystemInterface trial = freshGasLiquidEstimate(system);
     new TPmultiflash(trial, solidCheck).run();
@@ -2267,10 +2273,12 @@ At the reference state, both equations of state must recover the fresh public `T
 within `1e-12` of a bound and from an ordinary two-phase endpoint passed directly to `TPmultiflash`. Reused systems
 must agree with fresh calculations after a nearby pressure change, after return to the reference pressure, and on an
 immediate deterministic repeat. A water-free GAS+OIL control verifies that the aqueous-only guard does not broaden the
-restart to dry flashes.
+restart to dry flashes. A locked-phase regression invokes the bounded restart guard directly and requires the phase-role
+lock, logical-to-physical phase mapping, equilibrium state, and frozen numerical gates to remain unchanged.
 
-The focused class executes 34 complete flashes. That bounded count is the performance evidence for this test-only
-qualification; no wall-clock threshold or production speedup is claimed. Production solver code, public APIs, model
+The focused class executes 35 complete flashes plus one direct locked-phase guard invocation. That bounded count is the
+performance evidence for this test-only qualification; no wall-clock threshold or production speedup is claimed.
+Production solver code, public APIs, model
 parameters/defaults, electrolyte and reactive paths, solids/wax, saturation search, Column Solver, Process Performance,
 and Huldra are outside this tranche.
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashWaterRichVapourTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashWaterRichVapourTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 
 import neqsim.thermo.phase.PhaseType;
@@ -121,6 +122,31 @@ class TPmultiflashWaterRichVapourTest {
       assertFalse(fluid.hasPhaseType(PhaseType.AQUEOUS), model + " dry aqueous phase");
       assertClosedEquilibrium(fluid, model + " dry control");
     }
+  }
+
+  /** A locked phase-role mapping must make the bounded restart a strict no-op. */
+  @Test
+  void phaseShiftLockedRestartPreservesConvergedEndpoint() throws Exception {
+    SystemInterface reference = flash(false, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA,
+        true);
+    SystemInterface locked = reference.clone();
+    int[] phaseIndices = new int[locked.getNumberOfPhases()];
+    for (int phase = 0; phase < locked.getNumberOfPhases(); phase++) {
+      phaseIndices[phase] = locked.getPhaseIndex(phase);
+    }
+    locked.allowPhaseShift(false);
+
+    TPmultiflash operation = new TPmultiflash(locked, false);
+    Method restart = TPmultiflash.class.getDeclaredMethod("restartMultiphaseFromFreshEstimate");
+    restart.setAccessible(true);
+    restart.invoke(operation);
+    locked.init(3);
+
+    assertFalse(locked.allowPhaseShift(), "phase-shift lock");
+    for (int phase = 0; phase < locked.getNumberOfPhases(); phase++) {
+      assertEquals(phaseIndices[phase], locked.getPhaseIndex(phase), "physical phase slot " + phase);
+    }
+    assertEquivalentEquilibrium(reference, locked, NORMALIZATION_TOLERANCE, "phase-shift-locked restart");
   }
 
   private SystemInterface flash(boolean pengRobinson, double waterFraction, double temperature, double pressure,


### PR DESCRIPTION
Advances #2937.

## Capability

Qualifies the locked-phase rollback guard added to the water-rich cubic-EOS vapour-appearance restart on current `master`.

The retained three-phase SRK endpoint uses a non-identity logical-to-physical phase mapping (`GAS=0`, `OIL=2`, `AQUEOUS=1`). The regression locks phase shifting, invokes the bounded fresh-estimate restart guard, and requires a strict no-op:

- `allowPhaseShift(false)` remains active;
- every logical phase keeps its exact physical phase-array slot;
- phase roles, fractions, compositions, compressibility factors, Gibbs energy, and enthalpy remain unchanged;
- phase/composition normalization remains within `1e-12`;
- component material balance remains below `1e-10`;
- comparable interphase log-fugacity residual remains below `1e-8`.

The algorithm guide now records the physical-slot snapshot contract and explains why a phase-role-locked system cannot safely adopt or restore a retyped trial.

## Regression evidence

The new method fails on the exact parent of the solver repair, `1e248a9753d8bf6398b4a06ddd10e6606dcec860`, because logical OIL phase 1 is remapped from physical slot 2 to slot 1. It passes on exact base `7cdaa4d7259ee7b8d3d8c0db5d927270a1bef107`.

Local exact-tree checks:

- `TPmultiflashWaterRichVapourTest`: 6/6 passed.
- Combined with `TPflashCombinedLiquidPhaseSplitTest`: 9/9 passed.
- Spotless apply/check passed.
- Documentation search audit passed for 696 Markdown pages and one standalone HTML page.
- `git diff --check` passed.
- The pre-commit executable was unavailable; its Java formatting and documentation-search hooks were run directly and passed.

## Hosted exact-head qualification

Exact head `4726e485ce7943a76157f4dedec39d372191ca52` passes:

- Java 21 and Java 8 fast suites on Ubuntu and Windows: 13,756 tests per platform, zero failures or errors;
- all four Java 21 slow-test shards and Javadocs;
- Spotless, pre-commit, documentation search, CodeQL, agent cross-reference, and agentic benchmark checks.

The original Java 21 Ubuntu attempt had one unrelated wall-clock ratio failure in `ProcessGraphTest.testGraphConstructionOverhead`; a guarded same-head retry passed all 13,756 tests. No flash test failed. The draft has no reviews or unresolved threads and GitHub reports it mergeable.

## Evidence boundary and performance

The methane-through-n-octane/water composition is an existing synthetic regression fixture, not experimental PVT validation. This increment adds one complete SRK flash and one direct locked-phase guard invocation to the focused workload. It makes no wall-clock claim and changes no production solver, public API, EOS parameters, defaults, electrolyte/reactive path, solids/wax, saturation operation, process equipment, Column Solver, Process Performance, or Huldra behavior.

## Frozen scope and continuity

- Exact base: `7cdaa4d7259ee7b8d3d8c0db5d927270a1bef107`
- Exact head: `4726e485ce7943a76157f4dedec39d372191ca52`
- Branch: `codex/2937-water-rich-phase-slot-regression`
- One commit; exactly two intended files
- No open #2937 PR existed at reservation
- Positively identified autonomous implementation occupancy: **6/10**

**READY TO MERGE.**

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.