### PR TITLE
docs: execute GERG and EOS-CG examples

### DIFF
--- a/docs/thermo/gerg2008_eoscg.md
+++ b/docs/thermo/gerg2008_eoscg.md
@@ -1,9 +1,11 @@
 ---
 title: "GERG-2008 and EOS-CG Equations of State"
-description: "Guide to NeqSim's GERG-2008 and EOS-CG Helmholtz-energy models for high-accuracy natural-gas and CCS property calculations."
+description: "Guide to NeqSim's GERG-2008 and EOS-CG Helmholtz-energy implementations, model selection, property access, and validation boundaries."
 ---
 
-NeqSim supports the **GERG-2008** and **EOS-CG** equations of state, which are reference-quality models explicit in the Helmholtz free energy. These models are widely used for high-accuracy property calculations in natural gas and CCS (Carbon Capture and Storage) applications.
+NeqSim exposes implementations of the **GERG-2008** and **EOS-CG** equations of state, which are model families explicit in Helmholtz free energy. The published formulations target natural-gas and CCS (Carbon Capture and Storage) property calculations.
+
+The current `SystemGERG2008Eos` and `SystemEOSCGEos` implementations do not advertise analytical composition, pressure, or temperature fugacity derivatives. Positive finite results from the examples below prove API execution and model selection only; they do not establish custody-transfer accuracy, published-range reproduction, or fitness for a particular engineering decision. Validate the selected mixture and operating envelope against controlled reference data before use.
 
 ## 1. Mathematical Framework
 
@@ -34,7 +36,7 @@ $$
 \alpha^r(\delta, \tau, \bar{x}) = \sum_{i=1}^{N} x_i \alpha_{0i}^r(\delta, \tau) + \sum_{i=1}^{N-1} \sum_{j=i+1}^{N} x_i x_j F_{ij} \alpha_{ij}^r(\delta, \tau)
 $$
 
-This structure allows for extremely high accuracy in density, speed of sound, and heat capacity calculations, often superior to cubic equations of state (like SRK or PR), especially in the supercritical region.
+Published reference-EOS formulations can represent density, speed of sound, and heat capacity more directly than cubic equations of state such as SRK or PR. Accuracy from the NeqSim implementation remains mixture-, property-, and state-dependent and requires application-specific validation.
 
 ---
 
