### PR TITLE
[AI-Assisted] fix(pipeline): initialize TwoFluidPipe outlet after rate normalization

### DIFF
--- a/.github/skills/neqsim-api-patterns/SKILL.md
+++ b/.github/skills/neqsim-api-patterns/SKILL.md
@@ -258,6 +258,15 @@ an outlet has been handed to downstream equipment, preserve its object identity
 across `run(...)` calls by updating its thermodynamic system in place or using
 the established identity-preserving adoption helper.
 
+When publishing an equilibrium outlet, apply `SystemInterface.setTotalFlowRate(...)`
+before the final TP flash: the rate setter calls `init(0)` and resets the phase state.
+Initialize thermodynamic and transport properties with `initProperties()` after the
+flash, then publish without further rate mutations. Check raw outlet Cp, phase identity
+and component closure before any caller-side reflash; a sequential heat-transfer test
+can expose stale properties that a mass-balance test misses. See
+`TwoFluidPipeOutletThermodynamicsTest` and issue #3685. Handle zero inventory separately
+because its intensive properties are undefined.
+
 For phase-separated equipment, add a focused contract test after a successful
 solve that verifies:
 

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -1041,6 +1041,21 @@ update. The slip calculation first recovers the prescribed liquid mass flux, spl
 volume flow into oil and water, and synchronizes bulk liquid velocity and momentum with the phase
 momenta. This keeps the phase split consistent with the specified liquid throughput.
 
+For positive flow, the connected outlet retains the feed's total and component flow rates and is
+TP-flashed at the final section pressure and temperature **after** flow normalization. Thermodynamic
+and transport properties are then initialized before publication. Callers can read heat capacity,
+enthalpy and phase properties, or pass `getOutletStream()` directly to another pipe, without an
+additional stream run or TP flash. The outlet's equilibrium phase fractions are distinct from the
+hydraulic in-situ holdups. This fixes the stale phase state and invalid heat capacity tracked in
+[#3685](https://github.com/equinor/neqsim/issues/3685); downstream heat-transfer results produced by
+affected versions should be recalculated. It does not qualify pipeline thermal accuracy against
+experimental data.
+
+The shared transient publication path still uses the accepted interval-average total outlet flux.
+A closed outlet or clamped nonpositive net flux publishes zero inventory, whose intensive
+thermodynamic properties are undefined. Positive-flow outlet flash or property-initialization
+failures throw an exception before replacing the connected outlet fluid.
+
 **What happens during `run()`:**
 
 ```
@@ -1067,9 +1082,9 @@ momenta. This keeps the phase split consistent with the specified liquid through
 │    └─ Converge when max change < tolerance (1e-4)            │
 │                                                              │
 │ 3. updateOutletStream()                                      │
-│    ├─ Flash outlet fluid at outlet P, T                      │
-│    ├─ Calculate outlet mass flow from section state          │
-│    └─ Set outlet stream properties                           │
+│    ├─ Normalize outlet flow to the steady inlet flow         │
+│    ├─ TP-flash at final section pressure and temperature     │
+│    └─ Initialize properties and publish the outlet fluid     │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -1078,7 +1093,7 @@ momenta. This keeps the phase split consistent with the specified liquid through
 - **Iterative convergence:** Pressure, holdup and flashed phase properties must settle together
 - **Terrain-aware holdups:** Liquid accumulates at low points
 - **Single call:** Establishes initial state for subsequent transient runs
-- **Does not throw on failure:** the outcome must be read back (see below)
+- **Convergence limits:** read the outcome report (see below); outlet thermodynamic initialization failures throw
 
 **Example:**
 ```java

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4396,6 +4396,12 @@ public class TwoFluidPipe extends Pipeline {
     }
   }
 
