### PR TITLE
[AI-Assisted] feat(kinetics): add explicit mass-based S8 transfer receipt

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -360,6 +360,40 @@ stoichiometry or selectivity, consume O2, calculate heat, speciation, pressure, 
 water holdup, create a signed source, execute a solid flash, or mutate a stream, wall, deposit,
 filter, corrosion, process, transient, or pipeline state.
 
+## Explicit mass-based S8 transfer receipt
+
+`AqueousHydrogenSulfideOxidationS8Transfer.create(...)` selects exactly one lower-rate, nominal,
+or upper-rate path from an existing elemental-sulfur allocation and creates an immutable transfer
+receipt for NeqSim's existing `S8` component path. The caller must explicitly supply the fit path,
+a product-identity basis identifier, and a downstream idempotency key. The allocation-basis
+identifier and source-segment metadata are preserved.
+
+The receipt copies the selected path on a mass basis without an additional conversion:
+
+$
+\dot m_{S8,\mathrm{transfer}}=\dot m_{S,\mathrm{allocated}}, \qquad
+m_{S8,\mathrm{transfer}}=m_{S,\mathrm{allocated}}.
+$
+
+It also carries the source sulfur-equivalent budget, unallocated remainder, and existing rate- and
+mass-basis closure residuals. This exact kg/h and kg passthrough deliberately avoids calculating
+S8 moles or introducing another molecular-weight constant. Zero allocation gives an exact zero
+transfer, full allocation leaves an exact zero remainder, and the inherited fit-path ordering,
+water-inventory scaling, and unchanged-state segment-split mass sums are preserved.
+
+The product-identity identifier records why the caller selected the `S8` representation; it does
+not qualify that choice as a measured product distribution. The idempotency key is a hook for a
+downstream accounting ledger, not an in-memory consumption lock. A consumer must apply the
+transferred mass only once under that key and carry the unallocated sulfur-equivalent remainder
+separately. It must not also apply the original allocation or source budget as product.
+
+This is the narrow mass-unit seam toward the existing `SulfurDepositionAnalyser`, TP-solid-flash,
+and `SulfurFilter` path. The receipt does not add `S8` to a stream, run equilibrium or a solid
+flash, predict saturation, precipitation, deposition, capture or corrosion, consume O2, calculate
+heat, speciation, phase transfer or water holdup, or mutate any stream, wall, filter, process,
+transient, or pipeline state. Those operations remain separate and require independently
+qualified product identity and application evidence.
+
 ## Piecewise target crossing
 
 `AqueousHydrogenSulfideOxidationTrajectory.timeToRemainingFractionRange(...)` locates where a

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -47,6 +47,16 @@ ELEMENTAL_SULFUR_ALLOCATION_TEST = (
     / "src/test/java/neqsim/process/equipment/reactor/"
     / "AqueousHydrogenSulfideOxidationElementalSulfurAllocationTest.java"
 )
+S8_TRANSFER = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationS8Transfer.java"
+)
+S8_TRANSFER_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationS8TransferTest.java"
+)
 
 
 class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
@@ -72,6 +82,8 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         cls.elemental_sulfur_allocation_test = (
             ELEMENTAL_SULFUR_ALLOCATION_TEST.read_text(encoding="utf-8")
         )
+        cls.s8_transfer = S8_TRANSFER.read_text(encoding="utf-8")
+        cls.s8_transfer_test = S8_TRANSFER_TEST.read_text(encoding="utf-8")
         cls.normalized = " ".join(cls.guide.split())
 
     def test_source_equation_and_units_are_explicit(self):
@@ -463,6 +475,60 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "testMissingInvalidOrUnrepresentableAllocationFailsClosed",
         ):
             self.assertIn(token, self.elemental_sulfur_allocation_test)
