### PR TITLE
[AI-Assisted] fix(two-fluid): conserve steady phase mass flux beyond velocity caps

### DIFF
--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -505,9 +505,11 @@ if not steady.isConverged():
 ```
 
 The report also exposes pressure-momentum, pressure-update, total-holdup,
-thermodynamic-property, and pressure-drop residuals. Its `CONVERGED` result includes the mandatory
-final flash and holdup/oil-water resweep; an iteration-, wall-clock-, or pressure-floor-limited
-profile remains explicitly non-converged.
+thermodynamic-property, and pressure-drop residuals. `getMassFluxResidual()` checks the maximum
+relative total phase mass-flux error against `getMassFluxTolerance()` (1e-8). Its `CONVERGED`
+result includes the mandatory final flash, holdup/oil-water resweep, and mass-flux check of the
+final section state; an iteration-, wall-clock-, or pressure-floor-limited profile remains
+explicitly non-converged.
 
 > **Further Reading**: See [TwoFluidPipe Tutorial](../examples/TwoFluidPipe_Tutorial) for comprehensive examples including slug visualization and transient analysis.
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1388,7 +1388,7 @@ Algorithm per macro-step:
 
 ### Steady-State Solver Tuning
 
-The initial steady-state solve iterates between the transient solver and thermodynamic flashes
+The initial steady-state solve iterates between the hydraulic pressure/holdup sweep and thermodynamic flashes
 until convergence. Four parameters control this:
 
 | Parameter | Setter | Default | Description |
@@ -1425,6 +1425,18 @@ total-pressure-drop update. Every applicable value must be below `getTolerance()
 The mandatory final flash and unrelaxed holdup/oil-water resweep are included in that decision; a
 post-flash state that moves beyond tolerance is refined again instead of being returned under a
 stale convergence flag.
