### PR TITLE
[AI-Assisted] fix(mechanical-design): size separator walls from final diameter

### DIFF
--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -143,6 +143,22 @@ double designPressure = mecDesign.getMaxDesignPressure(); // bara
 mecDesign.displayResults();
 ```
 
+### Consistent separator sizing results
+
+`SeparatorMechanicalDesign.calcDesign()` calculates pressure-wall thickness using the final
+sized inner diameter, including any liquid-separation sizing override. Outside diameter,
+shell weight, internals and dependent module weights then use that same geometry. The
+`autoSize()` sizing path and `GasScrubberMechanicalDesign.calcDesign()` follow the same order.
+An unchanged design does not require a second `setDesign()` / `calcDesign()` cycle to obtain
+consistent thickness and weights. Use `setDesign()` to apply the design's process-side settings.
+
+For separators and gas scrubbers, `getWallThickness()` returns metres and
+`setCorrosionAllowance(double)` takes millimetres. Outside diameter is inner diameter plus
+twice the wall thickness. Changing the pressure basis, corrosion allowance or process flow
+requires recalculating the design before consuming its geometry or weights. The existing
+pressure-code correlations and empirical weight estimates are unchanged; this consistency
+fix does not add fabrication details or code certification.
+
 ### Gas-liquid contactor capacity
 
 The mechanical design attached to `PackedColumn`, `AbsorptionColumn`, `StrippingColumn`, and

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/PressureVesselDesignStandard.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/PressureVesselDesignStandard.java
@@ -27,17 +27,24 @@ public class PressureVesselDesignStandard extends DesignStandard {
   }
 
   /**
-   * calcWallThickness.
+   * Calculates wall thickness using the separator's current internal diameter.
    *
-   * @return a double
+   * @return wall thickness in metres, including corrosion allowance
    */
   public double calcWallThickness() {
-    if (standardName.startsWith("ASME-VIII-Div2") || standardName.startsWith("API-620")
-        || standardName.startsWith("API-625") || standardName.startsWith("API-650")) {
-      throw new UnsupportedOperationException(
-          "No edition-specific pressure-vessel calculation is implemented for " + standardName);
-    }
-    Separator separator = (Separator) equipment.getProcessEquipment();
+    checkSupportedStandard();
+    return calcWallThickness(((Separator) equipment.getProcessEquipment()).getInternalDiameter());
+  }
+
+  /**
+   * Calculates wall thickness for an explicitly sized vessel without applying geometry to the process equipment.
+   *
+   * @param innerDiameter vessel internal diameter in metres
+   * @return wall thickness in metres, including the configured corrosion allowance in millimetres
+   * @throws UnsupportedOperationException if the selected pressure-vessel code is not implemented
+   */
+  public double calcWallThickness(double innerDiameter) {
+    checkSupportedStandard();
     double wallT = 0;
     MaterialPlateDesignStandard matPlateStyandard = ((MaterialPlateDesignStandard) equipment.getDesignStandard()
         .get("material plate design codes"));
@@ -47,22 +54,30 @@ public class PressureVesselDesignStandard extends DesignStandard {
     double jointEfficiency = JEPlateStyandard.getJEFactor();
 
     if (standardName.equals("ASME - Pressure Vessel Code") || standardName.startsWith("ASME-VIII-Div1")) {
-      wallT = equipment.getMaxOperationPressure() / 10.0 * separator.getInternalDiameter() * 1e3
+      wallT = equipment.getMaxOperationPressure() / 10.0 * innerDiameter * 1e3
           / (2.0 * maxAllowableStress * jointEfficiency - 1.2 * equipment.getMaxOperationPressure() / 10.0)
           + equipment.getCorrosionAllowance();
     } else if (standardName.equals("BS 5500 - Pressure Vessel") || standardName.startsWith("PD-5500")) {
-      wallT = equipment.getMaxOperationPressure() / 10.0 * separator.getInternalDiameter() * 1e3
+      wallT = equipment.getMaxOperationPressure() / 10.0 * innerDiameter * 1e3
           / (2.0 * maxAllowableStress - jointEfficiency / 10.0) + equipment.getCorrosionAllowance();
     } else if (standardName.equals("European Code") || standardName.startsWith("EN-13445")) {
-      wallT = equipment.getMaxOperationPressure() / 10.0 * separator.getInternalDiameter() / 2.0 * 1e3
+      wallT = equipment.getMaxOperationPressure() / 10.0 * innerDiameter / 2.0 * 1e3
           / (2.0 * maxAllowableStress * jointEfficiency - 0.2 * equipment.getMaxOperationPressure() / 10.0)
           + equipment.getCorrosionAllowance();
     } else {
-      wallT = equipment.getMaxOperationPressure() / 10.0 * separator.getInternalDiameter() / 2.0 * 1e3
+      wallT = equipment.getMaxOperationPressure() / 10.0 * innerDiameter / 2.0 * 1e3
           / (2.0 * maxAllowableStress * jointEfficiency - 0.2 * equipment.getMaxOperationPressure() / 10.0)
           + equipment.getCorrosionAllowance();
     }
     return wallT / 1000.0; // return wall thickness in meter
+  }
+
+  private void checkSupportedStandard() {
+    if (standardName.startsWith("ASME-VIII-Div2") || standardName.startsWith("API-620")
+        || standardName.startsWith("API-625") || standardName.startsWith("API-650")) {
+      throw new UnsupportedOperationException(
+          "No edition-specific pressure-vessel calculation is implemented for " + standardName);
+    }
   }
 
   public MechanicalDesignMarginResult getSafetyMargins() {

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
@@ -173,6 +173,7 @@ public class GasScrubberMechanicalDesign extends SeparatorMechanicalDesign {
     innerDiameter = Math.sqrt(4.0 * (getMaxDesignVolumeFlow() / 3600.0)
         / (neqsim.thermo.ThermodynamicConstantsInterface.pi * maxGasVelocity * Fg));
     tantanLength = innerDiameter * 5.0;
+    updateWallThicknessForSizedDiameter();
     // System.out.println("inner Diameter " + innerDiameter);
 
     // calculating from standard codes

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
@@ -389,7 +389,6 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
 
     innerDiameter = Math.sqrt(4.0 * (getMaxDesignVolumeFlow() / 3600.0)
         / (neqsim.thermo.ThermodynamicConstantsInterface.pi * maxGasVelocity * gasAreaFraction));
-    outerDiameter = innerDiameter + 2.0 * wallThickness;
 
     // Calculate max allowable gas volume flow based on sized diameter
     // This is the design capacity used for capacity utilization calculations
@@ -425,6 +424,7 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
       innerDiameter = Daim;
       tantanLength = Length2;
     }
+    updateWallThicknessForSizedDiameter();
     // calculating from standard codes
     // sepLength = innerDiameter * 2.0;
     emptyVesselWeight = 0.032 * getWallThickness() * 1e3 * innerDiameter * 1e3 * tantanLength;
@@ -493,6 +493,18 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
+   * Updates pressure-wall thickness and outside diameter after the final sizing decision, before calculating shell,
+   * internals and module weights. Without a pressure-vessel standard, retains the specified wall thickness.
+   */
+  protected void updateWallThicknessForSizedDiameter() {
+    if (getDesignStandard().containsKey("pressure vessel design code")) {
+      wallThickness = ((PressureVesselDesignStandard) getDesignStandard().get("pressure vessel design code"))
+          .calcWallThickness(innerDiameter);
+    }
+    outerDiameter = innerDiameter + 2.0 * wallThickness;
+  }
+
+  /**
    * Performs the sizing calculations without reading design specifications. This method is called by autoSize() after
    * design specs have been read and any user overrides have been applied.
    */
@@ -531,7 +543,6 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
     // Calculate diameter based on the orientation-specific gas area.
     innerDiameter = Math.sqrt(4.0 * (maxDesignVolumeFlow / 3600.0)
         / (neqsim.thermo.ThermodynamicConstantsInterface.pi * maxGasVelocity * gasAreaFraction));
-    outerDiameter = innerDiameter + 2.0 * wallThickness;
 
     // Calculate max allowable gas volume flow based on sized diameter
     // This is the design capacity used for capacity utilization calculations
@@ -554,6 +565,8 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
     if (separatorTotalLength / innerDiameter > 6 || separatorTotalLength / innerDiameter < 3) {
       tantanLength = innerDiameter * 4.0; // Default to L/D = 5
     }
+
+    updateWallThicknessForSizedDiameter();
 
     // Weight calculations
     emptyVesselWeight = 0.032 * getWallThickness() * 1e3 * innerDiameter * 1e3 * tantanLength;
@@ -579,6 +592,7 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
 
     setWeigthVesselShell(emptyVesselWeight);
     setInnerDiameter(innerDiameter);
+    setWeigthInternals(internalsWeight);
     setOuterDiameter(outerDiameter);
     setWeightElectroInstrument(electricalWeight);
     setWeightNozzle(externalNozzelsWeight);

--- a/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorWallThicknessConsistencyTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorWallThicknessConsistencyTest.java
@@ -1,0 +1,167 @@
+package neqsim.process.mechanicaldesign.separator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.separator.GasScrubber;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.mechanicaldesign.designstandards.JointEfficiencyPlateStandard;
+import neqsim.process.mechanicaldesign.designstandards.MaterialPlateDesignStandard;
+import neqsim.process.mechanicaldesign.designstandards.PressureVesselDesignStandard;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for issue #3677: one sizing pass must describe one vessel. */
+class SeparatorWallThicknessConsistencyTest extends neqsim.NeqSimTest {
+  private Separator createSeparator(double initialDiameter, boolean scrubber, boolean liquidRich) {
+    SystemSrkEos fluid = new SystemSrkEos(313.15, 20.0);
+    fluid.addComponent("methane", liquidRich ? 0.1 : 0.8);
+    fluid.addComponent("ethane", liquidRich ? 0.0 : 0.05);
+    fluid.addComponent("propane", liquidRich ? 0.0 : 0.05);
+    fluid.addComponent("n-decane", liquidRich ? 0.9 : 0.1);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+    Separator separator = scrubber ? new GasScrubber("scrubber", feed) : new Separator("separator", feed);
+    if (!scrubber) {
+      separator.setOrientation("horizontal");
+    }
+    separator.setInternalDiameter(initialDiameter);
+    separator.addSeparatorSection("mesh", "mesh");
+    separator.run();
+    assertEquals(2, separator.getThermoSystem().getNumberOfPhases(), "Fixture must contain gas and liquid");
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    design.setCompanySpecificDesignStandards("default");
+    design.setMaxOperationPressure(25.0);
+    design.setMaxOperationTemperature(80.0, "C");
+    design.setCorrosionAllowance(0.0);
+    return separator;
+  }
+
+  private void assertCoherentDesign(Separator separator) {
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    double stress = ((MaterialPlateDesignStandard) design.getDesignStandard().get("material plate design codes"))
+        .getDivisionClass();
+    double efficiency = ((JointEfficiencyPlateStandard) design.getDesignStandard()
+        .get("plate Joint Efficiency design codes")).getJEFactor();
+    // ASME cylindrical-shell pressure term in metres; corrosion allowance is stored in mm.
+    double pressureMPa = design.getMaxOperationPressure() / 10.0;
+    double expectedThickness = pressureMPa * design.getInnerDiameter() / (2.0 * stress * efficiency - 1.2 * pressureMPa)
+        + design.getCorrosionAllowance() / 1000.0;
+    assertEquals(expectedThickness, design.getWallThickness(), 1e-12);
+    assertEquals(design.getInnerDiameter() + 2.0 * expectedThickness, design.getOuterDiameter(), 1e-12);
+    double expectedShellWeight = 0.032 * expectedThickness * 1e3 * design.getInnerDiameter() * 1e3
+        * design.getTantanLength();
+    assertEquals(expectedShellWeight, design.getWeigthVesselShell(), expectedShellWeight * 1e-12);
+    double internalsWeight = separator.getSeparatorSections().stream()
+        .mapToDouble(section -> section.getMechanicalDesign().getTotalWeight()).sum();
+    assertEquals(internalsWeight, design.getWeigthInternals(), 1e-9);
+    double vesselWeight = expectedShellWeight + internalsWeight + design.getWeightNozzle();
+    assertEquals(0.4 * vesselWeight, design.getWeightPiping(), vesselWeight * 1e-12);
+    assertEquals(0.1 * vesselWeight, design.getWeightStructualSteel(), vesselWeight * 1e-12);
+    assertEquals(0.08 * vesselWeight, design.getWeightElectroInstrument(), vesselWeight * 1e-12);
+    assertEquals(1.58 * vesselWeight, design.getWeightTotal(), vesselWeight * 1e-12);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.4, 1.0, 4.0 })
+  void firstPassAndRepeatedDesignUseFinalDiameter(double initialDiameter) {
+    Separator separator = createSeparator(initialDiameter, false, false);
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    design.calcDesign();
+    assertCoherentDesign(separator);
+    assertEquals(1.440917294605802, design.getInnerDiameter(), 1e-8);
+    assertEquals(0.004253002640512992, design.getWallThickness(), 1e-10);
+    double thickness = design.getWallThickness();
+    double weight = design.getWeightTotal();
+    double length = design.getTantanLength();
+    design.calcDesign();
+    assertCoherentDesign(separator);
+    assertEquals(thickness, design.getWallThickness(), 1e-12);
+    assertEquals(weight, design.getWeightTotal(), 1e-8);
+    design.setDesign();
+    design.calcDesign();
+    assertCoherentDesign(separator);
+    assertEquals(thickness, design.getWallThickness(), 1e-12);
+    assertEquals(weight, design.getWeightTotal(), 1e-8);
+    assertEquals(length, design.getTantanLength(), 1e-12);
+  }
+
+  @Test
+  void pressureAndCorrosionAllowanceAffectFirstPassWeights() {
+    Separator separator = createSeparator(4.0, false, false);
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    design.calcDesign();
+    double initialThickness = design.getWallThickness();
+    double initialWeight = design.getWeightTotal();
+    design.setMaxOperationPressure(50.0);
+    design.calcDesign();
+    assertCoherentDesign(separator);
+    assertTrue(design.getWallThickness() > initialThickness);
+    assertTrue(design.getWeightTotal() > initialWeight);
+    double pressureThickness = design.getWallThickness();
+    double pressureWeight = design.getWeightTotal();
+    design.setCorrosionAllowance(3.0);
+    design.calcDesign();
+    assertCoherentDesign(separator);
+    assertEquals(0.003, design.getWallThickness() - pressureThickness, 1e-12);
+    assertTrue(design.getWeightTotal() > pressureWeight);
+  }
+
+  @Test
+  void liquidSizingOverrideUsesFinalDiameter() {
+    Separator separator = createSeparator(4.0, false, true);
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    design.calcDesign();
+    // The liquid/bubble sizing branch selects L = 4D, rather than the gas branch's fallback L = 5D.
+    assertEquals(4.0 * design.getInnerDiameter(), design.getTantanLength(), 1e-10);
+    assertCoherentDesign(separator);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.4, 4.0 })
+  void autoSizeRefreshesWallAndWeights(double initialDiameter) {
+    Separator separator = createSeparator(initialDiameter, false, false);
+    separator.autoSize(1.2);
+    assertCoherentDesign(separator);
+    double thickness = separator.getMechanicalDesign().getWallThickness();
+    double weight = separator.getMechanicalDesign().getWeightTotal();
+    separator.autoSize(1.2);
+    assertCoherentDesign(separator);
+    assertEquals(thickness, separator.getMechanicalDesign().getWallThickness(), 1e-12);
+    assertEquals(weight, separator.getMechanicalDesign().getWeightTotal(), 1e-8);
+  }
+
+  @Test
+  void scrubberRefreshesWallAfterItsOwnDiameterSizing() {
+    Separator separator = createSeparator(4.0, true, false);
+    separator.getMechanicalDesign().calcDesign();
+    assertCoherentDesign(separator);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "ASME - Pressure Vessel Code", "BS 5500 - Pressure Vessel", "European Code", "legacy" })
+  void explicitDiameterPreservesPressureCodeAndAllowance(String standardName) {
+    Separator separator = createSeparator(1.0, false, false);
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    design.setCorrosionAllowance(3.0);
+    PressureVesselDesignStandard standard = new PressureVesselDesignStandard(standardName, design);
+    double originalThickness = standard.calcWallThickness();
+    assertEquals(originalThickness, standard.calcWallThickness(1.0), 1e-12);
+    assertEquals(2.0 * (originalThickness - 0.003) + 0.003, standard.calcWallThickness(2.0), 1e-12);
+    assertEquals(1.0, separator.getInternalDiameter(), 1e-12, "Trial diameter must not mutate process geometry");
+  }
+
+  @Test
+  void unsupportedCodeFailsBeforeCastingProcessEquipment() {
+    PressureVesselDesignStandard standard = new PressureVesselDesignStandard("ASME-VIII-Div2",
+        new Pump("pump").getMechanicalDesign());
+    assertThrows(UnsupportedOperationException.class, () -> standard.calcWallThickness());
+    assertThrows(UnsupportedOperationException.class, () -> standard.calcWallThickness(2.0));
+  }
+}


### PR DESCRIPTION
Closes #3677.

Separator wall thickness was calculated while reading specifications, before gas/liquid sizing selected the final diameter. The first-pass shell, outside diameter and weights therefore depended on the previous vessel geometry. The reported case returned 2.95159 mm before applying the design and 4.25300 mm afterward.

This change refreshes pressure-wall thickness from the final sized diameter before computing dependent geometry and weights. It covers calcDesign(), the autoSize()/performSizingCalculations() path, and the gas scrubber's additional sizing pass. The autoSize path now also stores the internals weight used in its total. A diameter-taking pressure-standard overload preserves the existing formulas, units, no-argument API and unsupported-code rejection without applying trial geometry to process equipment.

Regression coverage includes initial diameters 0.4/1/4 m; first, repeated and design/apply/repeated calls; a gas/liquid fixture exercising the liquid-sizing override; 25-to-50 bara pressure and 0-to-3 mm corrosion allowance changes; shell/outside-diameter/internals/piping/structural/electrical/total-weight consistency; autoSize and gas scrubber paths; all legacy pressure-formula branches; and fail-closed handling of unsupported codes.

Documentation impact: updated the mechanical-design guide and pressure-standard Javadocs with calculation order, units and recalculation semantics. Existing pressure correlations and empirical weight models are unchanged.

Validation on master 5eb26ebad6e180b3756248237ecc33129ec071f4 plus this change (OpenJDK 17; repository-configured Java 17 release target, with Java 8-compatible syntax in this change):
- Reproduced the defect before implementation: 8 regression cases failed, 0 errors.
- Final focused tests: `./mvnw -q -Dtest=SeparatorWallThicknessConsistencyTest,SeparatorMechanicalDesignTest,StandardSelectionTest,StandardSupportAuditTest,AutoSizeAndMechanicalDesignTest,MechanicalDesignJsonExportTest test`: exit 0, 94 tests passed, 0 failures/errors/skips (13 new regression cases).
- python devtools/run_spotless.py apply: exit 0, repeated; check: exit 0.
- python devtools/check_documentation_search.py: exit 0 (696 Markdown pages, 1 standalone HTML page).
- git diff --check: exit 0.

Maven was bootstrapped with the NeqSim skill helper; Python commands use the provided Python runtime. The pre-commit executable was unavailable, so the direct formatting and documentation hook commands were run. Full repository test matrix was not run locally.

Reported vessel after one calculation: D=1.4409172946 m, L=7.2045864730 m, t=0.004253002641 m, unchanged on repeated calculation.