+
+    def test_mass_based_s8_transfer_receipt_is_documented_and_executable(self):
+        for token in (
+            "Explicit mass-based S8 transfer receipt",
+            "`AqueousHydrogenSulfideOxidationS8Transfer.create(...)`",
+            "selects exactly one lower-rate, nominal, or upper-rate path",
+            r"\dot m_{S8,\mathrm{transfer}}=\dot m_{S,\mathrm{allocated}}",
+            r"m_{S8,\mathrm{transfer}}=m_{S,\mathrm{allocated}}",
+            "avoids calculating S8 moles",
+            "product-identity identifier",
+            "downstream idempotency key",
+            "must apply the transferred mass only once",
+            "narrow mass-unit seam",
+            "does not add `S8` to a stream",
+            "independently qualified product identity and application evidence",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            'public static final String S8_COMPONENT_NAME = "S8"',
+            "public enum FitPath",
+            "LOWER_RATE",
+            "NOMINAL",
+            "UPPER_RATE",
+            "public static Result create(",
+            "getComponentName()",
+            "getFitPath()",
+            "getProductIdentityBasisIdentifier()",
+            "getDownstreamIdempotencyKey()",
+            "getTransferredS8MassRateKgPerHour()",
+            "getTransferredS8MassKg()",
+            "getUnallocatedSulfurEquivalentMassKg()",
+            "Selected allocation closure evidence is inconsistent",
+        ):
+            self.assertIn(token, self.s8_transfer)
+
+        for forbidden in (
+            "SystemInterface",
+            "StreamInterface",
+            "addComponent(",
+            "TPSolidflash(",
+            "SulfurDepositionAnalyser(",
+            "SulfurFilter(",
+        ):
+            self.assertNotIn(forbidden, self.s8_transfer)
+
+        for token in (
+            "testEveryFitPathIsSelectedExplicitlyWithoutMassConversion",
+            "testZeroAndFullAllocationPreserveExactIdentities",
+            "testWaterScalingAndSegmentSplitMassSumsArePreserved",
+            "testReceiptRoundTripsThroughSerializationAndPreservesProvenance",
+            "testMissingOrInvalidTransferEvidenceFailsClosed",
+        ):
+            self.assertIn(token, self.s8_transfer_test)
 
 
     def test_absolute_reacted_moles_target_is_documented_and_executable(self):

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationS8Transfer.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationS8Transfer.java
@@ -1,0 +1,257 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Selects one explicit fit path from an elemental-sulfur allocation for mass-based transfer to NeqSim's existing S8
+ * component path.
+ *
+ * <p>
+ * This class records a caller-supplied product-identity basis and downstream idempotency key. It does not qualify the
+ * S8 representation, convert sulfur mass to S8 moles, mutate a stream, or run a flash, deposition, filter, wall,
+ * corrosion, process, transient, or pipeline model.
+ * </p>
+ *
+ * @author esol
+ * @version $Id: $
+ */
+public final class AqueousHydrogenSulfideOxidationS8Transfer {
+  /** Existing NeqSim component name used for an explicitly selected S8 representation. */
+  public static final String S8_COMPONENT_NAME = "S8";
+
+  private static final int MAXIMUM_IDENTIFIER_LENGTH = 256;
+
+  private AqueousHydrogenSulfideOxidationS8Transfer() {
+  }
+
+  /** Published fit-scatter path selected explicitly by the caller. */
+  public enum FitPath {
+    /** Lower-rate Millero fit path. */
+    LOWER_RATE,
+    /** Nominal Millero fit path. */
+    NOMINAL,
+    /** Upper-rate Millero fit path. */
+    UPPER_RATE
+  }
+
+  /**
+   * Create a mass-based transfer receipt for one explicitly selected fit path.
+   *
+   * @param allocation immutable elemental-sulfur allocation receipt
+   * @param fitPath explicit lower-rate, nominal, or upper-rate path
+   * @param productIdentityBasisIdentifier caller's basis for representing allocated elemental sulfur as the NeqSim S8
+   * component
+   * @param downstreamIdempotencyKey key that a downstream ledger must use to prevent repeat consumption
+   * @return immutable mass-based S8 transfer receipt
+   */
+  public static Result create(AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation,
+      FitPath fitPath, String productIdentityBasisIdentifier, String downstreamIdempotencyKey) {
+    if (allocation == null) {
+      throw new IllegalArgumentException("Elemental-sulfur allocation cannot be null");
+    }
+    if (fitPath == null) {
+      throw new IllegalArgumentException("Fit path cannot be null");
+    }
+    String productBasis = requireIdentifier(productIdentityBasisIdentifier, "Product-identity basis identifier");
+    String idempotencyKey = requireIdentifier(downstreamIdempotencyKey, "Downstream idempotency key");
+
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.PathResult selectedPath = selectPath(allocation, fitPath);
+    validatePath(selectedPath);
+
+    return new Result(allocation.getSourceSegmentIndex(), allocation.getDurationHours(),
+        allocation.getWaterInventoryKg(), fitPath, allocation.getAllocationBasisIdentifier(), productBasis,
+        idempotencyKey, selectedPath.getSourceSulfurEquivalentMassRateKgPerHour(),
+        selectedPath.getAllocatedElementalSulfurMassRateKgPerHour(),
+        selectedPath.getUnallocatedSulfurEquivalentMassRateKgPerHour(), selectedPath.getRateClosureResidualKgPerHour(),
+        selectedPath.getSourceSulfurEquivalentMassKg(), selectedPath.getAllocatedElementalSulfurMassKg(),
+        selectedPath.getUnallocatedSulfurEquivalentMassKg(), selectedPath.getMassClosureResidualKg());
+  }
+
+  private static AqueousHydrogenSulfideOxidationElementalSulfurAllocation.PathResult selectPath(
+      AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation, FitPath fitPath) {
+    switch (fitPath) {
+    case LOWER_RATE:
+      return allocation.getLowerRate();
+    case NOMINAL:
+      return allocation.getNominal();
+    case UPPER_RATE:
+      return allocation.getUpperRate();
+    default:
+      throw new IllegalArgumentException("Unsupported fit path");
+    }
+  }
+
+  private static String requireIdentifier(String identifier, String name) {
+    if (identifier == null || identifier.isEmpty() || !identifier.equals(identifier.trim())
+        || identifier.length() > MAXIMUM_IDENTIFIER_LENGTH) {
+      throw new IllegalArgumentException(name + " must be non-blank, trimmed, and no longer than 256 characters");
+    }
+    return identifier;
+  }
+
+  private static void validatePath(AqueousHydrogenSulfideOxidationElementalSulfurAllocation.PathResult path) {
+    requireNonNegativeFinite(path.getSourceSulfurEquivalentMassRateKgPerHour(), "Source sulfur-equivalent mass rate");
+    requireNonNegativeFinite(path.getAllocatedElementalSulfurMassRateKgPerHour(),
+        "Allocated elemental-sulfur mass rate");
+    requireNonNegativeFinite(path.getUnallocatedSulfurEquivalentMassRateKgPerHour(),
+        "Unallocated sulfur-equivalent mass rate");
+    requireNonNegativeFinite(path.getSourceSulfurEquivalentMassKg(), "Source sulfur-equivalent mass");
+    requireNonNegativeFinite(path.getAllocatedElementalSulfurMassKg(), "Allocated elemental-sulfur mass");
+    requireNonNegativeFinite(path.getUnallocatedSulfurEquivalentMassKg(), "Unallocated sulfur-equivalent mass");
+    requireFinite(path.getRateClosureResidualKgPerHour(), "Rate closure residual");
+    requireFinite(path.getMassClosureResidualKg(), "Mass closure residual");
+
+    if (path.getAllocatedElementalSulfurMassRateKgPerHour() > path.getSourceSulfurEquivalentMassRateKgPerHour()
+        || path.getUnallocatedSulfurEquivalentMassRateKgPerHour() > path.getSourceSulfurEquivalentMassRateKgPerHour()
+        || path.getAllocatedElementalSulfurMassKg() > path.getSourceSulfurEquivalentMassKg()
+        || path.getUnallocatedSulfurEquivalentMassKg() > path.getSourceSulfurEquivalentMassKg()) {
+      throw new IllegalArgumentException("Selected allocation exceeds its source sulfur budget");
+    }
+
+    double rateResidual = path.getSourceSulfurEquivalentMassRateKgPerHour()
+        - (path.getAllocatedElementalSulfurMassRateKgPerHour()
+            + path.getUnallocatedSulfurEquivalentMassRateKgPerHour());
+    double massResidual = path.getSourceSulfurEquivalentMassKg()
+        - (path.getAllocatedElementalSulfurMassKg() + path.getUnallocatedSulfurEquivalentMassKg());
+    if (Double.doubleToLongBits(rateResidual) != Double.doubleToLongBits(path.getRateClosureResidualKgPerHour())
+        || Double.doubleToLongBits(massResidual) != Double.doubleToLongBits(path.getMassClosureResidualKg())) {
+      throw new IllegalArgumentException("Selected allocation closure evidence is inconsistent");
+    }
+  }
+
+  private static void requireNonNegativeFinite(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  private static void requireFinite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+
+  /** Immutable mass-based transfer receipt for one fit path and one source segment. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final int sourceSegmentIndex;
+    private final double durationHours;
+    private final double waterInventoryKg;
+    private final FitPath fitPath;
+    private final String allocationBasisIdentifier;
+    private final String productIdentityBasisIdentifier;
+    private final String downstreamIdempotencyKey;
+    private final double sourceSulfurEquivalentMassRateKgPerHour;
+    private final double transferredS8MassRateKgPerHour;
+    private final double unallocatedSulfurEquivalentMassRateKgPerHour;
+    private final double rateClosureResidualKgPerHour;
+    private final double sourceSulfurEquivalentMassKg;
+    private final double transferredS8MassKg;
+    private final double unallocatedSulfurEquivalentMassKg;
+    private final double massClosureResidualKg;
+
+    private Result(int sourceSegmentIndex, double durationHours, double waterInventoryKg, FitPath fitPath,
+        String allocationBasisIdentifier, String productIdentityBasisIdentifier, String downstreamIdempotencyKey,
+        double sourceSulfurEquivalentMassRateKgPerHour, double transferredS8MassRateKgPerHour,
+        double unallocatedSulfurEquivalentMassRateKgPerHour, double rateClosureResidualKgPerHour,
+        double sourceSulfurEquivalentMassKg, double transferredS8MassKg, double unallocatedSulfurEquivalentMassKg,
+        double massClosureResidualKg) {
+      this.sourceSegmentIndex = sourceSegmentIndex;
+      this.durationHours = durationHours;
+      this.waterInventoryKg = waterInventoryKg;
+      this.fitPath = fitPath;
+      this.allocationBasisIdentifier = allocationBasisIdentifier;
+      this.productIdentityBasisIdentifier = productIdentityBasisIdentifier;
+      this.downstreamIdempotencyKey = downstreamIdempotencyKey;
+      this.sourceSulfurEquivalentMassRateKgPerHour = sourceSulfurEquivalentMassRateKgPerHour;
+      this.transferredS8MassRateKgPerHour = transferredS8MassRateKgPerHour;
+      this.unallocatedSulfurEquivalentMassRateKgPerHour = unallocatedSulfurEquivalentMassRateKgPerHour;
+      this.rateClosureResidualKgPerHour = rateClosureResidualKgPerHour;
+      this.sourceSulfurEquivalentMassKg = sourceSulfurEquivalentMassKg;
+      this.transferredS8MassKg = transferredS8MassKg;
+      this.unallocatedSulfurEquivalentMassKg = unallocatedSulfurEquivalentMassKg;
+      this.massClosureResidualKg = massClosureResidualKg;
+    }
+
+    /** @return existing NeqSim component name selected for downstream representation. */
+    public String getComponentName() {
+      return S8_COMPONENT_NAME;
+    }
+
+    /** @return source-order segment index. */
+    public int getSourceSegmentIndex() {
+      return sourceSegmentIndex;
+    }
+
+    /** @return source segment duration [h]. */
+    public double getDurationHours() {
+      return durationHours;
+    }
+
+    /** @return explicit liquid-water inventory used by the source projection [kg]. */
+    public double getWaterInventoryKg() {
+      return waterInventoryKg;
+    }
+
+    /** @return explicitly selected fit path. */
+    public FitPath getFitPath() {
+      return fitPath;
+    }
+
+    /** @return caller-supplied elemental-sulfur allocation-basis identifier. */
+    public String getAllocationBasisIdentifier() {
+      return allocationBasisIdentifier;
+    }
+
+    /** @return caller-supplied basis for selecting the S8 representation. */
+    public String getProductIdentityBasisIdentifier() {
+      return productIdentityBasisIdentifier;
+    }
+
+    /** @return caller-supplied downstream idempotency key. */
+    public String getDownstreamIdempotencyKey() {
+      return downstreamIdempotencyKey;
+    }
+
+    /** @return selected source sulfur-equivalent mass rate [kg S-equivalent/h]. */
+    public double getSourceSulfurEquivalentMassRateKgPerHour() {
+      return sourceSulfurEquivalentMassRateKgPerHour;
+    }
+
+    /** @return selected mass rate represented as the downstream S8 component [kg/h]. */
+    public double getTransferredS8MassRateKgPerHour() {
+      return transferredS8MassRateKgPerHour;
+    }
+
+    /** @return selected unallocated sulfur-equivalent mass rate [kg S-equivalent/h]. */
+    public double getUnallocatedSulfurEquivalentMassRateKgPerHour() {
+      return unallocatedSulfurEquivalentMassRateKgPerHour;
+    }
+
+    /** @return selected rate-basis closure residual [kg/h]. */
+    public double getRateClosureResidualKgPerHour() {
+      return rateClosureResidualKgPerHour;
+    }
+
+    /** @return selected source sulfur-equivalent mass [kg S-equivalent]. */
+    public double getSourceSulfurEquivalentMassKg() {
+      return sourceSulfurEquivalentMassKg;
+    }
+
+    /** @return selected mass represented as the downstream S8 component [kg]. */
+    public double getTransferredS8MassKg() {
+      return transferredS8MassKg;
+    }
+
+    /** @return selected unallocated sulfur-equivalent mass [kg S-equivalent]. */
+    public double getUnallocatedSulfurEquivalentMassKg() {
+      return unallocatedSulfurEquivalentMassKg;
+    }
+
+    /** @return selected mass-basis closure residual [kg]. */
+    public double getMassClosureResidualKg() {
+      return massClosureResidualKg;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationS8TransferTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationS8TransferTest.java
@@ -1,0 +1,185 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests explicit mass-based S8 transfer receipts from qualified sulfur allocations. */
+public class AqueousHydrogenSulfideOxidationS8TransferTest extends NeqSimTest {
+  private static final double INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
+  private static final double WATER_INVENTORY_KG = 1200.0;
+  private static final double TOLERANCE = 1.0e-17;
+  private static final String ALLOCATION_BASIS = "caller-allocation-case-A";
+  private static final String PRODUCT_BASIS = "caller-S8-identity-case-A";
+  private static final String IDEMPOTENCY_KEY = "segment-0-S8-transfer-case-A";
+
+  @Test
+  void testEveryFitPathIsSelectedExplicitlyWithoutMassConversion() {
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation = allocation(referenceSegment(10.0),
+        WATER_INVENTORY_KG, 0.25);
+
+    assertTransfer(allocation, AqueousHydrogenSulfideOxidationS8Transfer.FitPath.LOWER_RATE, allocation.getLowerRate());
+    assertTransfer(allocation, AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, allocation.getNominal());
+    assertTransfer(allocation, AqueousHydrogenSulfideOxidationS8Transfer.FitPath.UPPER_RATE, allocation.getUpperRate());
+  }
+
+  @Test
+  void testZeroAndFullAllocationPreserveExactIdentities() {
+    AqueousHydrogenSulfideOxidationS8Transfer.Result zero = transfer(
+        allocation(referenceSegment(10.0), WATER_INVENTORY_KG, 0.0),
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, "zero-transfer");
+    AqueousHydrogenSulfideOxidationS8Transfer.Result full = transfer(
+        allocation(referenceSegment(10.0), WATER_INVENTORY_KG, 1.0),
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, "full-transfer");
+
+    assertEquals(0.0, zero.getTransferredS8MassRateKgPerHour(), 0.0);
+    assertEquals(0.0, zero.getTransferredS8MassKg(), 0.0);
+    assertEquals(zero.getSourceSulfurEquivalentMassRateKgPerHour(),
+        zero.getUnallocatedSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(zero.getSourceSulfurEquivalentMassKg(), zero.getUnallocatedSulfurEquivalentMassKg(), 0.0);
+
+    assertEquals(full.getSourceSulfurEquivalentMassRateKgPerHour(), full.getTransferredS8MassRateKgPerHour(), 0.0);
+    assertEquals(full.getSourceSulfurEquivalentMassKg(), full.getTransferredS8MassKg(), 0.0);
+    assertEquals(0.0, full.getUnallocatedSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(0.0, full.getUnallocatedSulfurEquivalentMassKg(), 0.0);
+  }
+
+  @Test
+  void testWaterScalingAndSegmentSplitMassSumsArePreserved() {
+    AqueousHydrogenSulfideOxidationS8Transfer.Result small = transfer(allocation(referenceSegment(10.0), 100.0, 0.4),
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, "small-inventory");
+    AqueousHydrogenSulfideOxidationS8Transfer.Result large = transfer(allocation(referenceSegment(10.0), 250.0, 0.4),
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, "large-inventory");
+
+    assertEquals(2.5 * small.getTransferredS8MassRateKgPerHour(), large.getTransferredS8MassRateKgPerHour(), TOLERANCE);
+    assertEquals(2.5 * small.getTransferredS8MassKg(), large.getTransferredS8MassKg(), TOLERANCE);
+
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(10.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(4.0), referenceSegment(6.0)));
+
+    assertEquals(transferredNominalMass(unsplit, 0.4), transferredNominalMass(split, 0.4), TOLERANCE);
+  }
+
+  @Test
+  void testReceiptRoundTripsThroughSerializationAndPreservesProvenance() throws Exception {
+    AqueousHydrogenSulfideOxidationS8Transfer.Result original = transfer(
+        allocation(referenceSegment(10.0), WATER_INVENTORY_KG, 0.5),
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, IDEMPOTENCY_KEY);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(original);
+    }
+    AqueousHydrogenSulfideOxidationS8Transfer.Result restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (AqueousHydrogenSulfideOxidationS8Transfer.Result) input.readObject();
+    }
+
+    assertNotSame(original, restored);
+    assertEquals("S8", restored.getComponentName());
+    assertEquals(ALLOCATION_BASIS, restored.getAllocationBasisIdentifier());
+    assertEquals(PRODUCT_BASIS, restored.getProductIdentityBasisIdentifier());
+    assertEquals(IDEMPOTENCY_KEY, restored.getDownstreamIdempotencyKey());
+    assertEquals(original.getFitPath(), restored.getFitPath());
+    assertEquals(original.getTransferredS8MassRateKgPerHour(), restored.getTransferredS8MassRateKgPerHour(), 0.0);
+    assertEquals(original.getTransferredS8MassKg(), restored.getTransferredS8MassKg(), 0.0);
+  }
+
+  @Test
+  void testMissingOrInvalidTransferEvidenceFailsClosed() {
+    AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation = allocation(referenceSegment(10.0),
+        WATER_INVENTORY_KG, 0.5);
+    String oversizedIdentifier = new String(new char[257]).replace('\0', 'x');
+
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationS8Transfer.create(null,
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, PRODUCT_BASIS, IDEMPOTENCY_KEY));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationS8Transfer.create(allocation, null, PRODUCT_BASIS, IDEMPOTENCY_KEY));
+    assertInvalidIdentifier(allocation, null, IDEMPOTENCY_KEY);
+    assertInvalidIdentifier(allocation, "", IDEMPOTENCY_KEY);
+    assertInvalidIdentifier(allocation, " untrimmed", IDEMPOTENCY_KEY);
+    assertInvalidIdentifier(allocation, oversizedIdentifier, IDEMPOTENCY_KEY);
+    assertInvalidIdentifier(allocation, PRODUCT_BASIS, null);
+    assertInvalidIdentifier(allocation, PRODUCT_BASIS, "");
+    assertInvalidIdentifier(allocation, PRODUCT_BASIS, "untrimmed ");
+    assertInvalidIdentifier(allocation, PRODUCT_BASIS, oversizedIdentifier);
+  }
+
+  private static void assertTransfer(AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation,
+      AqueousHydrogenSulfideOxidationS8Transfer.FitPath fitPath,
+      AqueousHydrogenSulfideOxidationElementalSulfurAllocation.PathResult expected) {
+    AqueousHydrogenSulfideOxidationS8Transfer.Result transfer = transfer(allocation, fitPath,
+        IDEMPOTENCY_KEY + "-" + fitPath.name());
+
+    assertEquals("S8", transfer.getComponentName());
+    assertEquals(allocation.getSourceSegmentIndex(), transfer.getSourceSegmentIndex());
+    assertEquals(allocation.getDurationHours(), transfer.getDurationHours(), 0.0);
+    assertEquals(allocation.getWaterInventoryKg(), transfer.getWaterInventoryKg(), 0.0);
+    assertEquals(fitPath, transfer.getFitPath());
+    assertEquals(ALLOCATION_BASIS, transfer.getAllocationBasisIdentifier());
+    assertEquals(PRODUCT_BASIS, transfer.getProductIdentityBasisIdentifier());
+    assertEquals(expected.getSourceSulfurEquivalentMassRateKgPerHour(),
+        transfer.getSourceSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(expected.getAllocatedElementalSulfurMassRateKgPerHour(), transfer.getTransferredS8MassRateKgPerHour(),
+        0.0);
+    assertEquals(expected.getUnallocatedSulfurEquivalentMassRateKgPerHour(),
+        transfer.getUnallocatedSulfurEquivalentMassRateKgPerHour(), 0.0);
+    assertEquals(expected.getRateClosureResidualKgPerHour(), transfer.getRateClosureResidualKgPerHour(), 0.0);
+    assertEquals(expected.getSourceSulfurEquivalentMassKg(), transfer.getSourceSulfurEquivalentMassKg(), 0.0);
+    assertEquals(expected.getAllocatedElementalSulfurMassKg(), transfer.getTransferredS8MassKg(), 0.0);
+    assertEquals(expected.getUnallocatedSulfurEquivalentMassKg(), transfer.getUnallocatedSulfurEquivalentMassKg(), 0.0);
+    assertEquals(expected.getMassClosureResidualKg(), transfer.getMassClosureResidualKg(), 0.0);
+  }
+
+  private static void assertInvalidIdentifier(
+      AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation, String productBasis,
+      String idempotencyKey) {
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationS8Transfer.create(allocation,
+        AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, productBasis, idempotencyKey));
+  }
+
+  private static double transferredNominalMass(AqueousHydrogenSulfideOxidationTrajectory.Result trajectory,
+      double allocationFraction) {
+    double transferred = 0.0;
+    int index = 0;
+    for (AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segment : trajectory.getSegmentResults()) {
+      transferred += transfer(
+          AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(
+              AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segment, WATER_INVENTORY_KG),
+              allocationFraction, ALLOCATION_BASIS),
+          AqueousHydrogenSulfideOxidationS8Transfer.FitPath.NOMINAL, "split-transfer-" + index)
+          .getTransferredS8MassKg();
+      index++;
+    }
+    return transferred;
+  }
+
+  private static AqueousHydrogenSulfideOxidationS8Transfer.Result transfer(
+      AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation,
+      AqueousHydrogenSulfideOxidationS8Transfer.FitPath fitPath, String idempotencyKey) {
+    return AqueousHydrogenSulfideOxidationS8Transfer.create(allocation, fitPath, PRODUCT_BASIS, idempotencyKey);
+  }
+
+  private static AqueousHydrogenSulfideOxidationElementalSulfurAllocation.Result allocation(
+      AqueousHydrogenSulfideOxidationTrajectory.Segment segment, double waterInventoryKg, double allocationFraction) {
+    AqueousHydrogenSulfideOxidationTrajectory.SegmentResult segmentResult = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(segment)).getSegmentResults().get(0);
+    return AqueousHydrogenSulfideOxidationElementalSulfurAllocation.allocate(
+        AqueousHydrogenSulfideOxidationWaterInventoryProjection.project(segmentResult, waterInventoryKg),
+        allocationFraction, ALLOCATION_BASIS);
+  }
+
+  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(double durationHours) {
+    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, 298.15, 8.0, 0.723, 250.0e-6);
+  }
+}