@@ -55,233 +57,31 @@ Methane, Nitrogen, Carbon Dioxide, Ethane, Propane, Butanes, Pentanes, Hexane, H
 To use GERG-2008 in NeqSim, use the `SystemGERG2008Eos` class.
 
 ```java
-import neqsim.thermo.system.SystemGERG2008Eos;
-import neqsim.thermo.system.SystemInterface;
-
-public class GergExample {
-    public static void main(String[] args) {
-        // Create system
-        SystemInterface fluid = new SystemGERG2008Eos(298.15, 10.0); // T in K, P in bara
-
-        // Add components
-        fluid.addComponent("methane", 0.9);
-        fluid.addComponent("ethane", 0.1);
-
-        // Initialize
-        fluid.createDatabase(true);
-        fluid.setMixingRule("classic"); // Not strictly used by GERG but good practice for init
-
-        // Flash calculation
-        neqsim.thermodynamicoperations.ThermodynamicOperations ops =
-            new neqsim.thermodynamicoperations.ThermodynamicOperations(fluid);
-        ops.TPflash();
-
-        // Retrieve properties
-        // Note: GERG-2008 properties are often accessed via specific methods
-        double density = fluid.getPhase(0).getDensity_GERG2008();
-        double[] props = fluid.getPhase(0).getProperties_GERG2008();
-
-        System.out.println("Density (GERG): " + density + " kg/m3");
-    }
-}
-```
-
----
-
-## 3. GERG-2008-H2 (Hydrogen Enhanced)
-
-**Full Name:** Extension of the equation of state for natural gases GERG-2008 with improved hydrogen parameters.
-**Authors:** R. Beckmüller, M. Thol, I. Sampson, E.W. Lemmon, R. Span (Ruhr-Universität Bochum, NIST).
-
-### Application
-GERG-2008-H2 is an extension of GERG-2008 with **improved hydrogen binary interaction parameters**. This extension is particularly important for:
-- Hydrogen-rich natural gas blends (power-to-gas applications)
-- Hydrogen transport in existing natural gas pipelines
-- CO₂-H₂ mixtures in CCS with hydrogen
-
-### Key Improvements
-The GERG-2008-H2 model includes:
-- Updated binary reducing parameters for hydrogen with methane, nitrogen, CO₂, and other hydrocarbons
-- **New departure function** for N₂-H₂ (Model 8)
-- **New departure function** for CO₂-H₂ (Model 9)
-- Extended validation range for hydrogen-containing mixtures
-
-### Expected Differences from GERG-2008
-
-| Binary System | Typical Density Difference |
-|---------------|---------------------------|
-| CH₄-H₂        | ~0.1-0.25%               |
-| N₂-H₂         | ~0.05-0.5%               |
-| CO₂-H₂        | ~1-1.5% (largest)        |
-| C₂H₆-H₂       | ~0.5-0.8%                |
-
-Differences increase with:
-- Higher hydrogen content
-- Higher pressure
-- Lower temperature
-
-### Usage in NeqSim
-
-The GERG-2008-H2 model is available through `SystemGERG2008Eos` by enabling the hydrogen-enhanced mode:
-
-```java
-import neqsim.thermo.system.SystemGERG2008Eos;
-import neqsim.thermo.util.gerg.GERG2008Type;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-public class Gerg2008H2Example {
-    public static void main(String[] args) {
-        // Create system with GERG-2008
-        SystemGERG2008Eos fluid = new SystemGERG2008Eos(300.0, 50.0); // T in K, P in bara
-
-        // Add hydrogen-rich mixture
-        fluid.addComponent("methane", 0.7);
-        fluid.addComponent("hydrogen", 0.3);
-
-        // Enable GERG-2008-H2 model with improved hydrogen parameters
-        fluid.useHydrogenEnhancedModel();
-        // or equivalently:
-        // fluid.setGergModelType(GERG2008Type.HYDROGEN_ENHANCED);
-
-        // Flash calculation
-        ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-        ops.TPflash();
-
-        // Retrieve properties
-        double density = fluid.getPhase(0).getDensity();
-        System.out.println("Density (GERG-2008-H2): " + density + " kg/m3");
-        System.out.println("Model: " + fluid.getModelName()); // "GERG2008-H2-EOS"
-
-        // Check which model is active
-        if (fluid.isUsingHydrogenEnhancedModel()) {
-            System.out.println("Using hydrogen-enhanced GERG-2008-H2 model");
-        }
-    }
-}
-```
-
-### API Methods
-
-| Method | Description |
-|--------|-------------|
-| `useHydrogenEnhancedModel()` | Enable GERG-2008-H2 model |
-| `setGergModelType(GERG2008Type.STANDARD)` | Use standard GERG-2008 |
-| `setGergModelType(GERG2008Type.HYDROGEN_ENHANCED)` | Use GERG-2008-H2 |
-| `getGergModelType()` | Get current model type |
-| `isUsingHydrogenEnhancedModel()` | Check if H2 model is active |
-
----
-
-## 4. GERG-2008-NH3 (Ammonia Extended)
-
-**Full Name:** Extension of the GERG-2008 equation of state with ammonia as a 22nd component.
-**Authors:** T. Neumann, M. Thol, E.W. Lemmon, R. Span (Ruhr-Universität Bochum, NIST); ammonia pure-fluid equation by K. Gao, J. Wu, E.W. Lemmon (NIST, Xi'an Jiaotong Univ.).
-
-### Application
-GERG-2008-NH3 extends GERG-2008 to include **ammonia (NH₃)** as a fully integrated 22nd component. This is essential for:
-- Ammonia-based hydrogen energy carriers (green ammonia)
-- Ammonia co-firing in gas turbines
-- Ammonia refrigeration loops in LNG plants
-- CO₂-NH₃ mixtures in industrial processes
-
-### Key Features
-
-| Feature | Detail |
-|---------|--------|
-| Pure-fluid EOS | Full 20-term Gao et al. (2020) equation: 8 power + 10 Gaussian + 2 GaoB terms |
-| Critical properties | $T_c = 405.56$ K, $\rho_c = 13.696$ mol/L (Gao et al.) |
-| Ideal gas | Planck-Einstein terms with $v = [2.224, 3.148, 0.9579]$ and $\theta = [1646, 3965, 7231]$ K |
-| Binary interactions | Reducing parameters and GBS departure functions for NH₃ with CH₄, N₂, CO₂, H₂O, H₂, and other GERG components (Neumann et al. 2020) |
-| Accuracy | Density deviations $< 0.1\%$ from NIST reference data across 300–500 K and 0.1–10 MPa |
-
-### Usage in NeqSim
-
-The GERG-2008-NH3 model is available through `SystemGERG2008Eos` by enabling the ammonia-extended mode:
-
-```java
-import neqsim.thermo.system.SystemGERG2008Eos;
-import neqsim.thermo.util.gerg.GERG2008Type;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-public class Gerg2008NH3Example {
-    public static void main(String[] args) {
-        // Create system
-        SystemGERG2008Eos fluid = new SystemGERG2008Eos(400.0, 50.0); // T in K, P in bara
-
-        // Add ammonia-containing mixture
-        fluid.addComponent("nitrogen", 0.02);
-        fluid.addComponent("methane", 0.80);
-        fluid.addComponent("ammonia", 0.18);
-
-        // Enable GERG-2008-NH3 model with full Gao pure-fluid EOS
-        fluid.useAmmoniaExtendedModel();
-        // or equivalently:
-        // fluid.setGergModelType(GERG2008Type.AMMONIA_EXTENDED);
-
-        // Flash calculation
-        ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-        ops.TPflash();
-
-        // Retrieve properties
-        double density = fluid.getPhase(0).getDensity("kg/m3");
-        System.out.println("Density (GERG-2008-NH3): " + density + " kg/m3");
-        System.out.println("Model: " + fluid.getModelName()); // "GERG2008-NH3-EOS"
-    }
-}
-```
-
-### API Methods
-
-| Method | Description |
-|--------|-------------|
-| `useAmmoniaExtendedModel()` | Enable GERG-2008-NH3 model |
-| `setGergModelType(GERG2008Type.AMMONIA_EXTENDED)` | Enable GERG-2008-NH3 model (enum form) |
-| `isUsingAmmoniaExtendedModel()` | Check if NH3 model is active |
-| `getModelName()` | Returns `"GERG2008-NH3-EOS"` when NH3 model is active |
-
----
-
-## 5. EOS-CG
-
-**Full Name:** EOS-CG-2021: a Helmholtz energy equation of state for CCS mixtures.
-**Authors:** Tobias Neumann, Stefan Herrig, Ian Bell, Robin Beckmüller, Eric W. Lemmon, Monika Thol, and Roland Span.
-
-### Application
-EOS-CG is an extension of the GERG framework designed for **Carbon Capture and Storage (CCS)** and **combustion gas** applications. It includes additional components found in CO2-rich transport streams and impurities relevant to CCS.
-
-### EOS-CG-2021 component coverage
-The EOS-CG-2021 publication defines a 16-component CCS model: CO₂, water, N₂, O₂, Ar, CO, H₂, CH₄, H₂S, SO₂, monoethanolamine (MEA), diethanolamine (DEA), HCl, Cl₂, NH₃, and methyl diethanolamine (MDEA). NeqSim keeps the GERG-style hydrocarbon slots for compatibility while refreshing the EOS-CG reducing-parameter table and adding MDEA as an EOS-CG component.
-
-Recent updates refreshed the EOS-CG component tables with the EOS-CG-2021 gas constant, MDEA pure-fluid parameters, and binary reducing parameters, improving consistency with the current CCS-mixture model.
-
-### Usage in NeqSim
-
-To use EOS-CG in NeqSim, use the `SystemEOSCGEos` class.
-
-```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.thermo.system.SystemEOSCGEos;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-public class EosCgExample {
-    public static void main(String[] args) {
-        // Create system
-        SystemInterface fluid = new SystemEOSCGEos(298.15, 50.0);
+public final class EosCgExample {
+  private static final Logger logger = LogManager.getLogger(EosCgExample.class);
 
-        // Add components (including CCS impurities)
-        fluid.addComponent("CO2", 0.95);
-        fluid.addComponent("SO2", 0.05);
+  private EosCgExample() {}
 
-        // Initialize and Flash
-        fluid.createDatabase(true);
-        neqsim.thermodynamicoperations.ThermodynamicOperations ops =
-            new neqsim.thermodynamicoperations.ThermodynamicOperations(fluid);
-        ops.TPflash();
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemEOSCGEos(298.15, 50.0); // K, bara
+    fluid.addComponent("CO2", 0.95);
+    fluid.addComponent("SO2", 0.05);
+    fluid.createDatabase(true);
 
-        // Retrieve properties
-        double density = fluid.getPhase(0).getDensity_EOSCG();
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
 
-        System.out.println("Density (EOS-CG): " + density + " kg/m3");
-    }
+    double density = fluid.getPhase(0).getDensity_EOSCG();
+    assert Double.isFinite(density) && density > 0.0 : "EOS-CG density must be finite and positive";
+
+    logger.info("EOS-CG density: {} kg/m3", density);
+  }
 }
 ```
 

--- a/docs/thermo/gerg2008_eoscg.md
+++ b/docs/thermo/gerg2008_eoscg.md
@@ -255,7 +255,14 @@ Recent updates refreshed the EOS-CG component tables with the EOS-CG-2021 gas co
 
 ### Usage in NeqSim
 
-To use EOS-CG in NeqSim, use the `SystemEOSCGEos` class.
+To use EOS-CG in NeqSim, use the `SystemEOSCGEos` class. This introductory example
+uses pure CO2 gas at 298.15 K and 10 bara, also covered by the repository's CO2
+density regression. Mixture flashes require separate convergence and accuracy
+validation for the intended composition and operating range.
+
+The previously shown 95 mol% CO2 / 5 mol% SO2 flash at 298.15 K and 50 bara
+fails density-root convergence in the current implementation. The reproducible
+limitation is tracked in [issue #3702](https://github.com/equinor/neqsim/issues/3702).
 
 ```java
 import org.apache.logging.log4j.LogManager;
@@ -270,9 +277,8 @@ public final class EosCgExample {
   private EosCgExample() {}
 
   public static void main(String[] args) {
-    SystemInterface fluid = new SystemEOSCGEos(298.15, 50.0); // K, bara
-    fluid.addComponent("CO2", 0.95);
-    fluid.addComponent("SO2", 0.05);
+    SystemInterface fluid = new SystemEOSCGEos(298.15, 10.0); // K, bara
+    fluid.addComponent("CO2", 1.0);
     fluid.createDatabase(true);
 
     ThermodynamicOperations operations = new ThermodynamicOperations(fluid);

--- a/docs/thermo/gerg2008_eoscg.md
+++ b/docs/thermo/gerg2008_eoscg.md
@@ -59,6 +59,207 @@ To use GERG-2008 in NeqSim, use the `SystemGERG2008Eos` class.
 ```java
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.thermo.system.SystemGERG2008Eos;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public final class GergExample {
+  private static final Logger logger = LogManager.getLogger(GergExample.class);
+
+  private GergExample() {}
+
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemGERG2008Eos(298.15, 10.0); // K, bara
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.createDatabase(true);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+
+    double density = fluid.getPhase(0).getDensity_GERG2008();
+    double[] properties = fluid.getPhase(0).getProperties_GERG2008();
+    assert Double.isFinite(density) && density > 0.0 : "GERG density must be finite and positive";
+    assert properties != null && properties.length > 0 : "GERG property vector must be populated";
+
+    logger.info("GERG-2008 density: {} kg/m3", density);
+  }
+}
+```
+
+---
+
+## 3. GERG-2008-H2 (Hydrogen Enhanced)
+
+**Full Name:** Extension of the equation of state for natural gases GERG-2008 with improved hydrogen parameters.
+**Authors:** R. Beckmüller, M. Thol, I. Sampson, E.W. Lemmon, R. Span (Ruhr-Universität Bochum, NIST).
+
+### Application
+GERG-2008-H2 is an extension of GERG-2008 with **improved hydrogen binary interaction parameters**. This extension is particularly important for:
+- Hydrogen-rich natural gas blends (power-to-gas applications)
+- Hydrogen transport in existing natural gas pipelines
+- CO₂-H₂ mixtures in CCS with hydrogen
+
+### Key Improvements
+The GERG-2008-H2 model includes:
+- Updated binary reducing parameters for hydrogen with methane, nitrogen, CO₂, and other hydrocarbons
+- **New departure function** for N₂-H₂ (Model 8)
+- **New departure function** for CO₂-H₂ (Model 9)
+- Extended validation range for hydrogen-containing mixtures
+
+### Expected Differences from GERG-2008
+
+| Binary System | Typical Density Difference |
+|---------------|---------------------------|
+| CH₄-H₂        | ~0.1-0.25%               |
+| N₂-H₂         | ~0.05-0.5%               |
+| CO₂-H₂        | ~1-1.5% (largest)        |
+| C₂H₆-H₂       | ~0.5-0.8%                |
+
+Differences increase with:
+- Higher hydrogen content
+- Higher pressure
+- Lower temperature
+
+### Usage in NeqSim
+
+The GERG-2008-H2 model is available through `SystemGERG2008Eos` by enabling the hydrogen-enhanced mode:
+
+```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.thermo.system.SystemGERG2008Eos;
+import neqsim.thermo.util.gerg.GERG2008Type;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public final class Gerg2008H2Example {
+  private static final Logger logger = LogManager.getLogger(Gerg2008H2Example.class);
+
+  private Gerg2008H2Example() {}
+
+  public static void main(String[] args) {
+    SystemGERG2008Eos fluid = new SystemGERG2008Eos(300.0, 50.0); // K, bara
+    fluid.addComponent("methane", 0.7);
+    fluid.addComponent("hydrogen", 0.3);
+    fluid.useHydrogenEnhancedModel();
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+
+    double density = fluid.getPhase(0).getDensity("kg/m3");
+    assert Double.isFinite(density) && density > 0.0 : "H2-mixture density must be finite and positive";
+    assert fluid.getGergModelType() == GERG2008Type.HYDROGEN_ENHANCED;
+    assert fluid.isUsingHydrogenEnhancedModel();
+    assert "GERG2008-H2-EOS".equals(fluid.getModelName());
+
+    logger.info("GERG-2008-H2 density: {} kg/m3; model: {}", density, fluid.getModelName());
+  }
+}
+```
+
+### API Methods
+
+| Method | Description |
+|--------|-------------|
+| `useHydrogenEnhancedModel()` | Enable GERG-2008-H2 model |
+| `setGergModelType(GERG2008Type.STANDARD)` | Use standard GERG-2008 |
+| `setGergModelType(GERG2008Type.HYDROGEN_ENHANCED)` | Use GERG-2008-H2 |
+| `getGergModelType()` | Get current model type |
+| `isUsingHydrogenEnhancedModel()` | Check if H2 model is active |
+
+---
+
+## 4. GERG-2008-NH3 (Ammonia Extended)
+
+**Full Name:** Extension of the GERG-2008 equation of state with ammonia as a 22nd component.
+**Authors:** T. Neumann, M. Thol, E.W. Lemmon, R. Span (Ruhr-Universität Bochum, NIST); ammonia pure-fluid equation by K. Gao, J. Wu, E.W. Lemmon (NIST, Xi'an Jiaotong Univ.).
+
+### Application
+GERG-2008-NH3 extends GERG-2008 to include **ammonia (NH₃)** as a fully integrated 22nd component. This is essential for:
+- Ammonia-based hydrogen energy carriers (green ammonia)
+- Ammonia co-firing in gas turbines
+- Ammonia refrigeration loops in LNG plants
+- CO₂-NH₃ mixtures in industrial processes
+
+### Key Features
+
+| Feature | Detail |
+|---------|--------|
+| Pure-fluid EOS | Full 20-term Gao et al. (2020) equation: 8 power + 10 Gaussian + 2 GaoB terms |
+| Critical properties | $T_c = 405.56$ K, $\rho_c = 13.696$ mol/L (Gao et al.) |
+| Ideal gas | Planck-Einstein terms with $v = [2.224, 3.148, 0.9579]$ and $\theta = [1646, 3965, 7231]$ K |
+| Binary interactions | Reducing parameters and GBS departure functions for NH₃ with CH₄, N₂, CO₂, H₂O, H₂, and other GERG components (Neumann et al. 2020) |
+| Published formulation | Gao and Neumann reference data cover ammonia-containing states; NeqSim results require application-specific validation |
+
+### Usage in NeqSim
+
+The GERG-2008-NH3 model is available through `SystemGERG2008Eos` by enabling the ammonia-extended mode:
+
+```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.thermo.system.SystemGERG2008Eos;
+import neqsim.thermo.util.gerg.GERG2008Type;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public final class Gerg2008NH3Example {
+  private static final Logger logger = LogManager.getLogger(Gerg2008NH3Example.class);
+
+  private Gerg2008NH3Example() {}
+
+  public static void main(String[] args) {
+    SystemGERG2008Eos fluid = new SystemGERG2008Eos(400.0, 50.0); // K, bara
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ammonia", 0.18);
+    fluid.useAmmoniaExtendedModel();
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+
+    double density = fluid.getPhase(0).getDensity("kg/m3");
+    assert Double.isFinite(density) && density > 0.0 : "NH3-mixture density must be finite and positive";
+    assert fluid.getGergModelType() == GERG2008Type.AMMONIA_EXTENDED;
+    assert fluid.isUsingAmmoniaExtendedModel();
+    assert "GERG2008-NH3-EOS".equals(fluid.getModelName());
+
+    logger.info("GERG-2008-NH3 density: {} kg/m3; model: {}", density, fluid.getModelName());
+  }
+}
+```
+
+### API Methods
+
+| Method | Description |
+|--------|-------------|
+| `useAmmoniaExtendedModel()` | Enable GERG-2008-NH3 model |
+| `setGergModelType(GERG2008Type.AMMONIA_EXTENDED)` | Enable GERG-2008-NH3 model (enum form) |
+| `isUsingAmmoniaExtendedModel()` | Check if NH3 model is active |
+| `getModelName()` | Returns `"GERG2008-NH3-EOS"` when NH3 model is active |
+
+---
+
+## 5. EOS-CG
+
+**Full Name:** EOS-CG-2021: a Helmholtz energy equation of state for CCS mixtures.
+**Authors:** Tobias Neumann, Stefan Herrig, Ian Bell, Robin Beckmüller, Eric W. Lemmon, Monika Thol, and Roland Span.
+
+### Application
+EOS-CG is an extension of the GERG framework designed for **Carbon Capture and Storage (CCS)** and **combustion gas** applications. It includes additional components found in CO2-rich transport streams and impurities relevant to CCS.
+
+### EOS-CG-2021 component coverage
+The EOS-CG-2021 publication defines a 16-component CCS model: CO₂, water, N₂, O₂, Ar, CO, H₂, CH₄, H₂S, SO₂, monoethanolamine (MEA), diethanolamine (DEA), HCl, Cl₂, NH₃, and methyl diethanolamine (MDEA). NeqSim keeps the GERG-style hydrocarbon slots for compatibility while refreshing the EOS-CG reducing-parameter table and adding MDEA as an EOS-CG component.
+
+Recent updates refreshed the EOS-CG component tables with the EOS-CG-2021 gas constant, MDEA pure-fluid parameters, and binary reducing parameters, improving consistency with the current CCS-mixture model.
+
+### Usage in NeqSim
+
+To use EOS-CG in NeqSim, use the `SystemEOSCGEos` class.
+
+```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.thermo.system.SystemEOSCGEos;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;

--- a/src/test/java/neqsim/documentation/GergEoscgDocumentationTest.java
+++ b/src/test/java/neqsim/documentation/GergEoscgDocumentationTest.java
@@ -1,0 +1,109 @@
+package neqsim.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Compiles and executes the published GERG-2008 and EOS-CG examples with assertions enabled.
+ */
+public class GergEoscgDocumentationTest extends neqsim.NeqSimTest {
+  private static final Pattern JAVA_FENCE = Pattern.compile("(?m)^\x60\x60\x60java\\r?\\n([\\s\\S]*?)^\x60\x60\x60[ \\t]*$");
+  private static final Pattern PUBLIC_CLASS =
+      Pattern.compile("public\\s+(?:final\\s+)?class\\s+([A-Za-z][A-Za-z0-9_]*)");
+
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void gergAndEoscgExamplesCompileAndRunWithPhysicalAssertions() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    assertNotNull(compiler, "Documentation examples require a JDK compiler");
+    Path repositoryRoot = Paths.get(System.getProperty("basedir", ".")).toAbsolutePath();
+    Path document = repositoryRoot.resolve("docs/thermo/gerg2008_eoscg.md");
+    String markdown = new String(Files.readAllBytes(document), StandardCharsets.UTF_8);
+    assertTrue(markdown.contains("do not establish custody-transfer accuracy"),
+        "The guide must retain its implementation-validation boundary");
+
+    Matcher fences = JAVA_FENCE.matcher(markdown);
+    List<String> classNames = new ArrayList<String>();
+    List<Path> sourceFiles = new ArrayList<Path>();
+    while (fences.find()) {
+      String source = fences.group(1);
+      Matcher className = PUBLIC_CLASS.matcher(source);
+      assertTrue(className.find(), "Each Java example must be a complete public class");
+      assertTrue(!source.contains("System.out") && !source.contains("System.err"),
+          "GERG/EOS-CG examples must use the project logger");
+      assertTrue(source.contains("LogManager.getLogger"), "Each example must declare a project logger");
+      assertTrue(source.contains("assert "), "Each example must check its physical or model-selection result");
+      String name = className.group(1);
+      assertTrue(!classNames.contains(name), "Duplicate GERG/EOS-CG example class " + name);
+      classNames.add(name);
+      Path sourceFile = temporaryDirectory.resolve(name + ".java");
+      Files.write(sourceFile, source.getBytes(StandardCharsets.UTF_8));
+      sourceFiles.add(sourceFile);
+    }
+    assertEquals(Arrays.asList("GergExample", "Gerg2008H2Example", "Gerg2008NH3Example", "EosCgExample"),
+        classNames, "GERG/EOS-CG example coverage changed");
+    compile(compiler, sourceFiles);
+
+    try (URLClassLoader loader = new URLClassLoader(new URL[] {temporaryDirectory.toUri().toURL()},
+        getClass().getClassLoader())) {
+      loader.setDefaultAssertionStatus(true);
+      for (String className : classNames) {
+        Class<?> example = Class.forName(className, true, loader);
+        assertTrue(example.desiredAssertionStatus(), "Physical assertions must be enabled for " + className);
+        try {
+          example.getMethod("main", String[].class).invoke(null, (Object) new String[0]);
+        } catch (InvocationTargetException exception) {
+          throw new AssertionError(className + " failed", exception.getCause());
+        }
+      }
+    }
+  }
+
+  /**
+   * Compile with Java 8 syntax and the repository test classpath.
+   *
+   * @param compiler current JDK compiler
+   * @param sourceFiles extracted Markdown sources
+   * @throws IOException if a source cannot be read
+   */
+  private void compile(JavaCompiler compiler, List<Path> sourceFiles) throws IOException {
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+    List<java.io.File> files = new ArrayList<java.io.File>();
+    for (Path sourceFile : sourceFiles) {
+      files.add(sourceFile.toFile());
+    }
+    String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+    List<String> options = Arrays.asList("-source", "8", "-target", "8", "-classpath", classPath, "-d",
+        temporaryDirectory.toString());
+    try (StandardJavaFileManager manager =
+        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+      Boolean successful = compiler
+          .getTask(null, manager, diagnostics, options, null, manager.getJavaFileObjectsFromFiles(files)).call();
+      assertTrue(Boolean.TRUE.equals(successful),
+          "docs/thermo/gerg2008_eoscg.md: " + diagnostics.getDiagnostics());
+    }
+  }
+}