+
+Total source-free phase mass transport is an additional convergence condition.
+`getMassFluxResidual()` reports the largest absolute difference between the section sum of gas,
+oil and water mass flows and the inlet flow, normalized by `max(abs(inletMassFlow), 1e-12 kg/s)`.
+It must be below `getMassFluxTolerance()` (1e-8), both during the final consistency sweep and after
+the conservative-state rebuild. Nonfinite fluxes report an infinite residual. Legacy reports
+constructed without mass diagnostics return `NaN` from these getters.
+
+Steady velocities are calculated from phase continuity without clipping at 100 m/s for gas or
+50 m/s for liquid. Clipping at those numerical limits caused the #3686 high-rate well to report
+convergence with a 2.09% total mass-flux deficit. The transient boundary guards retain their
+existing limits. This correction preserves mass; it does not provide critical-flow qualification.
 
 ```java
 pipe.run();

--- a/docs/process/twofluidpipe-evidence-matrix.md
+++ b/docs/process/twofluidpipe-evidence-matrix.md
@@ -24,7 +24,7 @@ model converged or represents the requested physics.
 
 | Capability and configuration | Implemented | Numerically verified | Experimentally qualified | Evidence and use boundary |
 |---|---:|---:|---:|---|
-| Positive-flow steady gas/liquid pressure, holdup, thermal and terrain profiles | Yes | Yes | No general claim | Require the complete steady convergence report to be converged, every residual below its recorded tolerance, and no pressure-floor or wall-clock termination. Repeat mesh sensitivity for the actual geometry. |
+| Positive-flow steady gas/liquid pressure, holdup, thermal and terrain profiles | Yes | Yes | No general claim | Require the complete steady convergence report to be converged, every residual below its recorded tolerance (including total phase mass flux below `getMassFluxTolerance()`), and no pressure-floor or wall-clock termination. Repeat mesh sensitivity for the actual geometry. |
 | Steady gas/oil/water on the compact 3 km, 10-degree uphill fixture | Yes | Yes | No | The 30/60-cell results differ by 0.538% in arrival pressure and 0.983% in mean liquid holdup. All three phases remain present and the final thermodynamic/holdup reconciliation is inside the unchanged 1e-4 tolerance. The unavailable historical 73.8 km case is not covered. |
 | Liquid-rich unchanged-boundary transient with shared slug force balance, interfacial pressure, and coupled pressure/momentum | Opt-in | Yes | Not applicable | Over 1,800 s, inventory drift is 1.323% at 40 cells and 1.358% at 80 cells, below the declared 2% fixture gate, with total-mass closure. This does not qualify slug loads or another operating envelope. |
 | Default liquid-rich unchanged-boundary transient | Yes | No | No | The recorded 1,800 s inventory drift is 5.757%, above the unchanged 5% gate. Do not infer default-mode qualification from the opt-in shared-force result. |
@@ -48,7 +48,7 @@ Use **TwoFluidPipe** only when the case fits a row above and its runtime evidenc
 
 1. Run steady initialization and inspect the complete immutable convergence report. A stationary
    pressure profile is insufficient if liquid split, holdup, thermodynamics, or total pressure drop
-   remains outside tolerance.
+   remains outside tolerance, or if total phase mass flux does not close against the inlet.
 2. For transient work, require requested elapsed time, phase and total mass balances, positivity,
    and all sticky pressure/momentum, pressure-limiter, rejected-substep, outlet-backflow, component,
    and energy diagnostics applicable to the selected configuration.
@@ -60,6 +60,22 @@ Use **TwoFluidPipe** only when the case fits a row above and its runtime evidenc
 5. Use **PipeBeggsAndBrills** for a correlation-based steady or quasi-steady screen, not for
    conservative distributed line-pack dynamics. Use a separately qualified transient model or a
    controlled experimental study when the requested TwoFluidPipe row is failed or unsupported.
+
+## High-throughput steady mass conservation (#3686)
+
+`TwoFluidPipeSteadyMassFluxTest` reproduces the 3,100 m well with a 0.23 m diameter, 2,380 m rise,
+20 sections, 205 bara and 90 degrees Celsius inlet, and the issue's synthetic SRK fluid and
+stock-tank rates. The original 166.113217788 kg/s case lost 3.473846596 kg/s at the outlet section
+because gas velocity was capped at 100 m/s. At 5% higher flow the deficit was 7.007383459 kg/s;
+the 5% lower-flow case did not reach the cap.
+
+The regression checks all three rates against phase-summed section mass flux with relative
+tolerance 1e-10 and absolute tolerance 1e-12 kg/s. It also requires the original hydraulic and
+thermodynamic residuals to pass. Separate gas, oil and water fixtures exercise the former steady
+gas/liquid caps, and injected 2% and nonfinite reporting errors must prevent convergence even
+when the hydraulic residuals have settled. The existing 30/60-cell three-phase fixture remains
+the free-water and mesh-refinement check. This is conservation and numerical-convergence evidence,
+not experimental or critical-flow qualification.
 
 ## Executable steady and transient example
 

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -1117,12 +1117,27 @@ thermodynamic-property, and total-pressure-drop residuals against `getTolerance(
 includes the mandatory final flash and unrelaxed holdup/split resweep, so that pass cannot silently
 change the state after the convergence flag has been set.
 
+The report also checks source-free total mass transport. `getMassFluxResidual()` is the maximum
+over all sections of `abs(gasMassFlow + oilMassFlow + waterMassFlow - inletMassFlow)` divided by
+`max(abs(inletMassFlow), 1e-12 kg/s)`. It must be below `getMassFluxTolerance()` (1e-8), including
+after the final conservative-state initialization. A nonfinite flux fails this check. Reports
+created with the older constructor have no mass-flux measurement and return `NaN` for these two
+getters; reports produced by a new pipe solve always include the check.
+
+Steady phase velocities follow `massFlow / (density * holdup * area)` without the legacy 100 m/s
+gas or 50 m/s liquid caps. Those caps could discard mass while the pressure and holdup iterations
+appeared settled (#3686). The transient boundary velocity guards are unchanged. Phase changes may
+redistribute gas, oil and water flows, but their sum must remain equal to the inlet. Removing a
+numerical velocity cap does not add a critical-flow or choking model; pressure-floor and all
+existing convergence checks still apply.
+
 ```java
 SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
 if (!report.isConverged()) {
   throw new IllegalStateException("Steady state stopped at "
       + report.getTerminationReason() + "; liquid-split residual="
-      + report.getLiquidSplitResidual());
+      + report.getLiquidSplitResidual() + "; mass-flux residual="
+      + report.getMassFluxResidual());
 }
 ```
 

--- a/src/main/java/neqsim/process/equipment/pipeline/SteadyStateConvergenceReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/SteadyStateConvergenceReport.java
@@ -6,10 +6,11 @@ import java.io.Serializable;
  * Immutable diagnostics from a {@link TwoFluidPipe} steady-state initialization.
  *
  * <p>
- * Every residual is dimensionless and is compared with {@link #getTolerance()}. Holdup and liquid-split residuals are
- * absolute volume-fraction changes. Pressure-update, thermodynamic-property, pressure-drop, and pressure-momentum
- * residuals are relative changes. A report is converged only when every applicable residual is below the tolerance and
- * the mandatory final thermodynamic/holdup consistency pass has also settled.
+ * Every residual is dimensionless. The mass-flux residual is compared with {@link #getMassFluxTolerance()}, and the
+ * other residuals with {@link #getTolerance()}. Holdup and liquid-split residuals are absolute volume-fraction changes.
+ * Pressure-update, thermodynamic-property, pressure-drop, and pressure-momentum residuals are relative changes. A
+ * report is converged only when every applicable residual is below the tolerance and the mandatory final
+ * thermodynamic/holdup consistency pass has also settled.
  * </p>
  *
  * @author NeqSim
@@ -41,9 +42,12 @@ public final class SteadyStateConvergenceReport implements Serializable {
   private final double liquidSplitResidual;
   private final double thermodynamicResidual;
   private final double pressureDropResidual;
+  private final double massFluxResidual;
+  private final double massFluxTolerance;
 
   /**
-   * Create a steady-state convergence report.
+   * Create a legacy steady-state convergence report without a mass-flux measurement. The mass-flux getters return
+   * {@code NaN}; the supplied termination reason retains its original meaning.
    *
    * @param terminationReason reason the solver stopped
    * @param iterations number of refinement sweeps performed
@@ -58,6 +62,29 @@ public final class SteadyStateConvergenceReport implements Serializable {
   public SteadyStateConvergenceReport(TerminationReason terminationReason, int iterations, double tolerance,
       double pressureMomentumResidual, double pressureUpdateResidual, double liquidHoldupResidual,
       double liquidSplitResidual, double thermodynamicResidual, double pressureDropResidual) {
+    this(terminationReason, iterations, tolerance, pressureMomentumResidual, pressureUpdateResidual,
+        liquidHoldupResidual, liquidSplitResidual, thermodynamicResidual, pressureDropResidual, Double.NaN, Double.NaN);
+  }
+
+  /**
+   * Create a steady-state convergence report including source-free total mass transport.
+   *
+   * @param terminationReason reason the solver stopped
+   * @param iterations number of refinement sweeps performed
+   * @param tolerance dimensionless tolerance for the hydraulic and thermodynamic residuals
+   * @param pressureMomentumResidual accumulated pressure-march residual normalized by pressure drop
+   * @param pressureUpdateResidual maximum relative pressure correction
+   * @param liquidHoldupResidual maximum absolute total-liquid-holdup correction
+   * @param liquidSplitResidual maximum absolute water-holdup correction
+   * @param thermodynamicResidual maximum relative thermodynamic-property correction
+   * @param pressureDropResidual relative total-pressure-drop correction between sweeps
+   * @param massFluxResidual maximum section total mass-flux error normalized by absolute inlet mass flow
+   * @param massFluxTolerance dimensionless tolerance for the total mass-flux residual
+   */
+  public SteadyStateConvergenceReport(TerminationReason terminationReason, int iterations, double tolerance,
+      double pressureMomentumResidual, double pressureUpdateResidual, double liquidHoldupResidual,
+      double liquidSplitResidual, double thermodynamicResidual, double pressureDropResidual, double massFluxResidual,
+      double massFluxTolerance) {
     this.terminationReason = terminationReason;
     this.iterations = iterations;
     this.tolerance = tolerance;
@@ -67,6 +94,8 @@ public final class SteadyStateConvergenceReport implements Serializable {
     this.liquidSplitResidual = liquidSplitResidual;
     this.thermodynamicResidual = thermodynamicResidual;
     this.pressureDropResidual = pressureDropResidual;
+    this.massFluxResidual = massFluxResidual;
+    this.massFluxTolerance = massFluxTolerance;
   }
 
   /** @return reason the steady-state refinement stopped */
@@ -114,8 +143,22 @@ public final class SteadyStateConvergenceReport implements Serializable {
     return pressureDropResidual;
   }
 
-  /** @return true only when the solver stopped because every residual met the tolerance */
+  /**
+   * @return maximum relative total phase mass-flux error over all sections, or {@code NaN} for a legacy report without
+   * this measurement; the inlet normalization has a 1e-12 kg/s floor
+   */
+  public double getMassFluxResidual() {
+    return massFluxTolerance > 0.0 ? massFluxResidual : Double.NaN;
+  }
+
+  /** @return dimensionless mass-flux tolerance, or {@code NaN} for a legacy report without this check */
+  public double getMassFluxTolerance() {
+    return massFluxTolerance > 0.0 ? massFluxTolerance : Double.NaN;
+  }
+
+  /** @return true only when the solver converged and any recorded mass-flux check passed */
   public boolean isConverged() {
-    return terminationReason == TerminationReason.CONVERGED;
+    return terminationReason == TerminationReason.CONVERGED
+        && (!(massFluxTolerance > 0.0) || (Double.isFinite(massFluxResidual) && massFluxResidual < massFluxTolerance));
   }
 }

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -788,6 +788,9 @@ public class TwoFluidPipe extends Pipeline {
    */
   private static final double MIN_SECTION_PRESSURE_PA = 1.0e5;
 
+  /** Relative tolerance for source-free total phase mass transport in steady state. */
+  private static final double SS_MASS_FLUX_TOLERANCE = 1.0e-8;
+
   /** Set when the converged steady-state profile rests on {@link #MIN_SECTION_PRESSURE_PA}. */
   private boolean ssPressureFloorLimited = false;
 
@@ -810,7 +813,7 @@ public class TwoFluidPipe extends Pipeline {
   private SteadyStateConvergenceReport steadyStateConvergenceReport = new SteadyStateConvergenceReport(
       SteadyStateConvergenceReport.TerminationReason.NOT_RUN, 0, 1.0e-4, Double.POSITIVE_INFINITY,
       Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
-      Double.POSITIVE_INFINITY);
+      Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, SS_MASS_FLUX_TOLERANCE);
 
   /** Current step count. */
   private int currentStep = 0;
@@ -1364,7 +1367,7 @@ public class TwoFluidPipe extends Pipeline {
     steadyStateConvergenceReport = new SteadyStateConvergenceReport(
         SteadyStateConvergenceReport.TerminationReason.NOT_RUN, 0, tolerance, Double.POSITIVE_INFINITY,
         Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
-        Double.POSITIVE_INFINITY);
+        Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, SS_MASS_FLUX_TOLERANCE);
     transientOutletBackflowClamped = false;
     equations.clearOutletBackflowClamped();
 
@@ -1415,8 +1418,8 @@ public class TwoFluidPipe extends Pipeline {
       double[] h0 = calculateLocalHoldup(inletSec, null, mDotGas, mDotLiq, area);
       inletSec.setLiquidHoldup(h0[0]);
       inletSec.setGasHoldup(h0[1]);
-      inletSec.setGasVelocity(calculateFinitePhaseVelocity(mDotGas, h0[1], inletSec.getGasDensity(), area, 100.0));
-      inletSec.setLiquidVelocity(calculateFinitePhaseVelocity(mDotLiq, h0[0], inletSec.getLiquidDensity(), area, 50.0));
+      inletSec.setGasVelocity(calculateSteadyPhaseVelocity(mDotGas, h0[1], inletSec.getGasDensity(), area));
+      inletSec.setLiquidVelocity(calculateSteadyPhaseVelocity(mDotLiq, h0[0], inletSec.getLiquidDensity(), area));
       if (inletSec.getWaterDensity() > 0 && inletSec.getOilDensity() > 0 && h0[0] > 0.0) {
         updateLiquidPhaseSplit(inletSec, null, h0[0], area);
       }
@@ -1436,8 +1439,8 @@ public class TwoFluidPipe extends Pipeline {
         double[] hi = calculateLocalHoldup(sec, prev, mDotGas, mDotLiq, area);
         sec.setLiquidHoldup(hi[0]);
         sec.setGasHoldup(hi[1]);
-        sec.setGasVelocity(calculateFinitePhaseVelocity(mDotGas, hi[1], sec.getGasDensity(), area, 100.0));
-        sec.setLiquidVelocity(calculateFinitePhaseVelocity(mDotLiq, hi[0], sec.getLiquidDensity(), area, 50.0));
+        sec.setGasVelocity(calculateSteadyPhaseVelocity(mDotGas, hi[1], sec.getGasDensity(), area));
+        sec.setLiquidVelocity(calculateSteadyPhaseVelocity(mDotLiq, hi[0], sec.getLiquidDensity(), area));
 
         // Water/oil holdups for three-phase
         if (sec.getWaterDensity() > 0 && sec.getOilDensity() > 0 && hi[0] > 0.0) {
@@ -1465,6 +1468,7 @@ public class TwoFluidPipe extends Pipeline {
     double liquidSplitResidual = Double.POSITIVE_INFINITY;
     double thermodynamicResidual = Double.POSITIVE_INFINITY;
     double pressureDropResidual = Double.POSITIVE_INFINITY;
+    double massFluxResidual = Double.POSITIVE_INFINITY;
     for (int iter = 0; iter < maxIter; iter++) {
       ssIterationsUsed = iter + 1;
       // Wall-clock time guard
@@ -1507,10 +1511,9 @@ public class TwoFluidPipe extends Pipeline {
         liquidHoldupResidual = Math.max(liquidHoldupResidual, Math.abs(alphaL_inlet - inletLiquidHoldupBefore));
 
         // Update inlet velocities
-        inletSec.setGasVelocity(
-            calculateFinitePhaseVelocity(localMDotG, alphaG_inlet, inletSec.getGasDensity(), area, 100.0));
+        inletSec.setGasVelocity(calculateSteadyPhaseVelocity(localMDotG, alphaG_inlet, inletSec.getGasDensity(), area));
         inletSec.setLiquidVelocity(
-            calculateFinitePhaseVelocity(localMDotL, alphaL_inlet, inletSec.getLiquidDensity(), area, 50.0));
+            calculateSteadyPhaseVelocity(localMDotL, alphaL_inlet, inletSec.getLiquidDensity(), area));
 
         // Update water/oil holdups for inlet if three-phase
         if (inletSec.getWaterDensity() > 0 && inletSec.getOilDensity() > 0 && alphaL_inlet > 0.0) {
@@ -1560,8 +1563,8 @@ public class TwoFluidPipe extends Pipeline {
         sec.setGasHoldup(alphaG_new);
 
         // Update velocities based on new holdups
-        sec.setGasVelocity(calculateFinitePhaseVelocity(localMDotG, alphaG_new, sec.getGasDensity(), area, 100.0));
-        sec.setLiquidVelocity(calculateFinitePhaseVelocity(localMDotL, alphaL_new, sec.getLiquidDensity(), area, 50.0));
+        sec.setGasVelocity(calculateSteadyPhaseVelocity(localMDotG, alphaG_new, sec.getGasDensity(), area));
+        sec.setLiquidVelocity(calculateSteadyPhaseVelocity(localMDotL, alphaL_new, sec.getLiquidDensity(), area));
 
         // Update water and oil holdups for three-phase flow
         // Check if this is a three-phase system (both oil and water densities set)
@@ -1723,8 +1726,10 @@ public class TwoFluidPipe extends Pipeline {
         liquidHoldupResidual = Math.max(liquidHoldupResidual, finalConsistencyResiduals[1]);
         liquidSplitResidual = Math.max(liquidSplitResidual, finalConsistencyResiduals[2]);
         pressureMomentumResidual = calculateSteadyPressureMomentumResidual();
+        massFluxResidual = calculateSteadyMassFluxResidual(massFlow);
         boolean finalConsistencySettled = thermodynamicResidual < tolerance && liquidHoldupResidual < tolerance
-            && liquidSplitResidual < tolerance && pressureMomentumResidual < tolerance;
+            && liquidSplitResidual < tolerance && pressureMomentumResidual < tolerance
+            && massFluxResidual < SS_MASS_FLUX_TOLERANCE;
         if (finalConsistencySettled) {
           ssConverged = true;
           logger.info("Steady-state converged after {} iterations ({}ms wall-clock)", ssIterationsUsed,
@@ -1756,20 +1761,6 @@ public class TwoFluidPipe extends Pipeline {
       pressureMomentumResidual = calculateSteadyPressureMomentumResidual();
     }
 
-    SteadyStateConvergenceReport.TerminationReason terminationReason;
-    if (ssConverged) {
-      terminationReason = SteadyStateConvergenceReport.TerminationReason.CONVERGED;
-    } else if (ssPressureFloorLimited) {
-      terminationReason = SteadyStateConvergenceReport.TerminationReason.PRESSURE_FLOOR_LIMIT;
-    } else if (ssWallClockLimited) {
-      terminationReason = SteadyStateConvergenceReport.TerminationReason.WALL_CLOCK_LIMIT;
-    } else {
-      terminationReason = SteadyStateConvergenceReport.TerminationReason.ITERATION_LIMIT;
-    }
-    steadyStateConvergenceReport = new SteadyStateConvergenceReport(terminationReason, ssIterationsUsed, tolerance,
-        pressureMomentumResidual, pressureUpdateResidual, liquidHoldupResidual, liquidSplitResidual,
-        thermodynamicResidual, pressureDropResidual);
-
     // Final accumulation zone identification after convergence
     if (enableTerrainTracking && accumulationTracker != null) {
       accumulationTracker.identifyAccumulationZones(sections);
@@ -1797,6 +1788,24 @@ public class TwoFluidPipe extends Pipeline {
         sec.setLiquidMomentumPerLength(oilMomentum + waterMomentum);
       }
     }
+
+    // Check the exact final state exposed by the phase-flux profiles, including the conservative rebuild.
+    massFluxResidual = calculateSteadyMassFluxResidual(massFlow);
+    ssConverged &= massFluxResidual < SS_MASS_FLUX_TOLERANCE;
+
+    SteadyStateConvergenceReport.TerminationReason terminationReason;
+    if (ssConverged) {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.CONVERGED;
+    } else if (ssPressureFloorLimited) {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.PRESSURE_FLOOR_LIMIT;
+    } else if (ssWallClockLimited) {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.WALL_CLOCK_LIMIT;
+    } else {
+      terminationReason = SteadyStateConvergenceReport.TerminationReason.ITERATION_LIMIT;
+    }
+    steadyStateConvergenceReport = new SteadyStateConvergenceReport(terminationReason, ssIterationsUsed, tolerance,
+        pressureMomentumResidual, pressureUpdateResidual, liquidHoldupResidual, liquidSplitResidual,
+        thermodynamicResidual, pressureDropResidual, massFluxResidual, SS_MASS_FLUX_TOLERANCE);
 
     // Store initial profiles
     updateResultArrays();
@@ -1830,9 +1839,8 @@ public class TwoFluidPipe extends Pipeline {
       double[] holdups = calculateLocalHoldup(sec, prev, localMDotGas[i], localMDotLiq[i], area);
       sec.setLiquidHoldup(holdups[0]);
       sec.setGasHoldup(holdups[1]);
-      sec.setGasVelocity(calculateFinitePhaseVelocity(localMDotGas[i], holdups[1], sec.getGasDensity(), area, 100.0));
-      sec.setLiquidVelocity(
-          calculateFinitePhaseVelocity(localMDotLiq[i], holdups[0], sec.getLiquidDensity(), area, 50.0));
+      sec.setGasVelocity(calculateSteadyPhaseVelocity(localMDotGas[i], holdups[1], sec.getGasDensity(), area));
+      sec.setLiquidVelocity(calculateSteadyPhaseVelocity(localMDotLiq[i], holdups[0], sec.getLiquidDensity(), area));
       if (sec.getWaterDensity() > 0 && sec.getOilDensity() > 0 && holdups[0] > 0.0) {
         updateLiquidPhaseSplit(sec, prev, holdups[0], area);
       }
@@ -1842,6 +1850,31 @@ public class TwoFluidPipe extends Pipeline {
       liquidSplitResidual = Math.max(liquidSplitResidual, Math.abs(sec.getWaterHoldup() - waterHoldupBefore));
     }
     return new double[] { thermodynamicResidual, liquidHoldupResidual, liquidSplitResidual };
+  }
+
+  /**
+   * Check the source-free total mass flux reconstructed from the published section primitives.
+   *
+   * @param inletMassFlow prescribed inlet mass flow in kg/s
+   * @return maximum relative section mass-flux error, or positive infinity for a nonfinite flux
+   */
+  private double calculateSteadyMassFluxResidual(double inletMassFlow) {
+    if (!Double.isFinite(inletMassFlow) || sections == null || sections.length == 0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    double[] gas = getGasMassFlowProfile();
+    double[] oil = getOilMassFlowProfile();
+    double[] water = getWaterMassFlowProfile();
+    double normalization = Math.max(Math.abs(inletMassFlow), 1.0e-12);
+    double residual = 0.0;
+    for (int i = 0; i < gas.length; i++) {
+      double totalFlow = gas[i] + oil[i] + water[i];
+      if (!Double.isFinite(totalFlow)) {
+        return Double.POSITIVE_INFINITY;
+      }
+      residual = Math.max(residual, Math.abs(totalFlow - inletMassFlow) / normalization);
+    }
+    return residual;
   }
 
   /** Snapshot the properties that close the steady hydraulic equations. */
@@ -2760,6 +2793,21 @@ public class TwoFluidPipe extends Pipeline {
       double Nu = 0.023 * Math.pow(Re, 0.8) * Math.pow(Pr, 0.3);
       return Nu * k / diameter;
     }
+  }
+
+  /**
+   * Recover steady velocity from continuity without clipping the transported phase mass flux.
+   *
+   * @param massFlow phase mass flow rate in kg/s
+   * @param holdup phase holdup
+   * @param density phase density in kg/m3
+   * @param area pipe cross-sectional area in m2
+   * @return finite phase velocity in m/s, or zero if the state cannot carry the prescribed flow
+   */
+  private double calculateSteadyPhaseVelocity(double massFlow, double holdup, double density, double area) {
+    // Legacy transient boundary guards must not remove mass from a steady, source-free pipe.
+    // Invalid states still return zero and are rejected by the steady mass-flux diagnostic.
+    return calculateFinitePhaseVelocity(massFlow, holdup, density, area, Double.POSITIVE_INFINITY);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeSteadyMassFluxTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeSteadyMassFluxTest.java
@@ -1,0 +1,190 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression for source-free steady phase mass flux at high-throughput well conditions (#3686). */
+class TwoFluidPipeSteadyMassFluxTest extends neqsim.NeqSimTest {
+  private static final Logger logger = LogManager.getLogger(TwoFluidPipeSteadyMassFluxTest.class);
+
+  /** Translate the public stock-tank rates into the issue's synthetic SRK fluid. */
+  private TwoFluidPipe makeWell(double rateScale) {
+    double oilMass = rateScale * 15069.4462890625 * 859.5 / 86400.0;
+    double gasMass = rateScale * 1630701.625 * 0.854 / 86400.0;
+    double waterMass = rateScale * 7.13818359375 * 1033.0 / 86400.0;
+    String[] components = { "methane", "ethane", "propane", "nitrogen", "CO2" };
+    double[] fractions = { 0.86, 0.07, 0.035, 0.015, 0.02 };
+    double[] molarMasses = { 0.016043, 0.030070, 0.044097, 0.0280134, 0.04401 };
+    double gasMolarMass = 0.0;
+    for (int i = 0; i < components.length; i++) {
+      gasMolarMass += fractions[i] * molarMasses[i];
+    }
+    SystemInterface fluid = new SystemSrkEos(363.15, 205.0);
+    for (int i = 0; i < components.length; i++) {
+      fluid.addComponent(components[i], gasMass / gasMolarMass * fractions[i]);
+    }
+    fluid.addTBPfraction("stock_oil", oilMass / 0.200, 0.200, 0.8595);
+    fluid.addComponent("water", waterMass / 0.01801528);
+    fluid.setMixingRule(2);
+    fluid.setMultiPhaseCheck(true);
+    Stream inlet = new Stream("reservoir handoff", fluid);
+    inlet.setFlowRate(oilMass + gasMass + waterMass, "kg/sec");
+    inlet.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("well", inlet);
+    pipe.setLength(3100.0);
+    pipe.setDiameter(0.23);
+    pipe.setRoughness(4.5e-5);
+    pipe.setNumberOfSections(20);
+    double[] elevations = new double[20];
+    for (int i = 0; i < elevations.length; i++) {
+      elevations[i] = 2380.0 * i / (elevations.length - 1.0);
+    }
+    pipe.setElevationProfile(elevations);
+    pipe.setEnableWaterOilSlip(true);
+    pipe.setSteadyStateMaxIterations(250);
+    return pipe;
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.95, 1.0, 1.05 })
+  void convergedWellConservesTotalPhaseMassFlux(double rateScale) {
+    TwoFluidPipe pipe = makeWell(rateScale);
+    pipe.run();
+    SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
+    assertTrue(report.isConverged(), "steady solve: " + report.getTerminationReason());
+    assertTrue(pipe.isSteadyStateConverged());
+    assertFalse(pipe.isSteadyStatePressureFloorLimited());
+    assertHydraulicResidualsPassed(report);
+    assertMassFluxCloses(pipe);
+    if (rateScale >= 1.0) {
+      assertTrue(pipe.getGasVelocityProfile()[19] > 100.0, "continuity requires gas velocity above the old cap");
+    }
+    logger.info("rate scale={}, inlet={} kg/s, maximum relative mass-flux error={}, outlet gas velocity={} m/s",
+        rateScale, pipe.getInletStream().getFlowRate("kg/sec"), report.getMassFluxResidual(),
+        pipe.getGasVelocityProfile()[19]);
+  }
+
+  private void assertHydraulicResidualsPassed(SteadyStateConvergenceReport report) {
+    double[] residuals = { report.getPressureMomentumResidual(), report.getPressureUpdateResidual(),
+        report.getLiquidHoldupResidual(), report.getLiquidSplitResidual(), report.getThermodynamicResidual(),
+        report.getPressureDropResidual() };
+    for (double residual : residuals) {
+      assertTrue(Double.isFinite(residual) && residual < report.getTolerance(), "hydraulic residual=" + residual);
+    }
+  }
+
+  private void assertMassFluxCloses(TwoFluidPipe pipe) {
+    SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
+    assertEquals(1.0e-8, report.getMassFluxTolerance());
+    assertTrue(report.getMassFluxResidual() < report.getMassFluxTolerance());
+    double inletMass = pipe.getInletStream().getFlowRate("kg/sec");
+    double[] gas = pipe.getGasMassFlowProfile();
+    double[] oil = pipe.getOilMassFlowProfile();
+    double[] water = pipe.getWaterMassFlowProfile();
+    double maximumError = 0.0;
+    for (int i = 0; i < gas.length; i++) {
+      maximumError = Math.max(maximumError,
+          Math.abs(gas[i] + oil[i] + water[i] - inletMass) / Math.max(Math.abs(inletMass), 1.0e-12));
+      assertEquals(inletMass, gas[i] + oil[i] + water[i], Math.abs(inletMass) * 1.0e-10 + 1.0e-12,
+          "section " + i + ": gas=" + gas[i] + ", oil=" + oil[i] + ", water=" + water[i] + ", vg="
+              + pipe.getGasVelocityProfile()[i] + ", vl=" + pipe.getLiquidVelocityProfile()[i] + ", vo="
+              + pipe.getOilVelocityProfile()[i] + ", vw=" + pipe.getWaterVelocityProfile()[i]);
+      assertEquals(pipe.getLiquidHoldupProfile()[i], pipe.getOilHoldupProfile()[i] + pipe.getWaterHoldupProfile()[i],
+          1.0e-12);
+    }
+    assertEquals(maximumError, report.getMassFluxResidual(), 1.0e-15,
+        "the diagnostic must describe the final published profiles");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "methane", "nC10", "water" })
+  void singlePhaseSteadyFlowIsNotClipped(String component) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 100.0);
+    fluid.addComponent(component, 1.0);
+    fluid.setMixingRule(2);
+    Stream inlet = new Stream("single phase", fluid);
+    inlet.run();
+    assertEquals(1, inlet.getFluid().getNumberOfPhases());
+    boolean gas = inlet.getFluid().hasPhaseType("gas");
+    double velocityLimit = gas ? 100.0 : 50.0;
+    double area = Math.PI * 0.1 * 0.1 / 4.0;
+    inlet.setFlowRate(1.2 * velocityLimit * area * inlet.getFluid().getPhase(0).getDensity("kg/m3"), "kg/sec");
+    inlet.run();
+    TwoFluidPipe pipe = new TwoFluidPipe("short pipe", inlet);
+    pipe.setLength(0.01);
+    pipe.setDiameter(0.1);
+    pipe.setNumberOfSections(3);
+    pipe.run();
+    assertTrue(pipe.isSteadyStateConverged());
+    assertMassFluxCloses(pipe);
+    double[] velocities = gas ? pipe.getGasVelocityProfile() : pipe.getLiquidVelocityProfile();
+    for (double velocity : velocities) {
+      assertTrue(velocity > velocityLimit);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.98, Double.NaN })
+  void aSettledHydraulicProfileCannotHideAFluxError(double reportedFraction) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 100.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule(2);
+    Stream inlet = new Stream("gas", fluid);
+    inlet.setFlowRate(2.0, "kg/sec");
+    inlet.run();
+    // Fault injection: emulate a clipped or nonfinite phase-flux reconstruction while the
+    // hydraulic calculation still reaches its fixed point. The independent mass gate must fail.
+    TwoFluidPipe pipe = new TwoFluidPipe("bad flux", inlet) {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public double[] getGasMassFlowProfile() {
+        double[] flows = super.getGasMassFlowProfile();
+        for (int i = 0; i < flows.length; i++) {
+          flows[i] *= reportedFraction;
+        }
+        return flows;
+      }
+    };
+    pipe.setLength(1.0);
+    pipe.setNumberOfSections(3);
+    pipe.setSteadyStateMaxIterations(40);
+    pipe.run();
+    SteadyStateConvergenceReport report = pipe.getSteadyStateConvergenceReport();
+    assertHydraulicResidualsPassed(report);
+    assertFalse(report.isConverged());
+    assertFalse(pipe.isSteadyStateConverged());
+    assertFalse(pipe.isSteadyStatePressureFloorLimited());
+    assertEquals(SteadyStateConvergenceReport.TerminationReason.ITERATION_LIMIT, report.getTerminationReason());
+    assertEquals(Double.isNaN(reportedFraction) ? Double.POSITIVE_INFINITY : 0.02, report.getMassFluxResidual(),
+        1.0e-12);
+  }
+
+  @Test
+  void legacyReportsRetainTheirContractWithoutInventingAMassMeasurement() {
+    SteadyStateConvergenceReport legacy = new SteadyStateConvergenceReport(
+        SteadyStateConvergenceReport.TerminationReason.CONVERGED, 1, 1.0e-4, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    assertTrue(legacy.isConverged());
+    assertTrue(Double.isNaN(legacy.getMassFluxResidual()));
+    assertTrue(Double.isNaN(legacy.getMassFluxTolerance()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.02, Double.NaN, Double.POSITIVE_INFINITY })
+  void recordedMassFluxFailurePreventsAConvergedReport(double residual) {
+    SteadyStateConvergenceReport report = new SteadyStateConvergenceReport(
+        SteadyStateConvergenceReport.TerminationReason.CONVERGED, 1, 1.0e-4, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, residual,
+        1.0e-8);
+    assertFalse(report.isConverged());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeThreePhaseConvergenceReportTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeThreePhaseConvergenceReportTest.java
@@ -79,6 +79,7 @@ class TwoFluidPipeThreePhaseConvergenceReportTest {
     assertTrue(report.getLiquidSplitResidual() < report.getTolerance());
     assertTrue(report.getThermodynamicResidual() < report.getTolerance());
     assertTrue(report.getPressureDropResidual() < report.getTolerance());
+    assertTrue(report.getMassFluxResidual() < report.getMassFluxTolerance());
 
     double[] pressure = pipe.getPressureProfile();
     double[] liquidHoldup = pipe.getLiquidHoldupProfile();


### PR DESCRIPTION
Closes #3686.

The steady solver could report convergence while clipping gas velocity at 100 m/s or liquid velocity at 50 m/s. In the exact issue reproducer, that gas cap reduced the last section's total phase flux from 166.113217788 to 162.639371191 kg/s. At 5% higher flow, the deficit grew to 7.007383459 kg/s. The pressure and holdup residuals did not detect the lost mass.

This change:
- Recovers steady phase velocities from continuity without the legacy caps, throughout initialization, refinement, and final reconciliation.
- Adds `getMassFluxResidual()` and `getMassFluxTolerance()` to the convergence report. The maximum section error relative to inlet mass flow must be below 1e-8, including after the final conservative-state rebuild. Nonfinite fluxes fail the check. Existing report constructors remain available and return NaN for unavailable mass diagnostics.
- Adds the exact well reproducer and ±5% rates, single-phase gas/oil/water cases above the old caps, and fault injection proving that a 2% or nonfinite flux error prevents convergence even when all six hydraulic/thermodynamic residuals pass.
- Extends the existing three-phase convergence test and updates the model guide, wiki, pipeline recipes, and evidence matrix.

Validation on NeqSim 3.20.0, OpenJDK 17.0.20, based on master `3b0e8f4074bc83106653d4b5f01205eea65fd353`:
- Reproduced the original failure before changing production code: the nominal and +5% cases failed mass closure; −5% passed.
- **55 tests pass across 10 classes; zero failures, errors, or skips.** The three well rates meet relative mass tolerance 1e-10 plus absolute tolerance 1e-12 kg/s. Coverage includes the 30/60-cell three-phase refinement, phase degeneracy, gas-density coupling, pressure boundaries and floors, convergence limits, and sustained thermodynamic regressions.
- Direct Spotless apply, repeated unchanged apply, pre-commit and pre-push stages, direct Spotless check, documentation search, and whitespace checks pass. Documentation search covers 696 Markdown pages and one standalone HTML page. Tested Java file hashes remain unchanged after all final formatting gates.
- Javadoc generation for both production classes exits 0; it reports 15 missing-private-field-comment warnings.
- The complete published Git tree matches the locally verified tree.

Commands used (successful final runs):
```bash
./mvnw -q -DskipTests compile
./mvnw -q -Dtest=TwoFluidPipeSteadyMassFluxTest,TwoFluidPipeThreePhaseConvergenceReportTest,TwoFluidPipeSteadyStateConvergenceTest,TwoFluidPipePhaseDegeneracyTest,TwoFluidPipeSteadyBoundaryThermodynamicsTest,TwoFluidPipeGasDensityCouplingTest,TwoFluidPipePressureFloorTest,TwoFluidPipeThreePhaseConservationTest,TwoFluidPipeLeanGasHoldupTest,TwoFluidPipeSustainedThermodynamicRegressionTest test
python devtools/run_spotless.py apply
pre-commit run --all-files --hook-stage pre-commit
python devtools/run_spotless.py check
python devtools/check_documentation_search.py
pre-commit run --all-files --hook-stage pre-push
git diff --check
```
Maven was bootstrapped with the work-with-neqsim helper; Python commands used the supplied runtime and pre-commit used a task-specific environment. Javadoc ran through the JDK module entry point because the javadoc launcher was unavailable.

Documentation impact: steady velocity behavior and convergence diagnostics changed; all affected guides above are updated. The existing 1e-4 hydraulic tolerance and pressure-floor checks are unchanged. Transient velocity guards retain their limits. This is a steady conservation correction, not a critical-flow/choking qualification or a fix for the separate outlet-property issue #3685.

**VALIDATION PENDING CI** for the full repository matrix. Draft for review; no merge performed.

## CI investigation — 2026-09-13

Inspected the unchanged PR head `15ef65320b13187a908b84783a4bfce799bbb3cf`. The only failed job in run [34723141032](https://github.com/equinor/neqsim/actions/runs/34723141032) was Java 8 on Ubuntu: `ProductionOptimizationGuideExamplesTest.compressorSingleMultiAndTwoStageExamplesRunOnAThreeTrainProcess` threw `IllegalStateException: No feasible two-stage solution`. That job ran 13,796 tests with zero assertion failures, one error, and 209 skips. The two-fluid tests passed. Java 8 Windows, Java 21 Ubuntu/Windows, all four slow-test shards, Javadocs, benchmarks, agent checks, and the other PR workflows passed.

The complete source snapshot was reconstructed with all 7,850 file/symlink blob hashes matched to the exact remote head. Local OpenJDK 17 compilation and the complete guide test class passed. A focused final run passed **15 tests, zero failures/errors/skips** across `ProductionOptimizationGuideExamplesTest`, `TwoFluidPipeSteadyMassFluxTest`, and `TwoFluidPipeThreePhaseConvergenceReportTest`:

```bash
./mvnw -B -ntp -Dtest=ProductionOptimizationGuideExamplesTest test
./mvnw -B -ntp -Dtest=ProductionOptimizationGuideExamplesTest,TwoFluidPipeSteadyMassFluxTest,TwoFluidPipeThreePhaseConvergenceReportTest -Djacoco.skip=true surefire:test
python devtools/run_spotless.py check
python devtools/check_documentation_search.py
git diff --check
```

All commands above exited 0; the Python commands used the supplied runtime interpreter after the work-with-neqsim Maven bootstrap. Documentation search audited 696 Markdown pages and one standalone HTML page. No source changes were made; the failure has not been reproduced locally, and this evidence does not establish its root cause. Documentation impact of this investigation: none.

The failed Java 8 Ubuntu job was restarted on the same commit (attempt 2, [job 103691621509](https://github.com/equinor/neqsim/actions/runs/34723141032/job/103691621509)). **VALIDATION PENDING CI**: the retry is still running. The original job took approximately 71 minutes. No test was skipped, constraint relaxed, branch synchronized, or merge performed. The PR remains draft pending the retry result.