### PR TITLE
[AI-Assisted] feat(refinery): add source-bounded Sarir crude heating train

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_crude_heating_train.md
+++ b/docs/thermo/characterization/refinery_sarir_crude_heating_train.md
@@ -1,0 +1,89 @@
+---
+title: "Sarir crude heating train"
+description: "Source-bounded preheater and fired-heater screening to the public atmospheric-column feed boundary."
+---
+
+# Sarir crude heating train
+
+`SarirAtmosphericCrudeHeatingCase` carries the existing constrained Sarir assay through a sensible
+preheater and a fired heater to the published atmospheric-column feed boundary. It is a Phase 4
+process-integration screen, not a reconstruction of the refinery's undocumented heat-exchanger
+network or furnace.
+
+## Source and license
+
+The source is Hamza E. Omran Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen
+HYSYS*, Journal of Engineering Research (Libya), issue 33, pages 51-64, published 31 March 2022,
+DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46). The
+[open-access article](https://jer.ly/jer/index.php/jer/article/download/46/38/39) is licensed CC BY
+4.0.
+
+Only three heating-train boundary values come from the article: 54,420 kg/h crude, 350 degC at the
+atmospheric-column inlet, and 233 kPa absolute at that inlet. The paper does not publish a crude
+inlet temperature, preheat target, preheater or furnace pressure loss, fired-heater efficiency, fuel
+lower heating value, emission factors, or stack temperature. The case therefore requires all of
+those values from the caller and keeps them separate from source facts.
+
+## Capability contract
+
+The factory first delegates the 18-cut density and molar-mass profiles to
+`SarirAtmosphericAssay`. Its whole-crude density and average-molar-mass consistency gates remain
+authoritative. It then derives the crude inlet pressure by adding the caller's two nonnegative
+pressure losses to the published column-feed pressure. A `Heater` reaches the caller's intermediate
+preheat temperature; a `FiredHeater` reaches the published 350 degC and 233 kPa boundary.
+
+One `run(UUID)` call executes the inlet and both heaters with the same calculation identifier. The
+case fails closed unless:
+
+- inlet, preheat, and column-feed temperatures are strictly increasing;
+- efficiency is in (0, 1], fuel LHV is positive, and pressure losses and emission factors are
+  nonnegative;
+- both heaters conserve the published hydrocarbon mass flow and reach their configured temperature
+  and pressure boundaries;
+- both absorbed duties and fuel consumption are finite and positive;
+- fired duty equals absorbed furnace duty divided by efficiency, stack loss is their difference,
+  and fuel, CO2, and NOx rates reproduce the caller-supplied factors.
+
+## Java and Python/JPype access
+
+```java
+SarirAtmosphericCrudeHeatingCase.HeatingInputs inputs =
+    new SarirAtmosphericCrudeHeatingCase.HeatingInputs(
+        crudeInletTemperatureK,
+        preheatTemperatureK,
+        preheaterPressureLossBara,
+        furnacePressureLossBara,
+        thermalEfficiency,
+        fuelLowerHeatingValueJPerKg,
+        fuelCO2FactorKgPerKg,
+        noxFactorKgPerGJ,
+        stackTemperatureK);
+
+SarirAtmosphericCrudeHeatingCase heating =
+    SarirAtmosphericCrudeHeatingCase.create(
+        "Sarir heating screen", cutSpecificGravity, cutMolarMassKgPerMol, inputs);
+heating.run(java.util.UUID.randomUUID());
+
+double preheatDutyW = heating.getPreheater().getDuty("W");
+double firedDutyW = heating.getFurnace().getFiredDuty("W");
+double fuelKgPerHour = heating.getFurnace().getFuelConsumption("kg/hr");
+double co2KgPerHour = heating.getFurnace().getCO2Emissions("kg/hr");
+StreamInterface columnFeed = heating.getColumnFeedStream();
+```
+
+The same public classes and getters are available through JPype. Numerical values in the example
+must be selected and documented by the caller; the repository does not provide a hidden "typical"
+fuel or efficiency profile.
+
+## Limits and next boundary
+
+This screen does not model heat-exchanger topology, utility streams, fouling, radiant or convection
+sections, combustion chemistry, air demand, flue-gas composition, steam injection, pump-arounds,
+side strippers, tray efficiency, or product-yield tuning. `FiredHeater` applies arithmetic fuel and
+emission factors; its outputs are not a stack test, regulatory inventory, or calibrated plant
+prediction.
+
+The outlet matches the published atmospheric-column inlet state but is not automatically attached
+to `SarirAtmosphericFractionationCase`. A later integration increment must preserve the existing
+column MESH, conservation, product-ordering, and independent plant-comparison gates before it can
+claim a complete end-to-end workflow.

--- a/src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java
@@ -229,7 +229,8 @@ public final class SarirAtmosphericCrudeHeatingCase {
      * Create validated source-unreported heating inputs.
      *
      * @param crudeInletTemperatureKelvin crude temperature before sensible preheat, in kelvin
-     * @param preheatTemperatureKelvin crude temperature between preheater and furnace, in kelvin
+     * @param preheatTemperatureKelvin crude temperature between preheater and furnace, in kelvin; strictly below the
+     * published column-feed temperature
      * @param preheaterPressureLossBara absolute pressure loss across the preheater, in bar
      * @param furnacePressureLossBara absolute pressure loss across the furnace, in bar
      * @param thermalEfficiency fired-heater thermal efficiency in (0, 1]
@@ -237,6 +238,7 @@ public final class SarirAtmosphericCrudeHeatingCase {
      * @param fuelCO2FactorKgPerKg kg CO2 per kg fuel
      * @param noxFactorKgPerGJ kg NOx per GJ fired duty
      * @param stackTemperatureKelvin reported stack temperature in kelvin
+     * @throws IllegalArgumentException if an input is nonphysical or the temperatures are not strictly increasing
      */
     public HeatingInputs(double crudeInletTemperatureKelvin, double preheatTemperatureKelvin,
         double preheaterPressureLossBara, double furnacePressureLossBara, double thermalEfficiency,
@@ -255,6 +257,9 @@ public final class SarirAtmosphericCrudeHeatingCase {
       requireInputFinitePositive(stackTemperatureKelvin, "Stack temperature");
       if (!(crudeInletTemperatureKelvin < preheatTemperatureKelvin)) {
         throw new IllegalArgumentException("Crude inlet temperature must be below the preheat temperature");
+      }
+      if (!(preheatTemperatureKelvin < getPublishedColumnFeedTemperatureKelvin())) {
+        throw new IllegalArgumentException("Preheat temperature must be below the published column-feed temperature");
       }
 
       this.crudeInletTemperatureKelvin = crudeInletTemperatureKelvin;

--- a/src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java
@@ -1,0 +1,342 @@
+package neqsim.process.equipment.heatexchanger;
+
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.characterization.SarirAtmosphericAssay;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Source-bounded crude heating train for the public Sarir atmospheric-column feed.
+ *
+ * <p>
+ * The case preserves the published crude rate, atmospheric-column feed temperature, and absolute pressure from
+ * {@link SarirAtmosphericReference}. The source does not document a refinery preheat train, furnace pressure loss,
+ * efficiency, fuel, or emission factors. Callers must therefore provide those engineering choices explicitly through
+ * {@link HeatingInputs}. This is an executable screening case, not a reconstruction of the Sarir heater system.
+ * </p>
+ *
+ * <p>
+ * The configured train contains a sensible {@link Heater} followed by a {@link FiredHeater}. It deliberately excludes
+ * heat-exchanger topology, utility streams, fouling, radiant/convection sections, combustion chemistry, and plant
+ * calibration.
+ * </p>
+ */
+public final class SarirAtmosphericCrudeHeatingCase {
+  private static final double ABSOLUTE_TEMPERATURE_TOLERANCE_KELVIN = 1.0e-7;
+  private static final double ABSOLUTE_PRESSURE_TOLERANCE_BARA = 1.0e-10;
+  private static final double RELATIVE_FLOW_TOLERANCE = 1.0e-10;
+  private static final double RELATIVE_IDENTITY_TOLERANCE = 1.0e-10;
+
+  private final Stream crudeInletStream;
+  private final Heater preheater;
+  private final FiredHeater furnace;
+  private final HeatingInputs heatingInputs;
+
+  private SarirAtmosphericCrudeHeatingCase(Stream crudeInletStream, Heater preheater, FiredHeater furnace,
+      HeatingInputs heatingInputs) {
+    this.crudeInletStream = crudeInletStream;
+    this.preheater = preheater;
+    this.furnace = furnace;
+    this.heatingInputs = heatingInputs;
+  }
+
+  /**
+   * Create a configured but unsolved crude heating train.
+   *
+   * @param name non-blank case name
+   * @param cutSpecificGravity specific gravity for each of the 18 source-derived cuts
+   * @param cutMolarMassKgPerMol molar mass for each cut, in kg/mol
+   * @param heatingInputs explicit source-unreported heating, pressure-loss, fuel, and emission inputs
+   * @return configured heating train
+   * @throws NullPointerException if {@code heatingInputs} is {@code null}
+   * @throws IllegalArgumentException if the name, profiles, or heating inputs are invalid
+   */
+  public static SarirAtmosphericCrudeHeatingCase create(String name, double[] cutSpecificGravity,
+      double[] cutMolarMassKgPerMol, HeatingInputs heatingInputs) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Case name must be non-blank");
+    }
+    Objects.requireNonNull(heatingInputs, "heatingInputs");
+
+    double columnFeedTemperatureKelvin = getPublishedColumnFeedTemperatureKelvin();
+    if (!(heatingInputs.getPreheatTemperatureKelvin() < columnFeedTemperatureKelvin)) {
+      throw new IllegalArgumentException("Preheat temperature must be below the published column-feed temperature");
+    }
+
+    double columnFeedPressureBara = getPublishedColumnFeedPressureBara();
+    double furnaceInletPressureBara = columnFeedPressureBara + heatingInputs.getFurnacePressureLossBara();
+    double crudeInletPressureBara = furnaceInletPressureBara + heatingInputs.getPreheaterPressureLossBara();
+
+    SystemInterface crude = new SystemSrkEos(heatingInputs.getCrudeInletTemperatureKelvin(), crudeInletPressureBara);
+    OilAssayCharacterisation assay =
+        SarirAtmosphericAssay.create(crude, cutSpecificGravity, cutMolarMassKgPerMol);
+    assay.apply();
+    crude.setMixingRule("classic");
+
+    Stream crudeInlet = new Stream(name + " crude inlet", crude);
+    crudeInlet.setFlowRate(SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(), "kg/hr");
+    crudeInlet.setTemperature(heatingInputs.getCrudeInletTemperatureKelvin(), "K");
+    crudeInlet.setPressure(crudeInletPressureBara, "bara");
+
+    Heater configuredPreheater = new Heater(name + " preheater", crudeInlet);
+    configuredPreheater.setOutletTemperature(heatingInputs.getPreheatTemperatureKelvin(), "K");
+    configuredPreheater.setOutletPressure(furnaceInletPressureBara, "bara");
+
+    FiredHeater configuredFurnace = new FiredHeater(name + " furnace", configuredPreheater.getOutletStream());
+    configuredFurnace.setOutletTemperature(columnFeedTemperatureKelvin, "K");
+    configuredFurnace.setOutletPressure(columnFeedPressureBara, "bara");
+    configuredFurnace.setThermalEfficiency(heatingInputs.getThermalEfficiency());
+    configuredFurnace.setFuelLHV(heatingInputs.getFuelLowerHeatingValueJPerKg());
+    configuredFurnace.setFuelCO2Factor(heatingInputs.getFuelCO2FactorKgPerKg());
+    configuredFurnace.setNoxFactor(heatingInputs.getNoxFactorKgPerGJ());
+    configuredFurnace.setStackTemperature(heatingInputs.getStackTemperatureKelvin());
+
+    return new SarirAtmosphericCrudeHeatingCase(crudeInlet, configuredPreheater, configuredFurnace, heatingInputs);
+  }
+
+  /**
+   * Run the inlet, preheater, and furnace under one calculation identifier and verify the heating contract.
+   *
+   * @param id calculation identifier
+   * @throws NullPointerException if {@code id} is {@code null}
+   * @throws IllegalStateException if a solved boundary, balance, or fuel identity is invalid
+   */
+  public void run(UUID id) {
+    Objects.requireNonNull(id, "id");
+    crudeInletStream.run(id);
+    preheater.run(id);
+    furnace.run(id);
+    validateSolvedTrain();
+  }
+
+  /** @return mutable characterized crude inlet stream */
+  public Stream getCrudeInletStream() {
+    return crudeInletStream;
+  }
+
+  /** @return mutable sensible preheater */
+  public Heater getPreheater() {
+    return preheater;
+  }
+
+  /** @return mutable fired heater */
+  public FiredHeater getFurnace() {
+    return furnace;
+  }
+
+  /** @return mutable furnace outlet at the atmospheric-column feed boundary after a successful run */
+  public StreamInterface getColumnFeedStream() {
+    return furnace.getOutletStream();
+  }
+
+  /** @return immutable source-unreported inputs used to configure this case */
+  public HeatingInputs getHeatingInputs() {
+    return heatingInputs;
+  }
+
+  private void validateSolvedTrain() {
+    double sourceFlowKgPerHour = SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour();
+    double preheaterFlowKgPerHour = preheater.getOutletStream().getFlowRate("kg/hr");
+    double columnFeedFlowKgPerHour = getColumnFeedStream().getFlowRate("kg/hr");
+    requireClose(preheaterFlowKgPerHour, sourceFlowKgPerHour, RELATIVE_FLOW_TOLERANCE,
+        "Preheater mass-flow closure");
+    requireClose(columnFeedFlowKgPerHour, sourceFlowKgPerHour, RELATIVE_FLOW_TOLERANCE,
+        "Furnace mass-flow closure");
+    requireAbsoluteClose(preheater.getOutletStream().getTemperature("K"), heatingInputs.getPreheatTemperatureKelvin(),
+        ABSOLUTE_TEMPERATURE_TOLERANCE_KELVIN, "Preheater outlet temperature");
+    requireAbsoluteClose(preheater.getOutletStream().getPressure("bara"),
+        getPublishedColumnFeedPressureBara() + heatingInputs.getFurnacePressureLossBara(),
+        ABSOLUTE_PRESSURE_TOLERANCE_BARA, "Preheater outlet pressure");
+    requireAbsoluteClose(getColumnFeedStream().getTemperature("K"), getPublishedColumnFeedTemperatureKelvin(),
+        ABSOLUTE_TEMPERATURE_TOLERANCE_KELVIN, "Column-feed temperature");
+    requireAbsoluteClose(getColumnFeedStream().getPressure("bara"), getPublishedColumnFeedPressureBara(),
+        ABSOLUTE_PRESSURE_TOLERANCE_BARA, "Column-feed pressure");
+
+    double preheaterDutyW = preheater.getDuty("W");
+    double absorbedDutyW = furnace.getAbsorbedDuty("W");
+    double firedDutyW = furnace.getFiredDuty("W");
+    double stackLossW = furnace.getStackLoss("W");
+    requireFinitePositive(preheaterDutyW, "Preheater duty");
+    requireFinitePositive(absorbedDutyW, "Furnace absorbed duty");
+    requireFinitePositive(firedDutyW, "Furnace fired duty");
+    requireFiniteNonNegative(stackLossW, "Furnace stack loss");
+    requireClose(firedDutyW, absorbedDutyW / heatingInputs.getThermalEfficiency(), RELATIVE_IDENTITY_TOLERANCE,
+        "Fired-duty efficiency identity");
+    requireClose(stackLossW, firedDutyW - absorbedDutyW, RELATIVE_IDENTITY_TOLERANCE,
+        "Stack-loss identity");
+
+    double fuelKgPerHour = furnace.getFuelConsumption("kg/hr");
+    double co2KgPerHour = furnace.getCO2Emissions("kg/hr");
+    double noxKgPerHour = furnace.getNOxEmissions("kg/hr");
+    requireFinitePositive(fuelKgPerHour, "Fuel consumption");
+    requireFiniteNonNegative(co2KgPerHour, "CO2 emissions");
+    requireFiniteNonNegative(noxKgPerHour, "NOx emissions");
+    requireClose(fuelKgPerHour, firedDutyW / heatingInputs.getFuelLowerHeatingValueJPerKg() * 3600.0,
+        RELATIVE_IDENTITY_TOLERANCE, "Fuel-LHV identity");
+    requireClose(co2KgPerHour, fuelKgPerHour * heatingInputs.getFuelCO2FactorKgPerKg(),
+        RELATIVE_IDENTITY_TOLERANCE, "CO2-factor identity");
+    requireClose(noxKgPerHour, firedDutyW / 1.0e9 * heatingInputs.getNoxFactorKgPerGJ() * 3600.0,
+        RELATIVE_IDENTITY_TOLERANCE, "NOx-factor identity");
+  }
+
+  private static double getPublishedColumnFeedTemperatureKelvin() {
+    return SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
+  }
+
+  private static double getPublishedColumnFeedPressureBara() {
+    return SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0;
+  }
+
+  private static void requireFinitePositive(double value, String label) {
+    if (!Double.isFinite(value) || !(value > 0.0)) {
+      throw new IllegalStateException(label + " must be finite and positive");
+    }
+  }
+
+  private static void requireFiniteNonNegative(double value, String label) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalStateException(label + " must be finite and non-negative");
+    }
+  }
+
+  private static void requireClose(double value, double expected, double relativeTolerance, String label) {
+    if (!Double.isFinite(value) || !Double.isFinite(expected)
+        || Math.abs(value - expected) > relativeTolerance * Math.max(1.0, Math.abs(expected))) {
+      throw new IllegalStateException(label + " is outside the qualified tolerance");
+    }
+  }
+
+  private static void requireAbsoluteClose(double value, double expected, double absoluteTolerance, String label) {
+    if (!Double.isFinite(value) || Math.abs(value - expected) > absoluteTolerance) {
+      throw new IllegalStateException(label + " is outside the qualified tolerance");
+    }
+  }
+
+  /** Explicit source-unreported crude-heating engineering inputs. */
+  public static final class HeatingInputs {
+    private final double crudeInletTemperatureKelvin;
+    private final double preheatTemperatureKelvin;
+    private final double preheaterPressureLossBara;
+    private final double furnacePressureLossBara;
+    private final double thermalEfficiency;
+    private final double fuelLowerHeatingValueJPerKg;
+    private final double fuelCO2FactorKgPerKg;
+    private final double noxFactorKgPerGJ;
+    private final double stackTemperatureKelvin;
+
+    /**
+     * Create validated source-unreported heating inputs.
+     *
+     * @param crudeInletTemperatureKelvin crude temperature before sensible preheat, in kelvin
+     * @param preheatTemperatureKelvin crude temperature between preheater and furnace, in kelvin
+     * @param preheaterPressureLossBara absolute pressure loss across the preheater, in bar
+     * @param furnacePressureLossBara absolute pressure loss across the furnace, in bar
+     * @param thermalEfficiency fired-heater thermal efficiency in (0, 1]
+     * @param fuelLowerHeatingValueJPerKg fuel lower heating value in J/kg
+     * @param fuelCO2FactorKgPerKg kg CO2 per kg fuel
+     * @param noxFactorKgPerGJ kg NOx per GJ fired duty
+     * @param stackTemperatureKelvin reported stack temperature in kelvin
+     */
+    public HeatingInputs(double crudeInletTemperatureKelvin, double preheatTemperatureKelvin,
+        double preheaterPressureLossBara, double furnacePressureLossBara, double thermalEfficiency,
+        double fuelLowerHeatingValueJPerKg, double fuelCO2FactorKgPerKg, double noxFactorKgPerGJ,
+        double stackTemperatureKelvin) {
+      requireInputFinitePositive(crudeInletTemperatureKelvin, "Crude inlet temperature");
+      requireInputFinitePositive(preheatTemperatureKelvin, "Preheat temperature");
+      requireInputFiniteNonNegative(preheaterPressureLossBara, "Preheater pressure loss");
+      requireInputFiniteNonNegative(furnacePressureLossBara, "Furnace pressure loss");
+      if (!Double.isFinite(thermalEfficiency) || !(thermalEfficiency > 0.0) || thermalEfficiency > 1.0) {
+        throw new IllegalArgumentException("Thermal efficiency must be finite and in (0, 1]");
+      }
+      requireInputFinitePositive(fuelLowerHeatingValueJPerKg, "Fuel lower heating value");
+      requireInputFiniteNonNegative(fuelCO2FactorKgPerKg, "Fuel CO2 factor");
+      requireInputFiniteNonNegative(noxFactorKgPerGJ, "NOx factor");
+      requireInputFinitePositive(stackTemperatureKelvin, "Stack temperature");
+      if (!(crudeInletTemperatureKelvin < preheatTemperatureKelvin)) {
+        throw new IllegalArgumentException("Crude inlet temperature must be below the preheat temperature");
+      }
+
+      this.crudeInletTemperatureKelvin = crudeInletTemperatureKelvin;
+      this.preheatTemperatureKelvin = preheatTemperatureKelvin;
+      this.preheaterPressureLossBara = preheaterPressureLossBara;
+      this.furnacePressureLossBara = furnacePressureLossBara;
+      this.thermalEfficiency = thermalEfficiency;
+      this.fuelLowerHeatingValueJPerKg = fuelLowerHeatingValueJPerKg;
+      this.fuelCO2FactorKgPerKg = fuelCO2FactorKgPerKg;
+      this.noxFactorKgPerGJ = noxFactorKgPerGJ;
+      this.stackTemperatureKelvin = stackTemperatureKelvin;
+    }
+
+    /** @return crude inlet temperature in kelvin */
+    public double getCrudeInletTemperatureKelvin() {
+      return crudeInletTemperatureKelvin;
+    }
+
+    /** @return preheater outlet temperature in kelvin */
+    public double getPreheatTemperatureKelvin() {
+      return preheatTemperatureKelvin;
+    }
+
+    /** @return preheater pressure loss in bar */
+    public double getPreheaterPressureLossBara() {
+      return preheaterPressureLossBara;
+    }
+
+    /** @return furnace pressure loss in bar */
+    public double getFurnacePressureLossBara() {
+      return furnacePressureLossBara;
+    }
+
+    /** @return fired-heater thermal efficiency */
+    public double getThermalEfficiency() {
+      return thermalEfficiency;
+    }
+
+    /** @return fuel lower heating value in J/kg */
+    public double getFuelLowerHeatingValueJPerKg() {
+      return fuelLowerHeatingValueJPerKg;
+    }
+
+    /** @return fuel CO2 factor in kg/kg */
+    public double getFuelCO2FactorKgPerKg() {
+      return fuelCO2FactorKgPerKg;
+    }
+
+    /** @return NOx factor in kg/GJ */
+    public double getNoxFactorKgPerGJ() {
+      return noxFactorKgPerGJ;
+    }
+
+    /** @return stack temperature in kelvin */
+    public double getStackTemperatureKelvin() {
+      return stackTemperatureKelvin;
+    }
+
+    /** @return total explicit preheater-plus-furnace pressure loss in bar */
+    public double getTotalPressureLossBara() {
+      return preheaterPressureLossBara + furnacePressureLossBara;
+    }
+
+    /** @return derived crude inlet pressure required to meet the published column-feed pressure, in bar absolute */
+    public double getCrudeInletPressureBara() {
+      return getPublishedColumnFeedPressureBara() + getTotalPressureLossBara();
+    }
+
+    private static void requireInputFinitePositive(double value, String label) {
+      if (!Double.isFinite(value) || !(value > 0.0)) {
+        throw new IllegalArgumentException(label + " must be finite and positive");
+      }
+    }
+
+    private static void requireInputFiniteNonNegative(double value, String label) {
+      if (!Double.isFinite(value) || value < 0.0) {
+        throw new IllegalArgumentException(label + " must be finite and non-negative");
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java
@@ -73,8 +73,7 @@ public final class SarirAtmosphericCrudeHeatingCase {
     double crudeInletPressureBara = furnaceInletPressureBara + heatingInputs.getPreheaterPressureLossBara();
 
     SystemInterface crude = new SystemSrkEos(heatingInputs.getCrudeInletTemperatureKelvin(), crudeInletPressureBara);
-    OilAssayCharacterisation assay =
-        SarirAtmosphericAssay.create(crude, cutSpecificGravity, cutMolarMassKgPerMol);
+    OilAssayCharacterisation assay = SarirAtmosphericAssay.create(crude, cutSpecificGravity, cutMolarMassKgPerMol);
     assay.apply();
     crude.setMixingRule("classic");
 
@@ -143,10 +142,8 @@ public final class SarirAtmosphericCrudeHeatingCase {
     double sourceFlowKgPerHour = SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour();
     double preheaterFlowKgPerHour = preheater.getOutletStream().getFlowRate("kg/hr");
     double columnFeedFlowKgPerHour = getColumnFeedStream().getFlowRate("kg/hr");
-    requireClose(preheaterFlowKgPerHour, sourceFlowKgPerHour, RELATIVE_FLOW_TOLERANCE,
-        "Preheater mass-flow closure");
-    requireClose(columnFeedFlowKgPerHour, sourceFlowKgPerHour, RELATIVE_FLOW_TOLERANCE,
-        "Furnace mass-flow closure");
+    requireClose(preheaterFlowKgPerHour, sourceFlowKgPerHour, RELATIVE_FLOW_TOLERANCE, "Preheater mass-flow closure");
+    requireClose(columnFeedFlowKgPerHour, sourceFlowKgPerHour, RELATIVE_FLOW_TOLERANCE, "Furnace mass-flow closure");
     requireAbsoluteClose(preheater.getOutletStream().getTemperature("K"), heatingInputs.getPreheatTemperatureKelvin(),
         ABSOLUTE_TEMPERATURE_TOLERANCE_KELVIN, "Preheater outlet temperature");
     requireAbsoluteClose(preheater.getOutletStream().getPressure("bara"),
@@ -167,8 +164,7 @@ public final class SarirAtmosphericCrudeHeatingCase {
     requireFiniteNonNegative(stackLossW, "Furnace stack loss");
     requireClose(firedDutyW, absorbedDutyW / heatingInputs.getThermalEfficiency(), RELATIVE_IDENTITY_TOLERANCE,
         "Fired-duty efficiency identity");
-    requireClose(stackLossW, firedDutyW - absorbedDutyW, RELATIVE_IDENTITY_TOLERANCE,
-        "Stack-loss identity");
+    requireClose(stackLossW, firedDutyW - absorbedDutyW, RELATIVE_IDENTITY_TOLERANCE, "Stack-loss identity");
 
     double fuelKgPerHour = furnace.getFuelConsumption("kg/hr");
     double co2KgPerHour = furnace.getCO2Emissions("kg/hr");
@@ -178,8 +174,8 @@ public final class SarirAtmosphericCrudeHeatingCase {
     requireFiniteNonNegative(noxKgPerHour, "NOx emissions");
     requireClose(fuelKgPerHour, firedDutyW / heatingInputs.getFuelLowerHeatingValueJPerKg() * 3600.0,
         RELATIVE_IDENTITY_TOLERANCE, "Fuel-LHV identity");
-    requireClose(co2KgPerHour, fuelKgPerHour * heatingInputs.getFuelCO2FactorKgPerKg(),
-        RELATIVE_IDENTITY_TOLERANCE, "CO2-factor identity");
+    requireClose(co2KgPerHour, fuelKgPerHour * heatingInputs.getFuelCO2FactorKgPerKg(), RELATIVE_IDENTITY_TOLERANCE,
+        "CO2-factor identity");
     requireClose(noxKgPerHour, firedDutyW / 1.0e9 * heatingInputs.getNoxFactorKgPerGJ() * 3600.0,
         RELATIVE_IDENTITY_TOLERANCE, "NOx-factor identity");
   }

--- a/src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java
@@ -49,8 +49,8 @@ public class SarirAtmosphericCrudeHeatingCaseTest {
   /** Reject missing, nonphysical, or source-boundary-inconsistent assumptions before solving. */
   @Test
   public void invalidHeatingInputsFailClosed() {
-    assertThrows(IllegalArgumentException.class, () -> new HeatingInputs(400.0, 390.0, 0.10, 0.05, 0.85, 48.0e6,
-        2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(400.0, 390.0, 0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
     assertThrows(IllegalArgumentException.class,
         () -> new HeatingInputs(300.0, 500.0, -0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
     assertThrows(IllegalArgumentException.class,
@@ -64,8 +64,8 @@ public class SarirAtmosphericCrudeHeatingCaseTest {
     assertThrows(IllegalArgumentException.class,
         () -> new HeatingInputs(300.0, 623.15, 0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
 
-    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericCrudeHeatingCase.create(" ", SPECIFIC_GRAVITY,
-        MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericCrudeHeatingCase.create(" ", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
     assertThrows(NullPointerException.class,
         () -> SarirAtmosphericCrudeHeatingCase.create("Sarir", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, null));
   }

--- a/src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java
@@ -1,0 +1,103 @@
+package neqsim.process.equipment.heatexchanger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.SarirAtmosphericCrudeHeatingCase.HeatingInputs;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+
+/** Qualification tests for {@link SarirAtmosphericCrudeHeatingCase}. */
+public class SarirAtmosphericCrudeHeatingCaseTest {
+  private static final double[] SPECIFIC_GRAVITY = { 0.641826000, 0.671826000, 0.691826000, 0.711826000, 0.741826000,
+      0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000, 0.901826000,
+      0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
+  private static final double[] MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992, 0.272675861324,
+      0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318, 0.495774293317, 0.545351722649,
+      0.743661439976 };
+
+  /** Carry the constrained assay through both heaters to the published column-feed boundary. */
+  @Test
+  public void explicitInputsProduceQualifiedHeatingTrain() {
+    HeatingInputs inputs = qualifiedInputs();
+    SarirAtmosphericCrudeHeatingCase model = SarirAtmosphericCrudeHeatingCase.create("Sarir heating screen",
+        SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, inputs);
+
+    assertTrue(inputs == model.getHeatingInputs());
+    assertEquals(2.48, inputs.getCrudeInletPressureBara(), 1.0e-12);
+    assertEquals(SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(),
+        model.getCrudeInletStream().getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(inputs.getCrudeInletTemperatureKelvin(), model.getCrudeInletStream().getTemperature("K"), 1.0e-12);
+
+    model.run(UUID.randomUUID());
+    assertQualifiedResult(model, inputs);
+
+    double preheaterDutyW = model.getPreheater().getDuty("W");
+    double firedDutyW = model.getFurnace().getFiredDuty("W");
+    double fuelKgPerHour = model.getFurnace().getFuelConsumption("kg/hr");
+    model.run(UUID.randomUUID());
+    assertQualifiedResult(model, inputs);
+    assertEquals(preheaterDutyW, model.getPreheater().getDuty("W"), Math.abs(preheaterDutyW) * 1.0e-12);
+    assertEquals(firedDutyW, model.getFurnace().getFiredDuty("W"), Math.abs(firedDutyW) * 1.0e-12);
+    assertEquals(fuelKgPerHour, model.getFurnace().getFuelConsumption("kg/hr"), Math.abs(fuelKgPerHour) * 1.0e-12);
+  }
+
+  /** Reject missing, nonphysical, or source-boundary-inconsistent assumptions before solving. */
+  @Test
+  public void invalidHeatingInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class, () -> new HeatingInputs(400.0, 390.0, 0.10, 0.05, 0.85, 48.0e6,
+        2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 500.0, -0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 500.0, 0.10, 0.05, 0.0, 48.0e6, 2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 500.0, 0.10, 0.05, 1.01, 48.0e6, 2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 500.0, 0.10, 0.05, 0.85, Double.NaN, 2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 500.0, 0.10, 0.05, 0.85, 48.0e6, -1.0, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 623.15, 0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
+
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericCrudeHeatingCase.create(" ", SPECIFIC_GRAVITY,
+        MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));
+    assertThrows(NullPointerException.class,
+        () -> SarirAtmosphericCrudeHeatingCase.create("Sarir", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, null));
+  }
+
+  private static void assertQualifiedResult(SarirAtmosphericCrudeHeatingCase model, HeatingInputs inputs) {
+    double publishedFlow = SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour();
+    double publishedTemperatureKelvin = SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
+    double publishedPressureBara = SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0;
+    assertEquals(inputs.getPreheatTemperatureKelvin(), model.getPreheater().getOutletStream().getTemperature("K"),
+        1.0e-7);
+    assertEquals(publishedTemperatureKelvin, model.getColumnFeedStream().getTemperature("K"), 1.0e-7);
+    assertEquals(publishedPressureBara, model.getColumnFeedStream().getPressure("bara"), 1.0e-10);
+    assertEquals(publishedFlow, model.getColumnFeedStream().getFlowRate("kg/hr"), publishedFlow * 1.0e-10);
+    assertArrayEquals(model.getCrudeInletStream().getThermoSystem().getMolarComposition(),
+        model.getColumnFeedStream().getThermoSystem().getMolarComposition(), 1.0e-12);
+
+    double preheaterDutyW = model.getPreheater().getDuty("W");
+    double absorbedDutyW = model.getFurnace().getAbsorbedDuty("W");
+    double firedDutyW = model.getFurnace().getFiredDuty("W");
+    assertTrue(Double.isFinite(preheaterDutyW) && preheaterDutyW > 0.0);
+    assertTrue(Double.isFinite(absorbedDutyW) && absorbedDutyW > 0.0);
+    assertEquals(absorbedDutyW / inputs.getThermalEfficiency(), firedDutyW, firedDutyW * 1.0e-10);
+    assertEquals(firedDutyW - absorbedDutyW, model.getFurnace().getStackLoss("W"), firedDutyW * 1.0e-10);
+    assertEquals(firedDutyW / inputs.getFuelLowerHeatingValueJPerKg() * 3600.0,
+        model.getFurnace().getFuelConsumption("kg/hr"), 1.0e-10);
+    assertEquals(model.getFurnace().getFuelConsumption("kg/hr") * inputs.getFuelCO2FactorKgPerKg(),
+        model.getFurnace().getCO2Emissions("kg/hr"), 1.0e-10);
+    assertEquals(firedDutyW / 1.0e9 * inputs.getNoxFactorKgPerGJ() * 3600.0,
+        model.getFurnace().getNOxEmissions("kg/hr"), 1.0e-12);
+  }
+
+  private static HeatingInputs qualifiedInputs() {
+    return new HeatingInputs(300.0, 500.0, 0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java
@@ -63,6 +63,8 @@ public class SarirAtmosphericCrudeHeatingCaseTest {
         () -> new HeatingInputs(300.0, 500.0, 0.10, 0.05, 0.85, 48.0e6, -1.0, 0.08, 423.15));
     assertThrows(IllegalArgumentException.class,
         () -> new HeatingInputs(300.0, 623.15, 0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> new HeatingInputs(300.0, 650.0, 0.10, 0.05, 0.85, 48.0e6, 2.75, 0.08, 423.15));
 
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericCrudeHeatingCase.create(" ", SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL, qualifiedInputs()));


### PR DESCRIPTION
## Campaign

Phase 4 increment for #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5652130879

## What changed

- Add a reusable Java/JPype-accessible Sarir crude heating train: constrained assay → sensible preheater → fired heater → published atmospheric-column feed boundary.
- Require every source-unreported temperature, pressure-loss, efficiency, fuel, emission, and stack input explicitly.
- Run the train under one UUID and fail closed on mass-flow, temperature, pressure, duty, fuel-LHV, stack-loss, CO2-factor, and NOx-factor identities.
- Add focused invalid-input, boundary, composition, energy/fuel, and repeatability regressions.
- Document provenance, the source/assumption split, API usage, and the bounded non-goals.

## Provenance and engineering boundary

Source: H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya) 33 (31 March 2022), DOI 10.66411/jer.v33i.46, CC BY 4.0.

Only 54,420 kg/h, 350 °C, and 233 kPa absolute at the atmospheric-column inlet are taken from the source. The model does not reconstruct or calibrate the refinery preheat network/furnace and does not add steam, pump-arounds, side strippers, combustion chemistry, or product tuning. Fuel and emission outputs are arithmetic screens from caller-supplied factors, not regulatory or plant predictions.

## Frozen scope

Exactly three new files:

- `src/main/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCase.java`
- `src/test/java/neqsim/process/equipment/heatexchanger/SarirAtmosphericCrudeHeatingCaseTest.java`
- `docs/thermo/characterization/refinery_sarir_crude_heating_train.md`

Starting `master`: `1e7fda16e3872f74d918367a708737fbbad93927`
Current head: `8f1df3e32045fb24eb6676c2269113e285919960`

The four other active autonomous PRs have no file overlap.

## Hosted formatting repair

The initial pre-commit run failed only the two new Java files' Spotless formatting. Artifact `spotless-format-patch` / `10314821176` from exact head `f456808d85ab542b76c5862f4504b1a86f4839c3` had verified digest `sha256:66aaf98a2d0cc5fa56b07f102d052470d55a312f748295f6a7e75567a8d16b73`. Its patch changed line wrapping only. The resulting production/test blob hashes are `11e899a19ed61f176da92a77a8d04e8a6c864ecf` and `2a1ef779467091f5cc833da2ec033282f4a98df6`; the documentation blob remains `52034fbfaea1c1b6c3e3e35733c5bb94b2c28ceb`.

## Validation state

**Focused validation passed; hosted CI is pending for `8f1df3e32045fb24eb6676c2269113e285919960`.**

The Actions failure at `invalidHeatingInputsFailClosed:64` was reproduced locally. The constructor now rejects preheat temperatures at or above the published column-feed temperature, preserving the positive furnace-duty contract. Equality and above-boundary regressions are covered.

Validation on Java 17 / NeqSim 3.20.0:
- `./mvnw -B -ntp test -Dtest=SarirAtmosphericCrudeHeatingCaseTest,SarirAtmosphericAssayTest,FiredHeaterTest -Djacoco.skip=true`: exit 0, 10 tests passed.
- `python devtools/run_spotless.py apply`: exit 0; second application made no changes.
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0.
- Both `pre-commit run --all-files --hook-stage pre-commit` and `--hook-stage pre-push`: exit 0 (invoked with the selected interpreter via `-m pre_commit`).

Documentation impact: constructor Javadoc now states the temperature bound and exception; the guide already requires strictly increasing inlet, preheat, and column-feed temperatures.

This PR is intentionally draft-only. Because it introduces a public workflow API, subsystem-owner and independent-maintainer reviews remain mandatory before READY TO MERGE or merge. Do not mark ready, merge, rebase, synchronize, replace, close, or abandon it automatically.