### PR TITLE
fix(distillation): publish consistent Naphtali-Sandholm state

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -290,6 +290,29 @@ targets manipulated through condenser or reboiler temperature.
 - Restores the intended single gas or liquid phase after composition initialization when applying
   no-side-draw products. This prevents initialization from re-expanding both phase slots with the
   same accepted component inventory.
+- Publishes the accepted adjacent-tray phase flows into the existing tray inlet streams before
+  evaluating balances. Reboiler and condenser duties are recalculated from those same material
+  streams, without another tray flash, and copied to calculated `heatDuty` energy ports. Duties
+  are in W: positive adds heat to the column and negative removes heat. A connected energy port
+  in specification mode retains its prescribed value.
+- The applied public state determines acceptance for ordinary columns as well as side-draw
+  columns. A directly accepted result reports `RIGOROUS_CONVERGED`; an unqualified result is
+  rejected and can proceed to the existing coordinated fallback. `getLastEnergyResidual()`
+  describes the published streams and duties, including fixed-temperature terminal stages.
+  MESH energy diagnostics include terminal heat duties and use the published phase outlets,
+  including side and pumparound draws, rather than a separately flashed mixed-stream phase split.
+  Non-finite flowing enthalpies or duties fail the MESH energy check.
+- `getEnergyBalanceError()` initializes cloned material-stream properties before reading their
+  enthalpies, includes any separate condenser liquid product, and preserves non-finite values.
+  Cloning keeps this public diagnostic from changing the adaptive relaxation controller's state.
+  Sequential solvers also refresh their final energy residual after product reconciliation and
+  property finalization, so the reported residual describes the published state.
+- Exact repeated runs retain stream object identities and update calculation identifiers on
+  tray inlets, outlets, and column products. Nearby feed or terminal-temperature changes refresh
+  the retained inlet and product objects when the simultaneous result is accepted. For a column
+  with both terminal stages, cold and changed warm states receive Newton correction unless the
+  full residual already meets the solver tolerance. The percent-level initializer shortcuts
+  remain limited to the reboiler-only topology for which they were introduced.
 - Package-level solver diagnostics record Jacobian base-refinement passes and the residual-vector
   mutation measured after each completed build. The mutation is expected to be bitwise zero; these
   counters support deterministic regression and do not change the public column API.

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
@@ -176,10 +176,19 @@ final class ColumnMeshResidualEvaluator {
     for (int trayIndex = 0; trayIndex < column.getTrays().size(); trayIndex++) {
       SimpleTray tray = column.getTray(trayIndex);
       try {
-        double targetEnthalpy = finiteOrZero(tray.calcMixStreamEnthalpy());
-        SystemInterface traySystem = tray.getThermoSystem().clone();
-        traySystem.init(3);
-        double actualEnthalpy = finiteOrZero(traySystem.getEnthalpy());
+        double targetEnthalpy;
+        if (tray instanceof Reboiler) {
+          targetEnthalpy = tray.calcMixStreamEnthalpy0() + ((Reboiler) tray).getDuty();
+        } else if (tray instanceof Condenser) {
+          targetEnthalpy = tray.calcMixStreamEnthalpy0() + ((Condenser) tray).getDuty();
+        } else {
+          targetEnthalpy = tray.calcMixStreamEnthalpy();
+        }
+        double actualEnthalpy = tray.getMaterialOutletEnthalpy();
+        if (!Double.isFinite(targetEnthalpy) || !Double.isFinite(actualEnthalpy)) {
+          builder.add(Double.POSITIVE_INFINITY, ColumnMeshEquationType.ENERGY, trayIndex, null);
+          continue;
+        }
         double scale = Math.max(1.0, Math.abs(targetEnthalpy) + Math.abs(actualEnthalpy));
         builder.add((actualEnthalpy - targetEnthalpy) / scale, ColumnMeshEquationType.ENERGY, trayIndex, null);
       } catch (Exception ex) {
@@ -363,16 +372,6 @@ final class ColumnMeshResidualEvaluator {
     } catch (Exception ex) {
       return 0.0;
     }
-  }
-
-  /**
-   * Convert a non-finite diagnostic value to zero.
-   *
-   * @param value value to sanitize
-   * @return value when finite, otherwise zero
-   */
-  private static double finiteOrZero(double value) {
-    return Double.isFinite(value) ? value : 0.0;
   }
 
   /** Builder for residual vectors and metadata. */

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -226,6 +226,27 @@ public class Condenser extends SimpleTray {
     return powerUnit.getValue(unit);
   }
 
+  /**
+   * Publish the heat duty of the applied phase streams without flashing the accepted tray again.
+   */
+  void updateDutyFromPublishedStreams() {
+    duty = getMaterialOutletEnthalpy() - calcMixStreamEnthalpy0();
+    if (getEnergyPort("heatDuty").getMode() == EnergyPortMode.CALCULATED) {
+      getEnergyPort("heatDuty").setDuty(duty);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  double getMaterialOutletEnthalpy() {
+    double enthalpy = super.getMaterialOutletEnthalpy();
+    StreamInterface liquidProduct = getLiquidProductStream();
+    if (!totalCondenser && liquidProduct != null) {
+      enthalpy += getMaterialStreamEnthalpy(liquidProduct);
+    }
+    return enthalpy;
+  }
+
   /** {@inheritDoc} */
   @Override
   public StreamInterface getGasOutStream() {

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -3053,8 +3053,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * </p>
    *
    * @param id calculation identifier
-   * @return {@code true} when the solver accepted its direct result and, for active side draws, the applied state
-   * satisfies the active rigorous convergence gates
+   * @return {@code true} when the solver accepted its direct result and the published streams and duties satisfy the
+   * active rigorous convergence gates
    */
   boolean solveNaphtaliSandholm(UUID id) {
     captureDirectExternalTrayFeeds();
@@ -3118,6 +3118,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (initialized) {
       this.init();
     }
+    StreamInterface[] previousGasOutlets = new StreamInterface[numberOfTrays];
+    StreamInterface[] previousLiquidOutlets = new StreamInterface[numberOfTrays];
+    for (int i = 0; i < numberOfTrays; i++) {
+      previousGasOutlets[i] = trays.get(i).getGasOutStream();
+      previousLiquidOutlets[i] = trays.get(i).getLiquidOutStream();
+    }
     prepareColumnForSolve();
 
     NaphtaliSandholmSolver solver = new NaphtaliSandholmSolver(this, originalFeedSystems, originalFeedFlowRates);
@@ -3137,21 +3143,30 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     storeNaphtaliTelemetry(solver);
     markSolverTypeUsed(SolverType.NAPHTALI_SANDHOLM);
 
+    for (int i = 0; i < numberOfTrays; i++) {
+      trays.get(i)
+          .setCachedGasOutStream(adoptSolvedProductStream(previousGasOutlets[i], trays.get(i).getGasOutStream()));
+      trays.get(i).setCachedLiquidOutStream(
+          adoptSolvedProductStream(previousLiquidOutlets[i], trays.get(i).getLiquidOutStream()));
+    }
+    synchronizeAppliedTrayInlets(id);
+    if (hasReboiler) {
+      getReboiler().updateDutyFromPublishedStreams();
+    }
+    if (hasCondenser) {
+      getCondenser().updateDutyFromPublishedStreams();
+    }
+
     double temperatureResidual = accepted ? solver.getLastTemperatureResidual() : 1.0e10;
     finalizeNaphtaliSolve(id, accepted, solver.getLastIterations(), temperatureResidual,
-        solver.getLastMassBalanceError(), solver.getLastEnergyResidual(), startTime);
+        solver.getLastMassBalanceError(), getEnergyBalanceError(), startTime);
     hasBeenSolvedBefore = true;
     lastTotalFeedFlow = -1.0;
     // The solver wrote the tray network of this column instance, so the state is eligible for the
     // warm-state cache. init() has already recorded the matching thermodynamic identity.
     naphtaliSandholmStateOwned = true;
     trayStateThermodynamicIdentitySignature = thermodynamicIdentitySignature;
-    boolean hasActiveSideDraw = hasActiveSideDrawFractions();
-    // This PR makes the applied-state gate authoritative for side-draw columns because
-    // intermediate products expose any species leakage. Preserve the established direct
-    // solver acceptance contract for columns without side draws; broadening that contract
-    // changes their warm-state/fallback behavior and belongs in a separate migration.
-    boolean appliedResultAccepted = accepted && (!hasActiveSideDraw || solved());
+    boolean appliedResultAccepted = accepted && solved();
     hasNaphtaliSandholmWarmState = appliedResultAccepted;
     if (appliedResultAccepted) {
       lastNaphtaliSandholmInputSignature = inputSignature;
@@ -3162,6 +3177,53 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
           getName());
     }
     return appliedResultAccepted;
+  }
+
+  /**
+   * Refresh existing tray inlet objects from one snapshot of the applied adjacent outlets and external feeds.
+   *
+   * <p>
+   * Snapshot every source before writing any inlet because the initialized tray network can share stream objects.
+   * Updating thermodynamic systems in place keeps caller-held inlet references current without another tray flash.
+   * External feeds and pumparound returns precede the generated vapor and liquid inlets.
+   * </p>
+   *
+   * @param id calculation identifier for the applied state
+   */
+  private void synchronizeAppliedTrayInlets(UUID id) {
+    List<List<SystemInterface>> inletSystems = new ArrayList<>();
+    for (int i = 0; i < numberOfTrays; i++) {
+      List<SystemInterface> sources = new ArrayList<>();
+      for (StreamInterface feed : getExternalFeedStreams(i)) {
+        sources.add(feed.getThermoSystem().clone());
+      }
+      for (ColumnPumparound pumparound : pumparounds) {
+        if (pumparound.getReturnTrayNumber() == i && pumparound.getReturnStream() != null) {
+          sources.add(pumparound.getReturnStream().getThermoSystem().clone());
+        }
+      }
+      if (i > 0) {
+        sources.add(trays.get(i - 1).getGasOutStream().getThermoSystem().clone());
+      }
+      if (i + 1 < numberOfTrays) {
+        sources.add(trays.get(i + 1).getLiquidOutStream().getThermoSystem().clone());
+      }
+      inletSystems.add(sources);
+    }
+    for (int i = 0; i < numberOfTrays; i++) {
+      SimpleTray tray = trays.get(i);
+      List<SystemInterface> sources = inletSystems.get(i);
+      if (tray.getNumberOfInputStreams() != sources.size()) {
+        throw new IllegalStateException("Applied tray inlet topology does not match tray " + i);
+      }
+      for (int k = 0; k < sources.size(); k++) {
+        tray.getStream(k).setThermoSystem(sources.get(k));
+        tray.getStream(k).setCalculationIdentifier(id);
+      }
+      tray.getGasOutStream().setCalculationIdentifier(id);
+      tray.getLiquidOutStream().setCalculationIdentifier(id);
+      tray.getOutletStream().setCalculationIdentifier(id);
+    }
   }
 
   /**
@@ -3295,6 +3357,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     liquidOutStream.setCalculationIdentifier(id);
     for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
       trays.get(trayIndex).setCalculationIdentifier(id);
+      trays.get(trayIndex).getGasOutStream().setCalculationIdentifier(id);
+      trays.get(trayIndex).getLiquidOutStream().setCalculationIdentifier(id);
+      trays.get(trayIndex).getOutletStream().setCalculationIdentifier(id);
+      for (int k = 0; k < trays.get(trayIndex).getNumberOfInputStreams(); k++) {
+        trays.get(trayIndex).getStream(k).setCalculationIdentifier(id);
+      }
     }
     setCalculationIdentifier(id);
     lastSolveStatusReason = "Reused unchanged Naphtali-Sandholm solution";
@@ -3736,6 +3804,10 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     liquidOutStream.setThermoSystem(trays.get(0).getLiquidOutStream().getThermoSystem());
     liquidOutStream.setCalculationIdentifier(id);
 
+    // A prior fallback can leave terminal draw snapshots from another accepted state or fluid.
+    // The direct result has no product reconciliation: capture its actual terminal outlets.
+    captureTerminalProductDrawStreams(id);
+
     // Recompute the balance diagnostics from the applied state. The solver reports its own
     // internal mass balance only, and never touched lastInternalTrafficRatio at all, so a stale
     // ratio from a previous solver run used to leak into the solved() gate.
@@ -3745,25 +3817,17 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     for (int i = 0; i < numberOfTrays; i++) {
       trays.get(i).setCalculationIdentifier(id);
     }
-    if (isEffectiveMeshResidualToleranceEnforced() || lastMeshResidual != null) {
-      updateMeshResiduals();
-    }
-    boolean hasActiveSideDraw = hasActiveSideDrawFractions();
-    if (accepted && hasActiveSideDraw && residualConvergenceSatisfied()) {
+    updateMeshResiduals();
+    if (accepted && residualConvergenceSatisfied() && Double.isFinite(getLastMeshEnergyResidualNorm())) {
       lastSolveStatus = SolveStatus.RIGOROUS_CONVERGED;
-      lastSolveStatusReason = "Naphtali-Sandholm side-draw products satisfy the active rigorous convergence gates";
-    } else if (accepted && !hasActiveSideDraw
-        && (!hasCondenser || getCondenser() == null || getCondenser().isFixedLiquidRefluxSpecificationSatisfied())) {
-      lastSolveStatus = SolveStatus.RECONCILED_PRODUCTS;
-      lastSolveStatusReason = "Naphtali-Sandholm direct products were applied";
+      lastSolveStatusReason = "Published Naphtali-Sandholm streams and duties satisfy the active convergence gates";
     } else {
       lastSolveStatus = SolveStatus.FAILED;
       if (accepted && hasCondenser && getCondenser() != null
           && !getCondenser().isFixedLiquidRefluxSpecificationSatisfied()) {
         lastSolveStatusReason = "Available condenser liquid was insufficient for the fixed liquid reflux specification";
       } else {
-        lastSolveStatusReason = accepted
-            ? "Applied Naphtali-Sandholm side-draw state failed the active convergence gates"
+        lastSolveStatusReason = accepted ? "Published Naphtali-Sandholm state failed the active convergence gates"
             : "Naphtali-Sandholm solver did not accept its result";
       }
     }
@@ -12044,6 +12108,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       if (includeSideDraws && trays.get(i).getLiquidSideDrawFraction() > 0.0) {
         outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidSideDrawStream(), true);
       }
+      if (includeSideDraws && trays.get(i) instanceof Condenser) {
+        Condenser condenser = (Condenser) trays.get(i);
+        if (!condenser.isTotalCondenser() && condenser.getLiquidProductStream() != null) {
+          outlet += getFiniteStreamEnthalpy(condenser.getLiquidProductStream(), true);
+        }
+      }
       if (includeSideDraws) {
         for (ColumnPumparound pumparound : pumparounds) {
           if (pumparound.getDrawTrayNumber() == i && pumparound.getDrawFraction() > 0.0) {
@@ -12053,9 +12123,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       }
 
       if (trays.get(i) instanceof Reboiler) {
-        inlet += getFiniteDiagnosticValue(((Reboiler) trays.get(i)).getDuty());
+        double duty = ((Reboiler) trays.get(i)).getDuty();
+        inlet += ignoreZeroFlowStreams ? duty : getFiniteDiagnosticValue(duty);
       } else if (trays.get(i) instanceof Condenser) {
-        inlet += getFiniteDiagnosticValue(((Condenser) trays.get(i)).getDuty());
+        double duty = ((Condenser) trays.get(i)).getDuty();
+        inlet += ignoreZeroFlowStreams ? duty : getFiniteDiagnosticValue(duty);
       }
 
       double absInlet = Math.abs(inlet);
@@ -12072,21 +12144,20 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
-   * Read stream enthalpy for diagnostics, treating non-finite values as no contribution.
+   * Read stream enthalpy for diagnostics, preserving the historical adaptive-controller signal when requested.
    *
    * @param stream stream to inspect
-   * @param ignoreZeroFlow whether zero-flow streams are excluded before reading enthalpy
-   * @return finite stream enthalpy contribution
+   * @param ignoreZeroFlow whether to initialize the published state and exclude zero-flow templates
+   * @return material enthalpy contribution, including non-finite values in the published-state diagnostic
    */
   private double getFiniteStreamEnthalpy(StreamInterface stream, boolean ignoreZeroFlow) {
     if (stream == null || stream.getThermoSystem() == null) {
       return 0.0;
     }
     if (ignoreZeroFlow) {
-      double flowRate = Math.abs(stream.getThermoSystem().getFlowRate("kg/hr"));
-      if (!Double.isFinite(flowRate) || flowRate <= 1.0e-12) {
-        return 0.0;
-      }
+      // Phase extraction can leave enthalpy properties uninitialized. Read an initialized clone
+      // so diagnostics do not change the cached state consumed by the adaptive controller.
+      return SimpleTray.getMaterialStreamEnthalpy(stream.clone());
     }
     double enthalpy = stream.getFluid().getEnthalpy();
     if (Double.isFinite(enthalpy)) {
@@ -12456,6 +12527,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (isEffectiveMeshResidualToleranceEnforced() || lastMeshResidual != null) {
       updateMeshResiduals();
     }
+    // Product reconciliation and property finalization can change the exposed phase streams.
+    // Qualify the published energy balance, not a cached residual from the preceding sweep.
+    lastEnergyResidual = getEnergyBalanceError();
     updateLastSolveStatus(productReconciled, fallbackProductsApplied);
     warnOnNonFiniteColumnEndDuty();
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -744,7 +744,11 @@ public class NaphtaliSandholmSolver {
       // energy is in the 1-5% range, run Sum-Rates (which adjusts T from the
       // energy balance) — that refines T without invoking Newton, which is
       // documented to diverge for the no-condenser/T-spec topology.
-      if (useOverallMBClosure && mbErrorBP < 0.005 && energyErrorBP < 0.01 && meshClosureAcceptable("Bubble-Point")) {
+      // With both terminal stages, require Newton correction unless the full residual passed
+      // above. The no-condenser shortcut otherwise publishes only approximate tray traffic,
+      // including the previous traffic after a small temperature or feed change.
+      if (useOverallMBClosure && !hasCondenser && mbErrorBP < 0.005 && energyErrorBP < 0.01
+          && meshClosureAcceptable("Bubble-Point")) {
         logger.info("NS: mass+energy balance OK (mb={}%, E={}%), accepting solution",
             String.format("%.4f", mbErrorBP * 100), String.format("%.2f", energyErrorBP * 100));
         logger.debug("NS: accepting Bubble-Point solution without Sum-Rates correction");
@@ -786,7 +790,7 @@ public class NaphtaliSandholmSolver {
         // sensitivities propagate exponentially — observed Newton blowup
         // from ||F||=4 to 1e5 in one step). Once SR has closed mass balance
         // and energy balance, accept that result and skip Newton.
-        if (useOverallMBClosure && mbAfterSR < 0.05 && energyAfterSR < 0.05
+        if (useOverallMBClosure && !hasCondenser && mbAfterSR < 0.05 && energyAfterSR < 0.05
             && meshClosureAcceptable("Sum-Rates without Newton")) {
           logger.debug("NS: accepting Sum-Rates result without Newton because overall-MB closure is ill-conditioned "
               + "(mass balance={}%, energy={}%);", mbAfterSR * 100, energyAfterSR * 100);

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -121,6 +121,16 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
     return powerUnit.getValue(unit);
   }
 
+  /**
+   * Publish the heat duty of the applied phase streams without flashing the accepted tray again.
+   */
+  void updateDutyFromPublishedStreams() {
+    duty = getMaterialOutletEnthalpy() - calcMixStreamEnthalpy0();
+    if (getEnergyPort("heatDuty").getMode() == EnergyPortMode.CALCULATED) {
+      getEnergyPort("heatDuty").setDuty(duty);
+    }
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {

--- a/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
@@ -150,6 +150,48 @@ public class SimpleTray extends neqsim.process.equipment.mixer.Mixer implements 
     return enthalpy;
   }
 
+  /**
+   * Sum the enthalpy rates of the published material outlets, including side and pumparound draws.
+   *
+   * <p>
+   * A simultaneous solver can publish phase flows independently of the mixed-stream flash. Energy balances must use
+   * those same phase streams. Non-finite flowing states remain non-finite so residual gates cannot hide them.
+   * </p>
+   *
+   * @return total material outlet enthalpy rate in W
+   */
+  double getMaterialOutletEnthalpy() {
+    double enthalpy = getMaterialStreamEnthalpy(getGasOutStream()) + getMaterialStreamEnthalpy(getLiquidOutStream());
+    if (gasSideDrawFraction > 0.0) {
+      enthalpy += getMaterialStreamEnthalpy(getGasSideDrawStream());
+    }
+    if (liquidSideDrawFraction > 0.0) {
+      enthalpy += getMaterialStreamEnthalpy(getLiquidSideDrawStream());
+    }
+    if (liquidPumparoundDrawFraction > 0.0) {
+      enthalpy += getMaterialStreamEnthalpy(getLiquidPumparoundDrawStream());
+    }
+    return enthalpy;
+  }
+
+  /**
+   * Read a material stream's energy contribution without counting zero-flow phase templates.
+   *
+   * @param stream material stream
+   * @return enthalpy rate in W, or a non-finite value for an invalid flowing state
+   */
+  static double getMaterialStreamEnthalpy(StreamInterface stream) {
+    double flow = stream.getFlowRate("kg/hr");
+    if (!Double.isFinite(flow)) {
+      return Double.NaN;
+    }
+    if (Math.abs(flow) <= 1.0e-12) {
+      return 0.0;
+    }
+    stream.getThermoSystem().init(2);
+    return stream.getThermoSystem().getEnthalpy();
+  }
+
   /** {@inheritDoc} */
   @Override
   public double calcMixStreamEnthalpy() {

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -123,8 +123,8 @@ public class ColumnStudyRegressionTest {
     column.run();
 
     assertTrue(column.solved(), "Column-study case should converge with Naphtali-Sandholm");
-    assertEquals(DistillationColumn.SolveStatus.RECONCILED_PRODUCTS, column.getLastSolveStatus(),
-        "a no-side-draw direct result should preserve the established reconciled-product status");
+    assertEquals(DistillationColumn.SolveStatus.RIGOROUS_CONVERGED, column.getLastSolveStatus(),
+        "the applied no-side-draw state must satisfy the same active gates as its published streams and duties");
     assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, column.getLastSolverTypeUsed(),
         "the nominal case must be accepted by the simultaneous solver rather than a premature SR fallback");
     assertTrue(column.getLastIterationCount() > 0, "the nominal rigorous solve should exercise Newton refinement");

--- a/src/test/java/neqsim/process/equipment/distillation/NaphtaliSandholmPublishedStateTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/NaphtaliSandholmPublishedStateTest.java
@@ -1,0 +1,249 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression for issue #3698: the accepted column must publish one material and energy state. */
+class NaphtaliSandholmPublishedStateTest extends neqsim.NeqSimTest {
+  private static final Logger logger = LogManager.getLogger(NaphtaliSandholmPublishedStateTest.class);
+  private static final int FEED_TRAY = 6;
+  private static final double ENERGY_TOLERANCE_W = 0.02;
+
+  private static DistillationColumn createColumn(DistillationColumn.SolverType solver) {
+    return createColumn(solver, 8, FEED_TRAY);
+  }
+
+  private static DistillationColumn createColumn(DistillationColumn.SolverType solver, int stages, int feedTray) {
+    String[] names = { "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane", "n-pentane", "n-hexane" };
+    double[] fractions = { 0.22, 0.34, 0.20, 0.08, 0.08, 0.03, 0.03, 0.02 };
+    SystemSrkEos fluid = new SystemSrkEos(283.15, 25.0);
+    for (int i = 0; i < names.length; i++) {
+      fluid.addComponent(names[i], fractions[i]);
+    }
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.run();
+    DistillationColumn column = new DistillationColumn("deethanizer", stages, true, true);
+    column.addFeedStream(feed, feedTray);
+    column.setCondenserTemperature(0.0, "C");
+    column.setReboilerTemperature(80.0, "C");
+    column.setTopPressure(24.0);
+    column.setBottomPressure(25.0);
+    column.setSolverType(solver);
+    column.setMaxNumberOfIterations(80, true);
+    column.setTemperatureTolerance(1.0e-5);
+    return column;
+  }
+
+  private static double enthalpy(StreamInterface stream) {
+    stream.getFluid().init(3);
+    return stream.getFluid().getEnthalpy();
+  }
+
+  private static double componentFlow(StreamInterface stream, int component) {
+    return stream.getFlowRate("mol/hr") * stream.getFluid().getMolarComposition()[component];
+  }
+
+  private static void assertPublishedBalances(DistillationColumn column) {
+    assertPublishedBalances(column, FEED_TRAY);
+  }
+
+  private static void assertPublishedBalances(DistillationColumn column, int feedTray) {
+    assertPublishedBalances(column, feedTray, DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+  }
+
+  private static void assertPublishedBalances(DistillationColumn column, int feedTray,
+      DistillationColumn.SolverType expectedSolver) {
+    StreamInterface feed = column.getFeedStreams(feedTray).get(0);
+    int count = column.getNumberOfTrays();
+    StreamInterface[] gas = new StreamInterface[count];
+    StreamInterface[] liquid = new StreamInterface[count];
+    for (int i = 0; i < count; i++) {
+      gas[i] = column.getTray(i).getGasOutStream();
+      liquid[i] = column.getTray(i).getLiquidOutStream();
+    }
+    double reboilerDuty = enthalpy(gas[0]) + enthalpy(liquid[0]) - enthalpy(liquid[1]);
+    double condenserDuty = enthalpy(gas[count - 1]) + enthalpy(liquid[count - 1]) - enthalpy(gas[count - 2]);
+    logger.info("Published duties W: reboiler={}, condenser={}; adjacent-outlet duties W: {}, {}",
+        column.getReboiler().getDuty(), column.getCondenser().getDuty(), reboilerDuty, condenserDuty);
+    assertEquals(reboilerDuty, column.getReboiler().getDuty(), ENERGY_TOLERANCE_W,
+        "Reboiler duty from accepted outlets");
+    assertEquals(condenserDuty, column.getCondenser().getDuty(), ENERGY_TOLERANCE_W,
+        "Condenser duty from accepted outlets");
+    assertEquals(reboilerDuty, column.getReboiler().getEnergyPort("heatDuty").getDuty(), ENERGY_TOLERANCE_W);
+    assertEquals(condenserDuty, column.getCondenser().getEnergyPort("heatDuty").getDuty(), ENERGY_TOLERANCE_W);
+    assertEquals(reboilerDuty / 1000.0, column.getReboiler().getDuty("kW"), ENERGY_TOLERANCE_W / 1000.0);
+
+    for (int i = 0; i < count; i++) {
+      double inlet = i == feedTray ? enthalpy(feed) : 0.0;
+      if (i > 0) {
+        inlet += enthalpy(gas[i - 1]);
+      }
+      if (i + 1 < count) {
+        inlet += enthalpy(liquid[i + 1]);
+      }
+      double publicInlet = 0.0;
+      for (int k = 0; k < column.getTray(i).getNumberOfInputStreams(); k++) {
+        publicInlet += enthalpy(column.getTray(i).getStream(k));
+      }
+      assertEquals(inlet, publicInlet, ENERGY_TOLERANCE_W, "Tray " + i + " public inlets");
+      double duty = i == 0 ? reboilerDuty : i == count - 1 ? condenserDuty : 0.0;
+      assertEquals(inlet + duty, enthalpy(gas[i]) + enthalpy(liquid[i]), ENERGY_TOLERANCE_W, "Tray " + i + " energy");
+      for (int c = 0; c < feed.getFluid().getNumberOfComponents(); c++) {
+        double componentInlet = i == feedTray ? componentFlow(feed, c) : 0.0;
+        if (i > 0) {
+          componentInlet += componentFlow(gas[i - 1], c);
+        }
+        if (i + 1 < count) {
+          componentInlet += componentFlow(liquid[i + 1], c);
+        }
+        assertEquals(componentInlet, componentFlow(gas[i], c) + componentFlow(liquid[i], c),
+            Math.max(1.0e-5, Math.abs(componentInlet) * 1.0e-7), "Tray component closure");
+        double publicComponentInlet = 0.0;
+        for (int k = 0; k < column.getTray(i).getNumberOfInputStreams(); k++) {
+          publicComponentInlet += componentFlow(column.getTray(i).getStream(k), c);
+        }
+        assertEquals(componentInlet, publicComponentInlet, Math.max(1.0e-5, Math.abs(componentInlet) * 1.0e-7),
+            "Tray public inlet component closure");
+      }
+    }
+    assertEquals(feed.getFlowRate("kg/hr"),
+        column.getGasOutStream().getFlowRate("kg/hr") + column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-4);
+    assertEquals(enthalpy(feed) + reboilerDuty + condenserDuty,
+        enthalpy(column.getGasOutStream()) + enthalpy(column.getLiquidOutStream()), ENERGY_TOLERANCE_W);
+    for (int c = 0; c < feed.getFluid().getNumberOfComponents(); c++) {
+      assertEquals(componentFlow(feed, c),
+          componentFlow(column.getGasOutStream(), c) + componentFlow(column.getLiquidOutStream(), c),
+          Math.max(1.0e-5, componentFlow(feed, c) * 1.0e-7));
+    }
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals(expectedSolver, column.getLastSolverTypeUsed());
+    if (expectedSolver == DistillationColumn.SolverType.NAPHTALI_SANDHOLM) {
+      assertEquals(DistillationColumn.SolveStatus.RIGOROUS_CONVERGED, column.getLastSolveStatus());
+    }
+    assertTrue(column.getLastEnergyResidual() < 1.0e-7, column.getConvergenceDiagnostics());
+    assertEquals(column.getEnergyBalanceError(), column.getLastEnergyResidual(), 1.0e-12);
+    assertTrue(column.getLastMeshEnergyResidualNorm() < 1.0e-7, column.getConvergenceDiagnostics());
+  }
+
+  @Test
+  void coldSolvePublishesBalancedDutiesAndInlets() {
+    DistillationColumn column = createColumn(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    column.run();
+    assertPublishedBalances(column);
+    column.getCondenser().duty = Double.NaN;
+    assertFalse(Double.isFinite(column.getEnergyBalanceError()), "The public energy diagnostic must fail closed");
+    ColumnMeshResidual invalid = ColumnMeshResidualEvaluator.evaluate(column);
+    assertFalse(invalid.isFinite(), "Non-finite duty must not be sanitized into a finite MESH residual");
+    assertEquals(Double.POSITIVE_INFINITY, invalid.getInfinityNorm(ColumnMeshEquationType.ENERGY));
+  }
+
+  @Test
+  void fixedLiquidRefluxIncludesTheSeparateCondenserProduct() {
+    StreamInterface feed = createColumn(DistillationColumn.SolverType.NAPHTALI_SANDHOLM).getFeedStreams(FEED_TRAY)
+        .get(0);
+    Condenser condenser = new Condenser("condenser");
+    condenser.addStream(feed);
+    condenser.setOutTemperature(273.15);
+    condenser.setSeparation_with_liquid_reflux(true, 10.0, "kg/hr");
+    condenser.run();
+    assertTrue(condenser.getLiquidProductStream().getFlowRate("kg/hr") > 1.0);
+    double expected = enthalpy(condenser.getGasOutStream()) + enthalpy(condenser.getLiquidOutStream())
+        + enthalpy(condenser.getLiquidProductStream()) - enthalpy(feed);
+    condenser.updateDutyFromPublishedStreams();
+    assertEquals(expected, condenser.getDuty(), ENERGY_TOLERANCE_W);
+    assertEquals(expected, condenser.getEnergyPort("heatDuty").getDuty(), ENERGY_TOLERANCE_W);
+  }
+
+  @Test
+  void directSolveRejectsAnUnqualifiedPublishedEnergyState() {
+    DistillationColumn column = createColumn(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    column.setEnforceEnergyBalanceTolerance(true);
+    column.setEnthalpyBalanceTolerance(1.0e-20);
+    assertFalse(column.solveNaphtaliSandholm(UUID.randomUUID()));
+    assertFalse(column.solved());
+    assertEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus());
+    assertTrue(column.getLastEnergyResidual() > column.getEnthalpyBalanceTolerance());
+  }
+
+  @Test
+  void convergedSequentialReferenceAgreesWithPublishedState() {
+    // Use a compact, independently initialized reference: the ten-stage reproducer can stall
+    // under sequential substitution, so its acceptance is covered by the full balance audit.
+    DistillationColumn simultaneous = createColumn(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, 1, 1);
+    simultaneous.run();
+    assertPublishedBalances(simultaneous, 1);
+    DistillationColumn sequential = createColumn(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, 1, 1);
+    sequential.setRelaxationFactor(1.0);
+    sequential.setMinSequentialRelaxation(1.0);
+    sequential.setMaxNumberOfIterations(600, true);
+    sequential.setTemperatureTolerance(1.0e-10);
+    sequential.setMassBalanceTolerance(1.0e-9);
+    sequential.setEnthalpyBalanceTolerance(1.0e-8);
+    sequential.setEnforceEnergyBalanceTolerance(true);
+    sequential.run();
+    logger.info("Sequential reference: {}", sequential.getConvergenceDiagnostics());
+    assertPublishedBalances(sequential, 1, DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    // Independent Newton and TP/PH calculations agree to 1e-7 relative duty. The unscaled
+    // 0.02 W material/energy audit above is applied identically to both states.
+    assertEquals(simultaneous.getReboiler().getDuty(), sequential.getReboiler().getDuty(),
+        Math.abs(simultaneous.getReboiler().getDuty()) * 1.0e-7);
+    assertEquals(simultaneous.getCondenser().getDuty(), sequential.getCondenser().getDuty(),
+        Math.abs(simultaneous.getCondenser().getDuty()) * 1.0e-7);
+    assertEquals(simultaneous.getGasOutStream().getFlowRate("kg/hr"), sequential.getGasOutStream().getFlowRate("kg/hr"),
+        1.0e-4);
+    for (int i = 0; i < simultaneous.getNumberOfTrays(); i++) {
+      assertEquals(simultaneous.getTray(i).getTemperature(), sequential.getTray(i).getTemperature(), 1.0e-5);
+    }
+  }
+
+  @Test
+  void repeatAndNearbyInputsKeepCallerHeldStreamsCurrent() {
+    DistillationColumn column = createColumn(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    StreamInterface gasProduct = column.getGasOutStream();
+    StreamInterface liquidProduct = column.getLiquidOutStream();
+    column.run();
+    StreamInterface[][] inlets = new StreamInterface[column.getNumberOfTrays()][];
+    for (int i = 0; i < inlets.length; i++) {
+      inlets[i] = new StreamInterface[column.getTray(i).getNumberOfInputStreams()];
+      for (int k = 0; k < inlets[i].length; k++) {
+        inlets[i][k] = column.getTray(i).getStream(k);
+      }
+    }
+    StreamInterface condenserProduct = column.getCondenser().getProductOutStream();
+    StreamInterface reboilerProduct = column.getReboiler().getLiquidOutStream();
+    for (int scenario = 0; scenario < 3; scenario++) {
+      if (scenario == 1) {
+        column.setReboilerTemperature(81.0, "C");
+      } else if (scenario == 2) {
+        StreamInterface feed = column.getFeedStreams(FEED_TRAY).get(0);
+        feed.setTemperature(284.15, "K");
+        feed.run();
+      }
+      UUID id = UUID.randomUUID();
+      column.run(id);
+      assertPublishedBalances(column);
+      assertSame(gasProduct, column.getGasOutStream());
+      assertSame(liquidProduct, column.getLiquidOutStream());
+      assertSame(condenserProduct, column.getCondenser().getProductOutStream());
+      assertSame(reboilerProduct, column.getReboiler().getLiquidOutStream());
+      assertEquals(id, gasProduct.getCalculationIdentifier());
+      for (int i = 0; i < inlets.length; i++) {
+        for (int k = 0; k < inlets[i].length; k++) {
+          assertSame(inlets[i][k], column.getTray(i).getStream(k), "Retained inlet reference");
+          assertEquals(id, inlets[i][k].getCalculationIdentifier());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Synchronize accepted tray inlets and terminal duties, preserve stream identity, and qualify energy diagnostics against the final public material state.

Add balance, warm-state, fail-closed, and sequential-reference regressions.

Closes #3698

AI-assisted implementation and validation.

# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion
- [ ] Request the applicable `CODEOWNERS` and record independent domain review where required
- [ ] Add an accepted NRC and migration note if this changes a major public contract

See [CONTRIBUTING.md](../CONTRIBUTING.md), [GOVERNANCE.md](../GOVERNANCE.md), and
[the API lifecycle policy](../docs/development/api-lifecycle.md) for the full contribution process.

## Repair validation — 2026-09-14

Repair commit: `854b4af0ea67613c418979f2161283fd8b587d88`, added directly to the existing branch at `99f479b981ef7dad8d0db14d313ac7b1947b89f4`.

The remaining CI failure, `DistillationColumnTest.adaptiveSolverRecordsSolveMetrics`, was reproduced locally. The all-vapor column has a zero-flow liquid inlet whose initialized enthalpy is NaN; including it in the raw inlet sum made the reboiler duty and published energy residual NaN.

- Reuse the published-stream enthalpy reader for terminal inlet sums. Empty phase templates contribute zero; invalid flowing enthalpies still propagate as non-finite values.
- Refresh sequential MESH diagnostics after terminal duties are recalculated.
- Add regressions for empty-only and mixed empty/flowing terminal inlets and invalid flowing enthalpy. Extend the converged sequential reference to a changed warm terminal temperature.
- Documentation impact: updated `SimpleTray.calcMixStreamEnthalpy0()` Javadoc and the distillation guide to describe zero-flow inlet handling and diagnostic ordering.

In the original failing case, the repaired public energy residual is **0.0**, with both terminal duties **0.0 W**, consistent with the all-vapor material state.

### Local checks

OpenJDK 17.0.20; NeqSim 3.20.0 source at this PR head plus the repair. Maven was prepared with the work-with-neqsim bootstrap helper.

- `./mvnw surefire:test -Dtest=DistillationColumnTest#adaptiveSolverRecordsSolveMetrics -DexcludedTestGroups= -Djacoco.skip=true`: exit 1 before the repair, reproducing the CI assertion.
- `./mvnw test -Dtest=DistillationColumnTest,NaphtaliSandholmPublishedStateTest,ColumnSpecificationTest,CondenserFixedLiquidRefluxTest,TegRegenerationEnergyBalanceTest,SimpleTrayPropertySkipTest -DexcludedTestGroups= -Djacoco.skip=true`: exit 0; **74 tests, 0 failures, 0 errors, 1 existing skip** (6 min 13 s). The original CI failure and all seven published-state tests pass.
- `python devtools/run_spotless.py apply`: exit 0, repeated successfully with no further changes.
- `pre-commit run --all-files --hook-stage pre-commit`: exit 0 (pre-commit 4.6.2).
- `python devtools/run_spotless.py check`: exit 0.
- `python devtools/check_documentation_search.py`: exit 0; 696 Markdown pages and one standalone HTML page audited.
- `pre-commit run --all-files --hook-stage pre-push`: exit 0.
- `git diff --check`: exit 0.

**VALIDATION PENDING CI** for the new commit. Full remote Java/platform/shard checks are not claimed complete.
