### PR TITLE
[AI-Assisted] fix(separator): correct actual-flow outlet nozzle sizing

### DIFF
--- a/docs/process/equipment/separators.md
+++ b/docs/process/equipment/separators.md
@@ -483,6 +483,32 @@ double effectiveGasLength = design.getEffectiveLengthGas();
 double effectiveLiquidLength = design.getEffectiveLengthLiquid();
 ```
 
+### Outlet Nozzle Sizing
+
+After running the separator, `calcDesign()` calculates outlet nozzle IDs. The
+individual `calcGasOutletNozzleID()` and `calcOilOutletNozzleID()` methods also
+recalculate and store their results. Sizing uses actual phase flow in **m3/s**
+at operating conditions: minimum area is flow divided by the velocity limit,
+and minimum ID is the square root of four times that area divided by pi.
+
+| Method | Flow basis | Velocity limit | Upward ID rounding | Absent phase / zero flow |
+| --- | --- | --- | --- | --- |
+| `calcGasOutletNozzleID()` | Named gas phase | 20 m/s | 50 mm increments | 0 m |
+| `calcOilOutletNozzleID()` on `Separator` | Oil + aqueous phases in the common liquid outlet | 1.5 m/s | 25 mm increments, minimum 50 mm | 0.05 m |
+| `calcOilOutletNozzleID()` on `ThreePhaseSeparator` | Named oil phase only | 1.5 m/s | 25 mm increments, minimum 50 mm | 0.05 m |
+
+Phase selection does not depend on phase indices. No additional division by
+3,600 is applied to flow already expressed per second. For example, a gas flow
+of 3,580.35 actual m3/h requires approximately 0.2516 m ID at 20 m/s, rounded
+up to 0.30 m. These are preliminary velocity-based dimensions with simple
+rounding increments, not a pipe schedule or a certified nozzle design.
+
+The calculation return values and `getGasOutletNozzleID()` /
+`getOilOutletNozzleID()` use **metres**. The corresponding `toJson()` fields
+`gasOutletNozzleDiameter` and `liquidOutletNozzleDiameter` use **millimetres**.
+Recalculation at zero flow resets the stored values and subsequent JSON exports.
+Water outlet sizing for `ThreePhaseSeparator` is separate from these methods.
+
 ### Pre-Designed Separator Setup
 
 Pre-designed geometry is configured on `SeparatorMechanicalDesign`. Set the process-equipment geometry as well when runtime or dynamic vessel holdup uses the imported dimensions. All values below are in meters.

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
@@ -961,49 +961,67 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Calculate gas outlet nozzle diameter. Based on gas velocity limit (typically 15-20 m/s).
+   * Calculate and store gas outlet nozzle diameter using actual gas flow in m3/s and a 20 m/s velocity limit. Selects
+   * the gas phase by type, independently of its phase index. Rounds upward in 50 mm increments; absent gas or zero gas
+   * flow gives a diameter of zero. Run the separator before sizing.
    *
    * @return gas outlet nozzle ID in meters
    */
   public double calcGasOutletNozzleID() {
     Separator separator = (Separator) getProcessEquipment();
-    double gasFlowRate = separator.getThermoSystem().getPhase(0).getVolume() / 1e5; // m³/hr
+    double gasFlowRate = getActualPhaseFlowRate(separator.getThermoSystem(), "gas");
 
     // Max gas velocity in outlet nozzle: 20 m/s
     double maxVelocity = 20.0;
-    double minArea = (gasFlowRate / 3600.0) / maxVelocity;
+    double minArea = gasFlowRate / maxVelocity;
     gasOutletNozzleID = Math.sqrt(4.0 * minArea / Math.PI);
 
-    // Round up to nearest standard size
+    // Round the calculated diameter upward in 50 mm increments
     gasOutletNozzleID = Math.ceil(gasOutletNozzleID / 0.05) * 0.05;
 
     return gasOutletNozzleID;
   }
 
   /**
-   * Calculate oil outlet nozzle diameter. Based on liquid velocity limit (typically 1-2 m/s).
+   * Calculate and store liquid outlet nozzle diameter using actual liquid flow in m3/s and a 1.5 m/s velocity limit.
+   * For a two-outlet {@link Separator}, includes both oil and aqueous phases in the common liquid outlet. For a
+   * {@link ThreePhaseSeparator}, includes only oil. Selects phases by type, independently of their indices. Rounds
+   * upward in 25 mm increments with a 50 mm minimum, including absent liquid or zero flow. Run the separator before
+   * sizing.
    *
    * @return oil outlet nozzle ID in meters
    */
   public double calcOilOutletNozzleID() {
     Separator separator = (Separator) getProcessEquipment();
-    double oilFlowRate = 0.0;
-    if (separator.getThermoSystem().getNumberOfPhases() > 1) {
-      oilFlowRate = separator.getThermoSystem().getPhase(1).getVolume() / 1e5; // m³/hr
-    }
-    if (oilFlowRate < 1e-10) {
-      return 0.05; // Minimum 50mm
+    SystemInterface fluid = separator.getThermoSystem();
+    double oilFlowRate = getActualPhaseFlowRate(fluid, "oil");
+    if (!(separator instanceof ThreePhaseSeparator)) {
+      oilFlowRate += getActualPhaseFlowRate(fluid, "aqueous");
     }
 
     // Max liquid velocity in outlet nozzle: 1.5 m/s
     double maxVelocity = 1.5;
-    double minArea = (oilFlowRate / 3600.0) / maxVelocity;
+    double minArea = oilFlowRate / maxVelocity;
     oilOutletNozzleID = Math.sqrt(4.0 * minArea / Math.PI);
 
-    // Round up to nearest standard size, minimum 50mm
+    // Round the calculated diameter upward in 25 mm increments, minimum 50 mm
     oilOutletNozzleID = Math.max(0.05, Math.ceil(oilOutletNozzleID / 0.025) * 0.025);
 
     return oilOutletNozzleID;
+  }
+
+  /**
+   * Get actual volumetric flow for a named phase without evaluating density for an empty phase.
+   *
+   * @param fluid the separator fluid after the process calculation
+   * @param phaseType the phase type to select
+   * @return actual volumetric flow in m3/s, or zero for an absent or empty phase
+   */
+  private double getActualPhaseFlowRate(SystemInterface fluid, String phaseType) {
+    if (!fluid.hasPhaseType(phaseType) || fluid.getPhase(phaseType).getNumberOfMolesInPhase() == 0.0) {
+      return 0.0;
+    }
+    return fluid.getPhase(phaseType).getFlowRate("m3/sec");
   }
 
   // ==================== Setters for Level Fractions ====================

--- a/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorOutletNozzleSizingTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorOutletNozzleSizingTest.java
@@ -1,0 +1,113 @@
+package neqsim.process.mechanicaldesign.separator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for actual-volume outlet nozzle sizing (issue #3675). */
+class SeparatorOutletNozzleSizingTest extends neqsim.NeqSimTest {
+  @Test
+  void gasAndOilNozzlesRespectVelocityLimitsAtHighFlow() {
+    Separator separator = createSeparator(false, true, true, false);
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    design.calcDesign();
+    assertNozzle(separator.getThermoSystem().getPhase("gas").getFlowRate("m3/sec"), design.calcGasOutletNozzleID(),
+        20.0, 0.05);
+    assertEquals(0.30, design.getGasOutletNozzleID(), 1e-12);
+    assertNozzle(separator.getThermoSystem().getPhase("oil").getFlowRate("m3/sec"), design.calcOilOutletNozzleID(), 1.5,
+        0.025);
+    assertJsonAgreement(design);
+  }
+
+  @Test
+  void twoPhaseSeparatorSizesCombinedOilAndWaterOutlet() {
+    Separator separator = createSeparator(false, true, true, true);
+    SystemInterface fluid = separator.getThermoSystem();
+    assertEquals(3, fluid.getNumberOfPhases());
+    double liquidFlow = fluid.getPhase("oil").getFlowRate("m3/sec") + fluid.getPhase("aqueous").getFlowRate("m3/sec");
+    assertNozzle(liquidFlow, separator.getMechanicalDesign().calcOilOutletNozzleID(), 1.5, 0.025);
+  }
+
+  @Test
+  void threePhaseSeparatorSizesOilIndependentlyOfWater() {
+    Separator separator = createSeparator(true, true, true, true);
+    SystemInterface fluid = separator.getThermoSystem();
+    assertEquals(3, fluid.getNumberOfPhases());
+    assertNozzle(fluid.getPhase("oil").getFlowRate("m3/sec"), separator.getMechanicalDesign().calcOilOutletNozzleID(),
+        1.5, 0.025);
+    assertNozzle(fluid.getPhase("gas").getFlowRate("m3/sec"), separator.getMechanicalDesign().calcGasOutletNozzleID(),
+        20.0, 0.05);
+    assertJsonAgreement(separator.getMechanicalDesign());
+  }
+
+  @Test
+  void waterOnlyOutletIsLiquidAndNotGas() {
+    Separator separator = createSeparator(false, false, false, true);
+    SystemInterface fluid = separator.getThermoSystem();
+    assertFalse(fluid.hasPhaseType("gas"));
+    assertEquals(1, fluid.getNumberOfPhases());
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    assertEquals(0.0, design.calcGasOutletNozzleID(), 0.0);
+    assertNozzle(fluid.getPhase("aqueous").getFlowRate("m3/sec"), design.calcOilOutletNozzleID(), 1.5, 0.025);
+    assertJsonAgreement(design);
+  }
+
+  @Test
+  void zeroFlowResetsPreviouslyCalculatedNozzlesAndJson() {
+    Separator separator = createSeparator(false, true, true, false);
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    assertTrue(design.calcGasOutletNozzleID() > 0.05);
+    assertTrue(design.calcOilOutletNozzleID() > 0.05);
+    separator.getThermoSystem().setEmptyFluid();
+    assertEquals(0.0, design.calcGasOutletNozzleID(), 0.0);
+    assertEquals(0.05, design.calcOilOutletNozzleID(), 0.0);
+    assertJsonAgreement(design);
+  }
+
+  private Separator createSeparator(boolean threePhase, boolean gas, boolean oil, boolean water) {
+    SystemInterface fluid = new SystemSrkEos(313.15, 20.0);
+    if (gas) {
+      fluid.addComponent("methane", 0.80);
+      fluid.addComponent("ethane", 0.05);
+      fluid.addComponent("propane", 0.05);
+    }
+    if (oil) {
+      fluid.addComponent("n-decane", 0.10);
+    }
+    if (water) {
+      fluid.addComponent("water", 2.0);
+    }
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+    Separator separator = threePhase ? new ThreePhaseSeparator("separator", feed) : new Separator("separator", feed);
+    separator.setOrientation("horizontal");
+    separator.run();
+    return separator;
+  }
+
+  private void assertNozzle(double flow, double diameter, double velocityLimit, double increment) {
+    assertTrue(flow > 0.0);
+    double minimumDiameter = Math.sqrt(4.0 * flow / (Math.PI * velocityLimit));
+    assertTrue(diameter >= minimumDiameter - 1e-12);
+    assertTrue(diameter < minimumDiameter + increment + 1e-12);
+    assertEquals(Math.rint(diameter / increment), diameter / increment, 1e-12);
+    assertTrue(4.0 * flow / (Math.PI * diameter * diameter) <= velocityLimit + 1e-12);
+  }
+
+  private void assertJsonAgreement(SeparatorMechanicalDesign design) {
+    JsonObject json = JsonParser.parseString(design.toJson()).getAsJsonObject();
+    assertEquals(design.getGasOutletNozzleID() * 1000.0, json.get("gasOutletNozzleDiameter").getAsDouble(), 1e-9);
+    assertEquals(design.getOilOutletNozzleID() * 1000.0, json.get("liquidOutletNozzleDiameter").getAsDouble(), 1e-9);
+  }
+}


### PR DESCRIPTION
Closes #3675.

Separator outlet sizing treated internal actual m3/s as m3/h and divided by 3,600 again. This severely undersized both gas and liquid nozzles: the reported 100,000 kg/h SRK case produced 0.05 m gas ID instead of 0.30 m after rounding.

This change uses the explicit phase `getFlowRate("m3/sec")` API and applies A = Q/v once. It selects phases by identity: gas for the gas nozzle; oil plus aqueous for a two-outlet Separator's common liquid outlet; oil only for ThreePhaseSeparator. Empty phases are handled without evaluating density. Zero-flow sizing updates the stored fields, fixing disagreement between the returned minimum liquid ID and getters/JSON.

Existing limits and increments are retained: gas 20 m/s, 50 mm increments; liquid 1.5 m/s, 25 mm increments with a 50 mm minimum. No gas gives 0 m; no liquid gives 0.05 m. These remain preliminary velocity-based sizing methods, not pipe schedule selection. The separate water-nozzle sizing path is outside this fix.

Five new regressions cover high-flow gas/oil velocity bounds and rounding, combined oil/water liquid flow, separate three-phase oil flow, single-phase water, zero-flow recalculation, and getter/JSON agreement. All five failed against unchanged production source before the fix.

Documentation impact: updated method Javadocs and the separator guide with actual-flow units, phase selection, zero-flow behavior, rounding, an analytical example, and metre getters versus millimetre JSON fields. No public method signatures or JSON field names changed. The inlet method was inspected and already correctly converts explicit m3/h once. Related JSON-contract work in #3679 is not duplicated.

Validation on baseline `5eb26ebad6e180b3756248237ecc33129ec071f4` plus this change, OpenJDK 17.0.20 with the repository Java 8 compilation target:
- `./mvnw -q -DskipTests compile`: exit 0 on baseline.
- `./mvnw -q -Dtest=SeparatorOutletNozzleSizingTest test` before the fix: expected exit 1, 5 failures / 0 errors.
- `./mvnw -q -Dtest=SeparatorOutletNozzleSizingTest,SeparatorMechanicalDesignTest,MechanicalDesignJsonExportTest test`: exit 0 after the fix; 59 tests passed (5 + 41 + 13), including recompilation of changed source.
- `python devtools/run_spotless.py apply`: exit 0; repeated successfully with no further modifications.
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0, 696 Markdown pages and one standalone HTML page.
- `git diff --check`: exit 0.
- Published tree blob hashes for all three files match the locally tested and formatted files.

Maven was prepared with the work-with-neqsim bootstrap helper. Python commands used the runtime-provided interpreter. The pre-commit executable was unavailable; direct formatter and documentation gates passed. The full repository test matrix was not run.

VALIDATION PENDING CI. Draft for review; the issue should close when merged into master.