### PR TITLE
[AI-Assisted] fix(compressor): keep impeller sizing consistent with head and speed

### DIFF
--- a/docs/process/CompressorMechanicalDesign.md
+++ b/docs/process/CompressorMechanicalDesign.md
@@ -40,7 +40,7 @@ The mechanical design module provides sizing and design calculations for centrif
 
 ### 1. Number of Stages
 
-The number of compression stages is determined by the total polytropic head and the maximum allowable head per stage:
+The initial number of compression stages is determined by the total polytropic head and the maximum allowable head per stage:
 
 ```
 numberOfStages = ceil(totalPolytropicHead / maxHeadPerStage)
@@ -52,6 +52,12 @@ The actual head per stage is then:
 ```
 headPerStage = totalPolytropicHead / numberOfStages
 ```
+
+Impeller sizing tries this stage count and then additional equal-head stages up to
+`getMaxStagesPerCasing()` (default 10). It selects the first count satisfying all the
+preliminary impeller limits below while keeping the specified shaft speed and total
+head unchanged. If none is feasible, it retains the initial head-based candidate for
+diagnostics and reports infeasibility.
 
 ### 2. Impeller Sizing
 
@@ -81,6 +87,33 @@ The design verifies the flow coefficient is within acceptable range (0.01-0.15):
 ```
 flowCoefficient = volumeFlow [m³/s] / (D² × U)
 ```
+
+Here `D` is the diameter in metres, `U` is tip speed in m/s, and volume flow is actual
+inlet flow, not standard flow. Every candidate satisfies both identities:
+
+$$U=\frac{\pi D N}{60}$$
+$$H_{\mathrm{stage}}=\frac{0.50 U^2}{1000}\quad[\mathrm{kJ/kg}]$$
+
+`N` is the specified shaft speed in rpm. The diameter must be 100–1500 mm, tip speed
+must be at most 350 m/s, head per stage at most 30 kJ/kg, and inlet flow coefficient
+0.01–0.15. These are the model's preliminary screening limits, not a vendor map or
+universal API 617 acceptance criteria. The work coefficient remains fixed at 0.50.
+Increasing the stage count reduces diameter and tip speed and increases the inlet
+flow coefficient. The calculation never resizes or clamps diameter independently
+of shaft speed and required head.
+
+Check `isImpellerSizingFeasible()` and `getImpellerSizingIssues()` after `calcDesign()`.
+An infeasible candidate can have dimensions outside the screening bounds; do not use
+those dimensions as a qualified CAD or equipment design. Invalid or nonpositive speed,
+inlet flow or head produces unavailable impeller quantities (`NaN` in Java, `null`
+in JSON), not a default diameter. Changes to sizing inputs or manual stage/diameter
+overrides invalidate qualification; rerun the process and `calcDesign()`.
+
+`validateDesign()` includes impeller sizing issues, and `CompressorDesignFeasibilityReport`
+classifies them as `IMPELLER_SIZING` blockers. Passing this screen only checks equal-head
+staging and the inlet-stage flow coefficient; downstream-stage aerodynamics, diffuser
+geometry, surge/choke maps, shaft clearances and full mechanical qualification require
+separate checks.
 
 ### 3. Shaft Diameter
 
@@ -426,6 +459,10 @@ String jsonReport = calc.toJson();
 | Head per stage | `getHeadPerStage()` | kJ/kg |
 | Impeller diameter | `getImpellerDiameter()` | mm |
 | Tip speed | `getTipSpeed()` | m/s |
+| Shaft speed used for impeller sizing | `getImpellerSizingSpeedRPM()` | rpm |
+| Inlet flow coefficient | `getFlowCoefficient()` | - |
+| Preliminary impeller sizing passes | `isImpellerSizingFeasible()` | boolean |
+| Sizing limit / freshness diagnostics | `getImpellerSizingIssues()` | List of strings |
 | Shaft diameter | `getShaftDiameter()` | mm |
 | Bearing span | `getBearingSpan()` | mm |
 | Design pressure | `getDesignPressure()` | bara |
@@ -487,7 +524,16 @@ Access via `comp.getMechanicalDesign().getCasingDesignCalculator()`:
 
 ## JSON Output Structure
 
-The `toJson()` method returns a comprehensive JSON report including all design sections. The casing design is nested under the `casingDesign` key:
+The `toJson()` method returns a comprehensive JSON report including all design sections.
+It includes `impellerSizingFeasible`, `impellerSizingIssues`, `impellerSizingSpeedRPM`
+and `flowCoefficient`; `headPerStage` and `totalHead` are in kJ/kg.
+The casing design is nested under the `casingDesign` key:
+
+For CAD handoff, `toDesignDataJson()` also includes `impellerSizingFeasible` and
+`impellerSizingIssues`. Its `designBasis` contains unit-labelled `impellerSizingSpeed`
+(rpm), `impellerTipSpeed` (m/s), `inletFlowCoefficient` (dimensionless), `headPerStage`
+(J/kg), and `numberOfStages`. Its impeller diameter is in metres. Shell
+`geometryConsistency` is a separate check and does not qualify the impeller.
 
 ```json
 {

--- a/docs/process/CompressorMechanicalDesign.md
+++ b/docs/process/CompressorMechanicalDesign.md
@@ -109,6 +109,13 @@ inlet flow or head produces unavailable impeller quantities (`NaN` in Java, `nul
 in JSON), not a default diameter. Changes to sizing inputs or manual stage/diameter
 overrides invalidate qualification; rerun the process and `calcDesign()`.
 
+Each `calcDesign()` attempt clears the previous calculated geometry, shaft and rotor
+results, driver sizing, weights and module dimensions before recalculating them.
+If the compressor is uninitialized or sizing inputs are invalid, these dependent
+results remain unavailable (`NaN` in Java, `null` in JSON), the stage count is zero,
+and the casing calculator is absent. A reused JSON response also drops the previous
+casing calculation. Restore valid inputs and rerun to obtain a new complete design.
+
 `validateDesign()` includes impeller sizing issues, and `CompressorDesignFeasibilityReport`
 classifies them as `IMPELLER_SIZING` blockers. Passing this screen only checks equal-head
 staging and the inlet-stage flow coefficient; downstream-stage aerodynamics, diffuser

--- a/docs/process/compressor_design_feasibility.md
+++ b/docs/process/compressor_design_feasibility.md
@@ -92,6 +92,10 @@ Runs `CompressorMechanicalDesign.calcDesign()` to compute API 617-based sizing:
 | Impeller diameter | `impellerDiameter_mm` | mm |
 | Shaft diameter | `shaftDiameter_mm` | mm |
 | Tip speed | `tipSpeed_ms` | m/s |
+| Preliminary impeller sizing passes | `impellerSizingFeasible` | boolean |
+| Impeller sizing diagnostics | `impellerSizingIssues` | list of strings |
+| Shaft speed used for impeller sizing | `impellerSizingSpeed_rpm` | rpm |
+| Inlet flow coefficient | `inletFlowCoefficient` | - |
 | Bearing span | `bearingSpan_mm` | mm |
 | Casing type | `casingType` | BARREL / HORIZONTALLY_SPLIT / VERTICALLY_SPLIT |
 | Driver power (with margin) | `driverPower_kW` | kW |
@@ -188,7 +192,7 @@ comp.run();
 
 ## Feasibility Checks
 
-The report runs eight automated feasibility checks. Each check can produce issues at three severity levels:
+The report runs nine automated feasibility checks. Each check can produce issues at three severity levels:
 
 | Severity | Meaning | Effect |
 |----------|---------|--------|
@@ -200,6 +204,7 @@ The report runs eight automated feasibility checks. Each check can produce issue
 
 | Check | Category | Blocker Condition | Warning Condition |
 |-------|----------|-------------------|-------------------|
+| Coupled impeller sizing | `IMPELLER_SIZING` | Invalid/stale inputs or infeasible head, diameter, speed, inlet flow coefficient or casing stage count | - |
 | Discharge temperature | `TEMPERATURE` | Exceeds max (API 617 limit) | Within 10% of max |
 | Pressure ratio/stage | `PRESSURE_RATIO` | Exceeds max per stage | - |
 | Impeller tip speed | `TIP_SPEED` | Exceeds 350 m/s (steel limit) | Above 315 m/s |
@@ -208,6 +213,17 @@ The report runs eight automated feasibility checks. Each check can produce issue
 | Rotor dynamics | `ROTOR_DYNAMICS` | - | Operating speed within 15% of critical |
 | Efficiency | `EFFICIENCY` | - | Above 90% or below 65% |
 | Cost reasonableness | `COST` | - | Specific cost above 5,000 or below 100 USD/kW |
+
+The impeller check preserves the specified shaft speed and required total head.
+It may add equal-head stages within the configured casing limit, but it does not
+independently clamp diameter or tip speed to make the geometry look feasible.
+`impellerSizingFeasible` only qualifies the preliminary inlet-stage sizing screen;
+see [Compressor Mechanical Design](CompressorMechanicalDesign#2-impeller-sizing)
+for its fixed work coefficient and limits. A generated map or supplier match does
+not override an `IMPELLER_SIZING` blocker.
+
+Unavailable impeller dimensions, speeds and flow coefficients for invalid sizing
+inputs are represented as `null` rather than non-finite numeric literals.
 
 ## Verdicts
 

--- a/docs/process/compressor_design_feasibility.md
+++ b/docs/process/compressor_design_feasibility.md
@@ -224,6 +224,9 @@ not override an `IMPELLER_SIZING` blocker.
 
 Unavailable impeller dimensions, speeds and flow coefficients for invalid sizing
 inputs are represented as `null` rather than non-finite numeric literals.
+Shaft and rotor results, driver sizing, weights and module dimensions that cannot
+be recalculated are also unavailable; an invalid sizing attempt clears previous
+results and removes the casing calculation.
 
 ## Verdicts
 

--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -377,6 +377,10 @@ the sizing speed (rpm), tip speed (m/s), inlet flow coefficient, head per stage
 for the assumptions and limits. These checks do not establish aerodynamic or
 fabrication qualification.
 
+An invalid compressor sizing attempt clears the previous envelope, shaft, rotor,
+weight and layout results. Their JSON quantities are unavailable instead of
+retaining values from an earlier successful run, and the casing calculation is absent.
+
 The runnable [JSON-to-mesh example](../../examples/mechanical_design_json_to_mesh.py)
 uses `trimesh` and rejects missing units, unavailable dimensions and inconsistent
 shell geometry. With the JSON above saved as `separator-design.json`:

--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -367,6 +367,16 @@ geometric arithmetic only, not pressure-code adequacy. Correct an inconsistent
 source design before meshing it. A missing head type is expected: the separator
 model does not specify a fabrication head profile.
 
+Compressor snapshots also expose `impellerSizingFeasible` and `impellerSizingIssues`.
+Check these before using impeller dimensions: diameter, shaft speed, tip speed,
+equal-stage head and inlet flow coefficient are screened together. An infeasible
+candidate retains its head-based dimensions even outside the sizing limits; shell
+`geometryConsistency` does not qualify it. The unit-labelled `designBasis` includes
+the sizing speed (rpm), tip speed (m/s), inlet flow coefficient, head per stage
+(J/kg) and stage count. See [Compressor Mechanical Design](CompressorMechanicalDesign#2-impeller-sizing)
+for the assumptions and limits. These checks do not establish aerodynamic or
+fabrication qualification.
+
 The runnable [JSON-to-mesh example](../../examples/mechanical_design_json_to_mesh.py)
 uses `trimesh` and rejects missing units, unavailable dimensions and inconsistent
 shell geometry. With the JSON above saved as `separator-design.json`:

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignData.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignData.java
@@ -50,6 +50,10 @@ public final class MechanicalDesignData implements Serializable {
   private String geometryConsistency = "incomplete";
   private String orientation;
   private String headType;
+  /** Compressor-only preliminary impeller sizing qualification; null for other equipment. */
+  private Boolean impellerSizingFeasible;
+  /** Compressor-only sizing diagnostics, distinct from shell geometry consistency. */
+  private List<String> impellerSizingIssues;
   private final Map<String, Quantity> geometry = new LinkedHashMap<String, Quantity>();
   private final Map<String, Quantity> operatingConditions = new LinkedHashMap<String, Quantity>();
   private final Map<String, Quantity> designBasis = new LinkedHashMap<String, Quantity>();
@@ -148,6 +152,15 @@ public final class MechanicalDesignData implements Serializable {
     } else if (design instanceof CompressorMechanicalDesign) {
       geometryKind = "compressor_envelope";
       CompressorMechanicalDesign compressorDesign = (CompressorMechanicalDesign) design;
+      impellerSizingIssues = compressorDesign.getImpellerSizingIssues();
+      impellerSizingFeasible = impellerSizingIssues.isEmpty();
+      put(designBasis, "impellerSizingSpeed", compressorDesign.getImpellerSizingSpeedRPM(), "rpm",
+          "getImpellerSizingSpeedRPM", true);
+      put(designBasis, "impellerTipSpeed", compressorDesign.getTipSpeed(), "m/s", "getTipSpeed", true);
+      put(designBasis, "inletFlowCoefficient", compressorDesign.getFlowCoefficient(), "1", "getFlowCoefficient", true);
+      put(designBasis, "headPerStage", compressorDesign.getHeadPerStage() * 1000.0, "J/kg", "getHeadPerStage (kJ/kg)",
+          true);
+      put(designBasis, "numberOfStages", compressorDesign.getNumberOfStages(), "1", "getNumberOfStages", true);
       put(geometry, "impellerDiameter", compressorDesign.getImpellerDiameter() / 1000.0, "m",
           "getImpellerDiameter (mm)", true);
       put(geometry, "shaftDiameter", compressorDesign.getShaftDiameter() / 1000.0, "m", "getShaftDiameter (mm)", true);
@@ -168,6 +181,8 @@ public final class MechanicalDesignData implements Serializable {
       }
       limitations.add(
           "Compressor wallThickness is an envelope gap; use pressureCasingWallThickness for the casing calculation result.");
+      limitations.add(
+          "Check impellerSizingFeasible and impellerSizingIssues before using compressor dimensions; this is an inlet-stage preliminary sizing screen, not aerodynamic or fabrication qualification.");
     } else if (design instanceof PumpMechanicalDesign) {
       geometryKind = "pump_envelope";
       PumpMechanicalDesign pump = (PumpMechanicalDesign) design;

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorDesignFeasibilityReport.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorDesignFeasibilityReport.java
@@ -387,6 +387,9 @@ public class CompressorDesignFeasibilityReport {
    * Run all feasibility checks.
    */
   private void runFeasibilityChecks() {
+    for (String issue : mechanicalDesign.getImpellerSizingIssues()) {
+      issues.add(new FeasibilityIssue(IssueSeverity.BLOCKER, "IMPELLER_SIZING", issue));
+    }
     checkDischargeTemperature();
     checkPressureRatioPerStage();
     checkTipSpeed();
@@ -760,7 +763,8 @@ public class CompressorDesignFeasibilityReport {
     operatingPoint.put("polytropicHead_kJkg", round(polytropicHead, 2));
     operatingPoint.put("polytropicEfficiency", round(polytropicEfficiency, 4));
     operatingPoint.put("gasMolecularWeight_kgkmol", round(gasMolecularWeight, 2));
-    operatingPoint.put("speed_rpm", compressor.getSpeed());
+    double operatingSpeed = compressor.getSpeed();
+    operatingPoint.put("speed_rpm", Double.isFinite(operatingSpeed) ? operatingSpeed : null);
     report.put("operatingPoint", operatingPoint);
 
     // Mechanical design
@@ -771,6 +775,12 @@ public class CompressorDesignFeasibilityReport {
       mechDesign.put("impellerDiameter_mm", round(mechanicalDesign.getImpellerDiameter(), 0));
       mechDesign.put("shaftDiameter_mm", round(mechanicalDesign.getShaftDiameter(), 0));
       mechDesign.put("tipSpeed_ms", round(mechanicalDesign.getTipSpeed(), 1));
+      mechDesign.put("impellerSizingFeasible", mechanicalDesign.isImpellerSizingFeasible());
+      mechDesign.put("impellerSizingIssues", mechanicalDesign.getImpellerSizingIssues());
+      double sizingSpeed = mechanicalDesign.getImpellerSizingSpeedRPM();
+      double inletFlowCoefficient = mechanicalDesign.getFlowCoefficient();
+      mechDesign.put("impellerSizingSpeed_rpm", Double.isFinite(sizingSpeed) ? sizingSpeed : null);
+      mechDesign.put("inletFlowCoefficient", Double.isFinite(inletFlowCoefficient) ? inletFlowCoefficient : null);
       mechDesign.put("bearingSpan_mm", round(mechanicalDesign.getBearingSpan(), 0));
       mechDesign.put("casingType", mechanicalDesign.getCasingType().name());
       mechDesign.put("driverPower_kW", round(mechanicalDesign.getDriverPower(), 1));
@@ -881,7 +891,8 @@ public class CompressorDesignFeasibilityReport {
     }
     report.put("issues", issueList);
 
-    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(report);
+    return new GsonBuilder().setPrettyPrinting().serializeNulls().serializeSpecialFloatingPointValues().create()
+        .toJson(report);
   }
 
   /**
@@ -889,11 +900,11 @@ public class CompressorDesignFeasibilityReport {
    *
    * @param value the value to round
    * @param decimals number of decimal places
-   * @return rounded value
+   * @return rounded value, or null when the value is unavailable
    */
-  private double round(double value, int decimals) {
+  private Double round(double value, int decimals) {
     if (Double.isNaN(value) || Double.isInfinite(value)) {
-      return value;
+      return null;
     }
     double factor = Math.pow(10, decimals);
     return Math.round(value * factor) / factor;

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorDesignFeasibilityReport.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorDesignFeasibilityReport.java
@@ -421,6 +421,10 @@ public class CompressorDesignFeasibilityReport {
    */
   private void checkPressureRatioPerStage() {
     int stages = mechanicalDesign.getNumberOfStages();
+    if (stages <= 0) {
+      // The impeller-sizing check already reports that no stage count is available.
+      return;
+    }
     double prPerStage = Math.pow(pressureRatio, 1.0 / stages);
     double maxPR = mechanicalDesign.getMaxPressureRatioPerStage();
     if (prPerStage > maxPR) {

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesign.java
@@ -288,16 +288,14 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
   /** {@inheritDoc} */
   @Override
   public void calcDesign() {
-    impellerSizingCalculated = false;
-    casingDesignCalculator = null;
-    super.calcDesign();
-
+    clearCalculatedDesign();
     Compressor compressor = (Compressor) getProcessEquipment();
-
     // Ensure compressor has been run
-    if (compressor.getThermoSystem() == null) {
+    if (compressor == null || compressor.getThermoSystem() == null || compressor.getInletStream() == null
+        || compressor.getOutletStream() == null) {
       return;
     }
+    super.calcDesign();
 
     // Get operating conditions
     double suctionPressure = compressor.getInletStream().getPressure("bara");
@@ -348,6 +346,50 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
 
     // Run casing mechanical design per API 617 / ASME Section VIII
     calculateCasingDesign(compressor, shaftPowerKW);
+  }
+
+  /**
+   * Clear calculated results before sizing so an incomplete run cannot expose geometry or weights from an earlier run.
+   * Configured design limits, materials and the process mechanical-loss model are preserved.
+   */
+  private void clearCalculatedDesign() {
+    impellerSizingCalculated = false;
+    casingDesignCalculator = null;
+    impellerSizingSpeedRPM = Double.NaN;
+    impellerSizingFlowM3hr = Double.NaN;
+    impellerSizingHead = Double.NaN;
+    numberOfStages = 0;
+    headPerStage = Double.NaN;
+    impellerDiameter = Double.NaN;
+    tipSpeed = Double.NaN;
+    flowCoefficient = Double.NaN;
+    shaftDiameter = Double.NaN;
+    driverPower = Double.NaN;
+    driverMargin = Double.NaN;
+    setMaxDesignPower(Double.NaN);
+    designPressure = Double.NaN;
+    designTemperature = Double.NaN;
+    maxContinuousSpeed = Double.NaN;
+    tripSpeed = Double.NaN;
+    firstCriticalSpeed = Double.NaN;
+    bearingSpan = Double.NaN;
+    casingWeight = Double.NaN;
+    rotorWeight = Double.NaN;
+    bundleWeight = Double.NaN;
+    innerDiameter = Double.NaN;
+    outerDiameter = Double.NaN;
+    wallThickness = Double.NaN;
+    tantanLength = Double.NaN;
+    setWeigthVesselShell(Double.NaN);
+    setWeigthInternals(Double.NaN);
+    setWeightNozzle(Double.NaN);
+    setWeightPiping(Double.NaN);
+    setWeightElectroInstrument(Double.NaN);
+    setWeightStructualSteel(Double.NaN);
+    setWeightTotal(Double.NaN);
+    moduleLength = Double.NaN;
+    moduleWidth = Double.NaN;
+    moduleHeight = Double.NaN;
   }
 
   /**
@@ -461,6 +503,8 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
     flowCoefficient = Double.NaN;
     if (!Double.isFinite(speedRPM) || speedRPM <= 0.0 || !Double.isFinite(volumeFlowM3hr) || volumeFlowM3hr <= 0.0
         || !Double.isFinite(polytropicHead) || polytropicHead <= 0.0) {
+      numberOfStages = 0;
+      headPerStage = Double.NaN;
       return;
     }
 
@@ -922,6 +966,11 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
       return issues;
     }
     Compressor compressor = (Compressor) getProcessEquipment();
+    if (compressor == null || compressor.getThermoSystem() == null || compressor.getInletStream() == null
+        || compressor.getOutletStream() == null) {
+      issues.add("Compressor is missing or not properly initialized; rerun the process and calcDesign().");
+      return issues;
+    }
     if (Double.compare(compressor.getSpeed(), impellerSizingSpeedRPM) != 0
         || Double.compare(compressor.getInletStream().getFlowRate("m3/hr"), impellerSizingFlowM3hr) != 0
         || Double.compare(compressor.getPolytropicFluidHead(), impellerSizingHead) != 0) {
@@ -1546,7 +1595,8 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
     }
 
     Compressor compressor = (Compressor) getProcessEquipment();
-    if (compressor == null || compressor.getThermoSystem() == null) {
+    if (compressor == null || compressor.getThermoSystem() == null || compressor.getInletStream() == null
+        || compressor.getOutletStream() == null) {
       result.addIssue("Compressor not properly initialized");
       result.setValid(false);
       return result;
@@ -1570,10 +1620,12 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
     double suctionPressure = compressor.getInletStream().getPressure("bara");
     double dischargePressure = compressor.getOutletStream().getPressure("bara");
     double totalPressureRatio = dischargePressure / suctionPressure;
-    double pressureRatioPerStage = Math.pow(totalPressureRatio, 1.0 / numberOfStages);
-    if (!validatePressureRatioPerStage(pressureRatioPerStage)) {
-      result.addIssue("Pressure ratio per stage " + String.format("%.2f", pressureRatioPerStage) + " exceeds maximum "
-          + String.format("%.2f", maxPressureRatioPerStage));
+    if (numberOfStages > 0) {
+      double pressureRatioPerStage = Math.pow(totalPressureRatio, 1.0 / numberOfStages);
+      if (!validatePressureRatioPerStage(pressureRatioPerStage)) {
+        result.addIssue("Pressure ratio per stage " + String.format("%.2f", pressureRatioPerStage) + " exceeds maximum "
+            + String.format("%.2f", maxPressureRatioPerStage));
+      }
     }
 
     // Validate surge margin

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesign.java
@@ -2,6 +2,8 @@ package neqsim.process.mechanicaldesign.compressor;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
+import java.util.ArrayList;
+import java.util.List;
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -55,7 +57,12 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
   /** Typical flow coefficient range for centrifugal impellers. */
   private static final double FLOW_COEFFICIENT_MIN = 0.01;
   private static final double FLOW_COEFFICIENT_MAX = 0.15;
-  private static final double FLOW_COEFFICIENT_DESIGN = 0.05;
+  /** Preliminary head coefficient H [J/kg] / U squared [m2/s2]. */
+  private static final double WORK_COEFFICIENT = 0.50;
+
+  /** Preliminary impeller diameter bounds [mm]. */
+  private static final double MIN_IMPELLER_DIAMETER = 100.0;
+  private static final double MAX_IMPELLER_DIAMETER = 1500.0;
 
   /** Driver sizing margin per API 617. */
   private static final double DRIVER_MARGIN_SMALL = 1.25; // For power < 150 kW
@@ -86,6 +93,21 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
 
   /** Impeller tip speed [m/s]. */
   private double tipSpeed = 250.0;
+
+  /** Inlet flow coefficient Q / (D squared * U), using actual m3/s and diameter in m. */
+  private double flowCoefficient = Double.NaN;
+
+  /** Shaft speed used for the last impeller sizing [rpm]. */
+  private double impellerSizingSpeedRPM = Double.NaN;
+
+  /** Actual inlet volume flow used for the last sizing [m3/hr]. */
+  private double impellerSizingFlowM3hr = Double.NaN;
+
+  /** Required total polytropic head used for the last sizing [kJ/kg]. */
+  private double impellerSizingHead = Double.NaN;
+
+  /** Whether impeller sizing has run since a manual geometry override. */
+  private boolean impellerSizingCalculated = false;
 
   /** Required driver power [kW]. */
   private double driverPower = 0.0;
@@ -266,6 +288,8 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
   /** {@inheritDoc} */
   @Override
   public void calcDesign() {
+    impellerSizingCalculated = false;
+    casingDesignCalculator = null;
     super.calcDesign();
 
     Compressor compressor = (Compressor) getProcessEquipment();
@@ -297,6 +321,9 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
 
     // Calculate impeller sizing
     calculateImpellerSizing(volumeFlowRate, polytropicHead, compressor.getSpeed());
+    if (!Double.isFinite(impellerDiameter)) {
+      return;
+    }
 
     // Calculate shaft diameter
     calculateShaftDiameter(shaftPowerKW, compressor.getSpeed());
@@ -396,7 +423,7 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
    * @param totalPolytropicHead total polytropic head in kJ/kg
    */
   private void calculateNumberOfStages(double totalPolytropicHead) {
-    if (totalPolytropicHead <= 0) {
+    if (!Double.isFinite(totalPolytropicHead) || totalPolytropicHead <= 0) {
       numberOfStages = 1;
       headPerStage = 0;
       return;
@@ -411,45 +438,58 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Calculate impeller diameter and tip speed.
+   * Size equal-head stages at the specified shaft speed using a fixed preliminary work coefficient.
+   *
+   * <p>
+   * Additional stages may satisfy the diameter, tip-speed and inlet-flow limits. If no stage count up to
+   * {@link #getMaxStagesPerCasing()} is feasible, retain the head-based candidate without clamping its dimensions;
+   * {@link #getImpellerSizingIssues()} reports the violated limits. This is a preliminary inlet-stage screen, not an
+   * aerodynamic performance map or an API 617 qualification.
+   * </p>
    *
    * @param volumeFlowM3hr inlet volume flow rate in m3/hr
    * @param polytropicHead total polytropic head in kJ/kg
    * @param speedRPM shaft speed in rpm
    */
   private void calculateImpellerSizing(double volumeFlowM3hr, double polytropicHead, double speedRPM) {
-    if (speedRPM <= 0 || volumeFlowM3hr <= 0) {
-      impellerDiameter = 300.0; // Default
-      tipSpeed = 0.0;
+    impellerSizingCalculated = true;
+    impellerSizingSpeedRPM = speedRPM;
+    impellerSizingFlowM3hr = volumeFlowM3hr;
+    impellerSizingHead = polytropicHead;
+    impellerDiameter = Double.NaN;
+    tipSpeed = Double.NaN;
+    flowCoefficient = Double.NaN;
+    if (!Double.isFinite(speedRPM) || speedRPM <= 0.0 || !Double.isFinite(volumeFlowM3hr) || volumeFlowM3hr <= 0.0
+        || !Double.isFinite(polytropicHead) || polytropicHead <= 0.0) {
       return;
     }
 
-    // Convert volume flow to m3/s
-    double volumeFlowM3s = volumeFlowM3hr / 3600.0;
-
-    // Work coefficient (head coefficient) - typical range 0.4-0.6 for backward curved
-    double workCoefficient = 0.50;
-
-    // Calculate required tip speed from head: U^2 = H * g / (workCoeff * numStages)
-    double headPerStageJ_kg = headPerStage * 1000.0; // J/kg
-    tipSpeed = Math.sqrt(headPerStageJ_kg / workCoefficient);
-
-    // Limit tip speed
-    tipSpeed = Math.min(tipSpeed, MAX_TIP_SPEED);
-
-    // Calculate impeller diameter from tip speed: D = U * 60 / (pi * N)
-    impellerDiameter = (tipSpeed * 60.0) / (Math.PI * speedRPM) * 1000.0; // mm
-
-    // Ensure reasonable range (100-1500 mm typical for process compressors)
-    impellerDiameter = Math.max(100.0, Math.min(1500.0, impellerDiameter));
-
-    // Verify flow coefficient is in acceptable range
-    double flowCoefficient = volumeFlowM3s / (Math.pow(impellerDiameter / 1000.0, 2) * tipSpeed);
-    if (flowCoefficient < FLOW_COEFFICIENT_MIN || flowCoefficient > FLOW_COEFFICIENT_MAX) {
-      // Adjust impeller diameter to achieve design flow coefficient
-      impellerDiameter = Math.sqrt(volumeFlowM3s / (FLOW_COEFFICIENT_DESIGN * tipSpeed)) * 1000.0;
-      impellerDiameter = Math.max(100.0, Math.min(1500.0, impellerDiameter));
+    int headBasedStages = numberOfStages;
+    // Larger stage counts decrease D and U and increase the inlet flow coefficient monotonically.
+    for (int stages = headBasedStages; stages > 0 && stages <= maxStagesPerCasing; stages++) {
+      setImpellerCandidate(stages);
+      if (getImpellerSizingIssues().isEmpty()) {
+        return;
+      }
+      if (impellerDiameter < MIN_IMPELLER_DIAMETER || flowCoefficient > FLOW_COEFFICIENT_MAX) {
+        break;
+      }
     }
+    setImpellerCandidate(headBasedStages);
+  }
+
+  /**
+   * Recompute all coupled quantities for one equal-head stage count, without clipping.
+   *
+   * @param stages number of stages
+   */
+  private void setImpellerCandidate(int stages) {
+    numberOfStages = stages;
+    headPerStage = impellerSizingHead / stages;
+    double requiredTipSpeed = Math.sqrt(headPerStage * 1000.0 / WORK_COEFFICIENT);
+    impellerDiameter = requiredTipSpeed * 60.0 / (Math.PI * impellerSizingSpeedRPM) * 1000.0;
+    tipSpeed = Math.PI * (impellerDiameter / 1000.0) * impellerSizingSpeedRPM / 60.0;
+    flowCoefficient = (impellerSizingFlowM3hr / 3600.0) / (Math.pow(impellerDiameter / 1000.0, 2) * tipSpeed);
   }
 
   /**
@@ -783,6 +823,7 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
    */
   public void setNumberOfStages(int numberOfStages) {
     this.numberOfStages = numberOfStages;
+    impellerSizingCalculated = false;
   }
 
   /**
@@ -801,6 +842,7 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
    */
   public void setImpellerDiameter(double impellerDiameter) {
     this.impellerDiameter = impellerDiameter;
+    impellerSizingCalculated = false;
   }
 
   /**
@@ -828,6 +870,84 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
    */
   public double getTipSpeed() {
     return tipSpeed;
+  }
+
+  /**
+   * Get the inlet flow coefficient of the last sizing candidate.
+   *
+   * @return dimensionless Q / (D squared * U), or NaN for unavailable sizing inputs
+   */
+  public double getFlowCoefficient() {
+    return flowCoefficient;
+  }
+
+  /**
+   * Get the fixed shaft speed used to size the impeller.
+   *
+   * @return sizing speed in rpm, or NaN before sizing
+   */
+  public double getImpellerSizingSpeedRPM() {
+    return impellerSizingSpeedRPM;
+  }
+
+  /**
+   * Check the coupled preliminary impeller sizing, including input freshness.
+   *
+   * @return true only when head, speed, flow, diameter and stage-count checks pass
+   */
+  public boolean isImpellerSizingFeasible() {
+    return getImpellerSizingIssues().isEmpty();
+  }
+
+  /**
+   * Describe why the last impeller candidate is infeasible or unavailable.
+   *
+   * <p>
+   * An empty list only qualifies the equal-head, fixed-work-coefficient inlet-stage sizing screen. It does not qualify
+   * downstream-stage aerodynamics, rotor dynamics, casing design or a vendor compressor map.
+   * </p>
+   *
+   * @return independent list of violated limits and stale-input diagnostics
+   */
+  public List<String> getImpellerSizingIssues() {
+    List<String> issues = new ArrayList<String>();
+    if (!impellerSizingCalculated) {
+      issues.add("Impeller sizing has not been calculated or geometry was overridden; run calcDesign().");
+      return issues;
+    }
+    if (!Double.isFinite(impellerSizingSpeedRPM) || impellerSizingSpeedRPM <= 0.0
+        || !Double.isFinite(impellerSizingFlowM3hr) || impellerSizingFlowM3hr <= 0.0
+        || !Double.isFinite(impellerSizingHead) || impellerSizingHead <= 0.0) {
+      issues.add("Impeller sizing requires finite positive shaft speed, inlet volume flow and polytropic head.");
+      return issues;
+    }
+    Compressor compressor = (Compressor) getProcessEquipment();
+    if (Double.compare(compressor.getSpeed(), impellerSizingSpeedRPM) != 0
+        || Double.compare(compressor.getInletStream().getFlowRate("m3/hr"), impellerSizingFlowM3hr) != 0
+        || Double.compare(compressor.getPolytropicFluidHead(), impellerSizingHead) != 0) {
+      issues.add("Compressor speed, inlet flow or head changed after sizing; rerun the process and calcDesign().");
+    }
+    if (numberOfStages < 1 || numberOfStages > maxStagesPerCasing) {
+      issues.add("Impeller stage count " + numberOfStages + " exceeds the configured casing limit " + maxStagesPerCasing
+          + " or is not positive.");
+    }
+    if (!Double.isFinite(headPerStage) || headPerStage <= 0.0 || headPerStage > MAX_HEAD_PER_STAGE) {
+      issues.add("Impeller head per stage must be positive and at most " + MAX_HEAD_PER_STAGE + " kJ/kg.");
+    }
+    if (!Double.isFinite(impellerDiameter) || impellerDiameter < MIN_IMPELLER_DIAMETER
+        || impellerDiameter > MAX_IMPELLER_DIAMETER) {
+      issues.add("Impeller diameter " + impellerDiameter + " mm is outside " + MIN_IMPELLER_DIAMETER + "-"
+          + MAX_IMPELLER_DIAMETER + " mm.");
+    }
+    if (!Double.isFinite(tipSpeed) || tipSpeed <= 0.0 || tipSpeed > MAX_TIP_SPEED) {
+      issues.add("Impeller tip speed must be positive and at most " + MAX_TIP_SPEED + " m/s.");
+    }
+    if (!Double.isFinite(flowCoefficient) || flowCoefficient < FLOW_COEFFICIENT_MIN
+        || flowCoefficient > FLOW_COEFFICIENT_MAX) {
+      issues.add("Impeller inlet flow coefficient " + flowCoefficient + " is outside " + FLOW_COEFFICIENT_MIN + "-"
+          + FLOW_COEFFICIENT_MAX + " at the specified shaft speed.");
+    }
+    return issues;
   }
 
   /**
@@ -1421,6 +1541,9 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
    */
   public CompressorValidationResult validateDesign() {
     CompressorValidationResult result = new CompressorValidationResult();
+    for (String issue : getImpellerSizingIssues()) {
+      result.addIssue(issue);
+    }
 
     Compressor compressor = (Compressor) getProcessEquipment();
     if (compressor == null || compressor.getThermoSystem() == null) {

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignResponse.java
@@ -1,5 +1,6 @@
 package neqsim.process.mechanicaldesign.compressor;
 
+import java.util.List;
 import java.util.Map;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.mechanicaldesign.MechanicalDesignResponse;
@@ -46,6 +47,18 @@ public class CompressorMechanicalDesignResponse extends MechanicalDesignResponse
 
   /** Impeller tip speed [m/s]. */
   private double tipSpeed = Double.NaN;
+
+  /** Inlet flow coefficient Q / (D squared * U). */
+  private double flowCoefficient = Double.NaN;
+
+  /** Shaft speed used for impeller sizing [rpm]. */
+  private double impellerSizingSpeedRPM = Double.NaN;
+
+  /** Whether the preliminary coupled impeller sizing checks pass. */
+  private boolean impellerSizingFeasible;
+
+  /** Impeller sizing limit violations and stale-input diagnostics. */
+  private List<String> impellerSizingIssues;
 
   /** Maximum continuous speed [rpm]. */
   private double maxContinuousSpeed = Double.NaN;
@@ -169,6 +182,10 @@ public class CompressorMechanicalDesignResponse extends MechanicalDesignResponse
     this.impellerDiameter = mecDesign.getImpellerDiameter();
     this.shaftDiameter = mecDesign.getShaftDiameter();
     this.tipSpeed = mecDesign.getTipSpeed();
+    this.flowCoefficient = mecDesign.getFlowCoefficient();
+    this.impellerSizingSpeedRPM = mecDesign.getImpellerSizingSpeedRPM();
+    this.impellerSizingIssues = mecDesign.getImpellerSizingIssues();
+    this.impellerSizingFeasible = impellerSizingIssues.isEmpty();
     this.maxContinuousSpeed = mecDesign.getMaxContinuousSpeed();
     this.tripSpeed = mecDesign.getTripSpeed();
     this.firstCriticalSpeed = mecDesign.getFirstCriticalSpeed();

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignResponse.java
@@ -235,9 +235,7 @@ public class CompressorMechanicalDesignResponse extends MechanicalDesignResponse
 
     // Populate casing design calculation results
     CompressorCasingDesignCalculator casingCalc = mecDesign.getCasingDesignCalculator();
-    if (casingCalc != null) {
-      this.casingDesign = casingCalc.toMap();
-    }
+    this.casingDesign = casingCalc == null ? null : casingCalc.toMap();
   }
 
   // ============================================================================

--- a/src/test/java/neqsim/process/mechanicaldesign/compressor/CompressorImpellerSizingTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/compressor/CompressorImpellerSizingTest.java
@@ -1,0 +1,281 @@
+package neqsim.process.mechanicaldesign.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for coupled impeller diameter, speed, head and inlet flow sizing. */
+class CompressorImpellerSizingTest extends neqsim.NeqSimTest {
+  private static final Logger logger = LogManager.getLogger(CompressorImpellerSizingTest.class);
+
+  @Test
+  void adjustedFlowCasePreservesTipSpeedIdentity() {
+    Compressor compressor = runCompressor(6000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertEquals(Math.PI * design.getImpellerDiameter() / 1000.0 * compressor.getSpeed() / 60.0, design.getTipSpeed(),
+        1e-10);
+    assertHeadAndFlowIdentity(compressor);
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(design.getFlowCoefficient() < 0.01);
+    assertTrue(design.getImpellerSizingIssues().stream().anyMatch(issue -> issue.contains("flow coefficient")));
+    assertFalse(design.validateDesign().isValid());
+    assertTrue(design.validateDesign().getIssues().containsAll(design.getImpellerSizingIssues()));
+    logger.info("6000 rpm: stages={}, diameter={} mm, tip={} m/s, head={} kJ/kg, phi={}, feasible={}",
+        design.getNumberOfStages(), design.getImpellerDiameter(), design.getTipSpeed(),
+        compressor.getPolytropicFluidHead(), design.getFlowCoefficient(), design.isImpellerSizingFeasible());
+  }
+
+  @Test
+  void teachingCaseSatisfiesAllCoupledLimitsAndExportsQualification() {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertEquals(8, design.getNumberOfStages());
+    assertQualified(compressor);
+    JsonObject legacy = JsonParser.parseString(design.toJson()).getAsJsonObject();
+    assertTrue(legacy.get("impellerSizingFeasible").getAsBoolean());
+    assertEquals(0, legacy.getAsJsonArray("impellerSizingIssues").size());
+    assertEquals(design.getFlowCoefficient(), legacy.get("flowCoefficient").getAsDouble(), 1e-12);
+    assertEquals(18000.0, legacy.get("impellerSizingSpeedRPM").getAsDouble(), 1e-12);
+    assertEquals(compressor.getPolytropicFluidHead(), legacy.get("totalHead").getAsDouble(), 1e-10);
+    JsonObject cad = JsonParser.parseString(design.toDesignDataJson()).getAsJsonObject();
+    assertTrue(cad.get("impellerSizingFeasible").getAsBoolean());
+    assertEquals(0, cad.getAsJsonArray("impellerSizingIssues").size());
+    JsonObject basis = cad.getAsJsonObject("designBasis");
+    assertEquals("rpm", basis.getAsJsonObject("impellerSizingSpeed").get("unit").getAsString());
+    assertEquals("J/kg", basis.getAsJsonObject("headPerStage").get("unit").getAsString());
+    double diameterM = cad.getAsJsonObject("geometry").getAsJsonObject("impellerDiameter").get("value").getAsDouble();
+    double speed = basis.getAsJsonObject("impellerSizingSpeed").get("value").getAsDouble();
+    double tip = basis.getAsJsonObject("impellerTipSpeed").get("value").getAsDouble();
+    assertEquals(Math.PI * diameterM * speed / 60.0, tip, 1e-10);
+    logger.info("18000 rpm: stages={}, diameter={} mm, tip={} m/s, phi={}, feasible={}", design.getNumberOfStages(),
+        design.getImpellerDiameter(), design.getTipSpeed(), design.getFlowCoefficient(),
+        design.isImpellerSizingFeasible());
+  }
+
+  @Test
+  void addingAStageCanSatisfyTheInletFlowLimitWithoutChangingSpeedOrHead() {
+    double initialTip = Math.sqrt(30000.0 / 0.5);
+    double initialDiameter = initialTip * 60.0 / (Math.PI * 6000.0);
+    double flowM3s = 0.009 * initialDiameter * initialDiameter * initialTip;
+    Compressor compressor = specifiedHeadCompressor(240.0, flowM3s, 6000.0);
+    compressor.getMechanicalDesign().calcDesign();
+    assertEquals(9, compressor.getMechanicalDesign().getNumberOfStages());
+    assertEquals(6000.0, compressor.getSpeed(), 0.0);
+    assertQualified(compressor);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 2000.0, 100000.0 })
+  void diameterBoundsAreReportedWithoutClippingAndConcealingHeadErrors(double speed) {
+    Compressor compressor = specifiedHeadCompressor(240.0, 1.0, speed);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(design.getImpellerSizingIssues().stream().anyMatch(issue -> issue.contains("diameter")));
+    assertTrue(design.getImpellerDiameter() < 100.0 || design.getImpellerDiameter() > 1500.0);
+    assertHeadAndFlowIdentity(compressor);
+  }
+
+  @Test
+  void flowAboveTheUpperLimitIsInfeasible() {
+    Compressor compressor = specifiedHeadCompressor(240.0, 10.0, 18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(design.getFlowCoefficient() > 0.15);
+    assertHeadAndFlowIdentity(compressor);
+  }
+
+  @Test
+  void stageLimitAndRepeatedSizingDoNotRetainAFeasibleStatus() {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertQualified(compressor);
+    design.setMaxStagesPerCasing(7);
+    assertFalse(design.isImpellerSizingFeasible());
+    design.calcDesign();
+    assertTrue(design.getImpellerSizingIssues().stream().anyMatch(issue -> issue.contains("stage count")));
+    assertHeadAndFlowIdentity(compressor);
+    design.setMaxStagesPerCasing(10);
+    compressor.setSpeed(6000.0);
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(design.getImpellerSizingIssues().stream().anyMatch(issue -> issue.contains("changed after sizing")));
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    compressor.setSpeed(18000.0);
+    design.calcDesign();
+    assertQualified(compressor);
+    design.setImpellerDiameter(500.0);
+    assertFalse(design.isImpellerSizingFeasible());
+    design.calcDesign();
+    assertQualified(compressor);
+    design.setNumberOfStages(1);
+    assertFalse(design.isImpellerSizingFeasible());
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY })
+  void invalidSpeedDoesNotReturnAQualifiedDefaultDiameter(double speed) {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertQualified(compressor);
+    compressor.setSpeed(speed);
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(Double.isNaN(design.getImpellerDiameter()));
+    assertTrue(design.getImpellerSizingIssues().stream().anyMatch(issue -> issue.contains("finite positive")));
+    JsonObject json = JsonParser.parseString(design.toJson()).getAsJsonObject();
+    assertFalse(json.get("impellerSizingFeasible").getAsBoolean());
+    assertTrue(json.get("impellerDiameter").isJsonNull());
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY })
+  void invalidHeadIsUnavailable(double head) {
+    Compressor compressor = specifiedHeadCompressor(head, 1.0, 18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(Double.isNaN(design.getTipSpeed()));
+  }
+
+  @Test
+  void changedAndZeroInletFlowInvalidateSizing() {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    design.calcDesign();
+    assertQualified(compressor);
+    compressor.getInletStream().setFlowRate(1.0, "kg/hr");
+    assertFalse(design.isImpellerSizingFeasible());
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    compressor.getInletStream().setFlowRate(0.0, "kg/hr");
+    design.calcDesign();
+    assertFalse(design.isImpellerSizingFeasible());
+    assertTrue(Double.isNaN(design.getImpellerDiameter()));
+  }
+
+  @Test
+  void infeasibilityReachesBothJsonExportsAndTheFeasibilityReport() {
+    Compressor compressor = runCompressor(6000.0);
+    CompressorDesignFeasibilityReport report = new CompressorDesignFeasibilityReport(compressor);
+    report.setGenerateCurves(false);
+    report.generateReport();
+    assertEquals("NOT_FEASIBLE", report.getVerdict());
+    assertTrue(report.getIssues().stream().anyMatch(issue -> "IMPELLER_SIZING".equals(issue.getCategory())
+        && issue.getSeverity() == CompressorDesignFeasibilityReport.IssueSeverity.BLOCKER));
+    CompressorMechanicalDesign design = report.getMechanicalDesign();
+    for (String export : new String[] { design.toJson(), design.toDesignDataJson() }) {
+      JsonObject json = JsonParser.parseString(export).getAsJsonObject();
+      assertFalse(json.get("impellerSizingFeasible").getAsBoolean());
+      assertTrue(json.getAsJsonArray("impellerSizingIssues").size() > 0);
+    }
+  }
+
+  @Test
+  void unavailableImpellerValuesRemainSerializableInTheFeasibilityReport() {
+    Compressor compressor = runCompressor(18000.0);
+    compressor.setSpeed(Double.NaN);
+    CompressorDesignFeasibilityReport report = new CompressorDesignFeasibilityReport(compressor);
+    report.setGenerateCurves(false);
+    report.generateReport();
+    assertEquals("NOT_FEASIBLE", report.getVerdict());
+    String json = report.toJson();
+    assertFalse(json.contains("NaN"));
+    assertFalse(json.contains("Infinity"));
+    JsonObject mechanical = JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("mechanicalDesign");
+    assertFalse(mechanical.get("impellerSizingFeasible").getAsBoolean());
+    assertTrue(mechanical.get("impellerDiameter_mm").isJsonNull());
+    assertTrue(mechanical.get("inletFlowCoefficient").isJsonNull());
+  }
+
+  private void assertQualified(Compressor compressor) {
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    assertTrue(design.isImpellerSizingFeasible(), design.getImpellerSizingIssues().toString());
+    assertTrue(design.getImpellerDiameter() >= 100.0 && design.getImpellerDiameter() <= 1500.0);
+    assertTrue(design.getTipSpeed() > 0.0 && design.getTipSpeed() <= 350.0);
+    assertTrue(design.getHeadPerStage() > 0.0 && design.getHeadPerStage() <= 30.0);
+    assertTrue(design.getNumberOfStages() <= design.getMaxStagesPerCasing());
+    assertTrue(design.getFlowCoefficient() >= 0.01 && design.getFlowCoefficient() <= 0.15);
+    assertHeadAndFlowIdentity(compressor);
+  }
+
+  private void assertHeadAndFlowIdentity(Compressor compressor) {
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    double diameterM = design.getImpellerDiameter() / 1000.0;
+    double tip = Math.PI * diameterM * compressor.getSpeed() / 60.0;
+    assertEquals(tip, design.getTipSpeed(), 1e-10);
+    double achievedHeadPerStage = 0.5 * tip * tip / 1000.0;
+    assertEquals(achievedHeadPerStage, design.getHeadPerStage(), 1e-10);
+    assertEquals(compressor.getPolytropicFluidHead(), achievedHeadPerStage * design.getNumberOfStages(), 1e-9);
+    double flowM3s = compressor.getInletStream().getFlowRate("m3/hr") / 3600.0;
+    assertEquals(flowM3s / (diameterM * diameterM * tip), design.getFlowCoefficient(), 1e-12);
+  }
+
+  /** Supply independent head and flow inputs to isolate the preliminary sizing equations. */
+  private Compressor specifiedHeadCompressor(final double head, double flowM3s, double speed) {
+    SystemInterface fluid = new SystemSrkEos(313.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream inlet = new Stream("inlet", fluid);
+    inlet.run();
+    inlet.setFlowRate(flowM3s * 3600.0, "m3/hr");
+    inlet.run();
+    Compressor compressor = new Compressor("specified-head compressor", inlet) {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public double getPolytropicFluidHead() {
+        return head;
+      }
+    };
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicEfficiency(0.78);
+    compressor.setOutletPressure(40.0, "bara");
+    compressor.setSpeed(speed);
+    compressor.run();
+    return compressor;
+  }
+
+  private Compressor runCompressor(double speed) {
+    SystemInterface fluid = new SystemSrkEos(313.15, 20.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-decane", 0.10);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(100000.0, "kg/hr");
+    Separator separator = new Separator("separator", feed);
+    separator.setOrientation("horizontal");
+    Compressor compressor = new Compressor("compressor", separator.getGasOutStream());
+    compressor.setOutletPressure(80.0, "bara");
+    compressor.setPolytropicEfficiency(0.78);
+    compressor.setUsePolytropicCalc(true);
+    compressor.setSpeed(speed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    process.run();
+    return compressor;
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/compressor/CompressorImpellerSizingTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/compressor/CompressorImpellerSizingTest.java
@@ -2,6 +2,7 @@ package neqsim.process.mechanicaldesign.compressor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -171,6 +172,86 @@ class CompressorImpellerSizingTest extends neqsim.NeqSimTest {
     design.calcDesign();
     assertFalse(design.isImpellerSizingFeasible());
     assertTrue(Double.isNaN(design.getImpellerDiameter()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY })
+  void invalidSizingClearsDependentResultsAndRecovers(double speed) {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertQualified(compressor);
+    double diameter = design.getImpellerDiameter();
+    double weight = design.getWeightTotal();
+    double driverPower = design.getDriverPower();
+    compressor.setSpeed(speed);
+    design.calcDesign();
+    assertUnavailableMechanicalResults(design);
+    JsonObject legacy = JsonParser.parseString(design.toJson()).getAsJsonObject();
+    for (String field : new String[] { "shaftDiameter", "bearingSpan", "headPerStage", "driverPower",
+        "firstCriticalSpeed", "maxContinuousSpeed", "tripSpeed", "rotorWeight", "casingWeight", "bundleWeight",
+        "innerDiameter", "outerDiameter", "wallThickness", "tangentLength", "totalWeight", "moduleLength",
+        "moduleWidth", "moduleHeight", "casingDesign" }) {
+      assertTrue(legacy.get(field).isJsonNull(), field + " must not retain a previous sizing result");
+    }
+    JsonObject cad = JsonParser.parseString(design.toDesignDataJson()).getAsJsonObject();
+    assertEquals("incomplete", cad.get("geometryConsistency").getAsString());
+    for (String field : new String[] { "impellerDiameter", "shaftDiameter", "bearingSpan", "innerDiameter",
+        "outerDiameter", "wallThickness" }) {
+      assertTrue(cad.getAsJsonObject("geometry").getAsJsonObject(field).get("value").isJsonNull(), field);
+    }
+    compressor.setSpeed(18000.0);
+    design.calcDesign();
+    assertQualified(compressor);
+    assertEquals(diameter, design.getImpellerDiameter(), 1e-10);
+    assertEquals(weight, design.getWeightTotal(), 1e-10);
+    assertEquals(driverPower, design.getDriverPower(), 1e-10);
+  }
+
+  @Test
+  void refreshedResponseDropsThePreviousCasingCalculation() {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    CompressorMechanicalDesignResponse response = new CompressorMechanicalDesignResponse(design);
+    assertFalse(JsonParser.parseString(response.toJson()).getAsJsonObject().get("casingDesign").isJsonNull());
+    compressor.setSpeed(0.0);
+    design.calcDesign();
+    response.populateFromCompressorDesign(design);
+    assertTrue(JsonParser.parseString(response.toJson()).getAsJsonObject().get("casingDesign").isJsonNull());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  void missingEquipmentCannotRetainQualificationOrPreviousGeometry(boolean detached) {
+    Compressor compressor = runCompressor(18000.0);
+    CompressorMechanicalDesign design = compressor.getMechanicalDesign();
+    design.calcDesign();
+    assertQualified(compressor);
+    Compressor replacement = new Compressor("uninitialized compressor");
+    replacement.setSpeed(18000.0);
+    design.setProcessEquipment(detached ? null : replacement);
+    assertFalse(design.isImpellerSizingFeasible());
+    assertFalse(design.validateDesign().isValid());
+    design.calcDesign();
+    assertUnavailableMechanicalResults(design);
+    assertTrue(Double.isNaN(design.getImpellerDiameter()));
+  }
+
+  private void assertUnavailableMechanicalResults(CompressorMechanicalDesign design) {
+    assertFalse(design.isImpellerSizingFeasible());
+    assertEquals(0, design.getNumberOfStages());
+    assertNull(design.getCasingDesignCalculator());
+    assertFalse(design.validateDesign().getIssues().toString().contains("Infinity"));
+    for (double value : new double[] { design.getShaftDiameter(), design.getBearingSpan(), design.getHeadPerStage(),
+        design.getDriverPower(), design.getPower(), design.getFirstCriticalSpeed(), design.getMaxContinuousSpeed(),
+        design.getTripSpeed(), design.getRotorWeight(), design.getCasingWeight(), design.getBundleWeight(),
+        design.getInnerDiameter(), design.getOuterDiameter(), design.getWallThickness(), design.getTantanLength(),
+        design.getWeightTotal(), design.getWeigthVesselShell(), design.getWeigthInternals(), design.getWeightNozzle(),
+        design.getWeightPiping(), design.getWeightElectroInstrument(), design.getWeightStructualSteel(),
+        design.getModuleLength(), design.getModuleWidth(), design.getModuleHeight() }) {
+      assertTrue(Double.isNaN(value), "Unavailable sizing must clear all dependent results, found " + value);
+    }
   }
 
   @Test


### PR DESCRIPTION
The flow-coefficient adjustment changed impeller diameter while retaining a tip speed and stage head calculated for the old diameter. In the issue's 6000-rpm reproducer, the reported tip speed was 241.627 m/s while the exported diameter and speed implied 90.137 m/s.

This change sizes equal-head stages at the specified shaft speed. Each candidate satisfies U = pi*D*N/60 and H_stage = 0.50*U^2/1000 kJ/kg. It selects the first stage count within the configured casing limit that also satisfies the existing head, diameter, tip-speed and inlet-flow-coefficient limits. If none passes, it retains the head-based candidate and exposes the violated limits instead of independently clamping or resizing the diameter.

Impeller feasibility and diagnostics are available through the Java API, validateDesign(), legacy JSON, unit-labelled CAD JSON and the compressor feasibility report. Invalid or changed sizing inputs and manual geometry overrides cannot retain a feasible status. Unavailable impeller values serialize as null. The fixed 0.50 work coefficient, equal-head assumption and inlet-stage-only aerodynamic screen are documented; passing this screen is not full compressor qualification.

Closes #3676.

Initial implementation validation (0d4f064):
- Reproduced the original defect on master 7878b74f5e2dee41600eb15c21d9425922d64e92: original regression failed with 90.13708511466767 expected versus 241.62744689861913 reported.
- Compiled the full baseline using Eclipse ECJ 3.41.0 at Java 17 source level, matching the current POM; compiled all four changed production classes and the new regression class with ECJ -8. All compilation commands exited 0. This runtime has Java 17 but no javac, so focused execution used precompiled classes and Maven Surefire.
- `./mvnw surefire:test -Dtest=CompressorImpellerSizingTest,CompressorMechanicalDesignTest,CompressorCasingDesignCalculatorTest,MechanicalDesignJsonContractTest` — 59 tests passed, 0 failures/errors/skips; exit 0.
- The 18 new regressions cover the 6000-rpm issue and 18000-rpm teaching cases; achieved head and flow identities; a feasible additional stage; both diameter bounds; excessive inlet flow; casing stage limits; unavailable/stale inputs; repeated sizing and manual overrides; JSON/CAD qualification; and feasibility-report blockers/nulls.
- `python devtools/run_spotless.py apply` — exit 0; repeated application made no changes.
- `pre-commit run --all-files --hook-stage pre-commit` — exit 0.
- `python devtools/run_spotless.py check` — exit 0.
- `python devtools/check_documentation_search.py` — exit 0; 696 Markdown pages and 1 standalone HTML page audited.
- `pre-commit run --all-files --hook-stage pre-push` — exit 0.
- `git diff --check` — exit 0.

Maven was prepared through the work-with-neqsim prepare_maven.py helper. Python commands used the selected Codex runtime interpreter; pre-commit 4.6.2 ran as `python -m pre_commit` using available cached dependencies.

Documentation impact: updated the compressor sizing guide, general mechanical-design/CAD guide and compressor feasibility-report guide for coupled sizing, limits, diagnostics, units and unavailable values.


Follow-up repair (2026-09-13, ef8093d)

An invalid recalculation could leave the last successful shaft, rotor, weights, driver sizing and layout in the getters and JSON. Reusing a response retained the previous casing map, and querying qualification after detaching the compressor or replacing it with an uninitialized compressor could throw a null-pointer exception.

The repair clears calculated mechanical results before each sizing attempt, returns unavailable dependent quantities as Java NaN / JSON null, uses a zero stage count when sizing is unavailable, and guards missing equipment. Per-stage pressure-ratio checks skip unavailable staging; the impeller blocker still prevents qualification. A reused response clears its old casing calculation. The sizing equations and successful-case numerical results are preserved.

Follow-up validation:
- Ran seven new regression cases against the original PR head 0d4f064f283ab9001175b87333c8f57bd9f67802: five assertion failures and two null-pointer errors. The stale shaft diameter was 92.40335674190082 mm after invalid sizing.
- `./mvnw -q -DskipTests compile` on the full original-head source — exit 0 using Java 17.0.20.
- Compiled all three repaired production classes, the four focused test classes and NeqSimTest using `java com.sun.tools.javac.Main --release 8` with the resolved Maven test classpath — exit 0.
- `./mvnw -q surefire:test -Dtest=CompressorImpellerSizingTest,CompressorMechanicalDesignTest,CompressorCasingDesignCalculatorTest,MechanicalDesignJsonContractTest` — 66 tests passed, zero failures/errors/skips; exit 0. The impeller suite contains 25 cases, including the seven new regressions and successful recovery after restoring valid input.
- `python devtools/run_spotless.py apply` — exit 0; repeated application left the final files unchanged.
- `pre-commit run --all-files --hook-stage pre-commit` — exit 0.
- `python devtools/run_spotless.py check` — exit 0.
- `python devtools/check_documentation_search.py` — exit 0.
- `pre-commit run --all-files --hook-stage pre-push` — exit 0.
- `git diff --check` — exit 0.

Maven was prepared with the work-with-neqsim helper. Python commands used the selected Codex runtime interpreter. Pre-commit 4.6.2 ran as `python -m pre_commit`, loading its already available dependencies without changing the shared Python environment.

Documentation impact: updated all three compressor sizing / mechanical CAD / feasibility guides to describe invalid-recalculation clearing, unavailable outputs and recovery.

VALIDATION PENDING CI: the follow-up repair passed local validation; the GitHub matrix for the new commit is pending.