### PR TITLE
feat(refinery): expose scenario component recoveries

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -472,6 +472,9 @@ for (DoeBigHillVacuumScenarioScreen.PointResult point : screen.getPoints()) {
   double feedMassFlowKgPerHour = point.getScenario().getFeedMassFlowKgPerHour();
   double overheadMassFraction = point.getOverheadMassFraction();
   double overheadT50Kelvin = point.getOverheadBoilingPointQuantileKelvin(0.50);
+  DoeBigHillVacuumComponentRecovery recovery = point.getComponentRecovery();
+  double overheadHeavyRecovery =
+      recovery.getProduct("Overhead").getComponentMolarRecovery("DOE_BH_1050_PLUS_PC");
 }
 ```
 
@@ -481,19 +484,27 @@ flow simultaneously use the low/base/high values shown above. Tray topology and 
 remain fixed.
 
 Every scenario must pass the qualified MESH-residual, fallback, mass, component, energy,
-material-product, and boiling-point-order gates. The result returns defensive scenario-point arrays,
-the exact immutable scenario definitions and fractionation results, overhead-yield bounds, and the
-worst external mass closure, component closure, column energy error, and final MESH residual. Any
-failed scenario aborts the complete screen.
+material-product, and boiling-point-order gates. Each point also evaluates
+`DoeBigHillVacuumComponentRecovery` on the same solved model, without rebuilding or solving the
+scenario a second time. It exposes the exact DOE pseudo-component order, positive feed component
+flows in mol/h, product component flows in mol/h, and dimensionless overhead and bottoms recoveries.
+Every product recovery must remain finite and non-negative, and each component's two product
+recoveries must close to unity within 5%.
+
+The screen returns defensive scenario-point arrays, the exact immutable scenario definitions,
+fractionation results, and recovery results, overhead-yield bounds, and the worst external mass
+closure, component closure, component-recovery closure, column energy error, and final MESH
+residual. Any failed fractionation or recovery gate aborts the complete screen.
 
 These three discrete calculations are numerical robustness and interaction-screening evidence only.
-They do not define a continuous or measured operating envelope, response surface, interaction
-correlation, probability distribution, or optimization model. No monotonic trend is required. The
-screen does not establish hydraulic capacity, flooding, weeping, entrainment, pressure drop,
-scale-up, turndown, heat duty, utilities, equipment sizing, calibrated product yield, ASTM D1160 or
-TBP pressure correction, product-specification compliance, or plant agreement. All DOE assay
-provenance, three-cut 650 degF+ normalization, pseudo-component properties, and source-unreported
-engineering-input limitations remain unchanged.
+The component recoveries are numerical pseudo-component partition bookkeeping, not measured or
+calibrated yields. They do not define a continuous or measured operating envelope, response surface,
+interaction correlation, probability distribution, contaminant distribution, or optimization
+model. No monotonic trend is required. The screen does not establish hydraulic capacity, flooding,
+weeping, entrainment, pressure drop, scale-up, turndown, heat duty, utilities, equipment sizing,
+ASTM D1160 or TBP pressure correction, product-specification compliance, or plant agreement. All DOE
+assay provenance, three-cut 650 degF+ normalization, pseudo-component properties, and
+source-unreported engineering-input limitations remain unchanged.
 
 
 ## Pseudo-component recovery diagnostics

--- a/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java
@@ -23,6 +23,7 @@ public final class DoeBigHillVacuumScenarioScreen {
   private final double maximumOverheadMassFraction;
   private final double maximumMassClosureRelativeError;
   private final double maximumComponentMolarClosureRelativeError;
+  private final double maximumComponentRecoveryClosureError;
   private final double maximumColumnEnergyBalanceError;
   private final double maximumMeshResidualNorm;
 
@@ -33,6 +34,7 @@ public final class DoeBigHillVacuumScenarioScreen {
     double maximumOverheadFraction = Double.NEGATIVE_INFINITY;
     double maximumMassClosure = 0.0;
     double maximumComponentClosure = 0.0;
+    double maximumRecoveryClosure = 0.0;
     double maximumEnergyError = 0.0;
     double maximumMeshResidual = 0.0;
     for (PointResult point : points) {
@@ -43,6 +45,8 @@ public final class DoeBigHillVacuumScenarioScreen {
       maximumMassClosure = Math.max(maximumMassClosure, result.getMassClosureRelativeError());
       maximumComponentClosure = Math.max(maximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
+      maximumRecoveryClosure = Math.max(maximumRecoveryClosure,
+          point.getComponentRecovery().getMaximumComponentRecoveryClosureError());
       maximumEnergyError = Math.max(maximumEnergyError, result.getColumnEnergyBalanceError());
       maximumMeshResidual = Math.max(maximumMeshResidual, result.getMeshResidualNorm());
     }
@@ -51,6 +55,7 @@ public final class DoeBigHillVacuumScenarioScreen {
     maximumOverheadMassFraction = maximumOverheadFraction;
     maximumMassClosureRelativeError = maximumMassClosure;
     maximumComponentMolarClosureRelativeError = maximumComponentClosure;
+    maximumComponentRecoveryClosureError = maximumRecoveryClosure;
     maximumColumnEnergyBalanceError = maximumEnergyError;
     maximumMeshResidualNorm = maximumMeshResidual;
   }
@@ -85,7 +90,8 @@ public final class DoeBigHillVacuumScenarioScreen {
       try {
         model.getColumn().run(UUID.randomUUID());
         DoeBigHillVacuumFractionationResult result = DoeBigHillVacuumFractionationResult.evaluate(model);
-        evaluatedPoints[i] = new PointResult(scenario, result);
+        DoeBigHillVacuumComponentRecovery componentRecovery = DoeBigHillVacuumComponentRecovery.evaluate(model);
+        evaluatedPoints[i] = new PointResult(scenario, result, componentRecovery);
       } catch (RuntimeException exception) {
         throw new IllegalStateException("Vacuum scenario screen failed at point " + i + " (" + scenario.getName() + ")",
             exception);
@@ -131,6 +137,11 @@ public final class DoeBigHillVacuumScenarioScreen {
   /** @return largest component molar-closure relative error across the qualified scenarios */
   public double getMaximumComponentMolarClosureRelativeError() {
     return maximumComponentMolarClosureRelativeError;
+  }
+
+  /** @return largest component-recovery closure error across the qualified scenarios */
+  public double getMaximumComponentRecoveryClosureError() {
+    return maximumComponentRecoveryClosureError;
   }
 
   /** @return largest column energy-balance error across the qualified scenarios */
@@ -201,10 +212,13 @@ public final class DoeBigHillVacuumScenarioScreen {
   public static final class PointResult {
     private final Scenario scenario;
     private final DoeBigHillVacuumFractionationResult fractionationResult;
+    private final DoeBigHillVacuumComponentRecovery componentRecovery;
 
-    private PointResult(Scenario scenario, DoeBigHillVacuumFractionationResult fractionationResult) {
+    private PointResult(Scenario scenario, DoeBigHillVacuumFractionationResult fractionationResult,
+        DoeBigHillVacuumComponentRecovery componentRecovery) {
       this.scenario = Objects.requireNonNull(scenario, "scenario");
       this.fractionationResult = Objects.requireNonNull(fractionationResult, "fractionationResult");
+      this.componentRecovery = Objects.requireNonNull(componentRecovery, "componentRecovery");
     }
 
     /** @return immutable scenario definition applied at this point */
@@ -215,6 +229,11 @@ public final class DoeBigHillVacuumScenarioScreen {
     /** @return qualified immutable fractionation result for this scenario */
     public DoeBigHillVacuumFractionationResult getFractionationResult() {
       return fractionationResult;
+    }
+
+    /** @return immutable pseudo-component recovery evidence from the same solved scenario */
+    public DoeBigHillVacuumComponentRecovery getComponentRecovery() {
+      return componentRecovery;
     }
 
     /** @return overhead mass fraction of feed for this scenario */

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
@@ -72,8 +72,7 @@ public class DoeBigHillVacuumScenarioScreenTest {
       assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
-      String[] expectedComponentNames = {
-          "DOE_BH_650_850_PC", "DOE_BH_850_1050_PC", "DOE_BH_1050_PLUS_PC" };
+      String[] expectedComponentNames = { "DOE_BH_650_850_PC", "DOE_BH_850_1050_PC", "DOE_BH_1050_PLUS_PC" };
       assertArrayEquals(expectedComponentNames, recovery.getComponentNames());
       assertNotSame(recovery.getComponentNames(), recovery.getComponentNames());
       double[] feedComponentFlows = recovery.getFeedComponentMolarFlowsMolPerHour();

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.distillation;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -8,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.distillation.DoeBigHillVacuumComponentRecovery.ProductRecovery;
 import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationCase.OperatingInputs;
 import neqsim.process.equipment.distillation.DoeBigHillVacuumFractionationResult.ProductResult;
 import neqsim.process.equipment.distillation.DoeBigHillVacuumScenarioScreen.PointResult;
@@ -42,6 +44,7 @@ public class DoeBigHillVacuumScenarioScreenTest {
     double expectedMaximumOverhead = Double.NEGATIVE_INFINITY;
     double expectedMaximumMassClosure = 0.0;
     double expectedMaximumComponentClosure = 0.0;
+    double expectedMaximumRecoveryClosure = 0.0;
     double expectedMaximumEnergyError = 0.0;
     double expectedMaximumMeshResidual = 0.0;
 
@@ -49,6 +52,7 @@ public class DoeBigHillVacuumScenarioScreenTest {
       Scenario scenario = point.getScenario();
       OperatingInputs applied = scenario.getOperatingInputs();
       DoeBigHillVacuumFractionationResult result = point.getFractionationResult();
+      DoeBigHillVacuumComponentRecovery recovery = point.getComponentRecovery();
 
       assertEquals(12, applied.getSimpleTrayCount());
       assertEquals(4, applied.getFeedTrayIndex());
@@ -68,11 +72,35 @@ public class DoeBigHillVacuumScenarioScreenTest {
       assertTrue(result.getMaximumComponentMolarClosureRelativeError() <= BALANCE_TOLERANCE);
       assertTrue(result.getColumnEnergyBalanceError() <= BALANCE_TOLERANCE);
 
+      String[] expectedComponentNames = {
+          "DOE_BH_650_850_PC", "DOE_BH_850_1050_PC", "DOE_BH_1050_PLUS_PC" };
+      assertArrayEquals(expectedComponentNames, recovery.getComponentNames());
+      assertNotSame(recovery.getComponentNames(), recovery.getComponentNames());
+      double[] feedComponentFlows = recovery.getFeedComponentMolarFlowsMolPerHour();
+      ProductRecovery[] recoveredProducts = recovery.getProducts();
+      assertEquals(2, recoveredProducts.length);
+      assertNotSame(recoveredProducts, recovery.getProducts());
+      for (int componentIndex = 0; componentIndex < expectedComponentNames.length; componentIndex++) {
+        double recoverySum = 0.0;
+        for (ProductRecovery recoveredProduct : recoveredProducts) {
+          double componentFlow = recoveredProduct.getComponentMolarFlowsMolPerHour()[componentIndex];
+          double componentRecovery = recoveredProduct.getComponentMolarRecoveries()[componentIndex];
+          assertEquals(componentFlow / feedComponentFlows[componentIndex], componentRecovery, 1.0e-12);
+          assertEquals(componentRecovery,
+              recoveredProduct.getComponentMolarRecovery(expectedComponentNames[componentIndex]), 0.0);
+          recoverySum += componentRecovery;
+        }
+        assertEquals(1.0, recoverySum, BALANCE_TOLERANCE);
+      }
+      assertTrue(recovery.getMaximumComponentRecoveryClosureError() <= BALANCE_TOLERANCE);
+
       expectedMinimumOverhead = Math.min(expectedMinimumOverhead, point.getOverheadMassFraction());
       expectedMaximumOverhead = Math.max(expectedMaximumOverhead, point.getOverheadMassFraction());
       expectedMaximumMassClosure = Math.max(expectedMaximumMassClosure, result.getMassClosureRelativeError());
       expectedMaximumComponentClosure = Math.max(expectedMaximumComponentClosure,
           result.getMaximumComponentMolarClosureRelativeError());
+      expectedMaximumRecoveryClosure = Math.max(expectedMaximumRecoveryClosure,
+          recovery.getMaximumComponentRecoveryClosureError());
       expectedMaximumEnergyError = Math.max(expectedMaximumEnergyError, result.getColumnEnergyBalanceError());
       expectedMaximumMeshResidual = Math.max(expectedMaximumMeshResidual, result.getMeshResidualNorm());
     }
@@ -81,6 +109,7 @@ public class DoeBigHillVacuumScenarioScreenTest {
     assertEquals(expectedMaximumOverhead, screen.getMaximumOverheadMassFraction(), 0.0);
     assertEquals(expectedMaximumMassClosure, screen.getMaximumMassClosureRelativeError(), 0.0);
     assertEquals(expectedMaximumComponentClosure, screen.getMaximumComponentMolarClosureRelativeError(), 0.0);
+    assertEquals(expectedMaximumRecoveryClosure, screen.getMaximumComponentRecoveryClosureError(), 0.0);
     assertEquals(expectedMaximumEnergyError, screen.getMaximumColumnEnergyBalanceError(), 0.0);
     assertEquals(expectedMaximumMeshResidual, screen.getMaximumMeshResidualNorm(), 0.0);
   }


### PR DESCRIPTION
Advances #3305.

## Capability

Extends the qualified DOE Big Hill multivariable vacuum scenario screen with immutable Java/JPype-accessible pseudo-component recovery evidence from each scenario's existing solved model.

- evaluates `DoeBigHillVacuumComponentRecovery` after the same model has passed the existing fractionation-result gates;
- preserves caller-defined scenario order, exact scenario definitions, and the three DOE pseudo-component names/order;
- exposes per-point feed component molar flows, overhead/bottoms component molar flows, and dimensionless recoveries;
- reports the worst component-recovery closure error across the complete screen;
- aborts the complete screen if any scenario fails fractionation or component-recovery closure;
- retains defensive scenario, result, component-name, flow, recovery, and product arrays.

The focused low/base/high regression checks all three pseudo-components for every independently solved scenario, reconstructs each product recovery from molar flows, closes overhead-plus-bottoms recovery to unity within 5%, and verifies the screen-level worst-error aggregation.

## Provenance and engineering boundary

The public DOE Big Hill assay, qualified three-cut 650 °F+ normalization, pseudo-component properties, source provenance, and every source-unreported operating assumption are unchanged.

This is discrete numerical pseudo-component partition evidence for the existing synthetic low/base/high screen. It is not measured or calibrated yield, ASTM D1160/TBP or simulated-distillation evidence, contaminant distribution, a response surface, an interaction model, uncertainty, a monotonic trend, hydraulic capacity, equipment design, optimization, specification compliance, or plant agreement.

## Frozen scope and continuity

- Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5648378976
- Exact base: `e4baa50c8fb0815e52c38ddcb93f806e6907ece8`
- Initial publication head: `38366b78012adc0db8a641995e50ef995cf4352c`
- Exact repaired head: `e7a9af09ece14230431dafd9c00789b1e1d4d1ac`
- Branch: `codex/refinery-vacuum-scenario-component-recovery`
- Three ordered commits; exactly three intended files; zero commits behind the frozen base
- No changed-file overlap with autonomous drafts #3664, #3667, #3679, #3681, #3682, or #3684
- Positively identified autonomous implementation occupancy after reservation: **7/10**

Changed files:

1. `src/main/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreen.java`
2. `src/test/java/neqsim/process/equipment/distillation/DoeBigHillVacuumScenarioScreenTest.java`
3. `docs/thermo/characterization/refinery_big_hill_complete_slate.md`

## Validation

Connector-side pre-publication checks confirm the exact three-file scope, frozen-base continuity, Java 8-compatible constructs, same-solve recovery wiring, defensive result exposure, explicit molar-flow and dimensionless-recovery units, preserved DOE provenance, documentation impact, and no active ownership overlap.

Hosted exact-head CI is authoritative for compilation, focused scenario execution, regression behavior, Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, agent checks, cross-platform Java tests, and slow-test shards.

The campaign's single formatter repair applies the exact one-file patch from hosted Spotless run [34716368150](https://github.com/equinor/neqsim/actions/runs/34716368150), artifact `10304059290`, verified digest `sha256:db03577a3a8142e1ae163f7daa23ad1d8ab36b3a5438efdf952d4ee76381b51e`. It changes only the formatting of the three-name array in the focused test. The repaired test blob is `5d9cdcb78186267873a93b6612f06465177b628d`; no behavior, API, test intent, scientific assumption, provenance, or acceptance criterion changed. The formatter-repair allowance is exhausted.

Exact-head CI passes after a failed-job-only retry of an externally cancelled build attempt: Java 8/21 on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, production-optimization documentation, CodeQL, PaperLab, agent-skill cross-references, and the agentic benchmark.

**VALIDATION COMPLETE — HUMAN REVIEW REQUIRED.**

Because this extends public engineering API, subsystem-owner and independent-maintainer reviews are required before READY TO MERGE.

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.