+  /**
+   * Initialize the steady pipe state and publish its outlet fluid.
+   *
+   * @param id calculation identifier
+   * @throws IllegalStateException if the positive-flow outlet thermodynamic state cannot be initialized
+   */
   @Override
   public void run(UUID id) {
     lastMassBalanceReport = null;
@@ -4436,8 +4442,9 @@ public class TwoFluidPipe extends Pipeline {
    * @param dt Requested time step (s)
    * @param id Calculation identifier
    * @throws IllegalArgumentException if {@code dt} is not positive and finite
-   * @throws IllegalStateException if initialization is missing or the requested interval cannot be completed; the
-   * balance report and clocks retain only accepted substeps
+   * @throws IllegalStateException if initialization is missing, the requested interval cannot be completed, or the
+   * positive-flow outlet thermodynamic state cannot be initialized; the balance report and clocks retain only accepted
+   * substeps
    */
   @Override
   public void runTransient(double dt, UUID id) {
@@ -6145,6 +6152,12 @@ public class TwoFluidPipe extends Pipeline {
    * stream exposes the interval-average total outlet flux integrated over the accepted internal stages. Phase-resolved
    * integrals remain available from {@link #getLastMassBalanceReport()}.
    * </p>
+   *
+   * <p>
+   * Positive outlet flow is normalized before the final TP flash and property initialization. Rate normalization resets
+   * phase state, so it must not follow the flash. A zero or reverse net outlet flux publishes an empty fluid; intensive
+   * thermodynamic properties are not defined for that empty stream.
+   * </p>
    */
   private void updateOutletStream() {
     if (sections == null || sections.length == 0) {
@@ -6156,13 +6169,6 @@ public class TwoFluidPipe extends Pipeline {
 
     outFluid.setPressure(outlet.getPressure() / 1e5, "bara");
     outFluid.setTemperature(outlet.getTemperature(), "K");
-
-    try {
-      ThermodynamicOperations ops = new ThermodynamicOperations(outFluid);
-      ops.TPflash();
-    } catch (Exception e) {
-      logger.warn("Outlet flash failed: {}", e.getMessage());
-    }
 
     // Calculate outlet mass flow rate from section state
     double area = Math.PI * diameter * diameter / 4.0;
@@ -6199,7 +6205,20 @@ public class TwoFluidPipe extends Pipeline {
       throw new IllegalStateException(
           "Outlet mass flow must be finite: outlet=" + massFlowOut + " kg/s, inlet=" + massFlowIn + " kg/s");
     }
-    outFluid.setTotalFlowRate(Math.max(0.0, massFlowOut), "kg/sec");
+    if (massFlowOut > 0.0) {
+      // setTotalFlowRate calls init(0), which discards the equilibrium phase split.
+      // Complete every rate mutation before initializing the published state.
+      outFluid.setTotalFlowRate(massFlowOut, "kg/sec");
+      try {
+        new ThermodynamicOperations(outFluid).TPflash();
+        outFluid.initProperties();
+      } catch (Exception e) {
+        throw new IllegalStateException(getName() + ": outlet thermodynamic initialization failed", e);
+      }
+    } else {
+      // Do not flash zero inventory: a closed/clamped outlet must remain empty.
+      outFluid.setEmptyFluid();
+    }
 
     getOutletStream().setFluid(outFluid);
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeOutletThermodynamicsTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeOutletThermodynamicsTest.java
@@ -1,0 +1,242 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression coverage for initialized, composable outlet states after flow normalization (#3685). */
+class TwoFluidPipeOutletThermodynamicsTest extends neqsim.NeqSimTest {
+  private static final Logger logger = LogManager.getLogger(TwoFluidPipeOutletThermodynamicsTest.class);
+
+  @Test
+  void wetWellPublishesThreePhasesAndPropertiesWithoutASecondFlash() {
+    Stream feed = wetFeed();
+    SystemInterface originalFeed = feed.getFluid().clone();
+    TwoFluidPipe well = pipe("well", feed, 3100.0, 0.23, 2380.0, 0.0);
+    well.run();
+
+    assertOutletState(well, 3);
+    assertNotSame(feed.getFluid(), well.getOutletStream().getFluid());
+    assertEquals(originalFeed.getPressure(), feed.getPressure(), 0.0);
+    assertEquals(originalFeed.getTemperature(), feed.getTemperature(), 0.0);
+    assertEquals(originalFeed.getCp("J/kgK"), feed.getFluid().getCp("J/kgK"), 0.0);
+    assertComponentClosure(originalFeed, feed.getFluid());
+
+    // Reuse the same connected pipe after changing both pressure and rate.
+    feed.setPressure(220.0, "bara");
+    feed.setFlowRate(1.1 * originalFeed.getFlowRate("kg/sec"), "kg/sec");
+    feed.run();
+    well.run();
+    assertOutletState(well, 3);
+  }
+
+  @Test
+  void connectedHeatedPipeMatchesAnExplicitlyReflashedHandoff() {
+    Stream feed = wetFeed();
+    TwoFluidPipe well = pipe("upstream well", feed, 3100.0, 0.23, 2380.0, 0.0);
+    well.run();
+
+    SystemInterface refreshed = well.getOutletStream().getFluid().clone();
+    new ThermodynamicOperations(refreshed).TPflash();
+    refreshed.initProperties();
+    Stream referenceFeed = new Stream("explicitly refreshed handoff", refreshed);
+    TwoFluidPipe reference = pipe("reference flowline", referenceFeed, 6320.0, 0.35, 320.0, 2.0);
+    reference.run();
+
+    // Consume the actual connected outlet, without running or refreshing that stream.
+    TwoFluidPipe connected = pipe("connected flowline", well.getOutletStream(), 6320.0, 0.35, 320.0, 2.0);
+    connected.run();
+
+    assertTrue(reference.isSteadyStateConverged());
+    assertTrue(connected.isSteadyStateConverged());
+    assertEquals(reference.getOutletStream().getTemperature("K"), connected.getOutletStream().getTemperature("K"),
+        1.0e-5, "Downstream heat transfer must not depend on an extra caller-side flash");
+    assertEquals(reference.getOutletStream().getPressure("bara"), connected.getOutletStream().getPressure("bara"),
+        1.0e-5);
+    assertTrue(connected.getOutletStream().getTemperature("C") < well.getOutletStream().getTemperature("C") - 1.0,
+        "The fixture must resolve cooling rather than an effectively adiabatic pipe");
+    assertOutletState(well, 3);
+    assertOutletState(connected, 3);
+    assertComponentClosure(feed.getFluid(), connected.getOutletStream().getFluid());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = { 1, 2, 3 })
+  void gasAndLiquidPhaseCombinationsExposeInitializedProperties(int phases) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 70.0);
+    fluid.addComponent("methane", 1.0);
+    if (phases >= 2) {
+      fluid.addComponent("n-decane", 1.0);
+    }
+    if (phases == 3) {
+      fluid.addComponent("water", 1.0);
+    }
+    fluid.setMixingRule(2);
+    fluid.setMultiPhaseCheck(true);
+    Stream feed = new Stream("phase combination", fluid);
+    feed.setFlowRate(0.5, "kg/sec");
+    feed.run();
+    TwoFluidPipe pipe = pipe("short pipe", feed, 100.0, 0.3, 0.0, 0.0);
+    pipe.run();
+
+    assertOutletState(pipe, phases);
+  }
+
+  @Test
+  void propertyInitializationFailureDoesNotReplaceTheConnectedOutlet() {
+    PropertyFailureFluid fluid = new PropertyFailureFluid();
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule(2);
+    Stream feed = new Stream("failure fixture", fluid);
+    feed.setFlowRate(0.5, "kg/sec");
+    feed.run();
+    TwoFluidPipe pipe = pipe("publication failure", feed, 100.0, 0.3, 0.0, 0.0);
+    pipe.run();
+    SystemInterface acceptedOutlet = pipe.getOutletStream().getFluid();
+    ((PropertyFailureFluid) feed.getFluid()).failProperties = true;
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> pipe.run());
+
+    assertTrue(failure.getMessage().contains("outlet thermodynamic initialization failed"));
+    assertEquals("Injected property initialization failure", failure.getCause().getMessage());
+    assertSame(acceptedOutlet, pipe.getOutletStream().getFluid());
+  }
+
+  /** EOS fixture that fails only at the complete property-initialization boundary. */
+  private static final class PropertyFailureFluid extends SystemSrkEos {
+    private static final long serialVersionUID = 1L;
+    private boolean failProperties;
+
+    private PropertyFailureFluid() {
+      super(298.15, 70.0);
+    }
+
+    @Override
+    public void initProperties() {
+      if (failProperties) {
+        throw new IllegalStateException("Injected property initialization failure");
+      }
+      super.initProperties();
+    }
+  }
+
+  private static void assertOutletState(TwoFluidPipe pipe, int phases) {
+    assertTrue(pipe.isSteadyStateConverged(), "The steady solve must converge before publication");
+    SystemInterface actual = pipe.getOutletStream().getFluid();
+    double cp = actual.getCp("J/kgK");
+    logger.info("{}: outlet P={} bara, T={} C, Cp={} J/kgK, phases={}", pipe.getName(), actual.getPressure("bara"),
+        actual.getTemperature("C"), cp, actual.getNumberOfPhases());
+    assertTrue(Double.isFinite(cp) && cp > 100.0 && cp < 20000.0,
+        "Outlet Cp must be physically meaningful without a caller-side flash: " + cp);
+    assertEquals(phases, actual.getNumberOfPhases());
+
+    SystemInterface reference = pipe.getInletStream().getFluid().clone();
+    reference.setPressure(actual.getPressure(), "bara");
+    reference.setTemperature(actual.getTemperature(), "K");
+    new ThermodynamicOperations(reference).TPflash();
+    reference.initProperties();
+    assertEquals(phases, reference.getNumberOfPhases());
+    assertEquals(reference.getCp("J/kgK"), cp, Math.abs(cp) * 1.0e-7);
+    assertEquals(reference.getEnthalpy("J/kg"), actual.getEnthalpy("J/kg"),
+        Math.max(1.0, Math.abs(reference.getEnthalpy("J/kg"))) * 1.0e-7);
+    assertEquals(reference.getFlowRate("kg/sec"), actual.getFlowRate("kg/sec"),
+        reference.getFlowRate("kg/sec") * 1.0e-10);
+    assertComponentClosure(reference, actual);
+
+    double betaSum = 0.0;
+    for (int phaseIndex = 0; phaseIndex < reference.getNumberOfPhases(); phaseIndex++) {
+      PhaseInterface expectedPhase = reference.getPhase(phaseIndex);
+      String name = expectedPhase.getPhaseTypeName();
+      assertTrue(actual.hasPhaseType(name), "Missing outlet phase " + name);
+      PhaseInterface actualPhase = actual.getPhase(name);
+      assertEquals(expectedPhase.getBeta(), actualPhase.getBeta(), 1.0e-8);
+      assertEquals(expectedPhase.getDensity("kg/m3"), actualPhase.getDensity("kg/m3"),
+          expectedPhase.getDensity("kg/m3") * 1.0e-7);
+      double viscosity = actualPhase.getViscosity("kg/msec");
+      double conductivity = actualPhase.getThermalConductivity("W/mK");
+      assertTrue(Double.isFinite(viscosity) && viscosity > 0.0);
+      assertTrue(Double.isFinite(conductivity) && conductivity > 0.0);
+      betaSum += actualPhase.getBeta();
+    }
+    assertEquals(1.0, betaSum, 1.0e-10);
+    int last = pipe.getPressureProfile().length - 1;
+    assertEquals(pipe.getPressureProfile()[last] / 1.0e5, actual.getPressure(), 1.0e-10);
+    assertEquals(pipe.getTemperatureProfile("K")[last], actual.getTemperature(), 1.0e-10);
+  }
+
+  private static void assertComponentClosure(SystemInterface expected, SystemInterface actual) {
+    for (int component = 0; component < expected.getNumberOfComponents(); component++) {
+      String name = expected.getComponent(component).getComponentName();
+      double moles = expected.getComponent(component).getNumberOfmoles();
+      double tolerance = Math.max(1.0, Math.abs(moles)) * 1.0e-10;
+      assertEquals(moles, actual.getComponent(name).getNumberOfmoles(), tolerance, name + " total moles");
+      double phaseMoles = 0.0;
+      for (int phase = 0; phase < actual.getNumberOfPhases(); phase++) {
+        phaseMoles += actual.getPhase(phase).getComponent(name).getNumberOfMolesInPhase();
+      }
+      assertEquals(moles, phaseMoles, tolerance, name + " phase inventories");
+    }
+  }
+
+  private static Stream wetFeed() {
+    double oilMass = 500.0 * 859.5 / 86400.0;
+    double gasMass = 120000.0 * 0.854 / 86400.0;
+    double waterMass = 250.0 * 1033.0 / 86400.0;
+    String[] components = { "methane", "ethane", "propane", "nitrogen", "CO2" };
+    double[] fractions = { 0.86, 0.07, 0.035, 0.015, 0.02 };
+    double[] molarMasses = { 0.016043, 0.030070, 0.044097, 0.0280134, 0.04401 };
+    double gasMolarMass = 0.0;
+    for (int i = 0; i < fractions.length; i++) {
+      gasMolarMass += fractions[i] * molarMasses[i];
+    }
+    SystemInterface fluid = new SystemSrkEos(363.15, 230.0);
+    for (int i = 0; i < components.length; i++) {
+      fluid.addComponent(components[i], gasMass / gasMolarMass * fractions[i]);
+    }
+    fluid.addTBPfraction("stock_oil", oilMass / 0.200, 0.200, 0.8595);
+    fluid.addComponent("water", waterMass / 0.01801528);
+    fluid.setMixingRule(2);
+    fluid.setMultiPhaseCheck(true);
+    Stream feed = new Stream("wet reservoir feed", fluid);
+    feed.setFlowRate(oilMass + gasMass + waterMass, "kg/sec");
+    feed.run();
+    return feed;
+  }
+
+  private static TwoFluidPipe pipe(String name, StreamInterface feed, double length, double diameter, double rise,
+      double heatTransfer) {
+    TwoFluidPipe pipe = new TwoFluidPipe(name, feed);
+    pipe.setLength(length);
+    pipe.setDiameter(diameter);
+    pipe.setRoughness(4.5e-5);
+    int sections = 20;
+    pipe.setNumberOfSections(sections);
+    double[] elevation = new double[sections];
+    for (int i = 0; i < sections; i++) {
+      elevation[i] = rise * i / (sections - 1);
+    }
+    pipe.setElevationProfile(elevation);
+    pipe.setEnableWaterOilSlip(true);
+    pipe.setSteadyStateMaxIterations(250);
+    pipe.setSteadyStateMaxWallClockTime(90.0);
+    if (heatTransfer > 0.0) {
+      pipe.setSurfaceTemperature(4.0, "C");
+      pipe.setHeatTransferCoefficient(heatTransfer);
+    }
+    return pipe;
+  }
+}


### PR DESCRIPTION
A steady `TwoFluidPipe` could report convergence while publishing a two-phase outlet with invalid heat capacity. `setTotalFlowRate(...)` calls `init(0)`, so calling it after the outlet TP flash discarded the equilibrium state. Downstream heat-transfer calculations then consumed the invalid Cp.

This PR normalizes positive outlet flow before the final TP flash, initializes thermodynamic and transport properties, and only then replaces the connected outlet fluid. Zero or clamped nonpositive net outlet flux still publishes zero inventory. Flash/property-initialization failures now throw before outlet replacement.

Closes #3685.

### Regression and engineering evidence

The five numerical/phase regressions all fail on unchanged master `3b0e8f4074bc83106653d4b5f01205eea65fd353`. The wet well Cp was approximately `-7.42e17 J/(kg K)`; the two-phase short-pipe case returned `-Infinity`, and the gas-only outlet incorrectly exposed two phases. Direct flowline coupling differed from an explicitly reflashed handoff by **11.988 K**.

With the fix, the supplied SRK/TBP/water case gives:

| Outlet | Pressure (bara) | Temperature (°C) | Cp (J/kg/K) | Phases |
| --- | ---: | ---: | ---: | --- |
| Well | 82.805929 | 88.560747 | 3101.346455 | gas, oil, aqueous |
| Connected flowline/riser | 68.116226 | 56.592070 | 3019.314377 | gas, oil, aqueous |

The connected line agrees with the explicitly reflashed reference within `1e-5 K` and `1e-5 bar`. Tests also check enthalpy, phase identity/fractions, density and transport properties, total/component flow and phase-inventory closure, final section P/T, feed isolation, and reuse after changing pressure and rate. A failure-injection test verifies that property initialization cannot replace the previous outlet on failure.

These are thermodynamic handoff and conservation checks, not experimental qualification of pipeline thermal accuracy.

### Validation

Java 17.0.20, Maven 3.9.16, project Java 8 source/target configuration.

Final Surefire reports: **48 tests, 0 failures, 0 errors, 0 skipped** across eight classes:

- `TwoFluidPipeOutletThermodynamicsTest`: 6
- `TwoFluidPipeSteadyBoundaryThermodynamicsTest`: 5
- `TwoFluidPipeSteadyStateConvergenceTest`: 5
- `TwoFluidPipeThreePhaseConservationTest`: 7
- `TwoFluidPipeThreePhaseConvergenceReportTest`: 1
- `TwoFluidPipeMassBalanceTest`: 6
- `TwoFluidPipeClosedThermalTest`: 17
- `TwoFluidPipeThermalPressureCouplingTest`: 1

The initial eight-class command passed the 42 adjacent tests and the five numerical outlet checks but exposed one test-fixture mistake: failure injection targeted the fluid object from before `Stream.run()` cloned it. The fixture now targets the current feed fluid; rerunning the complete six-test outlet class passed. Production code did not change between these runs.

Final successful checks (exit 0):
- `./mvnw -q -DskipTests compile`
- `./mvnw -q -Dtest=TwoFluidPipeOutletThermodynamicsTest -Dlog4j2.configurationFile=/workspace/scratch/e26faf70d518/test-log4j2.xml test`
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py apply`, repeated with no further changes
- `pre-commit run --all-files --hook-stage pre-commit`
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/run_spotless.py check`
- `"$CODEX_PRIMARY_RUNTIME_PYTHON" devtools/check_documentation_search.py`: 696 Markdown pages and 1 standalone HTML page
- `pre-commit run --all-files --hook-stage pre-push`
- `./mvnw -q javadoc:javadoc -Dsubpackages=neqsim.process.equipment.pipeline -DjavadocExecutable=/workspace/scratch/e26faf70d518/javadoc`
- `git diff --exit-code` and `git diff --cached --check`

Maven was bootstrapped with the NeqSim skill helper before all Maven/Spotless stages. Pre-commit was installed in an isolated task environment. The runtime has the JDK Javadoc module but no `javadoc` launcher; the temporary executable invokes the installed `jdk.javadoc.internal.tool.Main` and forwards JVM arguments. No repository build configuration was changed.

The generic skill validator rejects the repository's existing `last_verified` frontmatter key; a targeted YAML/name/reference check passed and verified unchanged metadata.

### Documentation and integration

Updated the two-fluid guide and Javadocs with the outlet initialization order, zero-flow behavior, failure contract, and need to recalculate downstream thermal results from affected versions. Added the verified rate-before-flash rule to the repository API skill.

Related active PR #3667 also touches outlet publication and still contains the old ordering in its non-component path. Preserve this ordering fix when integrating that work; this PR does not alter its branch or expand its transient qualification scope.

Published tree is byte-identical to the locally validated Git tree. Full GitHub CI remains pending; no full repository test-matrix result is claimed.