--- a/src/test/java/neqsim/documentation/GergEoscgDocumentationTest.java
+++ b/src/test/java/neqsim/documentation/GergEoscgDocumentationTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.io.TempDir;
  * Compiles and executes the published GERG-2008 and EOS-CG examples with assertions enabled.
  */
 public class GergEoscgDocumentationTest extends neqsim.NeqSimTest {
-  private static final Pattern JAVA_FENCE = Pattern.compile("(?m)^\x60\x60\x60java\\r?\\n([\\s\\S]*?)^\x60\x60\x60[ \\t]*$");
-  private static final Pattern PUBLIC_CLASS =
-      Pattern.compile("public\\s+(?:final\\s+)?class\\s+([A-Za-z][A-Za-z0-9_]*)");
+  private static final Pattern JAVA_FENCE = Pattern.compile("(?m)^```java\\r?\\n([\\s\\S]*?)^```[ \\t]*$");
+  private static final Pattern PUBLIC_CLASS = Pattern
+      .compile("public\\s+(?:final\\s+)?class\\s+([A-Za-z][A-Za-z0-9_]*)");
 
   @TempDir
   Path temporaryDirectory;
@@ -63,11 +63,11 @@ public class GergEoscgDocumentationTest extends neqsim.NeqSimTest {
       Files.write(sourceFile, source.getBytes(StandardCharsets.UTF_8));
       sourceFiles.add(sourceFile);
     }
-    assertEquals(Arrays.asList("GergExample", "Gerg2008H2Example", "Gerg2008NH3Example", "EosCgExample"),
-        classNames, "GERG/EOS-CG example coverage changed");
+    assertEquals(Arrays.asList("GergExample", "Gerg2008H2Example", "Gerg2008NH3Example", "EosCgExample"), classNames,
+        "GERG/EOS-CG example coverage changed");
     compile(compiler, sourceFiles);
 
-    try (URLClassLoader loader = new URLClassLoader(new URL[] {temporaryDirectory.toUri().toURL()},
+    try (URLClassLoader loader = new URLClassLoader(new URL[] { temporaryDirectory.toUri().toURL() },
         getClass().getClassLoader())) {
       loader.setDefaultAssertionStatus(true);
       for (String className : classNames) {
@@ -98,12 +98,10 @@ public class GergEoscgDocumentationTest extends neqsim.NeqSimTest {
     String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
     List<String> options = Arrays.asList("-source", "8", "-target", "8", "-classpath", classPath, "-d",
         temporaryDirectory.toString());
-    try (StandardJavaFileManager manager =
-        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+    try (StandardJavaFileManager manager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
       Boolean successful = compiler
           .getTask(null, manager, diagnostics, options, null, manager.getJavaFileObjectsFromFiles(files)).call();
-      assertTrue(Boolean.TRUE.equals(successful),
-          "docs/thermo/gerg2008_eoscg.md: " + diagnostics.getDiagnostics());
+      assertTrue(Boolean.TRUE.equals(successful), "docs/thermo/gerg2008_eoscg.md: " + diagnostics.getDiagnostics());
     }
   }
 }


### PR DESCRIPTION
## Campaign

D151 in #2499 — documentation-quality roadmap scope 2 (thermo, fluids, phase equilibrium, and physical properties).

## What changed

- Reworked all four complete GERG-2008, GERG-H2, GERG-NH3, and EOS-CG Java programs to use parameterized Log4j2.
- Added finite/positive property checks and exact model-selection assertions while retaining the physical assertions. The EOS-CG introduction now uses the repository's tested pure-CO2 gas state; the previous CO2/SO2 convergence failure is tracked explicitly in #3702.
- Added an explicit implementation/validation boundary: successful execution does not establish custody-transfer accuracy, published-range reproduction, or engineering fitness.
- Added a Java 8 documentation gate intended to extract, compile, assertion-enable, and execute the four published Markdown programs.

## Frozen scope

Exactly two files:

- `docs/thermo/gerg2008_eoscg.md`
- `src/test/java/neqsim/documentation/GergEoscgDocumentationTest.java`

Four ordered commits. No production EOS code, interaction parameters, flash algorithms, numerical benchmark publication, notebooks, or Huldra material changed.

## Validation state

Fixed the six illegal Java string escapes in `JAVA_FENCE` and applied Spotless. The first executable run then exposed a separate density-root convergence failure for the previous 95 mol% CO2 / 5 mol% SO2 example at 298.15 K and 50 bara. The guide now uses the existing pure-CO2 regression state and links #3702; no EOS code or fallback acceptance was changed.

Validation on Java 17 / NeqSim 3.20.0:
- All four extracted documentation programs compile with Java 8 syntax and execute with assertions enabled.
- `./mvnw -B -ntp surefire:test -Dtest=GergEoscgDocumentationTest,SystemEOSCGEosCO2DensityTest -Djacoco.skip=true`: exit 0; 3 JUnit tests passed (four documentation programs plus two CO2 density regressions). The preceding full Maven `test` invocation compiled all production/test sources successfully after the regex repair.
- `python devtools/run_spotless.py apply`: exit 0; repeated apply made no further changes.
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0.
- Both `pre-commit run --all-files --hook-stage pre-commit` and `--hook-stage pre-push`: exit 0 (invoked as `python -m pre_commit` using the selected runtime).

Documentation impact: corrected the executable EOS-CG example and documented its mixture-convergence limitation, linked to #3702.

Current head: `973b01c0ccd74abeaf5a0828935fbc35fae44d5f`.

Hosted exact-head validation:
- Documentation/search, pre-commit, Spotless, and CodeQL pass.
- Javadocs, Java 21 Ubuntu/Windows fast suites, all four Java 21 slow shards, and Java 8 Ubuntu pass.
- Java 8 Windows remains running: **VALIDATION PENDING CI — 4 of 5 required workflows pass**.
- Draft is mergeable and intentionally four commits behind current `master`; no rebase or synchronization.
- No reviews or unresolved threads.
- The EOS-CG production repair is independently owned by draft [#3704](https://github.com/equinor/neqsim/pull/3704); this documentation branch does not overlap it.

This PR remains draft-only. Preserve its branch; do not merge, mark ready, rebase, synchronize, close, replace, or abandon it automatically.