### PR TITLE
[AI-Assisted] feat(kinetics): add explicit sulfur allocation boundary

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -323,6 +323,43 @@ Product and deposition calculations require separately qualified stoichiometry a
 and must compose with the existing sulfur analyser, wall inventory, oxidation source, solid
 flash, and filter implementations.
 
+## Explicit elemental-sulfur allocation boundary
+
+`AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(...)` creates an immutable,
+non-mutating accounting receipt between one qualified segment sulfur-equivalent budget and a
+caller-defined elemental-sulfur scenario. The caller must supply both an allocation fraction
+`f_ES` in `[0, 1]` and a non-blank allocation-basis identifier. The identifier records which
+external basis the caller used; its presence does not qualify that basis or turn the fraction
+into a measured product yield.
+
+For each lower-rate, nominal, and upper-rate fit path, the receipt applies the same explicit
+fraction to mass rate and mass:
+
+$
+\dot m_{S,\mathrm{allocated}}=f_{ES}\dot m_{S,\mathrm{equiv}}, \qquad
+\dot m_{S,\mathrm{unallocated}}=\dot m_{S,\mathrm{equiv}}-\dot m_{S,\mathrm{allocated}},
+$
+
+$
+m_{S,\mathrm{allocated}}=f_{ES}m_{S,\mathrm{equiv}}, \qquad
+m_{S,\mathrm{unallocated}}=m_{S,\mathrm{equiv}}-m_{S,\mathrm{allocated}}.
+$
+
+The result exposes the source sulfur-equivalent budget, allocated elemental-sulfur scenario,
+unallocated sulfur-equivalent remainder, and closure residual on both rate and mass bases.
+Zero allocation leaves the complete source budget unallocated; full allocation leaves an exact
+zero remainder. Values scale linearly with the explicit water inventory, and summing receipts
+from an unchanged-state segment subdivision reproduces the unsplit allocated mass. Missing or
+invalid inputs, numerical overflow, and positive products that underflow to zero fail closed.
+
+Downstream code may consume an allocated elemental-sulfur field once and must carry the
+unallocated remainder separately. It must not apply both the original source budget and the
+unallocated remainder as products, because that would double count sulfur. The receipt itself
+does not create S8 molecular amounts, supply a default fraction, select products, qualify
+stoichiometry or selectivity, consume O2, calculate heat, speciation, pressure, phase transfer or
+water holdup, create a signed source, execute a solid flash, or mutate a stream, wall, deposit,
+filter, corrosion, process, transient, or pipeline state.
+
 ## Piecewise target crossing
 
 `AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -37,6 +37,16 @@ WATER_INVENTORY_PROJECTION_TEST = (
     / "src/test/java/neqsim/process/equipment/reactor/"
     / "AqueousHydrogenSulfideOxidationWaterInventoryProjectionTest.java"
 )
+ELEMENTAL_SULFUR_ALLOCATION = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationElementalSulfurAllocation.java"
+)
+ELEMENTAL_SULFUR_ALLOCATION_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationElementalSulfurAllocationTest.java"
+)
 
 
 class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
@@ -55,6 +65,12 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         )
         cls.water_inventory_projection_test = WATER_INVENTORY_PROJECTION_TEST.read_text(
             encoding="utf-8"
+        )
+        cls.elemental_sulfur_allocation = ELEMENTAL_SULFUR_ALLOCATION.read_text(
+            encoding="utf-8"
+        )
+        cls.elemental_sulfur_allocation_test = (
+            ELEMENTAL_SULFUR_ALLOCATION_TEST.read_text(encoding="utf-8")
         )
         cls.normalized = " ".join(cls.guide.split())
 
@@ -407,6 +423,46 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "IronSulfideWallInventory.SULFUR_MOLAR_MASS_KG_PER_MOL",
         ):
             self.assertIn(token, self.water_inventory_projection_test)
+
+    def test_elemental_sulfur_allocation_boundary_is_documented_and_executable(self):
+        for token in (
+            "Explicit elemental-sulfur allocation boundary",
+            "`AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(...)`",
+            "caller-defined elemental-sulfur scenario",
+            r"\dot m_{S,\mathrm{allocated}}=f_{ES}\dot m_{S,\mathrm{equiv}}",
+            r"m_{S,\mathrm{unallocated}}=m_{S,\mathrm{equiv}}-m_{S,\mathrm{allocated}}",
+            "unallocated sulfur-equivalent remainder",
+            "presence does not qualify that basis",
+            "must not apply both the original source budget and the unallocated remainder",
+            "does not create S8 molecular amounts",
+            "execute a solid flash",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static Result allocate(",
+            "elementalSulfurAllocationFraction",
+            "allocationBasisIdentifier",
+            "getSourceSulfurEquivalentMassRateKgPerHour()",
+            "getAllocatedElementalSulfurMassRateKgPerHour()",
+            "getUnallocatedSulfurEquivalentMassRateKgPerHour()",
+            "getRateClosureResidualKgPerHour()",
+            "getAllocatedElementalSulfurMassKg()",
+            "getUnallocatedSulfurEquivalentMassKg()",
+            "getMassClosureResidualKg()",
+            "finiteProduct(",
+            "finiteDifference(",
+        ):
+            self.assertIn(token, self.elemental_sulfur_allocation)
+
+        for token in (
+            "testQuarterAllocationClosesEveryFitPathAndPreservesOrdering",
+            "testZeroAndFullAllocationAreExactIdentities",
+            "testAllocationScalesWithWaterInventoryAndIsSegmentSplitInvariant",
+            "testAllocationReceiptIsSerializableAndDeterministic",
+            "testMissingInvalidOrUnrepresentableAllocationFailsClosed",
+        ):
+            self.assertIn(token, self.elemental_sulfur_allocation_test)
 
 
     def test_absolute_reacted_moles_target_is_documented_and_executable(self):

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationElementalSulfurAllocation.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationElementalSulfurAllocation.java
@@ -1,0 +1,258 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Creates an explicit, non-mutating elemental-sulfur allocation scenario from one qualified aqueous H2S/O2
+ * sulfur-equivalent segment budget.
+ *
+ * <p>
+ * The caller supplies the allocation fraction and a basis identifier. This class does not provide a default fraction,
+ * qualify the caller's basis, infer a product yield, create S8, or mutate a process model. The unallocated
+ * sulfur-equivalent remainder is retained so downstream accounting can avoid applying the same sulfur twice.
+ * </p>
+ *
+ * @author esol
+ * @version $Id: $
+ */
+public final class AqueousHydrogenSulfideOxidationElementalSulfurAllocation {
+  private static final int MAXIMUM_BASIS_IDENTIFIER_LENGTH = 256;
+
+  private AqueousHydrogenSulfideOxidationElementalSulfurAllocation() {
+  }
+
+  /**
+   * Allocate an explicit fraction of one segment's sulfur-equivalent loss to an elemental-sulfur scenario.
+   *
+   * @param source qualified dimensional water-inventory projection for one segment
+   * @param elementalSulfurAllocationFraction caller-supplied allocation fraction [fraction]
+   * @param allocationBasisIdentifier non-blank identifier for the caller's allocation basis
+   * @return immutable allocation receipt for the lower, nominal, and upper fit-scatter paths
+   */
+  public static Result allocate(AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result source,
+      double elementalSulfurAllocationFraction, String allocationBasisIdentifier) {
+    if (source == null) {
+      throw new IllegalArgumentException("Source sulfur-equivalent budget cannot be null");
+    }
+    if (!Double.isFinite(elementalSulfurAllocationFraction) || elementalSulfurAllocationFraction < 0.0
+        || elementalSulfurAllocationFraction > 1.0) {
+      throw new IllegalArgumentException("Elemental-sulfur allocation fraction must be finite and in [0, 1]");
+    }
+    String basisIdentifier = requireBasisIdentifier(allocationBasisIdentifier);
+
+    PathResult lowerRate = allocatePath(source.getLowerRateMeanSulfurEquivalentMassRateKgPerHour(),
+        source.getLowerRateReactedSulfurEquivalentMassKg(), elementalSulfurAllocationFraction, "Lower-rate");
+    PathResult nominal = allocatePath(source.getNominalMeanSulfurEquivalentMassRateKgPerHour(),
+        source.getNominalReactedSulfurEquivalentMassKg(), elementalSulfurAllocationFraction, "Nominal");
+    PathResult upperRate = allocatePath(source.getUpperRateMeanSulfurEquivalentMassRateKgPerHour(),
+        source.getUpperRateReactedSulfurEquivalentMassKg(), elementalSulfurAllocationFraction, "Upper-rate");
+
+    return new Result(source.getSegmentIndex(), source.getDurationHours(), source.getWaterInventoryKg(),
+        elementalSulfurAllocationFraction, basisIdentifier, lowerRate, nominal, upperRate);
+  }
+
+  private static String requireBasisIdentifier(String identifier) {
+    if (identifier == null || identifier.isEmpty() || !identifier.equals(identifier.trim())
+        || identifier.length() > MAXIMUM_BASIS_IDENTIFIER_LENGTH) {
+      throw new IllegalArgumentException(
+          "Allocation basis identifier must be non-blank, trimmed, and no longer than 256 characters");
+    }
+    return identifier;
+  }
+
+  private static PathResult allocatePath(double sourceMassRateKgPerHour, double sourceMassKg, double allocationFraction,
+      String pathName) {
+    requireNonNegativeFinite(sourceMassRateKgPerHour, pathName + " source sulfur-equivalent mass rate");
+    requireNonNegativeFinite(sourceMassKg, pathName + " source sulfur-equivalent mass");
+
+    double allocatedMassRateKgPerHour = finiteProduct(sourceMassRateKgPerHour, allocationFraction,
+        pathName + " allocated elemental-sulfur mass rate");
+    double allocatedMassKg = finiteProduct(sourceMassKg, allocationFraction,
+        pathName + " allocated elemental-sulfur mass");
+    double unallocatedMassRateKgPerHour = finiteDifference(sourceMassRateKgPerHour, allocatedMassRateKgPerHour,
+        pathName + " unallocated sulfur-equivalent mass rate");
+    double unallocatedMassKg = finiteDifference(sourceMassKg, allocatedMassKg,
+        pathName + " unallocated sulfur-equivalent mass");
+
+    double rateClosureResidualKgPerHour = sourceMassRateKgPerHour
+        - (allocatedMassRateKgPerHour + unallocatedMassRateKgPerHour);
+    double massClosureResidualKg = sourceMassKg - (allocatedMassKg + unallocatedMassKg);
+    requireFinite(rateClosureResidualKgPerHour, pathName + " allocation rate closure residual");
+    requireFinite(massClosureResidualKg, pathName + " allocation mass closure residual");
+
+    return new PathResult(sourceMassRateKgPerHour, allocatedMassRateKgPerHour, unallocatedMassRateKgPerHour,
+        rateClosureResidualKgPerHour, sourceMassKg, allocatedMassKg, unallocatedMassKg, massClosureResidualKg);
+  }
+
+  private static void requireNonNegativeFinite(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  private static void requireFinite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+
+  private static double finiteProduct(double first, double second, String name) {
+    double product = first * second;
+    if (!Double.isFinite(product) || product < 0.0 || (first > 0.0 && second > 0.0 && product == 0.0)) {
+      throw new IllegalArgumentException(name + " is not finite and representable");
+    }
+    return product;
+  }
+
+  private static double finiteDifference(double minuend, double subtrahend, String name) {
+    double difference = minuend - subtrahend;
+    if (!Double.isFinite(difference) || difference < 0.0) {
+      throw new IllegalArgumentException(name + " is not finite and non-negative");
+    }
+    return difference;
+  }
+
+  /** Immutable allocation receipt for one qualified source segment. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final int sourceSegmentIndex;
+    private final double durationHours;
+    private final double waterInventoryKg;
+    private final double elementalSulfurAllocationFraction;
+    private final String allocationBasisIdentifier;
+    private final PathResult lowerRate;
+    private final PathResult nominal;
+    private final PathResult upperRate;
+
+    private Result(int sourceSegmentIndex, double durationHours, double waterInventoryKg,
+        double elementalSulfurAllocationFraction, String allocationBasisIdentifier, PathResult lowerRate,
+        PathResult nominal, PathResult upperRate) {
+      this.sourceSegmentIndex = sourceSegmentIndex;
+      this.durationHours = durationHours;
+      this.waterInventoryKg = waterInventoryKg;
+      this.elementalSulfurAllocationFraction = elementalSulfurAllocationFraction;
+      this.allocationBasisIdentifier = allocationBasisIdentifier;
+      this.lowerRate = lowerRate;
+      this.nominal = nominal;
+      this.upperRate = upperRate;
+    }
+
+    /** @return source-order segment index. */
+    public int getSourceSegmentIndex() {
+      return sourceSegmentIndex;
+    }
+
+    /** @return source segment duration [h]. */
+    public double getDurationHours() {
+      return durationHours;
+    }
+
+    /** @return explicit liquid-water inventory used by the source projection [kg]. */
+    public double getWaterInventoryKg() {
+      return waterInventoryKg;
+    }
+
+    /** @return caller-supplied elemental-sulfur allocation fraction [fraction]. */
+    public double getElementalSulfurAllocationFraction() {
+      return elementalSulfurAllocationFraction;
+    }
+
+    /**
+     * Return the caller's allocation-basis identifier.
+     *
+     * <p>
+     * Presence of this identifier records provenance but does not establish that the allocation is scientifically
+     * qualified.
+     * </p>
+     *
+     * @return allocation-basis identifier
+     */
+    public String getAllocationBasisIdentifier() {
+      return allocationBasisIdentifier;
+    }
+
+    /** @return lower-rate fit-path allocation receipt. */
+    public PathResult getLowerRate() {
+      return lowerRate;
+    }
+
+    /** @return nominal fit-path allocation receipt. */
+    public PathResult getNominal() {
+      return nominal;
+    }
+
+    /** @return upper-rate fit-path allocation receipt. */
+    public PathResult getUpperRate() {
+      return upperRate;
+    }
+  }
+
+  /** Immutable source, allocated, remainder, and closure evidence for one fit path. */
+  public static final class PathResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double sourceSulfurEquivalentMassRateKgPerHour;
+    private final double allocatedElementalSulfurMassRateKgPerHour;
+    private final double unallocatedSulfurEquivalentMassRateKgPerHour;
+    private final double rateClosureResidualKgPerHour;
+    private final double sourceSulfurEquivalentMassKg;
+    private final double allocatedElementalSulfurMassKg;
+    private final double unallocatedSulfurEquivalentMassKg;
+    private final double massClosureResidualKg;
+
+    private PathResult(double sourceSulfurEquivalentMassRateKgPerHour, double allocatedElementalSulfurMassRateKgPerHour,
+        double unallocatedSulfurEquivalentMassRateKgPerHour, double rateClosureResidualKgPerHour,
+        double sourceSulfurEquivalentMassKg, double allocatedElementalSulfurMassKg,
+        double unallocatedSulfurEquivalentMassKg, double massClosureResidualKg) {
+      this.sourceSulfurEquivalentMassRateKgPerHour = sourceSulfurEquivalentMassRateKgPerHour;
+      this.allocatedElementalSulfurMassRateKgPerHour = allocatedElementalSulfurMassRateKgPerHour;
+      this.unallocatedSulfurEquivalentMassRateKgPerHour = unallocatedSulfurEquivalentMassRateKgPerHour;
+      this.rateClosureResidualKgPerHour = rateClosureResidualKgPerHour;
+      this.sourceSulfurEquivalentMassKg = sourceSulfurEquivalentMassKg;
+      this.allocatedElementalSulfurMassKg = allocatedElementalSulfurMassKg;
+      this.unallocatedSulfurEquivalentMassKg = unallocatedSulfurEquivalentMassKg;
+      this.massClosureResidualKg = massClosureResidualKg;
+    }
+
+    /** @return source sulfur-equivalent mean loss rate [kg S-equivalent/h]. */
+    public double getSourceSulfurEquivalentMassRateKgPerHour() {
+      return sourceSulfurEquivalentMassRateKgPerHour;
+    }
+
+    /** @return caller-allocated elemental-sulfur mean rate [kg S/h]. */
+    public double getAllocatedElementalSulfurMassRateKgPerHour() {
+      return allocatedElementalSulfurMassRateKgPerHour;
+    }
+
+    /** @return unallocated sulfur-equivalent mean rate [kg S-equivalent/h]. */
+    public double getUnallocatedSulfurEquivalentMassRateKgPerHour() {
+      return unallocatedSulfurEquivalentMassRateKgPerHour;
+    }
+
+    /** @return rate-basis allocation closure residual [kg/h]. */
+    public double getRateClosureResidualKgPerHour() {
+      return rateClosureResidualKgPerHour;
+    }
+
+    /** @return source reacted sulfur-equivalent mass [kg S-equivalent]. */
+    public double getSourceSulfurEquivalentMassKg() {
+      return sourceSulfurEquivalentMassKg;
+    }
+
+    /** @return caller-allocated elemental-sulfur mass [kg S]. */
+    public double getAllocatedElementalSulfurMassKg() {
+      return allocatedElementalSulfurMassKg;
+    }
+
+    /** @return unallocated sulfur-equivalent mass [kg S-equivalent]. */
+    public double getUnallocatedSulfurEquivalentMassKg() {
+      return unallocatedSulfurEquivalentMassKg;
+    }
+
+    /** @return mass-basis allocation closure residual [kg]. */
+    public double getMassClosureResidualKg() {
+      return massClosureResidualKg;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationElementalSulfurAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationElementalSulfurAllocationTest.java
@@ -1,0 +1,183 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests explicit elemental-sulfur allocation from qualified H2S/O2 sulfur-equivalent evidence. */
+public class AqueousHydrogenSulfideOxidationElementalSulfurAllocationTest extends NeqSimTest {
+  private static final double INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
+  private static final double WATER_INVENTORY_KG = 1200.0;
+  private static final double TOLERANCE = 1.0e-17;
+  private static final String BASIS_IDENTIFIER = "caller-supplied-product-allocation-case-A";
+
+  @Test
+  void testQuarterAllocationClosesEveryFitPathAndPreservesOrdering() {
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result source = projection(referenceSegment(10.0),
+        WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(source, 0.25, BASIS_IDENTIFIER);
+
+    assertEquals(source.getSegmentIndex(), allocation.getSourceSegmentIndex());
+    assertEquals(source.getDurationHours(), allocation.getDurationHours(), 0.0);
+    assertEquals(source.getWaterInventoryKg(), allocation.getWaterInventoryKg(), 0.0);
+    assertEquals(0.25, allocation.getElementalSulfurAllocationFraction(), 0.0);
+    assertEquals(BASIS_IDENTIFIER, allocation.getAllocationBasisIdentifier());
+
+    assertPath(source.getLowerRateMeanSulfurEquivalentMassRateKgPerHour(),
+        source.getLowerRateReactedSulfurEquivalentMassKg(), allocation.getLowerRate(), 0.25);
+    assertPath(source.getNominalMeanSulfurEquivalentMassRateKgPerHour(),
+        source.getNominalReactedSulfurEquivalentMassKg(), allocation.getNominal(), 0.25);
+    assertPath(source.getUpperRateMeanSulfurEquivalentMassRateKgPerHour(),
+        source.getUpperRateReactedSulfurEquivalentMassKg(), allocation.getUpperRate(), 0.25);
+
+    assertTrue(allocation.getLowerRate().getAllocatedElementalSulfurMassKg() < allocation.getNominal()
+        .getAllocatedElementalSulfurMassKg());
+    assertTrue(allocation.getNominal().getAllocatedElementalSulfurMassKg() < allocation.getUpperRate()
+        .getAllocatedElementalSulfurMassKg());
+  }
+
+  @Test
+  void testZeroAndFullAllocationAreExactIdentities() {
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result source = projection(referenceSegment(10.0),
+        WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result zero = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(source, 0.0, "zero-allocation");
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result full = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(source, 1.0, "full-allocation");
+
+    assertEquals(0.0, zero.getNominal().getAllocatedElementalSulfurMassRateKgPerHour(), 0.0);
+    assertEquals(0.0, zero.getNominal().getAllocatedElementalSulfurMassKg(), 0.0);
+    assertEquals(zero.getNominal().getSourceSulfurEquivalentMassRateKgPerHour(),
+        zero.getNominal().getUnallocatedSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(zero.getNominal().getSourceSulfurEquivalentMassKg(),
+        zero.getNominal().getUnallocatedSulfurEquivalentMassKg(), 0.0);
+
+    assertEquals(full.getNominal().getSourceSulfurEquivalentMassRateKgPerHour(),
+        full.getNominal().getAllocatedElementalSulfurMassRateKgPerHour(), 0.0);
+    assertEquals(full.getNominal().getSourceSulfurEquivalentMassKg(),
+        full.getNominal().getAllocatedElementalSulfurMassKg(), 0.0);
+    assertEquals(0.0, full.getNominal().getUnallocatedSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(0.0, full.getNominal().getUnallocatedSulfurEquivalentMassKg(), 0.0);
+  }
+
+  @Test
+  void testAllocationScalesWithWaterInventoryAndIsSegmentSplitInvariant() {
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult = segmentResult(referenceSegment(10.0));
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result small = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segmentResult, 100.0), 0.4,
+            BASIS_IDENTIFIER);
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result large = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segmentResult, 250.0), 0.4,
+            BASIS_IDENTIFIER);
+
+    assertEquals(2.5 * small.getNominal().getAllocatedElementalSulfurMassRateKgPerHour(),
+        large.getNominal().getAllocatedElementalSulfurMassRateKgPerHour(), TOLERANCE);
+    assertEquals(2.5 * small.getNominal().getAllocatedElementalSulfurMassKg(),
+        large.getNominal().getAllocatedElementalSulfurMassKg(), TOLERANCE);
+    assertEquals(2.5 * small.getNominal().getUnallocatedSulfurEquivalentMassKg(),
+        large.getNominal().getUnallocatedSulfurEquivalentMassKg(), TOLERANCE);
+
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(10.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+    double unsplitAllocated = allocatedNominalMass(unsplit, 0.4);
+    double splitAllocated = allocatedNominalMass(split, 0.4);
+
+    assertEquals(unsplitAllocated, splitAllocated, TOLERANCE);
+  }
+
+  @Test
+  void testAllocationReceiptIsSerializableAndDeterministic() {
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result source = projection(referenceSegment(10.0),
+        WATER_INVENTORY_KG);
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result first = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(source, 0.5, BASIS_IDENTIFIER);
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result second = AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(source, 0.5, BASIS_IDENTIFIER);
+
+    assertTrue(first instanceof Serializable);
+    assertTrue(first.getNominal() instanceof Serializable);
+    assertEquals(first.getNominal().getAllocatedElementalSulfurMassRateKgPerHour(),
+        second.getNominal().getAllocatedElementalSulfurMassRateKgPerHour(), 0.0);
+    assertEquals(first.getNominal().getAllocatedElementalSulfurMassKg(),
+        second.getNominal().getAllocatedElementalSulfurMassKg(), 0.0);
+    assertEquals(first.getNominal().getUnallocatedSulfurEquivalentMassKg(),
+        second.getNominal().getUnallocatedSulfurEquivalentMassKg(), 0.0);
+  }
+
+  @Test
+  void testMissingInvalidOrUnrepresentableAllocationFailsClosed() {
+    AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result source = projection(referenceSegment(10.0),
+        WATER_INVENTORY_KG);
+    String oversizedIdentifier = new String(new char[257]).replace('\0', 'x');
+
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(null, 0.5, BASIS_IDENTIFIER));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, -0.1, BASIS_IDENTIFIER));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, 1.1, BASIS_IDENTIFIER));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, Double.NaN, BASIS_IDENTIFIER));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+        .allocate(source, Double.MIN_VALUE, BASIS_IDENTIFIER));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, 0.5, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, 0.5, ""));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, 0.5, " untrimmed"));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(source, 0.5, oversizedIdentifier));
+  }
+
+  private static double allocatedNominalMass(AqueousHydrogenSulfideOxidationTrajectory.Result trajectory,
+      double allocationFraction) {
+    double allocated = 0.0;
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : trajectory.getSegmentResults()) {
+      AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result source = AqueousHydrogenSulfideOxidationWaterInventoryProjection
+          .project(segment, WATER_INVENTORY_KG);
+      allocated += AqueousHydrogenSulfideOxidationElementalSulfurAllocation
+          .allocate(source, allocationFraction, BASIS_IDENTIFIER).getNominal().getAllocatedElementalSulfurMassKg();
+    }
+    return allocated;
+  }
+
+  private static void assertPath(double sourceRate, double sourceMass,
+      AqueousHydrogenSulfideOxidationElementalSulfurAllocation.PathResult allocation, double allocationFraction) {
+    assertEquals(sourceRate, allocation.getSourceSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(sourceMass, allocation.getSourceSulfurEquivalentMassKg(), 0.0);
+    assertEquals(sourceRate * allocationFraction, allocation.getAllocatedElementalSulfurMassRateKgPerHour(), 0.0);
+    assertEquals(sourceMass * allocationFraction, allocation.getAllocatedElementalSulfurMassKg(), 0.0);
+    assertEquals(sourceRate - sourceRate * allocationFraction,
+        allocation.getUnallocatedSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(sourceMass - sourceMass * allocationFraction, allocation.getUnallocatedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(0.0, allocation.getRateClosureResidualKgPerHour(), TOLERANCE);
+    assertEquals(0.0, allocation.getMassClosureResidualKg(), TOLERANCE);
+    assertTrue(allocation.getAllocatedElementalSulfurMassRateKgPerHour() <= allocation
+        .getSourceSulfurEquivalentMassRateKgPerHour());
+    assertTrue(allocation.getAllocatedElementalSulfurMassKg() <= allocation.getSourceSulfurEquivalentMassKg());
+  }
+
+  private static AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result projection(
+      AqueousHydrogenSulfideOxidationTrajectory.Segment segment, double waterInventoryKg) {
+    return AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segmentResult(segment), waterInventoryKg);
+  }
+
+  private static AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult(
+      AqueousHydrogenSulfideOxidationTrajectory.Segment segment) {
+    return AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(segment)).getSegmentResults().get(0);
+  }
+
+  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(double durationHours) {
+    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, 298.15, 8.0, 0.723, 250.0e-6);
+  }
+}


### PR DESCRIPTION
Advances #3318.

## Capability

Adds the smallest explicit accounting boundary between one qualified aqueous H2S/O2 sulfur-equivalent segment budget and a caller-defined elemental-sulfur scenario.

- consumes the existing immutable `AqueousHydrogenSulfideOxidationWaterInventoryProjection.Result`;
- requires a caller-supplied allocation fraction in `[0, 1]` and a non-blank allocation-basis identifier;
- reports source, allocated, unallocated, and closure quantities on both kg/h and kg bases for lower-rate, nominal, and upper-rate Millero paths;
- preserves the unallocated sulfur-equivalent remainder explicitly;
- provides exact zero/full-allocation identities, linear water-inventory scaling, segment-split invariance, deterministic immutable results, and fail-closed finite/representability guards.

For the existing 10 h, 1200 kg-water reference projection, a deliberately illustrative caller fraction of 0.25 allocates nominally `6.393394266643813e-6 kg S/h` and `6.393394266643813e-5 kg S`, leaving `1.9180182799931438e-5 kg S-equivalent/h` and `1.9180182799931436e-4 kg S-equivalent` unallocated. The fraction is test input, not a measured or recommended yield.

## Scientific and integration boundary

The underlying total-sulfide-loss evidence remains Millero et al. (1987), doi:10.1021/es00159a003. No new kinetic parameter, pressure qualification, stoichiometry, product distribution, selectivity, or oxygen demand is introduced.

The allocation-basis identifier records caller provenance but does not qualify it. Downstream code may consume the allocated elemental-sulfur fields once and must carry the unallocated remainder separately; applying both the original source budget and the remainder as products would double count sulfur.

This receipt does not create S8 molecular amounts, provide a default yield, mutate a stream, execute a solid flash, or update a wall, deposit, filter, corrosion, process, transient, or pipeline model. Any such coupling remains separately owned and requires qualified product/selectivity evidence. Existing `SulfurDepositionAnalyser`, `IronSulfideWallInventory`, `IronSulfideOxidationSource`, solid-flash, filter, #3144, #2937, #2911, pipeline, and #3153 paths remain unchanged.

## Validation

Local gates on the exact four-file tree:

- Spotless apply/check: pass.
- Java 8 compilation with ECJ 3.41.0: pass.
- Five focused Java tests: pass.
- Documentation contract: 19/19 pass.
- Python syntax compilation: pass.
- Remote and local Git blob hashes: exact match for all four files.

Hosted exact-head CI remains authoritative for the complete Java matrices, Javadocs, slow shards, CodeQL, PaperLab, pre-commit, and repository-wide documentation search.

## Frozen scope and continuity

- Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5648612089
- Exact base: `fbfa755b9508c6bd265003e58f3b6568c6569817`
- Exact publication head: `3e2471929f813302ca20624a3d416ef0e4f44b95`
- Branch: `automation/3318-h2s-elemental-sulfur-allocation-20260912`
- Four ordered commits; exactly four intended files; zero commits behind the frozen base.
- No active #3318 PR existed at reservation or publication.
- Positively identified autonomous implementation occupancy after reservation: **6/10**.

**VALIDATION PENDING EXACT-HEAD CI.**

Because this adds a public accounting interface adjacent to the sulfur/deposition path, subsystem-owner and independent-maintainer review are required before merge readiness.

This PR must remain open and draft-only. Do not merge, enable auto-merge, mark ready, rebase, synchronize, force-push, replace, close, or abandon its exact head for capacity.