### PR TITLE
[AI-Assisted] docs(cookbook): execute adsorption recipes

### DIFF
--- a/docs/cookbook/adsorption-recipes.md
+++ b/docs/cookbook/adsorption-recipes.md
@@ -53,8 +53,13 @@ exist in the packaged parameter inventory.
 import neqsim.physicalproperties.interfaceproperties.solidadsorption.LangmuirAdsorption;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CompetitiveAdsorptionScreen {
+    private static final Logger logger =
+        LogManager.getLogger(CompetitiveAdsorptionScreen.class);
+
     public static void main(String[] args) throws Exception {
         SystemSrkEos gas = new SystemSrkEos(298.15, 10.0);
         gas.addComponent("methane", 0.90);
@@ -70,12 +75,7 @@ public class CompetitiveAdsorptionScreen {
             "MOF HKUST-1"
         };
 
-        System.out.printf(
-            "%-18s %14s %14s %12s%n",
-            "Material",
-            "CO2 [mol/kg]",
-            "CH4 [mol/kg]",
-            "Selectivity");
+        logger.info("Material | CO2 [mol/kg] | CH4 [mol/kg] | Selectivity");
 
         for (String material : materials) {
             LangmuirAdsorption model = new LangmuirAdsorption(gas);
@@ -86,8 +86,11 @@ public class CompetitiveAdsorptionScreen {
             double methaneLoading = model.getSurfaceExcess("methane");
             double selectivity = model.getSelectivity(1, 0, 0);
 
-            System.out.printf(
-                "%-18s %14.4f %14.4f %12.2f%n",
+            assert Double.isFinite(co2Loading) && co2Loading >= 0.0;
+            assert Double.isFinite(methaneLoading) && methaneLoading >= 0.0;
+            assert Double.isFinite(selectivity) && selectivity > 0.0;
+            logger.info(
+                "{} | CO2 {} mol/kg | CH4 {} mol/kg | selectivity {}",
                 material,
                 co2Loading,
                 methaneLoading,
@@ -124,8 +127,13 @@ import neqsim.physicalproperties.interfaceproperties.solidadsorption.IsothermTyp
 import neqsim.process.equipment.adsorber.AdsorptionBed;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemSrkEos;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AdsorptionBedScreen {
+    private static final Logger logger =
+        LogManager.getLogger(AdsorptionBedScreen.class);
+
     private static Stream createFeed() {
         SystemSrkEos gas = new SystemSrkEos(298.15, 10.0);
         gas.addComponent("methane", 0.85);
@@ -157,8 +165,14 @@ public class AdsorptionBedScreen {
             .getPhase(0)
             .getComponent("CO2")
             .getx();
-        System.out.printf(
-            "Steady screen: adsorbent %.1f kg, pressure drop %.1f Pa, outlet CO2 %.6f%n",
+        assert Double.isFinite(steadyBed.getAdsorbentMass());
+        assert steadyBed.getAdsorbentMass() > 0.0;
+        assert Double.isFinite(steadyBed.getPressureDrop());
+        assert steadyBed.getPressureDrop() > 0.0;
+        assert Double.isFinite(outletCO2);
+        assert outletCO2 >= 0.0 && outletCO2 <= 1.0;
+        logger.info(
+            "Steady screen: adsorbent {} kg, pressure drop {} Pa, outlet CO2 {}",
             steadyBed.getAdsorbentMass(),
             steadyBed.getPressureDrop(),
             outletCO2);
@@ -174,8 +188,12 @@ public class AdsorptionBedScreen {
         }
 
         double co2Loading = transientBed.getAverageLoading(1);
-        System.out.printf(
-            "Transient screen: time %.2f s, average CO2 loading %.6f mol/kg, breakthrough %s%n",
+        assert Double.isFinite(transientBed.getElapsedTime());
+        assert transientBed.getElapsedTime() > 0.0;
+        assert Double.isFinite(co2Loading);
+        assert co2Loading >= 0.0;
+        logger.info(
+            "Transient screen: time {} s, average CO2 loading {} mol/kg, breakthrough {}",
             transientBed.getElapsedTime(),
             co2Loading,
             transientBed.isBreakthroughOccurred());
@@ -214,8 +232,13 @@ import neqsim.process.equipment.adsorber.AdsorptionCycleController;
 import neqsim.process.equipment.adsorber.AdsorptionCycleController.PhaseStep;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemSrkEos;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AdsorptionCycleSchedule {
+    private static final Logger logger =
+        LogManager.getLogger(AdsorptionCycleSchedule.class);
+
     private static AdsorptionBed createBed() {
         SystemSrkEos gas = new SystemSrkEos(298.15, 10.0);
         gas.addComponent("methane", 0.90);
@@ -236,10 +259,18 @@ public class AdsorptionCycleSchedule {
     private static void printSchedule(
             String name,
             AdsorptionCycleController controller) {
-        System.out.println(name);
+        assert !controller.getSchedule().isEmpty();
+        logger.info("{}:", name);
         for (PhaseStep step : controller.getSchedule()) {
-            System.out.printf(
-                "  %-18s duration %.0f s, target %.2f bara, %.2f K%n",
+            assert Double.isFinite(step.getDuration()) && step.getDuration() > 0.0;
+            assert step.getTargetPressure() == -1.0
+                || Double.isFinite(step.getTargetPressure())
+                    && step.getTargetPressure() > 0.0;
+            assert step.getTargetTemperature() == -1.0
+                || Double.isFinite(step.getTargetTemperature())
+                    && step.getTargetTemperature() > 0.0;
+            logger.info(
+                "{} duration {} s, target {} bara, {} K",
                 step.getPhase(),
                 step.getDuration(),
                 step.getTargetPressure(),
@@ -252,9 +283,11 @@ public class AdsorptionCycleSchedule {
             new AdsorptionCycleController(createBed());
 
         controller.configurePSA(300.0, 30.0, 60.0, 30.0, 1.0);
+        assert controller.getSchedule().size() == 4;
         printSchedule("PSA schedule", controller);
 
         controller.configureTSA(1800.0, 600.0, 300.0, 523.15);
+        assert controller.getSchedule().size() == 3;
         printSchedule("TSA schedule", controller);
     }
 }

--- a/src/test/java/neqsim/documentation/AdsorptionRecipesDocumentationTest.java
+++ b/src/test/java/neqsim/documentation/AdsorptionRecipesDocumentationTest.java
@@ -1,0 +1,134 @@
+package neqsim.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Compiles and executes the published adsorption recipes, including their physical assertions.
+ */
+public class AdsorptionRecipesDocumentationTest extends neqsim.NeqSimTest {
+  private static final Pattern JAVA_FENCE =
+      Pattern.compile("(?m)^```java\\r?\\n([\\s\\S]*?)^```[ \\t]*$");
+  private static final Pattern PUBLIC_CLASS =
+      Pattern.compile("public class ([A-Za-z][A-Za-z0-9_]*)");
+
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void adsorptionRecipesCompileAndRunWithPhysicalAssertions() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    assertNotNull(compiler, "Documentation examples require a JDK compiler");
+    Path repositoryRoot = Paths.get(System.getProperty("basedir", ".")).toAbsolutePath();
+    Path document = repositoryRoot.resolve("docs/cookbook/adsorption-recipes.md");
+    String markdown =
+        new String(Files.readAllBytes(document), StandardCharsets.UTF_8);
+    Matcher fences = JAVA_FENCE.matcher(markdown);
+    List<String> classNames = new ArrayList<String>();
+    List<Path> sourceFiles = new ArrayList<Path>();
+    while (fences.find()) {
+      String source = fences.group(1);
+      Matcher className = PUBLIC_CLASS.matcher(source);
+      assertTrue(className.find(), "Each Java recipe must be a complete public class");
+      assertTrue(
+          !source.contains("System.out") && !source.contains("System.err"),
+          "Adsorption recipes must use the project logger");
+      assertTrue(
+          source.contains("LogManager.getLogger"),
+          "Each adsorption recipe must declare a project logger");
+      assertTrue(
+          source.contains("    assert "),
+          "Each adsorption recipe must check its physical results");
+      String name = className.group(1);
+      assertTrue(!classNames.contains(name), "Duplicate adsorption recipe class " + name);
+      classNames.add(name);
+      Path sourceFile = temporaryDirectory.resolve(name + ".java");
+      Files.write(sourceFile, source.getBytes(StandardCharsets.UTF_8));
+      sourceFiles.add(sourceFile);
+    }
+    assertEquals(3, classNames.size(), "Adsorption recipe coverage changed");
+    compile(compiler, sourceFiles);
+
+    try (URLClassLoader loader =
+        new URLClassLoader(
+            new URL[] {temporaryDirectory.toUri().toURL()}, getClass().getClassLoader())) {
+      loader.setDefaultAssertionStatus(true);
+      for (String className : classNames) {
+        Class<?> example = Class.forName(className, true, loader);
+        assertTrue(
+            example.desiredAssertionStatus(),
+            "Physical assertions must be enabled for " + className);
+        try {
+          example.getMethod("main", String[].class).invoke(null, (Object) new String[0]);
+        } catch (InvocationTargetException exception) {
+          throw new AssertionError(className + " failed", exception.getCause());
+        }
+      }
+    }
+  }
+
+  /**
+   * Compile with Java 8 syntax and the same dependency classpath used by the repository tests.
+   *
+   * @param compiler current JDK compiler
+   * @param sourceFiles extracted Markdown sources
+   * @throws IOException if a source cannot be read
+   */
+  private void compile(JavaCompiler compiler, List<Path> sourceFiles) throws IOException {
+    DiagnosticCollector<JavaFileObject> diagnostics =
+        new DiagnosticCollector<JavaFileObject>();
+    List<java.io.File> files = new ArrayList<java.io.File>();
+    for (Path sourceFile : sourceFiles) {
+      files.add(sourceFile.toFile());
+    }
+    String classPath =
+        System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+    List<String> options =
+        Arrays.asList(
+            "-source",
+            "8",
+            "-target",
+            "8",
+            "-classpath",
+            classPath,
+            "-d",
+            temporaryDirectory.toString());
+    try (StandardJavaFileManager manager =
+        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+      Boolean successful =
+          compiler
+              .getTask(
+                  null,
+                  manager,
+                  diagnostics,
+                  options,
+                  null,
+                  manager.getJavaFileObjectsFromFiles(files))
+              .call();
+      assertTrue(
+          Boolean.TRUE.equals(successful),
+          "docs/cookbook/adsorption-recipes.md: " + diagnostics.getDiagnostics());
+    }
+  }
+}

--- a/src/test/java/neqsim/documentation/AdsorptionRecipesDocumentationTest.java
+++ b/src/test/java/neqsim/documentation/AdsorptionRecipesDocumentationTest.java
@@ -28,10 +28,8 @@ import org.junit.jupiter.api.io.TempDir;
  * Compiles and executes the published adsorption recipes, including their physical assertions.
  */
 public class AdsorptionRecipesDocumentationTest extends neqsim.NeqSimTest {
-  private static final Pattern JAVA_FENCE =
-      Pattern.compile("(?m)^```java\\r?\\n([\\s\\S]*?)^```[ \\t]*$");
-  private static final Pattern PUBLIC_CLASS =
-      Pattern.compile("public class ([A-Za-z][A-Za-z0-9_]*)");
+  private static final Pattern JAVA_FENCE = Pattern.compile("(?m)^```java\\r?\\n([\\s\\S]*?)^```[ \\t]*$");
+  private static final Pattern PUBLIC_CLASS = Pattern.compile("public class ([A-Za-z][A-Za-z0-9_]*)");
 
   @TempDir
   Path temporaryDirectory;
@@ -42,8 +40,7 @@ public class AdsorptionRecipesDocumentationTest extends neqsim.NeqSimTest {
     assertNotNull(compiler, "Documentation examples require a JDK compiler");
     Path repositoryRoot = Paths.get(System.getProperty("basedir", ".")).toAbsolutePath();
     Path document = repositoryRoot.resolve("docs/cookbook/adsorption-recipes.md");
-    String markdown =
-        new String(Files.readAllBytes(document), StandardCharsets.UTF_8);
+    String markdown = new String(Files.readAllBytes(document), StandardCharsets.UTF_8);
     Matcher fences = JAVA_FENCE.matcher(markdown);
     List<String> classNames = new ArrayList<String>();
     List<Path> sourceFiles = new ArrayList<Path>();
@@ -51,15 +48,10 @@ public class AdsorptionRecipesDocumentationTest extends neqsim.NeqSimTest {
       String source = fences.group(1);
       Matcher className = PUBLIC_CLASS.matcher(source);
       assertTrue(className.find(), "Each Java recipe must be a complete public class");
-      assertTrue(
-          !source.contains("System.out") && !source.contains("System.err"),
+      assertTrue(!source.contains("System.out") && !source.contains("System.err"),
           "Adsorption recipes must use the project logger");
-      assertTrue(
-          source.contains("LogManager.getLogger"),
-          "Each adsorption recipe must declare a project logger");
-      assertTrue(
-          source.contains("    assert "),
-          "Each adsorption recipe must check its physical results");
+      assertTrue(source.contains("LogManager.getLogger"), "Each adsorption recipe must declare a project logger");
+      assertTrue(source.contains("    assert "), "Each adsorption recipe must check its physical results");
       String name = className.group(1);
       assertTrue(!classNames.contains(name), "Duplicate adsorption recipe class " + name);
       classNames.add(name);
@@ -70,15 +62,12 @@ public class AdsorptionRecipesDocumentationTest extends neqsim.NeqSimTest {
     assertEquals(3, classNames.size(), "Adsorption recipe coverage changed");
     compile(compiler, sourceFiles);
 
-    try (URLClassLoader loader =
-        new URLClassLoader(
-            new URL[] {temporaryDirectory.toUri().toURL()}, getClass().getClassLoader())) {
+    try (URLClassLoader loader = new URLClassLoader(new URL[] { temporaryDirectory.toUri().toURL() },
+        getClass().getClassLoader())) {
       loader.setDefaultAssertionStatus(true);
       for (String className : classNames) {
         Class<?> example = Class.forName(className, true, loader);
-        assertTrue(
-            example.desiredAssertionStatus(),
-            "Physical assertions must be enabled for " + className);
+        assertTrue(example.desiredAssertionStatus(), "Physical assertions must be enabled for " + className);
         try {
           example.getMethod("main", String[].class).invoke(null, (Object) new String[0]);
         } catch (InvocationTargetException exception) {
@@ -96,38 +85,18 @@ public class AdsorptionRecipesDocumentationTest extends neqsim.NeqSimTest {
    * @throws IOException if a source cannot be read
    */
   private void compile(JavaCompiler compiler, List<Path> sourceFiles) throws IOException {
-    DiagnosticCollector<JavaFileObject> diagnostics =
-        new DiagnosticCollector<JavaFileObject>();
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
     List<java.io.File> files = new ArrayList<java.io.File>();
     for (Path sourceFile : sourceFiles) {
       files.add(sourceFile.toFile());
     }
-    String classPath =
-        System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
-    List<String> options =
-        Arrays.asList(
-            "-source",
-            "8",
-            "-target",
-            "8",
-            "-classpath",
-            classPath,
-            "-d",
-            temporaryDirectory.toString());
-    try (StandardJavaFileManager manager =
-        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
-      Boolean successful =
-          compiler
-              .getTask(
-                  null,
-                  manager,
-                  diagnostics,
-                  options,
-                  null,
-                  manager.getJavaFileObjectsFromFiles(files))
-              .call();
-      assertTrue(
-          Boolean.TRUE.equals(successful),
+    String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+    List<String> options = Arrays.asList("-source", "8", "-target", "8", "-classpath", classPath, "-d",
+        temporaryDirectory.toString());
+    try (StandardJavaFileManager manager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+      Boolean successful = compiler
+          .getTask(null, manager, diagnostics, options, null, manager.getJavaFileObjectsFromFiles(files)).call();
+      assertTrue(Boolean.TRUE.equals(successful),
           "docs/cookbook/adsorption-recipes.md: " + diagnostics.getDiagnostics());
     }
   }


### PR DESCRIPTION
## D149 — executable adsorption cookbook recipes

Campaign: #2499  
Roadmap rotation: scope 6 (tutorials, cookbook, troubleshooting, and examples)  
Status: **VALIDATION PENDING CI — 4 OF 5 WORKFLOWS PASS**

### Frozen scope

Exact base: `e4baa50c8fb0815e52c38ddcb93f806e6907ece8`  
Exact head: `7ac51266cab6062f5e9fec65d99ebbbd925658dc`

Exactly two files:

- `docs/cookbook/adsorption-recipes.md`
- `src/test/java/neqsim/documentation/AdsorptionRecipesDocumentationTest.java`

### Documentation repair

- Replaced all six console operations across the three complete adsorption programs with parameterized Log4j2 reporting.
- Added finite, nonnegative, bounded, duration, and schedule-cardinality assertions at the documented physical boundaries.
- Preserved the documented model inputs, API choices, units, limitations, and control flow.

### Executable gate

The focused test extracts the actual Markdown Java fences rather than duplicating them. It requires exactly three complete and uniquely named examples, rejects `System.out`/`System.err`, requires Log4j2 and physical assertions, compiles with `-source 8 -target 8`, enables assertions, and invokes every published `main`.

### Exact-head validation

- Documentation/search passes, including source audit, all documentation contracts, the new executable adsorption gate, site build, and generated search checks.
- Pre-commit, Spotless, and CodeQL pass.
- Javadocs, agent-skill references, agentic benchmark, and slow shards 1–3 pass.
- Ubuntu/Windows fast suites and slow shard 4 remain running; **VALIDATION PENDING CI**.
- No reviews or unresolved threads.

### Continuity and boundaries

- Three ordered commits; mergeable; the only post-publication change applies the hosted Spotless patch to the new test, with no documentation or scope change.
- Frozen paths were checked against the five positively identified autonomous drafts; no overlap was found.
- Autonomous implementation occupancy becomes **6 of 10**.
- No production-code, adsorption-model, parameter-data, API, notebook, generated-site, navigation, release, refinery, or Huldra change is included.
- The examples are executable screening workflows, not engineering qualification or equipment design.

This PR must remain draft-only. Do not merge, mark ready, rebase, synchronize, replace, close, or expand scope. Qualification requires all exact-head workflows, no unresolved review threads, and independent current-`master` byte verification after merge.