### PR DESCRIPTION
## Campaign

Advances #3318 under the Northern-Lights-type CO2 transport/injection chemistry roadmap.

Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5652319276

## What changed

- Adds an immutable mass-based transfer receipt from the caller-defined elemental-sulfur allocation to NeqSim's existing `S8` identity.
- Requires an explicit lower-rate, nominal, or upper-rate Millero fit path.
- Requires caller-supplied product-identity basis and downstream idempotency key.
- Preserves source, transferred, and unallocated mass rates/masses, closure residuals, and source-segment provenance.
- Adds five focused tests and extends the executable documentation contract.

## Scientific and integration boundary

Kinetics remain Millero et al. (1987), https://doi.org/10.1021/es00159a003. Elemental-sulfur allocation remains caller supplied. Allocated kg S-equivalent/h and kg pass through exactly as the selected `S8` representation's kg/h and kg. No S8-mole calculation or new molecular-weight constant is introduced. The idempotency key is an accounting hook, not enforcement.

No default yield, product selectivity, O2 consumption, heat release, speciation, pressure qualification, water holdup, stream mutation, flash, deposition, filtering, wall inventory, corrosion, or pipeline mutation is introduced.

## Frozen scope

Exactly four files:

- `src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationS8Transfer.java`
- `src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationS8TransferTest.java`
- `docs/chemicalreactions/h2s_oxygen_kinetics.md`
- `docs/test_h2s_oxygen_kinetics_documentation.py`

Starting `master`: `1e7fda16e3872f74d918367a708737fbbad93927`
Exact head: `f7d6cd96f3425cde39fd53acdc7da79f21dc66e0`

All four remote blobs match the locally validated files. No other PR head changed.

## Validation

Passed locally:

- direct Spotless apply/check
- Java 8 compilation
- five focused Java tests
- executable documentation contract: 20/20
- Python byte compilation

The targeted local materialization did not credit the repository-wide documentation-search audit. Hosted exact-head CI has now completed that audit and the full Java/slow-test matrix successfully.

**EXACT-HEAD CI PASSED; REVIEW PENDING.** All seven workflow groups pass on the unchanged head. Subsystem-owner/domain and independent-maintainer reviews remain outstanding.

Autonomous portfolio occupancy is **4/10**, below the ten-capability ceiling.

This PR is intentionally draft-only. GitHub reports the exact head mergeable and rebaseable; its policy state remains blocked while the draft and mandatory human-review gates are outstanding. Do not mark ready, merge, rebase, synchronize, replace, close, or abandon it automatically.